### PR TITLE
Enable kubectl exec pod name bash completion

### DIFF
--- a/contrib/completions/bash/kubectl
+++ b/contrib/completions/bash/kubectl
@@ -181,6 +181,11 @@ __kubectl_get_resource()
     __kubectl_parse_get "${nouns[${#nouns[@]} -1]}"
 }
 
+__kubectl_get_resource_pod()
+{
+    __kubectl_parse_get "pod"
+}
+
 # $1 is the name of the pod we want to get the list of containers inside
 __kubectl_get_containers()
 {
@@ -213,13 +218,17 @@ __kubectl_require_pod_and_container()
 __custom_func() {
     case ${last_command} in
         kubectl_get | kubectl_describe | kubectl_delete | kubectl_label | kubectl_stop)
-	    __kubectl_get_resource
+            __kubectl_get_resource
             return
             ;;
-	kubectl_logs)
-	    __kubectl_require_pod_and_container
-	    return
-	    ;;
+        kubectl_logs)
+            __kubectl_require_pod_and_container
+            return
+            ;;
+        kubectl_exec)
+            __kubectl_get_resource_pod
+            return
+            ;;
         *)
             ;;
     esac

--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -47,6 +47,11 @@ __kubectl_get_resource()
     __kubectl_parse_get "${nouns[${#nouns[@]} -1]}"
 }
 
+__kubectl_get_resource_pod()
+{
+    __kubectl_parse_get "pod"
+}
+
 # $1 is the name of the pod we want to get the list of containers inside
 __kubectl_get_containers()
 {
@@ -79,13 +84,17 @@ __kubectl_require_pod_and_container()
 __custom_func() {
     case ${last_command} in
         kubectl_get | kubectl_describe | kubectl_delete | kubectl_label | kubectl_stop)
-	    __kubectl_get_resource
+            __kubectl_get_resource
             return
             ;;
-	kubectl_logs)
-	    __kubectl_require_pod_and_container
-	    return
-	    ;;
+        kubectl_logs)
+            __kubectl_require_pod_and_container
+            return
+            ;;
+        kubectl_exec)
+            __kubectl_get_resource_pod
+            return
+            ;;
         *)
             ;;
     esac


### PR DESCRIPTION
Partially fixes #11310 

List all pod names when you type `kubectl exec [tab][tab]`. 
