### PR TITLE
Add hyper container runtime

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -186,6 +186,11 @@
 			"Rev": "2b27fe17a1b3fb8472fde96d768fa70996adf201"
 		},
 		{
+			"ImportPath": "github.com/docker/docker/pkg/stdcopy",
+			"Comment": "v1.4.1-4045-g2b27fe1",
+			"Rev": "2b27fe17a1b3fb8472fde96d768fa70996adf201"
+		},
+		{
 			"ImportPath": "github.com/docker/docker/pkg/term",
 			"Comment": "v1.4.1-4045-g2b27fe1",
 			"Rev": "2b27fe17a1b3fb8472fde96d768fa70996adf201"

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/stdcopy/stdcopy.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/stdcopy/stdcopy.go
@@ -1,0 +1,168 @@
+package stdcopy
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+
+	"github.com/Sirupsen/logrus"
+)
+
+const (
+	StdWriterPrefixLen = 8
+	StdWriterFdIndex   = 0
+	StdWriterSizeIndex = 4
+)
+
+type StdType [StdWriterPrefixLen]byte
+
+var (
+	Stdin  StdType = StdType{0: 0}
+	Stdout StdType = StdType{0: 1}
+	Stderr StdType = StdType{0: 2}
+)
+
+type StdWriter struct {
+	io.Writer
+	prefix  StdType
+	sizeBuf []byte
+}
+
+func (w *StdWriter) Write(buf []byte) (n int, err error) {
+	var n1, n2 int
+	if w == nil || w.Writer == nil {
+		return 0, errors.New("Writer not instantiated")
+	}
+	binary.BigEndian.PutUint32(w.prefix[4:], uint32(len(buf)))
+	n1, err = w.Writer.Write(w.prefix[:])
+	if err != nil {
+		n = n1 - StdWriterPrefixLen
+	} else {
+		n2, err = w.Writer.Write(buf)
+		n = n1 + n2 - StdWriterPrefixLen
+	}
+	if n < 0 {
+		n = 0
+	}
+	return
+}
+
+// NewStdWriter instantiates a new Writer.
+// Everything written to it will be encapsulated using a custom format,
+// and written to the underlying `w` stream.
+// This allows multiple write streams (e.g. stdout and stderr) to be muxed into a single connection.
+// `t` indicates the id of the stream to encapsulate.
+// It can be stdcopy.Stdin, stdcopy.Stdout, stdcopy.Stderr.
+func NewStdWriter(w io.Writer, t StdType) *StdWriter {
+	return &StdWriter{
+		Writer:  w,
+		prefix:  t,
+		sizeBuf: make([]byte, 4),
+	}
+}
+
+var ErrInvalidStdHeader = errors.New("Unrecognized input header")
+
+// StdCopy is a modified version of io.Copy.
+//
+// StdCopy will demultiplex `src`, assuming that it contains two streams,
+// previously multiplexed together using a StdWriter instance.
+// As it reads from `src`, StdCopy will write to `dstout` and `dsterr`.
+//
+// StdCopy will read until it hits EOF on `src`. It will then return a nil error.
+// In other words: if `err` is non nil, it indicates a real underlying error.
+//
+// `written` will hold the total number of bytes written to `dstout` and `dsterr`.
+func StdCopy(dstout, dsterr io.Writer, src io.Reader) (written int64, err error) {
+	var (
+		buf       = make([]byte, 32*1024+StdWriterPrefixLen+1)
+		bufLen    = len(buf)
+		nr, nw    int
+		er, ew    error
+		out       io.Writer
+		frameSize int
+	)
+
+	for {
+		// Make sure we have at least a full header
+		for nr < StdWriterPrefixLen {
+			var nr2 int
+			nr2, er = src.Read(buf[nr:])
+			nr += nr2
+			if er == io.EOF {
+				if nr < StdWriterPrefixLen {
+					logrus.Debugf("Corrupted prefix: %v", buf[:nr])
+					return written, nil
+				}
+				break
+			}
+			if er != nil {
+				logrus.Debugf("Error reading header: %s", er)
+				return 0, er
+			}
+		}
+
+		// Check the first byte to know where to write
+		switch buf[StdWriterFdIndex] {
+		case 0:
+			fallthrough
+		case 1:
+			// Write on stdout
+			out = dstout
+		case 2:
+			// Write on stderr
+			out = dsterr
+		default:
+			logrus.Debugf("Error selecting output fd: (%d)", buf[StdWriterFdIndex])
+			return 0, ErrInvalidStdHeader
+		}
+
+		// Retrieve the size of the frame
+		frameSize = int(binary.BigEndian.Uint32(buf[StdWriterSizeIndex : StdWriterSizeIndex+4]))
+		logrus.Debugf("framesize: %d", frameSize)
+
+		// Check if the buffer is big enough to read the frame.
+		// Extend it if necessary.
+		if frameSize+StdWriterPrefixLen > bufLen {
+			logrus.Debugf("Extending buffer cap by %d (was %d)", frameSize+StdWriterPrefixLen-bufLen+1, len(buf))
+			buf = append(buf, make([]byte, frameSize+StdWriterPrefixLen-bufLen+1)...)
+			bufLen = len(buf)
+		}
+
+		// While the amount of bytes read is less than the size of the frame + header, we keep reading
+		for nr < frameSize+StdWriterPrefixLen {
+			var nr2 int
+			nr2, er = src.Read(buf[nr:])
+			nr += nr2
+			if er == io.EOF {
+				if nr < frameSize+StdWriterPrefixLen {
+					logrus.Debugf("Corrupted frame: %v", buf[StdWriterPrefixLen:nr])
+					return written, nil
+				}
+				break
+			}
+			if er != nil {
+				logrus.Debugf("Error reading frame: %s", er)
+				return 0, er
+			}
+		}
+
+		// Write the retrieved frame (without header)
+		nw, ew = out.Write(buf[StdWriterPrefixLen : frameSize+StdWriterPrefixLen])
+		if ew != nil {
+			logrus.Debugf("Error writing frame: %s", ew)
+			return 0, ew
+		}
+		// If the frame has not been fully written: error
+		if nw != frameSize {
+			logrus.Debugf("Error Short Write: (%d on %d)", nw, frameSize)
+			return 0, io.ErrShortWrite
+		}
+		written += int64(nw)
+
+		// Move the rest of the buffer to the beginning
+		copy(buf, buf[frameSize+StdWriterPrefixLen:])
+		// Move the index
+		nr -= frameSize + StdWriterPrefixLen
+	}
+}

