### PR TITLE
Updated deprecated flags (address and port). Added an option to pass runtime-config.

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -45,17 +45,17 @@ GO_OUT=""
 while getopts "o:" OPTION
 do
     case $OPTION in
-        o) 
+        o)
             echo "skipping build"
             echo "using source $OPTARG"
             GO_OUT="$OPTARG"
             if [ $GO_OUT == "" ]; then
                 echo "You provided an invalid value for the build output directory."
-                exit 
+                exit
             fi
             ;;
         ?)
-            usage    
+            usage
             exit
             ;;
     esac
@@ -141,7 +141,7 @@ function detect_binary {
 
 cleanup_dockerized_kubelet()
 {
-  if [[ -e $KUBELET_CIDFILE ]]; then 
+  if [[ -e $KUBELET_CIDFILE ]]; then
     docker kill $(<$KUBELET_CIDFILE) > /dev/null
     rm -f $KUBELET_CIDFILE
   fi
@@ -209,16 +209,20 @@ function start_apiserver {
     if [[ -n "${ALLOW_PRIVILEGED}" ]]; then
       priv_arg="--allow-privileged "
     fi
+    runtime_config=""
+    if [[ -n "${RUNTIME_CONFIG}" ]]; then
+      runtime_config="--runtime-config=\"${RUNTIME_CONFIG}\""
+    fi
 
     APISERVER_LOG=/tmp/kube-apiserver.log
-    sudo -E "${GO_OUT}/kube-apiserver" ${priv_arg}\
+    sudo -E "${GO_OUT}/kube-apiserver" ${priv_arg} ${runtime_config} \
       --v=${LOG_LEVEL} \
       --cert-dir="${CERT_DIR}" \
       --service-account-key-file="${SERVICE_ACCOUNT_KEY}" \
       --service-account-lookup="${SERVICE_ACCOUNT_LOOKUP}" \
       --admission-control="${ADMISSION_CONTROL}" \
-      --address="${API_HOST}" \
-      --port="${API_PORT}" \
+      --insecure-bind-address="${API_HOST}" \
+      --insecure-port="${API_PORT}" \
       --etcd-servers="http://127.0.0.1:4001" \
       --service-cluster-ip-range="10.0.0.0/24" \
       --cors-allowed-origins="${API_CORS_ALLOWED_ORIGINS}" >"${APISERVER_LOG}" 2>&1 &
@@ -310,7 +314,7 @@ test_docker
 test_apiserver_off
 
 ### IF the user didn't supply an output/ for the build... Then we detect.
-if [ "$GO_OUT" == "" ]; then 
+if [ "$GO_OUT" == "" ]; then
     detect_binary
 fi
 echo "Detected host and ready to start services.  Doing some housekeeping first..."


### PR DESCRIPTION
This is handy when dealing with expapi, for example. You can run it with: `RUNTIME_CONFIG="experimental/v1=true" hack/local-up-cluster.sh`
@smarterclayton ptal
