### PR TITLE
Reenable Cacher

### DIFF
--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -431,7 +431,7 @@ func logStackOnRecover(panicReason interface{}, httpWriter http.ResponseWriter) 
 func (m *Master) init(c *Config) {
 	healthzChecks := []healthz.HealthzChecker{}
 	m.clock = util.RealClock{}
-	podStorage := podetcd.NewStorage(c.DatabaseStorage, false, c.KubeletClient)
+	podStorage := podetcd.NewStorage(c.DatabaseStorage, true, c.KubeletClient)
 
 	podTemplateStorage := podtemplateetcd.NewREST(c.DatabaseStorage)
 
@@ -447,10 +447,10 @@ func (m *Master) init(c *Config) {
 	namespaceStorage, namespaceStatusStorage, namespaceFinalizeStorage := namespaceetcd.NewREST(c.DatabaseStorage)
 	m.namespaceRegistry = namespace.NewRegistry(namespaceStorage)
 
-	endpointsStorage := endpointsetcd.NewREST(c.DatabaseStorage, false)
+	endpointsStorage := endpointsetcd.NewREST(c.DatabaseStorage, true)
 	m.endpointRegistry = endpoint.NewRegistry(endpointsStorage)
 
-	nodeStorage, nodeStatusStorage := nodeetcd.NewREST(c.DatabaseStorage, false, c.KubeletClient)
+	nodeStorage, nodeStatusStorage := nodeetcd.NewREST(c.DatabaseStorage, true, c.KubeletClient)
 	m.nodeRegistry = minion.NewRegistry(nodeStorage)
 
 	serviceStorage := serviceetcd.NewREST(c.DatabaseStorage)


### PR DESCRIPTION
Ref #10475 

It seems that problems from Friday where unrelated to enabling cacher:
- timeouts were caused by https://github.com/kubernetes/kubernetes/pull/13017
- services test failures were happening also after my PR was reverted, for timeouts see e.g.
  http://kubekins.dls.corp.google.com/job/kubernetes-e2e-gce/8191/

cc @zmerlynn @nikhiljindal @lavalamp @davidopp 