--- a/Godeps/_workspace/src/github.com/docker/docker/pkg/stdcopy/stdcopy_test.go
+++ b/Godeps/_workspace/src/github.com/docker/docker/pkg/stdcopy/stdcopy_test.go
@@ -1,0 +1,85 @@
+package stdcopy
+
+import (
+	"bytes"
+	"io/ioutil"
+	"strings"
+	"testing"
+)
+
+func TestNewStdWriter(t *testing.T) {
+	writer := NewStdWriter(ioutil.Discard, Stdout)
+	if writer == nil {
+		t.Fatalf("NewStdWriter with an invalid StdType should not return nil.")
+	}
+}
+
+func TestWriteWithUnitializedStdWriter(t *testing.T) {
+	writer := StdWriter{
+		Writer:  nil,
+		prefix:  Stdout,
+		sizeBuf: make([]byte, 4),
+	}
+	n, err := writer.Write([]byte("Something here"))
+	if n != 0 || err == nil {
+		t.Fatalf("Should fail when given an uncomplete or uninitialized StdWriter")
+	}
+}
+
+func TestWriteWithNilBytes(t *testing.T) {
+	writer := NewStdWriter(ioutil.Discard, Stdout)
+	n, err := writer.Write(nil)
+	if err != nil {
+		t.Fatalf("Shouldn't have fail when given no data")
+	}
+	if n > 0 {
+		t.Fatalf("Write should have written 0 byte, but has written %d", n)
+	}
+}
+
+func TestWrite(t *testing.T) {
+	writer := NewStdWriter(ioutil.Discard, Stdout)
+	data := []byte("Test StdWrite.Write")
+	n, err := writer.Write(data)
+	if err != nil {
+		t.Fatalf("Error while writing with StdWrite")
+	}
+	if n != len(data) {
+		t.Fatalf("Write should have written %d byte but wrote %d.", len(data), n)
+	}
+}
+
+func TestStdCopyWithInvalidInputHeader(t *testing.T) {
+	dstOut := NewStdWriter(ioutil.Discard, Stdout)
+	dstErr := NewStdWriter(ioutil.Discard, Stderr)
+	src := strings.NewReader("Invalid input")
+	_, err := StdCopy(dstOut, dstErr, src)
+	if err == nil {
+		t.Fatal("StdCopy with invalid input header should fail.")
+	}
+}
+
+func TestStdCopyWithCorruptedPrefix(t *testing.T) {
+	data := []byte{0x01, 0x02, 0x03}
+	src := bytes.NewReader(data)
+	written, err := StdCopy(nil, nil, src)
+	if err != nil {
+		t.Fatalf("StdCopy should not return an error with corrupted prefix.")
+	}
+	if written != 0 {
+		t.Fatalf("StdCopy should have written 0, but has written %d", written)
+	}
+}
+
+func BenchmarkWrite(b *testing.B) {
+	w := NewStdWriter(ioutil.Discard, Stdout)
+	data := []byte("Test line for testing stdwriter performance\n")
+	data = bytes.Repeat(data, 100)
+	b.SetBytes(int64(len(data)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := w.Write(data); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/kubelet/hyper/hyper.go
+++ b/pkg/kubelet/hyper/hyper.go
@@ -1,0 +1,745 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hyper
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/unversioned/record"
+	"k8s.io/kubernetes/pkg/credentialprovider"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/kubelet/prober"
+	"k8s.io/kubernetes/pkg/probe"
+	"k8s.io/kubernetes/pkg/types"
+	"k8s.io/kubernetes/pkg/util"
+)
+
+const (
+	hyperBinName             = "hyper"
+	hyperContainerNamePrefix = "kube"
+	hyperPodNamePrefix       = "kube"
+	hyperBaseMemory          = 64
+	hyperDefaultContainerCPU = 1
+	hyperDefaultContainerMem = 128
+)
+
+// runtime implements the container runtime for hyper
+type runtime struct {
+	hyperBinAbsPath     string
+	dockerKeyring       credentialprovider.DockerKeyring
+	containerRefManager *kubecontainer.RefManager
+	generator           kubecontainer.RunContainerOptionsGenerator
+	recorder            record.EventRecorder
+	prober              prober.Prober
+	readinessManager    *kubecontainer.ReadinessManager
+	volumeGetter        volumeGetter
+	hyperClient         *HyperClient
+	imagePuller         kubecontainer.ImagePuller
+}
+
+var _ kubecontainer.Runtime = &runtime{}
+
+type volumeGetter interface {
+	GetVolumes(podUID types.UID) (kubecontainer.VolumeMap, bool)
+}
+
+// New creates the hyper container runtime which implements the container runtime interface.
+func New(generator kubecontainer.RunContainerOptionsGenerator,
+	recorder record.EventRecorder,
+	containerRefManager *kubecontainer.RefManager,
+	readinessManager *kubecontainer.ReadinessManager,
+	volumeGetter volumeGetter) (kubecontainer.Runtime, error) {
+
+	// check hyper has already installed
+	hyperBinAbsPath, err := exec.LookPath(hyperBinName)
+	if err != nil {
+		glog.Errorf("Hyper: can't find hyper binary")
+		return nil, fmt.Errorf("cannot find hyper binary: %v", err)
+	}
+
+	hyper := &runtime{
+		hyperBinAbsPath:     hyperBinAbsPath,
+		dockerKeyring:       credentialprovider.NewDockerKeyring(),
+		containerRefManager: containerRefManager,
+		generator:           generator,
+		recorder:            recorder,
+		readinessManager:    readinessManager,
+		volumeGetter:        volumeGetter,
+		hyperClient:         NewHyperClient(),
+	}
+	hyper.prober = prober.New(hyper, readinessManager, containerRefManager, recorder)
+	hyper.imagePuller = kubecontainer.NewImagePuller(recorder, hyper)
+
+	return hyper, nil
+}
+
+func (r *runtime) buildCommand(args ...string) *exec.Cmd {
+	hyperBinAbsPath, err := exec.LookPath(hyperBinName)
+	if err != nil {
+		return nil
+	}
+
+	cmd := exec.Command(hyperBinAbsPath)
+	cmd.Args = append(cmd.Args, args...)
+	return cmd
+}
+
+// runCommand invokes hyper binary with arguments and returns the result
+// from stdout in a list of strings. Each string in the list is a line.
+func (r *runtime) runCommand(args ...string) ([]string, error) {
+	output, err := r.buildCommand(args...).Output()
+	if err != nil {
+		return nil, err
+	}
+	return strings.Split(strings.TrimSpace(string(output)), "\n"), nil
+}
+
+// Version invokes 'hyper version' to get the version information of the hyper
+// runtime on the machine.
+// The return values are an int array containers the version number.
+func (r *runtime) Version() (kubecontainer.Version, error) {
+	version, err := r.hyperClient.Version()
+	if err != nil {
+		return nil, err
+	}
+
+	return parseVersion(version)
+}
+
+func parseTimeString(str string) (time.Time, error) {
+	t := time.Date(0, 0, 0, 0, 0, 0, 0, time.Local)
+	if str == "" {
+		return t, nil
+	}
+
+	layout := "2006-01-02T15:04:05Z"
+	t, err := time.Parse(layout, str)
+	if err != nil {
+		return t, err
+	}
+
+	return t, nil
+}
+
+func (r *runtime) getContainerStatus(container ContainerStatus, image, imageID string) api.ContainerStatus {
+	var status api.ContainerStatus
+
+	_, _, _, containerName, err := r.parseHyperContainerFullName(container.Name)
+	if err != nil {
+		return status
+	}
+
+	status.Name = strings.Split(containerName, ".")[0]
+	status.ContainerID = container.ContainerID
+	status.Image = image
+	status.ImageID = imageID
+
+	switch container.Phase {
+	case StatusRunning:
+		runningStartedAt, err := parseTimeString(container.Running.StartedAt)
+		if err != nil {
+			glog.Errorf("Hyper: can't parse runningStartedAt %s", container.Running.StartedAt)
+			return status
+		}
+
+		status.State = api.ContainerState{
+			Running: &api.ContainerStateRunning{
+				StartedAt: util.Time{runningStartedAt},
+			},
+		}
+	case StatusPending:
+		status.State = api.ContainerState{
+			Waiting: &api.ContainerStateWaiting{
+				Reason: container.Waiting.Reason,
+			},
+		}
+	case StatusFailed, StatusSuccess:
+		terminatedStartedAt, err := parseTimeString(container.Terminated.StartedAt)
+		if err != nil {
+			glog.Errorf("Hyper: can't parse terminatedStartedAt %s", container.Terminated.StartedAt)
+			return status
+		}
+
+		terminatedFinishedAt, err := parseTimeString(container.Terminated.FinishedAt)
+		if err != nil {
+			glog.Errorf("Hyper: can't parse terminatedFinishedAt %s", container.Terminated.FinishedAt)
+			return status
+		}
+
+		status.State = api.ContainerState{
+			Terminated: &api.ContainerStateTerminated{
+				ExitCode:   container.Terminated.ExitCode,
+				Reason:     container.Terminated.Reason,
+				Message:    container.Terminated.Message,
+				StartedAt:  util.Time{terminatedStartedAt},
+				FinishedAt: util.Time{terminatedFinishedAt},
+			},
+		}
+	default:
+		glog.Warningf("Hyper: Unknown pod state: %q", container.Phase)
+	}
+
+	return status
+}
+
+func (r *runtime) buildHyperPodFullName(uid, name, namespace string) string {
+	return fmt.Sprintf("%s_%s_%s_%s", hyperPodNamePrefix, uid, name, namespace)
+}
+
+func (r *runtime) buildHyperContainerFullName(uid, podName, namespace, containerName string, container api.Container) string {
+	return fmt.Sprintf("%s_%s_%s_%s_%s_%08x",
+		hyperContainerNamePrefix,
+		uid,
+		podName,
+		namespace,
+		containerName+"."+strconv.FormatUint(kubecontainer.HashContainer(&container), 16),
+		rand.Uint32())
+}
+
+func (r *runtime) parseHyperPodFullName(podFullName string) (string, string, string, error) {
+	parts := strings.Split(podFullName, "_")
+	if len(parts) != 4 {
+		return "", "", "", fmt.Errorf("failed to parse the pod full name %q", podFullName)
+	}
+	return parts[1], parts[2], parts[3], nil
+}
+
+func (r *runtime) parseHyperContainerFullName(containerName string) (string, string, string, string, error) {
+	parts := strings.Split(containerName, "_")
+	if len(parts) != 6 {
+		return "", "", "", "", fmt.Errorf("failed to parse the container full name %q", containerName)
+	}
+	return parts[1], parts[2], parts[3], parts[4], nil
+}
+
+// GetPods returns a list containers group by pods. The boolean parameter
+// specifies whether the runtime returns all containers including those already
+// exited and dead containers (used for garbage collection).
+func (r *runtime) GetPods(all bool) ([]*kubecontainer.Pod, error) {
+	podInfos, err := r.hyperClient.ListPods()
+	if err != nil {
+		return nil, err
+	}
+
+	var kubepods []*kubecontainer.Pod
+	for _, podInfo := range podInfos {
+		if !all && podInfo.status != "running" {
+			continue
+		}
+
+		var pod kubecontainer.Pod
+		var containers []*kubecontainer.Container
+
+		podID, podName, podNamespace, err := r.parseHyperPodFullName(podInfo.podName)
+		if err != nil {
+			glog.Errorf("Hyper: can't parse pod name %s", podInfo.podName)
+			return nil, err
+		}
+
+		pod.ID = types.UID(podID)
+		pod.Name = podName
+		pod.Namespace = podNamespace
+
+		for _, cinfo := range podInfo.podInfo.Spec.Containers {
+			var container kubecontainer.Container
+			container.ID = types.UID(cinfo.ContainerID)
+			container.Image = cinfo.Image
+
+			for _, cstatus := range podInfo.podInfo.Status.Status {
+				if cstatus.ContainerID == cinfo.ContainerID {
+					createAt, err := parseTimeString(cstatus.Running.StartedAt)
+					if err == nil {
+						container.Created = createAt.Unix()
+					}
+				}
+			}
+
+			_, _, _, containerName, err := r.parseHyperContainerFullName(cinfo.Name)
+			if err != nil {
+				return nil, err
+			}
+			container.Name = strings.Split(containerName, ".")[0]
+
+			hash, err := strconv.ParseUint(strings.Split(containerName, ".")[1], 16, 8)
+			if err == nil {
+				container.Hash = hash
+			}
+
+			containers = append(containers, &container)
+		}
+		pod.Containers = containers
+
+		kubepods = append(kubepods, &pod)
+	}
+
+	return kubepods, nil
+}
+
+func (r *runtime) buildHyperPod(pod *api.Pod, pullSecrets []api.Secret) ([]byte, error) {
+	// check and pull image
+	for _, c := range pod.Spec.Containers {
+		if err := r.imagePuller.PullImage(pod, &c, pullSecrets); err != nil {
+			return nil, err
+		}
+	}
+
+	// build hyper volume spec
+	specMap := make(map[string]interface{})
+	volumeMap, ok := r.volumeGetter.GetVolumes(pod.UID)
+	if !ok {
+		return nil, fmt.Errorf("cannot get the volumes for pod %q", kubecontainer.GetPodFullName(pod))
+	}
+
+	volumes := []map[string]string{}
+	for name, volume := range volumeMap {
+		glog.V(4).Infof("Hyper: volume %s %s", name, volume.GetPath())
+		v := make(map[string]string)
+		v["name"] = name
+		v["source"] = volume.GetPath()
+		v["driver"] = "vfs"
+		volumes = append(volumes, v)
+	}
+	specMap["volumes"] = volumes
+
+	// build hyper containers spec
+	var containers []map[string]interface{}
+	for _, container := range pod.Spec.Containers {
+		c := make(map[string]interface{})
+		c["name"] = r.buildHyperContainerFullName(
+			string(pod.UID),
+			string(pod.Name),
+			string(pod.Namespace),
+			container.Name,
+			container)
+		c["image"] = container.Image
+		c["tty"] = container.TTY
+		if len(container.Command) > 0 {
+			c["command"] = container.Command
+		}
+		if container.WorkingDir != "" {
+			c["workdir"] = container.WorkingDir
+		}
+		if len(container.Args) > 0 {
+			c["args"] = container.Args
+		}
+		if len(container.Env) > 0 {
+			c["envs"] = container.Env
+		}
+
+		if len(container.Ports) > 0 {
+			var ports []map[string]interface{}
+			for _, port := range container.Ports {
+				p := make(map[string]interface{})
+				p["containerPort"] = port.ContainerPort
+				if port.HostPort != 0 {
+					p["hostPort"] = port.HostPort
+				}
+				if port.Protocol != "" {
+					p["protocol"] = port.Protocol
+				}
+				ports = append(ports, p)
+			}
+			c["ports"] = ports
+		}
+
+		if len(container.VolumeMounts) > 0 {
+			var containerVolumes []map[string]interface{}
+			for _, volume := range container.VolumeMounts {
+				v := make(map[string]interface{})
+				v["path"] = volume.MountPath
+				v["volume"] = volume.Name
+				v["readOnly"] = volume.ReadOnly
+				containerVolumes = append(containerVolumes, v)
+			}
+			c["volumes"] = containerVolumes
+		}
+
+		containers = append(containers, c)
+	}
+	specMap["containers"] = containers
+
+	// build hyper pod resources spec
+	var podCPULimit, podMemLimit int64
+	podResource := make(map[string]int64)
+	for _, container := range pod.Spec.Containers {
+		resource := container.Resources.Limits
+		var containerCPULimit, containerMemLimit int64
+		for name, limit := range resource {
+			switch name {
+			case api.ResourceCPU:
+				containerCPULimit = limit.MilliValue()
+			case api.ResourceMemory:
+				containerMemLimit = limit.MilliValue()
+			}
+		}
+		if containerCPULimit == 0 {
+			containerCPULimit = hyperDefaultContainerCPU
+		}
+		if containerMemLimit == 0 {
+			containerMemLimit = hyperDefaultContainerMem * 1024 * 1024 * 1000
+		}
+		podCPULimit += containerCPULimit
+		podMemLimit += containerMemLimit
+	}
+
+	podResource["vcpu"] = (podCPULimit + 999) / 1000
+	podResource["memory"] = int64(hyperBaseMemory) + ((podMemLimit)/1000/1024)/1024
+	specMap["resource"] = podResource
+	glog.V(5).Infof("Hyper: pod limit vcpu=%v mem=%vMiB", podResource["vcpu"], podResource["memory"])
+
+	// other params required
+	specMap["type"] = "pod"
+	specMap["id"] = r.buildHyperPodFullName(string(pod.UID), string(pod.Name), string(pod.Namespace))
+	specMap["tty"] = true
+
+	podData, err := json.Marshal(specMap)
+	if err != nil {
+		return nil, err
+	}
+
+	return podData, nil
+}
+
+func (r *runtime) RunPod(pod *api.Pod, pullSecrets []api.Secret) error {
+	podData, err := r.buildHyperPod(pod, pullSecrets)
+	if err != nil {
+		glog.Errorf("Hyper: buildHyperPod failed, error: %s", err)
+		return err
+	}
+
+	// TODO: process networks and volumes
+	result, err := r.hyperClient.CreatePod(string(podData))
+	if err != nil {
+		glog.Errorf("Hyper: create pod %s failed, error: %s", podData, err)
+		return err
+	}
+
+	podID := string(result["ID"].(string))
+	err = r.hyperClient.StartPod(podID)
+	if err != nil {
+		glog.Errorf("Hyper: start pod %s (ID:%s) failed, error: %s", pod.Name, podID, err)
+		destroyErr := r.hyperClient.RemovePod(podID)
+		if destroyErr != nil {
+			glog.Errorf("Hyper: destory pod %s (ID:%s) failed: %s", pod.Name, podID, destroyErr)
+		}
+		return err
+	}
+
+	return nil
+}
+
+// Syncs the running pod into the desired pod.
+func (r *runtime) SyncPod(pod *api.Pod, runningPod kubecontainer.Pod, podStatus api.PodStatus, pullSecrets []api.Secret, backOff *util.Backoff) error {
+	podFullName := r.buildHyperPodFullName(string(pod.UID), string(pod.Name), string(pod.Namespace))
+	if len(runningPod.Containers) == 0 {
+		glog.V(4).Infof("Pod %q is not running, will start it", podFullName)
+		return r.RunPod(pod, pullSecrets)
+	}
+
+	// Add references to all containers.
+	unidentifiedContainers := make(map[types.UID]*kubecontainer.Container)
+	for _, c := range runningPod.Containers {
+		unidentifiedContainers[c.ID] = c
+	}
+
+	restartPod := false
+	for _, container := range pod.Spec.Containers {
+		expectedHash := kubecontainer.HashContainer(&container)
+
+		c := runningPod.FindContainerByName(container.Name)
+		if c == nil {
+			if kubecontainer.ShouldContainerBeRestarted(&container, pod, &podStatus, r.readinessManager) {
+				glog.V(3).Infof("Container %+v is dead, but RestartPolicy says that we should restart it.", container)
+				restartPod = true
+				break
+			}
+			continue
+		}
+
+		containerChanged := c.Hash != 0 && c.Hash != expectedHash
+		if containerChanged {
+			glog.V(4).Infof("Pod %q container %q hash changed (%d vs %d), it will be killed and re-created.",
+				podFullName, container.Name, c.Hash, expectedHash)
+			restartPod = true
+			break
+		}
+
+		result, err := r.prober.Probe(pod, podStatus, container, string(c.ID), c.Created)
+		if err == nil && result != probe.Success {
+			glog.V(4).Infof("Pod %q container %q is unhealthy (probe result: %v), it will be killed and re-created.",
+				podFullName, container.Name, result)
+			restartPod = true
+			break
+		}
+
+		if err != nil {
+			glog.V(2).Infof("Hyper: probe container %q failed: %v", container.Name, err)
+		}
+
+		delete(unidentifiedContainers, c.ID)
+	}
+
+	// If there is any unidentified containers, restart the pod.
+	if len(unidentifiedContainers) > 0 {
+		restartPod = true
+	}
+
+	if restartPod {
+		if err := r.KillPod(nil, runningPod); err != nil {
+			glog.Errorf("Hyper: kill pod %s failed, error: %s", runningPod.Name, err)
+			return err
+		}
+		if err := r.RunPod(pod, pullSecrets); err != nil {
+			glog.Errorf("Hyper: run pod %s failed, error: %s", pod.Name, err)
+			return err
+		}
+	}
+	return nil
+}
+
+// KillPod kills all the containers of a pod.
+func (r *runtime) KillPod(pod *api.Pod, runningPod kubecontainer.Pod) error {
+	var podID string
+	podName := r.buildHyperPodFullName(string(runningPod.ID), runningPod.Name, runningPod.Namespace)
+	glog.V(4).Infof("Hyper: killing pod %q.", podName)
+
+	podInfos, err := r.hyperClient.ListPods()
+	if err != nil {
+		glog.Errorf("Hyper: ListPods failed, error: %s", err)
+		return err
+	}
+
+	for _, podInfo := range podInfos {
+		if podInfo.podName == podName {
+			podID = podInfo.podID
+			break
+		}
+	}
+
+	//err = r.hyperClient.RemovePod(podID)
+	cmds := append([]string{}, "rm", podID)
+	_, err = r.runCommand(cmds...)
+	if err != nil {
+		glog.Errorf("Hyper: remove pod %s failed, error: %s", podID, err)
+		return err
+	}
+
+	return nil
+}
+
+// GetPodStatus retrieves the status of the pod, including the information of
+// all containers in the pod. Clients of this interface assume the containers
+// statuses in a pod always have a deterministic ordering (eg: sorted by name).
+func (r *runtime) GetPodStatus(pod *api.Pod) (*api.PodStatus, error) {
+	podInfos, err := r.hyperClient.ListPods()
+	if err != nil {
+		glog.Errorf("Hyper: ListPods failed, error: %s", err)
+		return nil, err
+	}
+
+	var status api.PodStatus
+	podFullName := r.buildHyperPodFullName(string(pod.UID), string(pod.Name), string(pod.Namespace))
+	for _, podInfo := range podInfos {
+		if podInfo.podName != podFullName {
+			continue
+		}
+
+		if len(podInfo.podInfo.Status.PodIP) > 0 {
+			status.PodIP = podInfo.podInfo.Status.PodIP[0]
+		}
+
+		status.HostIP = podInfo.podInfo.Status.HostIP
+		status.Phase = api.PodPhase(podInfo.podInfo.Status.Phase)
+		status.Message = podInfo.podInfo.Status.Message
+		status.Reason = podInfo.podInfo.Status.Reason
+		for _, containerInfo := range podInfo.podInfo.Status.Status {
+			for _, container := range podInfo.podInfo.Spec.Containers {
+				if container.ContainerID == containerInfo.ContainerID {
+					status.ContainerStatuses = append(
+						status.ContainerStatuses,
+						r.getContainerStatus(containerInfo, container.Image, container.ImageID))
+				}
+			}
+		}
+	}
+
+	glog.V(5).Infof("Hyper: get pod %s status %s", podFullName, status)
+
+	return &status, nil
+}
+
+// PullImage pulls an image from the network to local storage using the supplied
+// secrets if necessary.
+func (r *runtime) PullImage(image kubecontainer.ImageSpec, pullSecrets []api.Secret) error {
+	img := image.Image
+
+	repoToPull, tag := parseImageName(img)
+	if exist, _ := r.hyperClient.IsImagePresent(repoToPull, tag); exist {
+		return nil
+	}
+
+	keyring, err := credentialprovider.MakeDockerKeyring(pullSecrets, r.dockerKeyring)
+	if err != nil {
+		return err
+	}
+
+	creds, ok := keyring.Lookup(repoToPull)
+	if !ok || len(creds) == 0 {
+		glog.V(4).Infof("Hyper: pulling image %s without credentials", img)
+	}
+
+	var credential string
+	if len(creds) > 0 {
+		var buf bytes.Buffer
+		if err := json.NewEncoder(&buf).Encode(creds[0]); err != nil {
+			return err
+		}
+		credential = base64.URLEncoding.EncodeToString(buf.Bytes())
+	}
+
+	err = r.hyperClient.PullImage(img, credential)
+	if err != nil {
+		return fmt.Errorf("Hyper: Failed to pull image: %v:", err)
+	}
+	return nil
+}
+
+// IsImagePresent checks whether the container image is already in the local storage.
+func (r *runtime) IsImagePresent(image kubecontainer.ImageSpec) (bool, error) {
+	repoToPull, tag := parseImageName(image.Image)
+	glog.V(4).Infof("Hyper: checking is image %s present", image.Image)
+	exist, err := r.hyperClient.IsImagePresent(repoToPull, tag)
+	if err != nil {
+		glog.Warningf("Hyper: checking image failed, error: %s", err)
+		return false, err
+	}
+
+	return exist, nil
+}
+
+// Gets all images currently on the machine.
+func (r *runtime) ListImages() ([]kubecontainer.Image, error) {
+	var images []kubecontainer.Image
+
+	if outputs, err := r.hyperClient.ListImages(); err != nil {
+		for _, imgInfo := range outputs {
+			image := kubecontainer.Image{
+				ID:   imgInfo.imageID,
+				Tags: []string{imgInfo.tag},
+				Size: imgInfo.virtualSize,
+			}
+			images = append(images, image)
+		}
+	}
+
+	return images, nil
+}
+
+// Removes the specified image.
+func (r *runtime) RemoveImage(image kubecontainer.ImageSpec) error {
+	err := r.hyperClient.RemoveImage(image.Image)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GetContainerLogs returns logs of a specific container. By
+// default, it returns a snapshot of the container log. Set 'follow' to true to
+// stream the log. Set 'follow' to false and specify the number of lines (e.g.
+// "100" or "all") to tail the log.
+func (r *runtime) GetContainerLogs(pod *api.Pod, containerID string, tail string, follow bool, stdout, stderr io.Writer) error {
+	// TODO: get container logs for hyper
+	return fmt.Errorf("Hyper: GetContainerLogs unimplemented")
+}
+
+// Runs the command in the container of the specified pod
+func (r *runtime) RunInContainer(containerID string, cmd []string) ([]byte, error) {
+	glog.V(4).Infof("Hyper: running %s in container %s.", cmd, containerID)
+
+	args := append([]string{}, "exec", containerID)
+	args = append(args, cmd...)
+
+	result, err := r.runCommand(args...)
+	return []byte(strings.Join(result, "\n")), err
+}
+
+// Forward the specified port from the specified pod to the stream.
+func (r *runtime) PortForward(pod *kubecontainer.Pod, port uint16, stream io.ReadWriteCloser) error {
+	// TODO: port forward for hyper
+	return fmt.Errorf("Hyper: PortForward unimplemented")
+}
+
+// Runs the command in the container of the specified pod.
+// Attaches the processes stdin, stdout, and stderr. Optionally uses a
+// tty.
+func (r *runtime) ExecInContainer(containerID string, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool) error {
+	glog.V(4).Infof("Hyper: execing %s in container %s.", cmd, containerID)
+
+	args := append([]string{}, "exec", "-a", containerID)
+	args = append(args, cmd...)
+	command := r.buildCommand(args...)
+
+	p, err := kubecontainer.StartPty(command)
+	if err != nil {
+		return err
+	}
+	defer p.Close()
+
+	// make sure to close the stdout stream
+	defer stdout.Close()
+
+	if stdin != nil {
+		go io.Copy(p, stdin)
+	}
+
+	if stdout != nil {
+		go io.Copy(stdout, p)
+	}
+	return command.Wait()
+
+}
+
+func (r *runtime) AttachContainer(containerID string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool) error {
+	glog.V(4).Infof("Hyper: attaching container %s.", containerID)
+
+	opts := AttachToContainerOptions{
+		Container:    containerID,
+		InputStream:  stdin,
+		OutputStream: stdout,
+		ErrorStream:  stderr,
+		Stream:       true,
+		Logs:         true,
+		Stdin:        stdin != nil,
+		Stdout:       stdout != nil,
+		Stderr:       stderr != nil,
+		RawTerminal:  tty,
+	}
+	return r.hyperClient.Attach(opts)
+}

--- a/pkg/kubelet/hyper/hyperclient.go
+++ b/pkg/kubelet/hyper/hyperclient.go
@@ -48,6 +48,7 @@ const (
 	KEY_IMAGEID        = "imageId"
 	KEY_IMAGENAME      = "imageName"
 	KEY_ITEM           = "item"
+	KEY_DNS            = "dns"
 	KEY_MEMORY         = "memory"
 	KEY_POD_ARGS       = "podArgs"
 	KEY_POD_ID         = "podId"

--- a/pkg/kubelet/hyper/hyperclient.go
+++ b/pkg/kubelet/hyper/hyperclient.go
@@ -1,0 +1,603 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hyper
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"mime"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/docker/docker/pkg/parsers"
+	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/golang/glog"
+	"time"
+)
+
+const (
+	HYPER_PROTO       = "unix"
+	HYPER_ADDR        = "/var/run/hyper.sock"
+	HYPER_MINVERSION  = "0.3.0"
+	DEFAULT_IMAGE_TAG = "latest"
+)
+
+type HyperClient struct {
+	proto  string
+	addr   string
+	scheme string
+}
+
+type AttachToContainerOptions struct {
+	Container    string
+	InputStream  io.Reader
+	OutputStream io.Writer
+	ErrorStream  io.Writer
+
+	// Get container logs, sending it to OutputStream.
+	Logs bool
+
+	// Stream the response?
+	Stream bool
+
+	// Attach to stdin, and use InputStream.
+	Stdin bool
+
+	// Attach to stdout, and use OutputStream.
+	Stdout bool
+
+	// Attach to stderr, and use ErrorStream.
+	Stderr bool
+
+	// If set, after a successful connect, a sentinel will be sent and then the
+	// client will block on receive before continuing.
+	//
+	// It must be an unbuffered channel. Using a buffered channel can lead
+	// to unexpected behavior.
+	Success chan struct{}
+
+	// Use raw terminal? Usually true when the container contains a TTY.
+	RawTerminal bool `qs:"-"`
+}
+
+type hijackOptions struct {
+	success        chan struct{}
+	setRawTerminal bool
+	in             io.Reader
+	stdout         io.Writer
+	stderr         io.Writer
+	data           interface{}
+}
+
+func NewHyperClient() *HyperClient {
+	var (
+		scheme = "http"
+		proto  = HYPER_PROTO
+		addr   = HYPER_ADDR
+	)
+
+	return &HyperClient{
+		proto:  proto,
+		addr:   addr,
+		scheme: scheme,
+	}
+}
+
+var (
+	ErrConnectionRefused = errors.New("Cannot connect to the Hyper daemon. Is 'hyperd' running on this host?")
+)
+
+func (cli *HyperClient) encodeData(data interface{}) (*bytes.Buffer, error) {
+	params := bytes.NewBuffer(nil)
+	if data != nil {
+		buf, err := json.Marshal(data)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := params.Write(buf); err != nil {
+			return nil, err
+		}
+	}
+	return params, nil
+}
+
+// parseImageName parses a docker image string into two parts: repo and tag.
+// If tag is empty, return the defaultImageTag.
+func parseImageName(image string) (string, string) {
+	repoToPull, tag := parsers.ParseRepositoryTag(image)
+	// If no tag was specified, use the default "latest".
+	if len(tag) == 0 {
+		tag = DEFAULT_IMAGE_TAG
+	}
+	return repoToPull, tag
+}
+
+func (cli *HyperClient) clientRequest(method, path string, in io.Reader, headers map[string][]string) (io.ReadCloser, string, int, error) {
+	expectedPayload := (method == "POST" || method == "PUT")
+	if expectedPayload && in == nil {
+		in = bytes.NewReader([]byte{})
+	}
+	req, err := http.NewRequest(method, path, in)
+	if err != nil {
+		return nil, "", -1, err
+	}
+	req.Header.Set("User-Agent", "kubelet")
+	req.URL.Host = cli.addr
+	req.URL.Scheme = cli.scheme
+
+	if headers != nil {
+		for k, v := range headers {
+			req.Header[k] = v
+		}
+	}
+
+	if expectedPayload && req.Header.Get("Content-Type") == "" {
+		req.Header.Set("Content-Type", "text/plain")
+	}
+
+	var dial net.Conn
+	dial, err = net.DialTimeout(HYPER_PROTO, HYPER_ADDR, 32*time.Second)
+	if err != nil {
+		return nil, "", -1, err
+	}
+	defer dial.Close()
+
+	clientconn := httputil.NewClientConn(dial, nil)
+	defer clientconn.Close()
+
+	resp, err := clientconn.Do(req)
+	statusCode := -1
+	if resp != nil {
+		statusCode = resp.StatusCode
+	}
+	if err != nil {
+		if strings.Contains(err.Error(), "connection refused") {
+			return nil, "", statusCode, ErrConnectionRefused
+		}
+
+		return nil, "", statusCode, fmt.Errorf("An error occurred trying to connect: %v", err)
+	}
+
+	if statusCode < 200 || statusCode >= 400 {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, "", statusCode, err
+		}
+		if len(body) == 0 {
+			return nil, "", statusCode, fmt.Errorf("Error: request returned %s for API route and version %s, check if the server supports the requested API version", http.StatusText(statusCode), req.URL)
+		}
+		if len(bytes.TrimSpace(body)) > 150 {
+			return nil, "", statusCode, fmt.Errorf("Error from daemon's response")
+		}
+		return nil, "", statusCode, fmt.Errorf("%s", bytes.TrimSpace(body))
+	}
+
+	return resp.Body, resp.Header.Get("Content-Type"), statusCode, nil
+}
+
+func (cli *HyperClient) call(method, path string, data interface{}, headers map[string][]string) (io.ReadCloser, int, error) {
+	params, err := cli.encodeData(data)
+	if err != nil {
+		return nil, -1, err
+	}
+
+	if data != nil {
+		if headers == nil {
+			headers = make(map[string][]string)
+		}
+		headers["Content-Type"] = []string{"application/json"}
+	}
+
+	body, _, statusCode, err := cli.clientRequest(method, path, params, headers)
+	return body, statusCode, err
+}
+
+func (cli *HyperClient) stream(method, path string, in io.Reader, out io.Writer, headers map[string][]string) error {
+	return cli.streamHelper(method, path, true, in, out, nil, headers)
+}
+
+func (cli *HyperClient) streamHelper(method, path string, setRawTerminal bool, in io.Reader, stdout, stderr io.Writer, headers map[string][]string) error {
+	body, contentType, _, err := cli.clientRequest(method, path, in, headers)
+	if err != nil {
+		return err
+	}
+	return cli.streamBody(body, contentType, setRawTerminal, stdout, stderr)
+}
+
+func MatchesContentType(contentType, expectedType string) bool {
+	mimetype, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		glog.V(4).Infof("Error parsing media type: %s error: %v", contentType, err)
+	}
+	return err == nil && mimetype == expectedType
+}
+
+func (cli *HyperClient) streamBody(body io.ReadCloser, contentType string, setRawTerminal bool, stdout, stderr io.Writer) error {
+	defer body.Close()
+
+	if MatchesContentType(contentType, "application/json") {
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(body)
+		if stdout != nil {
+			stdout.Write(buf.Bytes())
+		}
+		return nil
+	}
+	return nil
+}
+
+func readBody(stream io.ReadCloser, statusCode int, err error) ([]byte, int, error) {
+	if stream != nil {
+		defer stream.Close()
+	}
+	if err != nil {
+		return nil, statusCode, err
+	}
+	if stream == nil {
+		return nil, statusCode, err
+	}
+	body, err := ioutil.ReadAll(stream)
+	if err != nil {
+		return nil, -1, err
+	}
+	return body, statusCode, nil
+}
+
+func (client *HyperClient) Version() (string, error) {
+	body, _, err := readBody(client.call("GET", "/version", nil, nil))
+	if err != nil {
+		return "", err
+	}
+
+	var info map[string]interface{}
+	err = json.Unmarshal(body, &info)
+	if err != nil {
+		return "", err
+	}
+
+	version, ok := info["Version"]
+	if !ok {
+		return "", fmt.Errorf("Can not get hyper version")
+	}
+
+	return version.(string), nil
+}
+
+func (client *HyperClient) ListPods() ([]HyperPod, error) {
+	v := url.Values{}
+	v.Set("item", "pod")
+	body, _, err := readBody(client.call("GET", "/list?"+v.Encode(), nil, nil))
+	if err != nil {
+		return nil, err
+	}
+
+	var podList map[string]interface{}
+	err = json.Unmarshal(body, &podList)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []HyperPod
+	for _, pod := range podList["podData"].([]interface{}) {
+		fields := strings.Split(pod.(string), ":")
+		var hyperPod HyperPod
+		hyperPod.podID = fields[0]
+		hyperPod.podName = fields[1]
+		hyperPod.vmName = fields[2]
+		hyperPod.status = fields[3]
+
+		values := url.Values{}
+		values.Set("podName", hyperPod.podID)
+		body, _, err = readBody(client.call("GET", "/pod/info?"+values.Encode(), nil, nil))
+		if err != nil {
+			return nil, err
+		}
+
+		err = json.Unmarshal(body, &hyperPod.podInfo)
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, hyperPod)
+	}
+
+	return result, nil
+}
+
+func (client *HyperClient) ListContainers() ([]HyperContainer, error) {
+	v := url.Values{}
+	v.Set("item", "container")
+	body, _, err := readBody(client.call("GET", "/list?"+v.Encode(), nil, nil))
+	if err != nil {
+		return nil, err
+	}
+
+	var containerList map[string]interface{}
+	err = json.Unmarshal(body, &containerList)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []HyperContainer
+	for _, container := range containerList["cData"].([]interface{}) {
+		fields := strings.Split(container.(string), ":")
+		var h HyperContainer
+		h.containerID = fields[0]
+		if len(fields[1]) < 1 {
+			return nil, errors.New("Hyper container name not resolved")
+		}
+		h.name = fields[1][1:]
+		h.podID = fields[2]
+		h.status = fields[3]
+
+		result = append(result, h)
+	}
+
+	return result, nil
+}
+
+func (client *HyperClient) Info() (map[string]interface{}, error) {
+	body, _, err := readBody(client.call("GET", "/info", nil, nil))
+	if err != nil {
+		return nil, err
+	}
+
+	var result map[string]interface{}
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (client *HyperClient) ListImages() ([]HyperImage, error) {
+	v := url.Values{}
+	v.Set("all", "no")
+	body, _, err := readBody(client.call("GET", "/images/get?"+v.Encode(), nil, nil))
+	if err != nil {
+		return nil, err
+	}
+
+	var images map[string][]string
+	err = json.Unmarshal(body, &images)
+	if err != nil {
+		return nil, err
+	}
+
+	var hyperImages []HyperImage
+	for _, image := range images["imagesList"] {
+		imageDesc := strings.Split(image, ":")
+		if len(imageDesc) != 5 {
+			glog.Warning("Hyper: can not parse image info")
+			return nil, fmt.Errorf("Hyper: can not parse image info")
+		}
+
+		var imageHyper HyperImage
+		imageHyper.repository = imageDesc[0]
+		imageHyper.tag = imageDesc[1]
+		imageHyper.imageID = imageDesc[2]
+
+		createdAt, err := strconv.ParseInt(imageDesc[3], 10, 0)
+		if err != nil {
+			return nil, err
+		}
+		imageHyper.createdAt = createdAt
+
+		virtualSize, err := strconv.ParseInt(imageDesc[4], 10, 0)
+		if err != nil {
+			return nil, err
+		}
+		imageHyper.virtualSize = virtualSize
+
+		hyperImages = append(hyperImages, imageHyper)
+	}
+
+	return hyperImages, nil
+}
+
+func (client *HyperClient) RemoveImage(imageID string) error {
+	v := url.Values{}
+	v.Set("imageId", imageID)
+	_, _, err := readBody(client.call("POST", "/images/remove?"+v.Encode(), nil, nil))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (client *HyperClient) RemovePod(podID string) error {
+	v := url.Values{}
+	v.Set("podId", podID)
+	_, _, err := readBody(client.call("POST", "/pod/remove?"+v.Encode(), nil, nil))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (client *HyperClient) StartPod(podID string) error {
+	v := url.Values{}
+	v.Set("podId", podID)
+	_, _, err := readBody(client.call("POST", "/pod/start?"+v.Encode(), nil, nil))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (client *HyperClient) StopPod(podID string) error {
+	v := url.Values{}
+	v.Set("podId", podID)
+	v.Set("stopVM", "yes")
+	_, _, err := readBody(client.call("POST", "/pod/stop?"+v.Encode(), nil, nil))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (client *HyperClient) PullImage(image string, credential string) error {
+	v := url.Values{}
+	v.Set("imageName", image)
+
+	headers := make(map[string][]string)
+	if credential != "" {
+		headers["X-Registry-Auth"] = []string{credential}
+	}
+
+	//_, _, err := readBody(client.call("POST", "/image/create?"+v.Encode(), nil, headers))
+	err := client.stream("POST", "/image/create?"+v.Encode(), nil, nil, headers)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (client *HyperClient) CreatePod(podArgs string) (map[string]interface{}, error) {
+	glog.V(5).Infof("Hyper: starting to create pod %s", podArgs)
+	v := url.Values{}
+	v.Set("podArgs", podArgs)
+	body, _, err := readBody(client.call("POST", "/pod/create?"+v.Encode(), nil, nil))
+	if err != nil {
+		return nil, err
+	}
+
+	var result map[string]interface{}
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (c *HyperClient) hijack(method, path string, hijackOptions hijackOptions) error {
+	var params io.Reader
+	if hijackOptions.data != nil {
+		buf, err := json.Marshal(hijackOptions.data)
+		if err != nil {
+			return err
+		}
+		params = bytes.NewBuffer(buf)
+	}
+
+	if hijackOptions.stdout == nil {
+		hijackOptions.stdout = ioutil.Discard
+	}
+	if hijackOptions.stderr == nil {
+		hijackOptions.stderr = ioutil.Discard
+	}
+	req, err := http.NewRequest(method, fmt.Sprintf("/v%s%s", HYPER_MINVERSION, path), params)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("User-Agent", "kubelet")
+	req.Header.Set("Content-Type", "text/plain")
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", "tcp")
+	req.Host = HYPER_ADDR
+
+	dial, err := net.Dial(HYPER_PROTO, HYPER_ADDR)
+	if err != nil {
+		return err
+	}
+
+	clientconn := httputil.NewClientConn(dial, nil)
+	defer clientconn.Close()
+	clientconn.Do(req)
+	if hijackOptions.success != nil {
+		hijackOptions.success <- struct{}{}
+		<-hijackOptions.success
+	}
+	rwc, br := clientconn.Hijack()
+	defer rwc.Close()
+	errChanOut := make(chan error, 1)
+	errChanIn := make(chan error, 1)
+	exit := make(chan bool)
+	go func() {
+		defer close(exit)
+		defer close(errChanOut)
+		var err error
+		if hijackOptions.setRawTerminal {
+			// When TTY is ON, use regular copy
+			_, err = io.Copy(hijackOptions.stdout, br)
+		} else {
+			_, err = stdcopy.StdCopy(hijackOptions.stdout, hijackOptions.stderr, br)
+		}
+		errChanOut <- err
+	}()
+	go func() {
+		if hijackOptions.in != nil {
+			_, err := io.Copy(rwc, hijackOptions.in)
+			errChanIn <- err
+		}
+		rwc.(interface {
+			CloseWrite() error
+		}).CloseWrite()
+	}()
+	<-exit
+	select {
+	case err = <-errChanIn:
+		return err
+	case err = <-errChanOut:
+		return err
+	}
+}
+
+func (client *HyperClient) Attach(opts AttachToContainerOptions) error {
+	if opts.Container == "" {
+		return fmt.Errorf("No Such Container %s", opts.Container)
+	}
+
+	v := url.Values{}
+	v.Set("type", "container")
+	v.Set("value", opts.Container)
+	path := "/attach?" + v.Encode()
+	return client.hijack("POST", path, hijackOptions{
+		success:        opts.Success,
+		setRawTerminal: opts.RawTerminal,
+		in:             opts.InputStream,
+		stdout:         opts.OutputStream,
+		stderr:         opts.ErrorStream,
+	})
+}
+
+func (client *HyperClient) IsImagePresent(repo, tag string) (bool, error) {
+	if outputs, err := client.ListImages(); err == nil {
+		for _, imgInfo := range outputs {
+			if imgInfo.repository == repo && imgInfo.tag == tag {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}

--- a/pkg/kubelet/hyper/types.go
+++ b/pkg/kubelet/hyper/types.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hyper
+
+const (
+	StatusRunning = "running"
+	StatusPending = "pending"
+	StatusFailed  = "failed"
+	StatusSuccess = "succeeded"
+)
+
+type HyperImage struct {
+	repository  string
+	tag         string
+	imageID     string
+	createdAt   int64
+	virtualSize int64
+}
+
+// Container JSON Data Structure
+type ContainerPort struct {
+	Name          string `json:"name"`
+	HostPort      int    `json:"hostPort"`
+	ContainerPort int    `json:"containerPort"`
+	Protocol      string `json:"protocol"`
+	HostIP        string `json:"hostIP"`
+}
+
+type EnvironmentVar struct {
+	Env   string `json:"env"`
+	Value string `json:"value"`
+}
+
+type VolumeMount struct {
+	Name      string `json:"name"`
+	ReadOnly  bool   `json:"readOnly"`
+	MountPath string `json:"mountPath"`
+}
+
+type WaitingStatus struct {
+	Reason string `json:"reason"`
+}
+
+type RunningStatus struct {
+	StartedAt string `json:"startedAt"`
+}
+
+type TermStatus struct {
+	ExitCode   int    `json:"exitCode"`
+	Reason     string `json:"reason"`
+	Message    string `json:"message"`
+	StartedAt  string `json:"startedAt"`
+	FinishedAt string `json:"finishedAt"`
+}
+
+type ContainerStatus struct {
+	Name        string        `json:"name"`
+	ContainerID string        `json:"containerID"`
+	Phase       string        `json:"phase"`
+	Waiting     WaitingStatus `json:"waiting"`
+	Running     RunningStatus `json:"running"`
+	Terminated  TermStatus    `json:"terminated"`
+}
+
+// Pod JSON Data Structure
+type Container struct {
+	Name            string           `json:"name"`
+	ContainerID     string           `json:"containerID"`
+	Image           string           `json:"image"`
+	ImageID         string           `json:"imageID"`
+	Commands        []string         `json:"commands"`
+	Args            []string         `json:"args"`
+	Workdir         string           `json:"workingDir"`
+	Ports           []ContainerPort  `json:"ports"`
+	Environment     []EnvironmentVar `json:"env"`
+	Volume          []VolumeMount    `json:"volumeMounts"`
+	ImagePullPolicy string           `json:"imagePullPolicy"`
+}
+
+type RBDVolumeSource struct {
+	Monitors []string `json:"monitors"`
+	Image    string   `json:"image"`
+	FsType   string   `json:"fsType"`
+	Pool     string   `json:"pool"`
+	User     string   `json:"user"`
+	Keyring  string   `json:"keyring"`
+	ReadOnly bool     `json:"readOnly"`
+}
+
+type PodVolume struct {
+	Name     string          `json:"name"`
+	HostPath string          `json:"source"`
+	Driver   string          `json:"driver"`
+	Rbd      RBDVolumeSource `json:"rbd"`
+}
+
+type PodSpec struct {
+	Volumes    []PodVolume `json:"volumes"`
+	Containers []Container `json:"containers"`
+}
+
+type PodStatus struct {
+	Phase     string            `json:"phase"`
+	Message   string            `json:"message"`
+	Reason    string            `json:"reason"`
+	HostIP    string            `json:"hostIP"`
+	PodIP     []string          `json:"podIP"`
+	StartTime string            `json:"startTime"`
+	Status    []ContainerStatus `json:"containerStatus"`
+}
+
+type PodInfo struct {
+	Kind       string    `json:"kind"`
+	ApiVersion string    `json:"apiVersion"`
+	Vm         string    `json:"vm"`
+	Spec       PodSpec   `json:"spec"`
+	Status     PodStatus `json:"status"`
+}
+
+type HyperPod struct {
+	podID   string
+	podName string
+	vmName  string
+	status  string
+	podInfo PodInfo
+}
+
+type HyperContainer struct {
+	containerID string
+	name        string
+	podID       string
+	status      string
+}

--- a/pkg/kubelet/hyper/version.go
+++ b/pkg/kubelet/hyper/version.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hyper
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type hyperVersion []int
+
+func parseVersion(input string) (hyperVersion, error) {
+	tail := strings.Index(input, "+")
+	if tail > 0 {
+		input = input[:tail]
+	}
+	var result hyperVersion
+	tuples := strings.Split(input, ".")
+	for _, t := range tuples {
+		n, err := strconv.Atoi(t)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, n)
+	}
+	return result, nil
+}
+
+func (r hyperVersion) Compare(other string) (int, error) {
+	v, err := parseVersion(other)
+	if err != nil {
+		return -1, err
+	}
+
+	for i := range r {
+		if i > len(v)-1 {
+			return 1, nil
+		}
+		if r[i] < v[i] {
+			return -1, nil
+		}
+		if r[i] > v[i] {
+			return 1, nil
+		}
+	}
+
+	// When loop ends, len(r) is <= len(v).
+	if len(r) < len(v) {
+		return -1, nil
+	}
+	return 0, nil
+}
+
+func (r hyperVersion) String() string {
+	var version []string
+	for _, v := range r {
+		version = append(version, fmt.Sprintf("%d", v))
+	}
+	return strings.Join(version, ".")
+}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -49,6 +49,7 @@ import (
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/dockertools"
 	"k8s.io/kubernetes/pkg/kubelet/envvars"
+	"k8s.io/kubernetes/pkg/kubelet/hyper"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	"k8s.io/kubernetes/pkg/kubelet/network"
 	"k8s.io/kubernetes/pkg/kubelet/rkt"
@@ -325,6 +326,20 @@ func NewMainKubelet(
 			return nil, err
 		}
 		klet.containerRuntime = rktRuntime
+
+		// No Docker daemon to put in a container.
+		dockerDaemonContainer = ""
+	case "hyper":
+		hyperRuntime, err := hyper.New(
+			klet,
+			recorder,
+			containerRefManager,
+			readinessManager,
+			klet.volumeManager)
+		if err != nil {
+			return nil, err
+		}
+		klet.containerRuntime = hyperRuntime
 
 		// No Docker daemon to put in a container.
 		dockerDaemonContainer = ""


### PR DESCRIPTION
Add hyper container runtime for kubernetes.

Hyper is a Hypervisor-agnostic Docker Engine that allows you to run Docker images on any hypervisor (KVM, Xen, etc.).

Technically speaking, `Hyper = Hypervisor + Kernel + Docker Image`

By containing applications within separate VM instances and kernel spaces, Hyper is able to offer an excellent Hardware-enforced Isolation, which is much needed in multi-tenant environments.

Hyper also promises Immutable Infrastructure by eliminating the middle layer of Guest OS, along with the hassle to configure and manage them.

See https://hyper.sh for more documentation.

Task list:
- [x] hyper client
- [x] hyper container runtime
- [x] kubelet exec
- [x] kubelet attach
- [x] pull image with credentials

There will be another commit on _kubelet logs_, since hyper doesn't support `hyper log` now.

Note that host network, socat-based port-forwarding and privileged containers is not supported.
