### PR TITLE
Refactor to use docker-machine or boot2docker

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -126,66 +126,11 @@ readonly KUBE_ADDON_PATHS=(
 function kube::build::verify_prereqs() {
   kube::log::status "Verifying Prerequisites...."
   kube::build::ensure_tar || return 1
-
-  if [[ "${1-}" != "clean" ]]; then
-    if [[ -z "$(which docker)" ]]; then
-      echo "Can't find 'docker' in PATH, please fix and retry." >&2
-      echo "See https://docs.docker.com/installation/#installation for installation instructions." >&2
-      exit 1
-    fi
-
-    if kube::build::is_osx; then
-      if [[ -z "$DOCKER_NATIVE" ]];then
-        if [[ -z "$(which boot2docker)" ]]; then
-          echo "It looks like you are running on Mac OS X and boot2docker can't be found." >&2
-          echo "See: https://docs.docker.com/installation/mac/" >&2
-          exit 1
-        fi
-        if [[ $(boot2docker status) != "running" ]]; then
-          echo "boot2docker VM isn't started.  Please run 'boot2docker start'" >&2
-          exit 1
-        else
-          # Reach over and set the clock. After sleep/resume the clock will skew.
-          kube::log::status "Setting boot2docker clock"
-          boot2docker ssh sudo date -u -D "%Y%m%d%H%M.%S" --set "$(date -u +%Y%m%d%H%M.%S)" >/dev/null
-          if [[ -z "$DOCKER_HOST" ]]; then
-            kube::log::status "Setting boot2docker env variables"
-            $(boot2docker shellinit)
-          fi
-        fi
-      fi
-    fi
-
-    if ! "${DOCKER[@]}" info > /dev/null 2>&1 ; then
-      {
-        echo "Can't connect to 'docker' daemon.  please fix and retry."
-        echo
-        echo "Possible causes:"
-        echo "  - On Mac OS X, boot2docker VM isn't installed or started"
-        echo "  - On Mac OS X, docker env variable isn't set appropriately. Run:"
-        echo "      \$(boot2docker shellinit)"
-        echo "  - On Linux, user isn't in 'docker' group.  Add and relogin."
-        echo "    - Something like 'sudo usermod -a -G docker ${USER-user}'"
-        echo "    - RHEL7 bug and workaround: https://bugzilla.redhat.com/show_bug.cgi?id=1119282#c8"
-        echo "  - On Linux, Docker daemon hasn't been started or has crashed"
-      } >&2
-      exit 1
-    fi
-  else
-
-    # On OS X, set boot2docker env vars for the 'clean' target if boot2docker is running
-    if kube::build::is_osx && kube::build::has_docker ; then
-      if [[ ! -z "$(which boot2docker)" ]]; then
-        if [[ $(boot2docker status) == "running" ]]; then
-          if [[ -z "$DOCKER_HOST" ]]; then
-            kube::log::status "Setting boot2docker env variables"
-            $(boot2docker shellinit)
-          fi
-        fi
-      fi
-    fi
-
+  kube::build::ensure_docker_in_path || return 1
+  if kube::build::is_osx; then
+      kube::build::docker_available_on_osx || return 1
   fi
+  kube::build::ensure_docker_daemon_connectivity || return 1
 
   KUBE_ROOT_HASH=$(kube::build::short_hash "$KUBE_ROOT")
   KUBE_BUILD_IMAGE_TAG="build-${KUBE_ROOT_HASH}"
@@ -198,8 +143,94 @@ function kube::build::verify_prereqs() {
 # ---------------------------------------------------------------------------
 # Utility functions
 
+function kube::build::docker_available_on_osx() {
+  if [[ -z "${DOCKER_HOST}" ]]; then
+    kube::log::status "No docker host is set. Checking options for setting one..."
+
+    if [[ -z "$(which docker-machine)" && -z "$(which boot2docker)" ]]; then
+      kube::log::status "It looks like you're running Mac OS X, and neither docker-machine or boot2docker are nowhere to be found."
+      kube::log::status "See: https://docs.docker.com/machine/ for installation instructions."
+      return 1
+    elif [[ -n "$(which docker-machine)" ]]; then
+      kube::build::prepare_docker_machine
+    elif [[ -n "$(which boot2docker)" ]]; then
+      kube::build::prepare_boot2docker
+    fi
+  fi
+}
+
+function kube::build::prepare_docker_machine() {
+  kube::log::status "docker-machine was found."
+  docker-machine inspect kube-dev >/dev/null || {
+    kube::log::status "Creating a machine to build Kubernetes"
+    docker-machine create -d virtualbox kube-dev > /dev/null || {
+      kube::log::error "Something went wrong creating a machine."
+      kube::log::error "Try the following: "
+      kube::log::error "docker-machine create -d <provider> kube-dev"
+      return 1
+    }
+  }
+  docker-machine start kube-dev > /dev/null
+  eval $(docker-machine env kube-dev)
+  kube::log::status "A Docker host using docker-machine named kube-dev is ready to go!"
+  return 0
+}
+
+function kube::build::prepare_boot2docker() {
+  kube::log::status "boot2docker cli has been deprecated in favor of docker-machine."
+  kube::log::status "See: https://github.com/boot2docker/boot2docker-cli for more details."
+  if [[ $(boot2docker status) != "running" ]]; then
+    kube::log::status "boot2docker isn't running. We'll try to start it."
+    boot2docker up || {
+      kube::log::error "Can't start boot2docker."
+      kube::log::error "You may need to 'boot2docker init' to create your VM."
+      return 1
+    }
+  fi
+
+  # Reach over and set the clock. After sleep/resume the clock will skew.
+  kube::log::status "Setting boot2docker clock"
+  boot2docker ssh sudo date -u -D "%Y%m%d%H%M.%S" --set "$(date -u +%Y%m%d%H%M.%S)" >/dev/null
+
+  kube::log::status "Setting boot2docker env variables"
+  $(boot2docker shellinit)
+  kube::log::status "boot2docker-vm has been successfully started."
+
+  return 0
+}
+
 function kube::build::is_osx() {
   [[ "$(uname)" == "Darwin" ]]
+}
+
+function kube::build::ensure_docker_in_path() {
+  if [[ -z "$(which docker)" ]]; then
+    kube::log::error "Can't find 'docker' in PATH, please fix and retry."
+    kube::log::error "See https://docs.docker.com/installation/#installation for installation instructions."
+    return 1
+  fi
+}
+
+function kube::build::ensure_docker_daemon_connectivity {
+  if ! "${DOCKER[@]}" info > /dev/null 2>&1 ; then
+    {
+      echo "Can't connect to 'docker' daemon.  please fix and retry."
+      echo
+      echo "Possible causes:"
+      echo "  - On Mac OS X, DOCKER_HOST hasn't been set. You may need to: "
+      echo "    - Create and start your VM using docker-machine or boot2docker: "
+      echo "      - docker-machine create -f <provider> kube-dev"
+      echo "      - boot2docker init && boot2docker start"
+      echo "    - Set your environment variables using: "
+      echo "      - eval \$(docker-machine env kube-dev)"
+      echo "      - \$(boot2docker shellinit)"
+      echo "  - On Linux, user isn't in 'docker' group.  Add and relogin."
+      echo "    - Something like 'sudo usermod -a -G docker ${USER-user}'"
+      echo "    - RHEL7 bug and workaround: https://bugzilla.redhat.com/show_bug.cgi?id=1119282#c8"
+      echo "  - On Linux, Docker daemon hasn't been started or has crashed."
+    } >&2
+    return 1
+  fi
 }
 
 function kube::build::ensure_tar() {
@@ -615,7 +646,7 @@ function kube::release::package_server_tarballs() {
     # KUBE_SERVER_BINARIES array.
     cp "${KUBE_SERVER_BINARIES[@]/#/${LOCAL_OUTPUT_BINPATH}/${platform}/}" \
       "${release_stage}/server/bin/"
-    
+
     kube::release::create_docker_images_for_server "${release_stage}/server/bin";
     kube::release::write_addon_docker_images_for_server "${release_stage}/addons"
 


### PR DESCRIPTION
Hello! I was building k8s with Mac OS X and noticed building on OS X looks for boot2docker determine if Docker is available on Mac OS X. The boot2docker CLI is deprecated in favor of using docker-machine. I wanted to add docker-machine support without breaking things for boot2docker users. I've refactored the build/common.sh to:
- Check on OS X if DOCKER_HOST is set to avoid doing anything to the environment if it's already properly configured.
- Check for the existence of docker-machine and attempt to create and use a machine called kube-dev using virtualbox if DOCKER_HOST is not set.
- Check for the existence of boot2docker and attempt to setup and use boot2docker if docker-machine isn't available.
- Provide some guidance if neither docker-machine or boot2docker is available.

I've also done some additional refactoring to separate the various checks and operations into separate functions for (attempted) better readability.

I've tested this change using bash and zsh on Mac OS X and Fedora 22 (to make sure I didn't break anything for Linux users) successfully.
