### PR TITLE
WIP Versioned Client

### DIFF
--- a/pkg/client/v1/auth/clientauth.go
+++ b/pkg/client/v1/auth/clientauth.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package auth defines a file format for holding authentication
+information needed by clients of Kubernetes.  Typically,
+a Kubernetes cluster will put auth info for the admin in a known
+location when it is created, and will (soon) put it in a known
+location within a Container's file tree for Containers that
+need access to the Kubernetes API.
+
+Having a defined format allows:
+  - clients to be implmented in multiple languages
+  - applications which link clients to be portable across
+    clusters with different authentication styles (e.g.
+    some may use SSL Client certs, others may not, etc)
+  - when the format changes, applications only
+    need to update this code.
+
+The file format is json, marshalled from a struct authcfg.Info.
+
+Clinet libraries in other languages should use the same format.
+
+It is not intended to store general preferences, such as default
+namespace, output options, etc.  CLIs (such as kubectl) and UIs should
+develop their own format and may wish to inline the authcfg.Info type.
+
+The authcfg.Info is just a file format.  It is distinct from
+client.Config which holds options for creating a client.Client.
+Helper functions are provided in this package to fill in a
+client.Client from an authcfg.Info.
+
+Example:
+
+    import (
+        "pkg/client"
+        "pkg/client/auth"
+    )
+
+    info, err := auth.LoadFromFile(filename)
+    if err != nil {
+      // handle error
+    }
+    clientConfig = client.Config{}
+    clientConfig.Host = "example.com:4901"
+    clientConfig = info.MergeWithConfig()
+    client := client.New(clientConfig)
+    client.Pods(ns).List()
+*/
+package auth
+
+// TODO: need a way to rotate Tokens.  Therefore, need a way for client object to be reset when the authcfg is updated.
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+)
+
+// Info holds Kubernetes API authorization config.  It is intended
+// to be read/written from a file as a JSON object.
+type Info struct {
+	User        string
+	Password    string
+	CAFile      string
+	CertFile    string
+	KeyFile     string
+	BearerToken string
+	Insecure    *bool
+}
+
+// LoadFromFile parses an Info object from a file path.
+// If the file does not exist, then os.IsNotExist(err) == true
+func LoadFromFile(path string) (*Info, error) {
+	var info Info
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil, err
+	}
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(data, &info)
+	if err != nil {
+		return nil, err
+	}
+	return &info, err
+}
+
+// MergeWithConfig returns a copy of a client.Config with values from the Info.
+// The fields of client.Config with a corresponding field in the Info are set
+// with the value from the Info.
+func (info Info) MergeWithConfig(c client.Config) (client.Config, error) {
+	var config client.Config = c
+	config.Username = info.User
+	config.Password = info.Password
+	config.CAFile = info.CAFile
+	config.CertFile = info.CertFile
+	config.KeyFile = info.KeyFile
+	config.BearerToken = info.BearerToken
+	if info.Insecure != nil {
+		config.Insecure = *info.Insecure
+	}
+	return config, nil
+}
+
+func (info Info) Complete() bool {
+	return len(info.User) > 0 ||
+		len(info.CertFile) > 0 ||
+		len(info.BearerToken) > 0
+}

--- a/pkg/client/v1/auth/clientauth.go
+++ b/pkg/client/v1/auth/clientauth.go
@@ -68,7 +68,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	client "k8s.io/kubernetes/pkg/client/unversioned"
+	client "k8s.io/kubernetes/pkg/client/v1"
 )
 
 // Info holds Kubernetes API authorization config.  It is intended

--- a/pkg/client/v1/auth/clientauth_test.go
+++ b/pkg/client/v1/auth/clientauth_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth_test
+
+import (
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+
+	clientauth "k8s.io/kubernetes/pkg/client/unversioned/auth"
+)
+
+func TestLoadFromFile(t *testing.T) {
+	loadAuthInfoTests := []struct {
+		authData  string
+		authInfo  *clientauth.Info
+		expectErr bool
+	}{
+		{
+			`{"user": "user", "password": "pass"}`,
+			&clientauth.Info{User: "user", Password: "pass"},
+			false,
+		},
+		{
+			"", nil, true,
+		},
+	}
+	for _, loadAuthInfoTest := range loadAuthInfoTests {
+		tt := loadAuthInfoTest
+		aifile, err := ioutil.TempFile("", "testAuthInfo")
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if tt.authData != "missing" {
+			defer os.Remove(aifile.Name())
+			defer aifile.Close()
+			_, err = aifile.WriteString(tt.authData)
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+		} else {
+			aifile.Close()
+			os.Remove(aifile.Name())
+		}
+		authInfo, err := clientauth.LoadFromFile(aifile.Name())
+		gotErr := err != nil
+		if gotErr != tt.expectErr {
+			t.Errorf("expected errorness: %v, actual errorness: %v", tt.expectErr, gotErr)
+		}
+		if !reflect.DeepEqual(authInfo, tt.authInfo) {
+			t.Errorf("Expected %v, got %v", tt.authInfo, authInfo)
+		}
+	}
+}

--- a/pkg/client/v1/auth/clientauth_test.go
+++ b/pkg/client/v1/auth/clientauth_test.go
@@ -22,7 +22,7 @@ import (
 	"reflect"
 	"testing"
 
-	clientauth "k8s.io/kubernetes/pkg/client/unversioned/auth"
+	clientauth "k8s.io/kubernetes/pkg/client/v1/auth"
 )
 
 func TestLoadFromFile(t *testing.T) {

--- a/pkg/client/v1/client.go
+++ b/pkg/client/v1/client.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/version"
+)
+
+// Interface holds the methods for clients of Kubernetes,
+// an interface to allow mock testing.
+type Interface interface {
+	PodsNamespacer
+	PodTemplatesNamespacer
+	ReplicationControllersNamespacer
+	ServicesNamespacer
+	EndpointsNamespacer
+	VersionInterface
+	NodesInterface
+	EventNamespacer
+	LimitRangesNamespacer
+	ResourceQuotasNamespacer
+	ServiceAccountsNamespacer
+	SecretsNamespacer
+	NamespacesInterface
+	PersistentVolumesInterface
+	PersistentVolumeClaimsNamespacer
+	ComponentStatusesInterface
+	Experimental() ExperimentalInterface
+}
+
+func (c *Client) ReplicationControllers(namespace string) ReplicationControllerInterface {
+	return newReplicationControllers(c, namespace)
+}
+
+func (c *Client) Nodes() NodeInterface {
+	return newNodes(c)
+}
+
+func (c *Client) Events(namespace string) EventInterface {
+	return newEvents(c, namespace)
+}
+
+func (c *Client) Endpoints(namespace string) EndpointsInterface {
+	return newEndpoints(c, namespace)
+}
+
+func (c *Client) Pods(namespace string) PodInterface {
+	return newPods(c, namespace)
+}
+
+func (c *Client) PodTemplates(namespace string) PodTemplateInterface {
+	return newPodTemplates(c, namespace)
+}
+
+func (c *Client) Services(namespace string) ServiceInterface {
+	return newServices(c, namespace)
+}
+func (c *Client) LimitRanges(namespace string) LimitRangeInterface {
+	return newLimitRanges(c, namespace)
+}
+
+func (c *Client) ResourceQuotas(namespace string) ResourceQuotaInterface {
+	return newResourceQuotas(c, namespace)
+}
+
+func (c *Client) ServiceAccounts(namespace string) ServiceAccountsInterface {
+	return newServiceAccounts(c, namespace)
+}
+
+func (c *Client) Secrets(namespace string) SecretsInterface {
+	return newSecrets(c, namespace)
+}
+
+func (c *Client) Namespaces() NamespaceInterface {
+	return newNamespaces(c)
+}
+
+func (c *Client) PersistentVolumes() PersistentVolumeInterface {
+	return newPersistentVolumes(c)
+}
+
+func (c *Client) PersistentVolumeClaims(namespace string) PersistentVolumeClaimInterface {
+	return newPersistentVolumeClaims(c, namespace)
+}
+
+func (c *Client) ComponentStatuses() ComponentStatusInterface {
+	return newComponentStatuses(c)
+}
+
+// VersionInterface has a method to retrieve the server version.
+type VersionInterface interface {
+	ServerVersion() (*version.Info, error)
+	ServerAPIVersions() (*api.APIVersions, error)
+}
+
+// APIStatus is exposed by errors that can be converted to an api.Status object
+// for finer grained details.
+type APIStatus interface {
+	Status() unversioned.Status
+}
+
+// Client is the implementation of a Kubernetes client.
+type Client struct {
+	*RESTClient
+	*ExperimentalClient
+}
+
+// ServerVersion retrieves and parses the server's version.
+func (c *Client) ServerVersion() (*version.Info, error) {
+	body, err := c.Get().AbsPath("/version").Do().Raw()
+	if err != nil {
+		return nil, err
+	}
+	var info version.Info
+	err = json.Unmarshal(body, &info)
+	if err != nil {
+		return nil, fmt.Errorf("got '%s': %v", string(body), err)
+	}
+	return &info, nil
+}
+
+// ServerAPIVersions retrieves and parses the list of API versions the server supports.
+func (c *Client) ServerAPIVersions() (*api.APIVersions, error) {
+	body, err := c.Get().UnversionedPath("").Do().Raw()
+	if err != nil {
+		return nil, err
+	}
+	var v api.APIVersions
+	err = json.Unmarshal(body, &v)
+	if err != nil {
+		return nil, fmt.Errorf("got '%s': %v", string(body), err)
+	}
+	return &v, nil
+}
+
+type ComponentValidatorInterface interface {
+	ValidateComponents() (*api.ComponentStatusList, error)
+}
+
+// ValidateComponents retrieves and parses the master's self-monitored cluster state.
+// TODO: This should hit the versioned endpoint when that is implemented.
+func (c *Client) ValidateComponents() (*api.ComponentStatusList, error) {
+	body, err := c.Get().AbsPath("/validate").DoRaw()
+	if err != nil {
+		return nil, err
+	}
+
+	statuses := []api.ComponentStatus{}
+	if err := json.Unmarshal(body, &statuses); err != nil {
+		return nil, fmt.Errorf("got '%s': %v", string(body), err)
+	}
+	return &api.ComponentStatusList{Items: statuses}, nil
+}
+
+// IsTimeout tests if this is a timeout error in the underlying transport.
+// This is unbelievably ugly.
+// See: http://stackoverflow.com/questions/23494950/specifically-check-for-timeout-error for details
+func IsTimeout(err error) bool {
+	if err == nil {
+		return false
+	}
+	switch err := err.(type) {
+	case *url.Error:
+		if err, ok := err.Err.(net.Error); ok {
+			return err.Timeout()
+		}
+	case net.Error:
+		return err.Timeout()
+	}
+
+	if strings.Contains(err.Error(), "use of closed network connection") {
+		return true
+	}
+	return false
+}
+
+func (c *Client) Experimental() ExperimentalInterface {
+	return c.ExperimentalClient
+}

--- a/pkg/client/v1/client.go
+++ b/pkg/client/v1/client.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"encoding/json"
@@ -25,6 +25,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/version"
 )
 
@@ -156,22 +157,22 @@ func (c *Client) ServerAPIVersions() (*api.APIVersions, error) {
 }
 
 type ComponentValidatorInterface interface {
-	ValidateComponents() (*api.ComponentStatusList, error)
+	ValidateComponents() (*v1.ComponentStatusList, error)
 }
 
 // ValidateComponents retrieves and parses the master's self-monitored cluster state.
 // TODO: This should hit the versioned endpoint when that is implemented.
-func (c *Client) ValidateComponents() (*api.ComponentStatusList, error) {
+func (c *Client) ValidateComponents() (*v1.ComponentStatusList, error) {
 	body, err := c.Get().AbsPath("/validate").DoRaw()
 	if err != nil {
 		return nil, err
 	}
 
-	statuses := []api.ComponentStatus{}
+	statuses := []v1.ComponentStatus{}
 	if err := json.Unmarshal(body, &statuses); err != nil {
 		return nil, fmt.Errorf("got '%s': %v", string(body), err)
 	}
-	return &api.ComponentStatusList{Items: statuses}, nil
+	return &v1.ComponentStatusList{Items: statuses}, nil
 }
 
 // IsTimeout tests if this is a timeout error in the underlying transport.

--- a/pkg/client/v1/client_test.go
+++ b/pkg/client/v1/client_test.go
@@ -1,0 +1,292 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path"
+	"reflect"
+	"strings"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/version"
+)
+
+const nameRequiredError = "resource name may not be empty"
+
+type testRequest struct {
+	Method  string
+	Path    string
+	Header  string
+	Query   url.Values
+	Body    runtime.Object
+	RawBody *string
+}
+
+type Response struct {
+	StatusCode int
+	Body       runtime.Object
+	RawBody    *string
+}
+
+type testClient struct {
+	*Client
+	Request  testRequest
+	Response Response
+	Error    bool
+	Created  bool
+	Version  string
+	server   *httptest.Server
+	handler  *util.FakeHandler
+	// For query args, an optional function to validate the contents
+	// useful when the contents can change but still be correct.
+	// Maps from query arg key to validator.
+	// If no validator is present, string equality is used.
+	QueryValidator map[string]func(string, string) bool
+}
+
+func (c *testClient) Setup(t *testing.T) *testClient {
+	c.handler = &util.FakeHandler{
+		StatusCode: c.Response.StatusCode,
+	}
+	if responseBody := body(t, c.Response.Body, c.Response.RawBody); responseBody != nil {
+		c.handler.ResponseBody = *responseBody
+	}
+	c.server = httptest.NewServer(c.handler)
+	if c.Client == nil {
+		version := c.Version
+		if len(version) == 0 {
+			version = testapi.Default.Version()
+		}
+		c.Client = NewOrDie(&Config{
+			Host:    c.server.URL,
+			Version: version,
+		})
+
+		// TODO: caesarxuchao: hacky way to specify version of Experimental client.
+		// We will fix this by supporting multiple group versions in Config
+		version = c.Version
+		if len(version) == 0 {
+			version = testapi.Experimental.Version()
+		}
+		c.ExperimentalClient = NewExperimentalOrDie(&Config{
+			Host:    c.server.URL,
+			Version: version,
+		})
+	}
+	c.QueryValidator = map[string]func(string, string) bool{}
+	return c
+}
+
+func (c *testClient) Validate(t *testing.T, received runtime.Object, err error) {
+	c.ValidateCommon(t, err)
+
+	if c.Response.Body != nil && !api.Semantic.DeepDerivative(c.Response.Body, received) {
+		t.Errorf("bad response for request %#v: expected %#v, got %#v", c.Request, c.Response.Body, received)
+	}
+}
+
+func (c *testClient) ValidateRaw(t *testing.T, received []byte, err error) {
+	c.ValidateCommon(t, err)
+
+	if c.Response.Body != nil && !reflect.DeepEqual(c.Response.Body, received) {
+		t.Errorf("bad response for request %#v: expected %#v, got %#v", c.Request, c.Response.Body, received)
+	}
+}
+
+func (c *testClient) ValidateCommon(t *testing.T, err error) {
+	defer c.server.Close()
+
+	if c.Error {
+		if err == nil {
+			t.Errorf("error expected for %#v, got none", c.Request)
+		}
+		return
+	}
+	if err != nil {
+		t.Errorf("no error expected for %#v, got: %v", c.Request, err)
+	}
+
+	if c.handler.RequestReceived == nil {
+		t.Errorf("handler had an empty request, %#v", c)
+		return
+	}
+
+	requestBody := body(t, c.Request.Body, c.Request.RawBody)
+	actualQuery := c.handler.RequestReceived.URL.Query()
+	t.Logf("got query: %v", actualQuery)
+	t.Logf("path: %v", c.Request.Path)
+	// We check the query manually, so blank it out so that FakeHandler.ValidateRequest
+	// won't check it.
+	c.handler.RequestReceived.URL.RawQuery = ""
+	c.handler.ValidateRequest(t, path.Join(c.Request.Path), c.Request.Method, requestBody)
+	for key, values := range c.Request.Query {
+		validator, ok := c.QueryValidator[key]
+		if !ok {
+			switch key {
+			case api.LabelSelectorQueryParam(testapi.Default.Version()):
+				validator = validateLabels
+			case api.FieldSelectorQueryParam(testapi.Default.Version()):
+				validator = validateFields
+			default:
+				validator = func(a, b string) bool { return a == b }
+			}
+		}
+		observed := actualQuery.Get(key)
+		wanted := strings.Join(values, "")
+		if !validator(wanted, observed) {
+			t.Errorf("Unexpected query arg for key: %s.  Expected %s, Received %s", key, wanted, observed)
+		}
+	}
+	if c.Request.Header != "" {
+		if c.handler.RequestReceived.Header.Get(c.Request.Header) == "" {
+			t.Errorf("header %q not found in request %#v", c.Request.Header, c.handler.RequestReceived)
+		}
+	}
+
+	if expected, received := requestBody, c.handler.RequestBody; expected != nil && *expected != received {
+		t.Errorf("bad body for request %#v: expected %s, got %s", c.Request, *expected, received)
+	}
+}
+
+// buildResourcePath is a convenience function for knowing if a namespace should be in a path param or not
+func buildResourcePath(namespace, resource string) string {
+	if len(namespace) > 0 {
+		return path.Join("namespaces", namespace, resource)
+	}
+	return resource
+}
+
+// buildQueryValues is a convenience function for knowing if a namespace should be in a query param or not
+func buildQueryValues(query url.Values) url.Values {
+	v := url.Values{}
+	if query != nil {
+		for key, values := range query {
+			for _, value := range values {
+				v.Add(key, value)
+			}
+		}
+	}
+	return v
+}
+
+func validateLabels(a, b string) bool {
+	sA, eA := labels.Parse(a)
+	if eA != nil {
+		return false
+	}
+	sB, eB := labels.Parse(b)
+	if eB != nil {
+		return false
+	}
+	return sA.String() == sB.String()
+}
+
+func validateFields(a, b string) bool {
+	sA, _ := fields.ParseSelector(a)
+	sB, _ := fields.ParseSelector(b)
+	return sA.String() == sB.String()
+}
+
+func body(t *testing.T, obj runtime.Object, raw *string) *string {
+	if obj != nil {
+		_, kind, err := api.Scheme.ObjectVersionAndKind(obj)
+		if err != nil {
+			t.Errorf("unexpected encoding error: %v", err)
+		}
+		// TODO: caesarxuchao: we should detect which group an object belongs to
+		// by using the version returned by Schem.ObjectVersionAndKind() once we
+		// split the schemes for internal objects.
+		// TODO: caesarxuchao: we should add a map from kind to group in Scheme.
+		var bs []byte
+		if api.Scheme.Recognizes(testapi.Default.GroupAndVersion(), kind) {
+			bs, err = testapi.Default.Codec().Encode(obj)
+			if err != nil {
+				t.Errorf("unexpected encoding error: %v", err)
+			}
+		} else if api.Scheme.Recognizes(testapi.Experimental.GroupAndVersion(), kind) {
+			bs, err = testapi.Experimental.Codec().Encode(obj)
+			if err != nil {
+				t.Errorf("unexpected encoding error: %v", err)
+			}
+		} else {
+			t.Errorf("unexpected kind: %v", kind)
+		}
+		body := string(bs)
+		return &body
+	}
+	return raw
+}
+
+func TestGetServerVersion(t *testing.T) {
+	expect := version.Info{
+		Major:     "foo",
+		Minor:     "bar",
+		GitCommit: "baz",
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		output, err := json.Marshal(expect)
+		if err != nil {
+			t.Errorf("unexpected encoding error: %v", err)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(output)
+	}))
+	client := NewOrDie(&Config{Host: server.URL})
+
+	got, err := client.ServerVersion()
+	if err != nil {
+		t.Fatalf("unexpected encoding error: %v", err)
+	}
+	if e, a := expect, *got; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+}
+
+func TestGetServerAPIVersions(t *testing.T) {
+	versions := []string{"v1", "v2", "v3"}
+	expect := api.APIVersions{Versions: versions}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		output, err := json.Marshal(expect)
+		if err != nil {
+			t.Errorf("unexpected encoding error: %v", err)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(output)
+	}))
+	client := NewOrDie(&Config{Host: server.URL})
+	got, err := client.ServerAPIVersions()
+	if err != nil {
+		t.Fatalf("unexpected encoding error: %v", err)
+	}
+	if e, a := expect, *got; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+}

--- a/pkg/client/v1/client_test.go
+++ b/pkg/client/v1/client_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"encoding/json"

--- a/pkg/client/v1/clientcmd/api/helpers.go
+++ b/pkg/client/v1/clientcmd/api/helpers.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+)
+
+func init() {
+	sDec, _ := base64.StdEncoding.DecodeString("REDACTED+")
+	redactedBytes = []byte(string(sDec))
+}
+
+// MinifyConfig read the current context and uses that to keep only the relevant pieces of config
+// This is useful for making secrets based on kubeconfig files
+func MinifyConfig(config *Config) error {
+	if len(config.CurrentContext) == 0 {
+		return errors.New("current-context must exist in order to minify")
+	}
+
+	currContext, exists := config.Contexts[config.CurrentContext]
+	if !exists {
+		return fmt.Errorf("cannot locate context %v", config.CurrentContext)
+	}
+
+	newContexts := map[string]*Context{}
+	newContexts[config.CurrentContext] = currContext
+
+	newClusters := map[string]*Cluster{}
+	if len(currContext.Cluster) > 0 {
+		if _, exists := config.Clusters[currContext.Cluster]; !exists {
+			return fmt.Errorf("cannot locate cluster %v", currContext.Cluster)
+		}
+
+		newClusters[currContext.Cluster] = config.Clusters[currContext.Cluster]
+	}
+
+	newAuthInfos := map[string]*AuthInfo{}
+	if len(currContext.AuthInfo) > 0 {
+		if _, exists := config.AuthInfos[currContext.AuthInfo]; !exists {
+			return fmt.Errorf("cannot locate user %v", currContext.AuthInfo)
+		}
+
+		newAuthInfos[currContext.AuthInfo] = config.AuthInfos[currContext.AuthInfo]
+	}
+
+	config.AuthInfos = newAuthInfos
+	config.Clusters = newClusters
+	config.Contexts = newContexts
+
+	return nil
+}
+
+var redactedBytes []byte
+
+// Flatten redacts raw data entries from the config object for a human-readable view.
+func ShortenConfig(config *Config) {
+	// trick json encoder into printing a human readable string in the raw data
+	// by base64 decoding what we want to print. Relies on implementation of
+	// http://golang.org/pkg/encoding/json/#Marshal using base64 to encode []byte
+	for key, authInfo := range config.AuthInfos {
+		if len(authInfo.ClientKeyData) > 0 {
+			authInfo.ClientKeyData = redactedBytes
+		}
+		if len(authInfo.ClientCertificateData) > 0 {
+			authInfo.ClientCertificateData = redactedBytes
+		}
+		config.AuthInfos[key] = authInfo
+	}
+	for key, cluster := range config.Clusters {
+		if len(cluster.CertificateAuthorityData) > 0 {
+			cluster.CertificateAuthorityData = redactedBytes
+		}
+		config.Clusters[key] = cluster
+	}
+}
+
+// Flatten changes the config object into a self contained config (useful for making secrets)
+func FlattenConfig(config *Config) error {
+	for key, authInfo := range config.AuthInfos {
+		baseDir, err := MakeAbs(path.Dir(authInfo.LocationOfOrigin), "")
+		if err != nil {
+			return err
+		}
+
+		if err := FlattenContent(&authInfo.ClientCertificate, &authInfo.ClientCertificateData, baseDir); err != nil {
+			return err
+		}
+		if err := FlattenContent(&authInfo.ClientKey, &authInfo.ClientKeyData, baseDir); err != nil {
+			return err
+		}
+
+		config.AuthInfos[key] = authInfo
+	}
+	for key, cluster := range config.Clusters {
+		baseDir, err := MakeAbs(path.Dir(cluster.LocationOfOrigin), "")
+		if err != nil {
+			return err
+		}
+
+		if err := FlattenContent(&cluster.CertificateAuthority, &cluster.CertificateAuthorityData, baseDir); err != nil {
+			return err
+		}
+
+		config.Clusters[key] = cluster
+	}
+
+	return nil
+}
+
+func FlattenContent(path *string, contents *[]byte, baseDir string) error {
+	if len(*path) != 0 {
+		if len(*contents) > 0 {
+			return errors.New("cannot have values for both path and contents")
+		}
+
+		var err error
+		absPath := ResolvePath(*path, baseDir)
+		*contents, err = ioutil.ReadFile(absPath)
+		if err != nil {
+			return err
+		}
+
+		*path = ""
+	}
+
+	return nil
+}
+
+// ResolvePath returns the path as an absolute paths, relative to the given base directory
+func ResolvePath(path string, base string) string {
+	// Don't resolve empty paths
+	if len(path) > 0 {
+		// Don't resolve absolute paths
+		if !filepath.IsAbs(path) {
+			return filepath.Join(base, path)
+		}
+	}
+
+	return path
+}
+
+func MakeAbs(path, base string) (string, error) {
+	if filepath.IsAbs(path) {
+		return path, nil
+	}
+	if len(base) == 0 {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		base = cwd
+	}
+	return filepath.Join(base, path), nil
+}

--- a/pkg/client/v1/clientcmd/api/helpers_test.go
+++ b/pkg/client/v1/clientcmd/api/helpers_test.go
@@ -1,0 +1,301 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/ghodss/yaml"
+)
+
+func newMergedConfig(certFile, certContent, keyFile, keyContent, caFile, caContent string, t *testing.T) Config {
+	if err := ioutil.WriteFile(certFile, []byte(certContent), 0644); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if err := ioutil.WriteFile(keyFile, []byte(keyContent), 0600); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if err := ioutil.WriteFile(caFile, []byte(caContent), 0644); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	return Config{
+		AuthInfos: map[string]*AuthInfo{
+			"red-user":  {Token: "red-token", ClientCertificateData: []byte(certContent), ClientKeyData: []byte(keyContent)},
+			"blue-user": {Token: "blue-token", ClientCertificate: certFile, ClientKey: keyFile}},
+		Clusters: map[string]*Cluster{
+			"cow-cluster":     {Server: "http://cow.org:8080", CertificateAuthorityData: []byte(caContent)},
+			"chicken-cluster": {Server: "http://chicken.org:8080", CertificateAuthority: caFile}},
+		Contexts: map[string]*Context{
+			"federal-context": {AuthInfo: "red-user", Cluster: "cow-cluster"},
+			"shaker-context":  {AuthInfo: "blue-user", Cluster: "chicken-cluster"}},
+		CurrentContext: "federal-context",
+	}
+}
+
+func TestMinifySuccess(t *testing.T) {
+	certFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(certFile.Name())
+	keyFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(keyFile.Name())
+	caFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(caFile.Name())
+
+	mutatingConfig := newMergedConfig(certFile.Name(), "cert", keyFile.Name(), "key", caFile.Name(), "ca", t)
+
+	if err := MinifyConfig(&mutatingConfig); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if len(mutatingConfig.Contexts) > 1 {
+		t.Errorf("unexpected contexts: %v", mutatingConfig.Contexts)
+	}
+	if _, exists := mutatingConfig.Contexts["federal-context"]; !exists {
+		t.Errorf("missing context")
+	}
+
+	if len(mutatingConfig.Clusters) > 1 {
+		t.Errorf("unexpected clusters: %v", mutatingConfig.Clusters)
+	}
+	if _, exists := mutatingConfig.Clusters["cow-cluster"]; !exists {
+		t.Errorf("missing cluster")
+	}
+
+	if len(mutatingConfig.AuthInfos) > 1 {
+		t.Errorf("unexpected users: %v", mutatingConfig.AuthInfos)
+	}
+	if _, exists := mutatingConfig.AuthInfos["red-user"]; !exists {
+		t.Errorf("missing user")
+	}
+}
+
+func TestMinifyMissingContext(t *testing.T) {
+	certFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(certFile.Name())
+	keyFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(keyFile.Name())
+	caFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(caFile.Name())
+
+	mutatingConfig := newMergedConfig(certFile.Name(), "cert", keyFile.Name(), "key", caFile.Name(), "ca", t)
+	mutatingConfig.CurrentContext = "missing"
+
+	errMsg := "cannot locate context missing"
+
+	if err := MinifyConfig(&mutatingConfig); err == nil || err.Error() != errMsg {
+		t.Errorf("expected %v, got %v", errMsg, err)
+	}
+}
+
+func TestMinifyMissingCluster(t *testing.T) {
+	certFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(certFile.Name())
+	keyFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(keyFile.Name())
+	caFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(caFile.Name())
+
+	mutatingConfig := newMergedConfig(certFile.Name(), "cert", keyFile.Name(), "key", caFile.Name(), "ca", t)
+	delete(mutatingConfig.Clusters, mutatingConfig.Contexts[mutatingConfig.CurrentContext].Cluster)
+
+	errMsg := "cannot locate cluster cow-cluster"
+
+	if err := MinifyConfig(&mutatingConfig); err == nil || err.Error() != errMsg {
+		t.Errorf("expected %v, got %v", errMsg, err)
+	}
+}
+
+func TestMinifyMissingAuthInfo(t *testing.T) {
+	certFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(certFile.Name())
+	keyFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(keyFile.Name())
+	caFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(caFile.Name())
+
+	mutatingConfig := newMergedConfig(certFile.Name(), "cert", keyFile.Name(), "key", caFile.Name(), "ca", t)
+	delete(mutatingConfig.AuthInfos, mutatingConfig.Contexts[mutatingConfig.CurrentContext].AuthInfo)
+
+	errMsg := "cannot locate user red-user"
+
+	if err := MinifyConfig(&mutatingConfig); err == nil || err.Error() != errMsg {
+		t.Errorf("expected %v, got %v", errMsg, err)
+	}
+}
+
+func TestFlattenSuccess(t *testing.T) {
+	certFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(certFile.Name())
+	keyFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(keyFile.Name())
+	caFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(caFile.Name())
+
+	certData := "cert"
+	keyData := "key"
+	caData := "ca"
+
+	unchangingCluster := "cow-cluster"
+	unchangingAuthInfo := "red-user"
+	changingCluster := "chicken-cluster"
+	changingAuthInfo := "blue-user"
+
+	startingConfig := newMergedConfig(certFile.Name(), certData, keyFile.Name(), keyData, caFile.Name(), caData, t)
+	mutatingConfig := startingConfig
+
+	if err := FlattenConfig(&mutatingConfig); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if len(mutatingConfig.Contexts) != 2 {
+		t.Errorf("unexpected contexts: %v", mutatingConfig.Contexts)
+	}
+	if !reflect.DeepEqual(startingConfig.Contexts, mutatingConfig.Contexts) {
+		t.Errorf("expected %v, got %v", startingConfig.Contexts, mutatingConfig.Contexts)
+	}
+
+	if len(mutatingConfig.Clusters) != 2 {
+		t.Errorf("unexpected clusters: %v", mutatingConfig.Clusters)
+	}
+	if !reflect.DeepEqual(startingConfig.Clusters[unchangingCluster], mutatingConfig.Clusters[unchangingCluster]) {
+		t.Errorf("expected %v, got %v", startingConfig.Clusters[unchangingCluster], mutatingConfig.Clusters[unchangingCluster])
+	}
+	if len(mutatingConfig.Clusters[changingCluster].CertificateAuthority) != 0 {
+		t.Errorf("unexpected caFile")
+	}
+	if string(mutatingConfig.Clusters[changingCluster].CertificateAuthorityData) != caData {
+		t.Errorf("expected %v, got %v", caData, string(mutatingConfig.Clusters[changingCluster].CertificateAuthorityData))
+	}
+
+	if len(mutatingConfig.AuthInfos) != 2 {
+		t.Errorf("unexpected users: %v", mutatingConfig.AuthInfos)
+	}
+	if !reflect.DeepEqual(startingConfig.AuthInfos[unchangingAuthInfo], mutatingConfig.AuthInfos[unchangingAuthInfo]) {
+		t.Errorf("expected %v, got %v", startingConfig.AuthInfos[unchangingAuthInfo], mutatingConfig.AuthInfos[unchangingAuthInfo])
+	}
+	if len(mutatingConfig.AuthInfos[changingAuthInfo].ClientCertificate) != 0 {
+		t.Errorf("unexpected caFile")
+	}
+	if string(mutatingConfig.AuthInfos[changingAuthInfo].ClientCertificateData) != certData {
+		t.Errorf("expected %v, got %v", certData, string(mutatingConfig.AuthInfos[changingAuthInfo].ClientCertificateData))
+	}
+	if len(mutatingConfig.AuthInfos[changingAuthInfo].ClientKey) != 0 {
+		t.Errorf("unexpected caFile")
+	}
+	if string(mutatingConfig.AuthInfos[changingAuthInfo].ClientKeyData) != keyData {
+		t.Errorf("expected %v, got %v", keyData, string(mutatingConfig.AuthInfos[changingAuthInfo].ClientKeyData))
+	}
+
+}
+
+func ExampleMinifyAndShorten() {
+	certFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(certFile.Name())
+	keyFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(keyFile.Name())
+	caFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(caFile.Name())
+
+	certData := "cert"
+	keyData := "key"
+	caData := "ca"
+
+	config := newMergedConfig(certFile.Name(), certData, keyFile.Name(), keyData, caFile.Name(), caData, nil)
+
+	MinifyConfig(&config)
+	ShortenConfig(&config)
+
+	output, _ := yaml.Marshal(config)
+	fmt.Printf("%s", string(output))
+	// Output:
+	// clusters:
+	//   cow-cluster:
+	//     LocationOfOrigin: ""
+	//     certificate-authority-data: REDACTED
+	//     server: http://cow.org:8080
+	// contexts:
+	//   federal-context:
+	//     LocationOfOrigin: ""
+	//     cluster: cow-cluster
+	//     user: red-user
+	// current-context: federal-context
+	// preferences: {}
+	// users:
+	//   red-user:
+	//     LocationOfOrigin: ""
+	//     client-certificate-data: REDACTED
+	//     client-key-data: REDACTED
+	//     token: red-token
+}
+
+func TestShortenSuccess(t *testing.T) {
+	certFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(certFile.Name())
+	keyFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(keyFile.Name())
+	caFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(caFile.Name())
+
+	certData := "cert"
+	keyData := "key"
+	caData := "ca"
+
+	unchangingCluster := "chicken-cluster"
+	unchangingAuthInfo := "blue-user"
+	changingCluster := "cow-cluster"
+	changingAuthInfo := "red-user"
+
+	startingConfig := newMergedConfig(certFile.Name(), certData, keyFile.Name(), keyData, caFile.Name(), caData, t)
+	mutatingConfig := startingConfig
+
+	ShortenConfig(&mutatingConfig)
+
+	if len(mutatingConfig.Contexts) != 2 {
+		t.Errorf("unexpected contexts: %v", mutatingConfig.Contexts)
+	}
+	if !reflect.DeepEqual(startingConfig.Contexts, mutatingConfig.Contexts) {
+		t.Errorf("expected %v, got %v", startingConfig.Contexts, mutatingConfig.Contexts)
+	}
+
+	redacted := string(redactedBytes)
+	if len(mutatingConfig.Clusters) != 2 {
+		t.Errorf("unexpected clusters: %v", mutatingConfig.Clusters)
+	}
+	if !reflect.DeepEqual(startingConfig.Clusters[unchangingCluster], mutatingConfig.Clusters[unchangingCluster]) {
+		t.Errorf("expected %v, got %v", startingConfig.Clusters[unchangingCluster], mutatingConfig.Clusters[unchangingCluster])
+	}
+	if string(mutatingConfig.Clusters[changingCluster].CertificateAuthorityData) != redacted {
+		t.Errorf("expected %v, got %v", redacted, string(mutatingConfig.Clusters[changingCluster].CertificateAuthorityData))
+	}
+
+	if len(mutatingConfig.AuthInfos) != 2 {
+		t.Errorf("unexpected users: %v", mutatingConfig.AuthInfos)
+	}
+	if !reflect.DeepEqual(startingConfig.AuthInfos[unchangingAuthInfo], mutatingConfig.AuthInfos[unchangingAuthInfo]) {
+		t.Errorf("expected %v, got %v", startingConfig.AuthInfos[unchangingAuthInfo], mutatingConfig.AuthInfos[unchangingAuthInfo])
+	}
+	if string(mutatingConfig.AuthInfos[changingAuthInfo].ClientCertificateData) != redacted {
+		t.Errorf("expected %v, got %v", redacted, string(mutatingConfig.AuthInfos[changingAuthInfo].ClientCertificateData))
+	}
+	if string(mutatingConfig.AuthInfos[changingAuthInfo].ClientKeyData) != redacted {
+		t.Errorf("expected %v, got %v", redacted, string(mutatingConfig.AuthInfos[changingAuthInfo].ClientKeyData))
+	}
+}

--- a/pkg/client/v1/clientcmd/api/latest/latest.go
+++ b/pkg/client/v1/clientcmd/api/latest/latest.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package latest
+
+import (
+	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api/v1"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+// Version is the string that represents the current external default version.
+const Version = "v1"
+
+// OldestVersion is the string that represents the oldest server version supported,
+// for client code that wants to hardcode the lowest common denominator.
+const OldestVersion = "v1"
+
+// Versions is the list of versions that are recognized in code. The order provided
+// may be assumed to be least feature rich to most feature rich, and clients may
+// choose to prefer the latter items in the list over the former items when presented
+// with a set of versions to choose.
+var Versions = []string{"v1"}
+
+// Codec is the default codec for serializing output that should use
+// the latest supported version.  Use this Codec when writing to
+// disk, a data store that is not dynamically versioned, or in tests.
+// This codec can decode any object that Kubernetes is aware of.
+var Codec = runtime.YAMLDecoder(v1.Codec)

--- a/pkg/client/v1/clientcmd/api/latest/latest.go
+++ b/pkg/client/v1/clientcmd/api/latest/latest.go
@@ -17,7 +17,7 @@ limitations under the License.
 package latest
 
 import (
-	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api/v1"
+	"k8s.io/kubernetes/pkg/client/v1/clientcmd/api/v1"
 	"k8s.io/kubernetes/pkg/runtime"
 )
 

--- a/pkg/client/v1/clientcmd/api/register.go
+++ b/pkg/client/v1/clientcmd/api/register.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+// Scheme is the default instance of runtime.Scheme to which types in the Kubernetes API are already registered.
+var Scheme = runtime.NewScheme()
+
+func init() {
+	Scheme.AddKnownTypes("",
+		&Config{},
+	)
+}
+
+func (*Config) IsAnAPIObject() {}

--- a/pkg/client/v1/clientcmd/api/types.go
+++ b/pkg/client/v1/clientcmd/api/types.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+// Where possible, json tags match the cli argument names.
+// Top level config objects and all values required for proper functioning are not "omitempty".  Any truly optional piece of config is allowed to be omitted.
+
+// Config holds the information needed to build connect to remote kubernetes clusters as a given user
+type Config struct {
+	// Legacy field from pkg/api/types.go TypeMeta.
+	// TODO(jlowdermilk): remove this after eliminating downstream dependencies.
+	Kind string `json:"kind,omitempty"`
+	// Version of the schema for this config object.
+	APIVersion string `json:"apiVersion,omitempty"`
+	// Preferences holds general information to be use for cli interactions
+	Preferences Preferences `json:"preferences"`
+	// Clusters is a map of referencable names to cluster configs
+	Clusters map[string]*Cluster `json:"clusters"`
+	// AuthInfos is a map of referencable names to user configs
+	AuthInfos map[string]*AuthInfo `json:"users"`
+	// Contexts is a map of referencable names to context configs
+	Contexts map[string]*Context `json:"contexts"`
+	// CurrentContext is the name of the context that you would like to use by default
+	CurrentContext string `json:"current-context"`
+	// Extensions holds additional information. This is useful for extenders so that reads and writes don't clobber unknown fields
+	Extensions map[string]*runtime.EmbeddedObject `json:"extensions,omitempty"`
+}
+
+type Preferences struct {
+	Colors bool `json:"colors,omitempty"`
+	// Extensions holds additional information. This is useful for extenders so that reads and writes don't clobber unknown fields
+	Extensions map[string]*runtime.EmbeddedObject `json:"extensions,omitempty"`
+}
+
+// Cluster contains information about how to communicate with a kubernetes cluster
+type Cluster struct {
+	// LocationOfOrigin indicates where this object came from.  It is used for round tripping config post-merge, but never serialized.
+	LocationOfOrigin string
+	// Server is the address of the kubernetes cluster (https://hostname:port).
+	Server string `json:"server"`
+	// APIVersion is the preferred api version for communicating with the kubernetes cluster (v1, v2, etc).
+	APIVersion string `json:"api-version,omitempty"`
+	// InsecureSkipTLSVerify skips the validity check for the server's certificate. This will make your HTTPS connections insecure.
+	InsecureSkipTLSVerify bool `json:"insecure-skip-tls-verify,omitempty"`
+	// CertificateAuthority is the path to a cert file for the certificate authority.
+	CertificateAuthority string `json:"certificate-authority,omitempty"`
+	// CertificateAuthorityData contains PEM-encoded certificate authority certificates. Overrides CertificateAuthority
+	CertificateAuthorityData []byte `json:"certificate-authority-data,omitempty"`
+	// Extensions holds additional information. This is useful for extenders so that reads and writes don't clobber unknown fields
+	Extensions map[string]*runtime.EmbeddedObject `json:"extensions,omitempty"`
+}
+
+// AuthInfo contains information that describes identity information.  This is use to tell the kubernetes cluster who you are.
+type AuthInfo struct {
+	// LocationOfOrigin indicates where this object came from.  It is used for round tripping config post-merge, but never serialized.
+	LocationOfOrigin string
+	// ClientCertificate is the path to a client cert file for TLS.
+	ClientCertificate string `json:"client-certificate,omitempty"`
+	// ClientCertificateData contains PEM-encoded data from a client cert file for TLS. Overrides ClientCertificate
+	ClientCertificateData []byte `json:"client-certificate-data,omitempty"`
+	// ClientKey is the path to a client key file for TLS.
+	ClientKey string `json:"client-key,omitempty"`
+	// ClientKeyData contains PEM-encoded data from a client key file for TLS. Overrides ClientKey
+	ClientKeyData []byte `json:"client-key-data,omitempty"`
+	// Token is the bearer token for authentication to the kubernetes cluster.
+	Token string `json:"token,omitempty"`
+	// Username is the username for basic authentication to the kubernetes cluster.
+	Username string `json:"username,omitempty"`
+	// Password is the password for basic authentication to the kubernetes cluster.
+	Password string `json:"password,omitempty"`
+	// Extensions holds additional information. This is useful for extenders so that reads and writes don't clobber unknown fields
+	Extensions map[string]*runtime.EmbeddedObject `json:"extensions,omitempty"`
+}
+
+// Context is a tuple of references to a cluster (how do I communicate with a kubernetes cluster), a user (how do I identify myself), and a namespace (what subset of resources do I want to work with)
+type Context struct {
+	// LocationOfOrigin indicates where this object came from.  It is used for round tripping config post-merge, but never serialized.
+	LocationOfOrigin string
+	// Cluster is the name of the cluster for this context
+	Cluster string `json:"cluster"`
+	// AuthInfo is the name of the authInfo for this context
+	AuthInfo string `json:"user"`
+	// Namespace is the default namespace to use on unspecified requests
+	Namespace string `json:"namespace,omitempty"`
+	// Extensions holds additional information. This is useful for extenders so that reads and writes don't clobber unknown fields
+	Extensions map[string]*runtime.EmbeddedObject `json:"extensions,omitempty"`
+}
+
+// NewConfig is a convenience function that returns a new Config object with non-nil maps
+func NewConfig() *Config {
+	return &Config{
+		Preferences: *NewPreferences(),
+		Clusters:    make(map[string]*Cluster),
+		AuthInfos:   make(map[string]*AuthInfo),
+		Contexts:    make(map[string]*Context),
+		Extensions:  make(map[string]*runtime.EmbeddedObject),
+	}
+}
+
+// NewConfig is a convenience function that returns a new Config object with non-nil maps
+func NewContext() *Context {
+	return &Context{Extensions: make(map[string]*runtime.EmbeddedObject)}
+}
+
+// NewConfig is a convenience function that returns a new Config object with non-nil maps
+func NewCluster() *Cluster {
+	return &Cluster{Extensions: make(map[string]*runtime.EmbeddedObject)}
+}
+
+// NewConfig is a convenience function that returns a new Config object with non-nil maps
+func NewAuthInfo() *AuthInfo {
+	return &AuthInfo{Extensions: make(map[string]*runtime.EmbeddedObject)}
+}
+
+// NewConfig is a convenience function that returns a new Config object with non-nil maps
+func NewPreferences() *Preferences {
+	return &Preferences{Extensions: make(map[string]*runtime.EmbeddedObject)}
+}

--- a/pkg/client/v1/clientcmd/api/types_test.go
+++ b/pkg/client/v1/clientcmd/api/types_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"fmt"
+
+	"github.com/ghodss/yaml"
+)
+
+func ExampleEmptyConfig() {
+	defaultConfig := NewConfig()
+
+	output, err := yaml.Marshal(defaultConfig)
+	if err != nil {
+		fmt.Printf("Unexpected error: %v", err)
+	}
+
+	fmt.Printf("%v", string(output))
+	// Output:
+	// clusters: {}
+	// contexts: {}
+	// current-context: ""
+	// preferences: {}
+	// users: {}
+}
+
+func ExampleOfOptionsConfig() {
+	defaultConfig := NewConfig()
+	defaultConfig.Preferences.Colors = true
+	defaultConfig.Clusters["alfa"] = &Cluster{
+		Server:                "https://alfa.org:8080",
+		APIVersion:            "v1beta2",
+		InsecureSkipTLSVerify: true,
+		CertificateAuthority:  "path/to/my/cert-ca-filename",
+	}
+	defaultConfig.Clusters["bravo"] = &Cluster{
+		Server:                "https://bravo.org:8080",
+		APIVersion:            "v1beta1",
+		InsecureSkipTLSVerify: false,
+	}
+	defaultConfig.AuthInfos["white-mage-via-cert"] = &AuthInfo{
+		ClientCertificate: "path/to/my/client-cert-filename",
+		ClientKey:         "path/to/my/client-key-filename",
+	}
+	defaultConfig.AuthInfos["red-mage-via-token"] = &AuthInfo{
+		Token: "my-secret-token",
+	}
+	defaultConfig.Contexts["bravo-as-black-mage"] = &Context{
+		Cluster:   "bravo",
+		AuthInfo:  "black-mage-via-file",
+		Namespace: "yankee",
+	}
+	defaultConfig.Contexts["alfa-as-black-mage"] = &Context{
+		Cluster:   "alfa",
+		AuthInfo:  "black-mage-via-file",
+		Namespace: "zulu",
+	}
+	defaultConfig.Contexts["alfa-as-white-mage"] = &Context{
+		Cluster:  "alfa",
+		AuthInfo: "white-mage-via-cert",
+	}
+	defaultConfig.CurrentContext = "alfa-as-white-mage"
+
+	output, err := yaml.Marshal(defaultConfig)
+	if err != nil {
+		fmt.Printf("Unexpected error: %v", err)
+	}
+
+	fmt.Printf("%v", string(output))
+	// Output:
+	// clusters:
+	//   alfa:
+	//     LocationOfOrigin: ""
+	//     api-version: v1beta2
+	//     certificate-authority: path/to/my/cert-ca-filename
+	//     insecure-skip-tls-verify: true
+	//     server: https://alfa.org:8080
+	//   bravo:
+	//     LocationOfOrigin: ""
+	//     api-version: v1beta1
+	//     server: https://bravo.org:8080
+	// contexts:
+	//   alfa-as-black-mage:
+	//     LocationOfOrigin: ""
+	//     cluster: alfa
+	//     namespace: zulu
+	//     user: black-mage-via-file
+	//   alfa-as-white-mage:
+	//     LocationOfOrigin: ""
+	//     cluster: alfa
+	//     user: white-mage-via-cert
+	//   bravo-as-black-mage:
+	//     LocationOfOrigin: ""
+	//     cluster: bravo
+	//     namespace: yankee
+	//     user: black-mage-via-file
+	// current-context: alfa-as-white-mage
+	// preferences:
+	//   colors: true
+	// users:
+	//   red-mage-via-token:
+	//     LocationOfOrigin: ""
+	//     token: my-secret-token
+	//   white-mage-via-cert:
+	//     LocationOfOrigin: ""
+	//     client-certificate: path/to/my/client-cert-filename
+	//     client-key: path/to/my/client-key-filename
+}

--- a/pkg/client/v1/clientcmd/api/v1/conversion.go
+++ b/pkg/client/v1/clientcmd/api/v1/conversion.go
@@ -1,0 +1,231 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"sort"
+
+	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
+	"k8s.io/kubernetes/pkg/conversion"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+func init() {
+	err := api.Scheme.AddConversionFuncs(
+		func(in *Cluster, out *api.Cluster, s conversion.Scope) error {
+			return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
+		},
+		func(in *api.Cluster, out *Cluster, s conversion.Scope) error {
+			return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
+		},
+		func(in *Preferences, out *api.Preferences, s conversion.Scope) error {
+			return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
+		},
+		func(in *api.Preferences, out *Preferences, s conversion.Scope) error {
+			return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
+		},
+		func(in *AuthInfo, out *api.AuthInfo, s conversion.Scope) error {
+			return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
+		},
+		func(in *api.AuthInfo, out *AuthInfo, s conversion.Scope) error {
+			return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
+		},
+		func(in *Context, out *api.Context, s conversion.Scope) error {
+			return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
+		},
+		func(in *api.Context, out *Context, s conversion.Scope) error {
+			return s.DefaultConvert(in, out, conversion.IgnoreMissingFields)
+		},
+
+		func(in *Config, out *api.Config, s conversion.Scope) error {
+			out.CurrentContext = in.CurrentContext
+			if err := s.Convert(&in.Preferences, &out.Preferences, 0); err != nil {
+				return err
+			}
+
+			out.Clusters = make(map[string]*api.Cluster)
+			if err := s.Convert(&in.Clusters, &out.Clusters, 0); err != nil {
+				return err
+			}
+			out.AuthInfos = make(map[string]*api.AuthInfo)
+			if err := s.Convert(&in.AuthInfos, &out.AuthInfos, 0); err != nil {
+				return err
+			}
+			out.Contexts = make(map[string]*api.Context)
+			if err := s.Convert(&in.Contexts, &out.Contexts, 0); err != nil {
+				return err
+			}
+			out.Extensions = make(map[string]*runtime.EmbeddedObject)
+			if err := s.Convert(&in.Extensions, &out.Extensions, 0); err != nil {
+				return err
+			}
+			return nil
+		},
+		func(in *api.Config, out *Config, s conversion.Scope) error {
+			out.CurrentContext = in.CurrentContext
+			if err := s.Convert(&in.Preferences, &out.Preferences, 0); err != nil {
+				return err
+			}
+
+			out.Clusters = make([]NamedCluster, 0, 0)
+			if err := s.Convert(&in.Clusters, &out.Clusters, 0); err != nil {
+				return err
+			}
+			out.AuthInfos = make([]NamedAuthInfo, 0, 0)
+			if err := s.Convert(&in.AuthInfos, &out.AuthInfos, 0); err != nil {
+				return err
+			}
+			out.Contexts = make([]NamedContext, 0, 0)
+			if err := s.Convert(&in.Contexts, &out.Contexts, 0); err != nil {
+				return err
+			}
+			out.Extensions = make([]NamedExtension, 0, 0)
+			if err := s.Convert(&in.Extensions, &out.Extensions, 0); err != nil {
+				return err
+			}
+			return nil
+		},
+		func(in *[]NamedCluster, out *map[string]*api.Cluster, s conversion.Scope) error {
+			for _, curr := range *in {
+				newCluster := api.NewCluster()
+				if err := s.Convert(&curr.Cluster, newCluster, 0); err != nil {
+					return err
+				}
+				(*out)[curr.Name] = newCluster
+			}
+
+			return nil
+		},
+		func(in *map[string]*api.Cluster, out *[]NamedCluster, s conversion.Scope) error {
+			allKeys := make([]string, 0, len(*in))
+			for key := range *in {
+				allKeys = append(allKeys, key)
+			}
+			sort.Strings(allKeys)
+
+			for _, key := range allKeys {
+				newCluster := (*in)[key]
+				oldCluster := &Cluster{}
+				if err := s.Convert(newCluster, oldCluster, 0); err != nil {
+					return err
+				}
+
+				namedCluster := NamedCluster{key, *oldCluster}
+				*out = append(*out, namedCluster)
+			}
+
+			return nil
+		},
+		func(in *[]NamedAuthInfo, out *map[string]*api.AuthInfo, s conversion.Scope) error {
+			for _, curr := range *in {
+				newAuthInfo := api.NewAuthInfo()
+				if err := s.Convert(&curr.AuthInfo, newAuthInfo, 0); err != nil {
+					return err
+				}
+				(*out)[curr.Name] = newAuthInfo
+			}
+
+			return nil
+		},
+		func(in *map[string]*api.AuthInfo, out *[]NamedAuthInfo, s conversion.Scope) error {
+			allKeys := make([]string, 0, len(*in))
+			for key := range *in {
+				allKeys = append(allKeys, key)
+			}
+			sort.Strings(allKeys)
+
+			for _, key := range allKeys {
+				newAuthInfo := (*in)[key]
+				oldAuthInfo := &AuthInfo{}
+				if err := s.Convert(newAuthInfo, oldAuthInfo, 0); err != nil {
+					return err
+				}
+
+				namedAuthInfo := NamedAuthInfo{key, *oldAuthInfo}
+				*out = append(*out, namedAuthInfo)
+			}
+
+			return nil
+		},
+		func(in *[]NamedContext, out *map[string]*api.Context, s conversion.Scope) error {
+			for _, curr := range *in {
+				newContext := api.NewContext()
+				if err := s.Convert(&curr.Context, newContext, 0); err != nil {
+					return err
+				}
+				(*out)[curr.Name] = newContext
+			}
+
+			return nil
+		},
+		func(in *map[string]*api.Context, out *[]NamedContext, s conversion.Scope) error {
+			allKeys := make([]string, 0, len(*in))
+			for key := range *in {
+				allKeys = append(allKeys, key)
+			}
+			sort.Strings(allKeys)
+
+			for _, key := range allKeys {
+				newContext := (*in)[key]
+				oldContext := &Context{}
+				if err := s.Convert(newContext, oldContext, 0); err != nil {
+					return err
+				}
+
+				namedContext := NamedContext{key, *oldContext}
+				*out = append(*out, namedContext)
+			}
+
+			return nil
+		},
+		func(in *[]NamedExtension, out *map[string]*runtime.EmbeddedObject, s conversion.Scope) error {
+			for _, curr := range *in {
+				newExtension := &runtime.EmbeddedObject{}
+				if err := s.Convert(&curr.Extension, newExtension, 0); err != nil {
+					return err
+				}
+				(*out)[curr.Name] = newExtension
+			}
+
+			return nil
+		},
+		func(in *map[string]*runtime.EmbeddedObject, out *[]NamedExtension, s conversion.Scope) error {
+			allKeys := make([]string, 0, len(*in))
+			for key := range *in {
+				allKeys = append(allKeys, key)
+			}
+			sort.Strings(allKeys)
+
+			for _, key := range allKeys {
+				newExtension := (*in)[key]
+				oldExtension := &runtime.RawExtension{}
+				if err := s.Convert(newExtension, oldExtension, 0); err != nil {
+					return err
+				}
+
+				namedExtension := NamedExtension{key, *oldExtension}
+				*out = append(*out, namedExtension)
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		// If one of the conversion functions is malformed, detect it immediately.
+		panic(err)
+	}
+}

--- a/pkg/client/v1/clientcmd/api/v1/conversion.go
+++ b/pkg/client/v1/clientcmd/api/v1/conversion.go
@@ -19,7 +19,7 @@ package v1
 import (
 	"sort"
 
-	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
+	"k8s.io/kubernetes/pkg/client/v1/clientcmd/api"
 	"k8s.io/kubernetes/pkg/conversion"
 	"k8s.io/kubernetes/pkg/runtime"
 )

--- a/pkg/client/v1/clientcmd/api/v1/register.go
+++ b/pkg/client/v1/clientcmd/api/v1/register.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+// Codec encodes internal objects to the v1 scheme
+var Codec = runtime.CodecFor(api.Scheme, "v1")
+
+func init() {
+	api.Scheme.AddKnownTypes("v1",
+		&Config{},
+	)
+}
+
+func (*Config) IsAnAPIObject() {}

--- a/pkg/client/v1/clientcmd/api/v1/register.go
+++ b/pkg/client/v1/clientcmd/api/v1/register.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v1
 
 import (
-	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
+	"k8s.io/kubernetes/pkg/client/v1/clientcmd/api"
 	"k8s.io/kubernetes/pkg/runtime"
 )
 

--- a/pkg/client/v1/clientcmd/api/v1/types.go
+++ b/pkg/client/v1/clientcmd/api/v1/types.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+// Where possible, json tags match the cli argument names.
+// Top level config objects and all values required for proper functioning are not "omitempty".  Any truly optional piece of config is allowed to be omitted.
+
+// Config holds the information needed to build connect to remote kubernetes clusters as a given user
+type Config struct {
+	// Legacy field from pkg/api/types.go TypeMeta.
+	// TODO(jlowdermilk): remove this after eliminating downstream dependencies.
+	Kind string `json:"kind,omitempty"`
+	// Version of the schema for this config object.
+	APIVersion string `json:"apiVersion,omitempty"`
+	// Preferences holds general information to be use for cli interactions
+	Preferences Preferences `json:"preferences"`
+	// Clusters is a map of referencable names to cluster configs
+	Clusters []NamedCluster `json:"clusters"`
+	// AuthInfos is a map of referencable names to user configs
+	AuthInfos []NamedAuthInfo `json:"users"`
+	// Contexts is a map of referencable names to context configs
+	Contexts []NamedContext `json:"contexts"`
+	// CurrentContext is the name of the context that you would like to use by default
+	CurrentContext string `json:"current-context"`
+	// Extensions holds additional information. This is useful for extenders so that reads and writes don't clobber unknown fields
+	Extensions []NamedExtension `json:"extensions,omitempty"`
+}
+
+type Preferences struct {
+	Colors bool `json:"colors,omitempty"`
+	// Extensions holds additional information. This is useful for extenders so that reads and writes don't clobber unknown fields
+	Extensions []NamedExtension `json:"extensions,omitempty"`
+}
+
+// Cluster contains information about how to communicate with a kubernetes cluster
+type Cluster struct {
+	// Server is the address of the kubernetes cluster (https://hostname:port).
+	Server string `json:"server"`
+	// APIVersion is the preferred api version for communicating with the kubernetes cluster (v1, v2, etc).
+	APIVersion string `json:"api-version,omitempty"`
+	// InsecureSkipTLSVerify skips the validity check for the server's certificate. This will make your HTTPS connections insecure.
+	InsecureSkipTLSVerify bool `json:"insecure-skip-tls-verify,omitempty"`
+	// CertificateAuthority is the path to a cert file for the certificate authority.
+	CertificateAuthority string `json:"certificate-authority,omitempty"`
+	// CertificateAuthorityData contains PEM-encoded certificate authority certificates. Overrides CertificateAuthority
+	CertificateAuthorityData []byte `json:"certificate-authority-data,omitempty"`
+	// Extensions holds additional information. This is useful for extenders so that reads and writes don't clobber unknown fields
+	Extensions []NamedExtension `json:"extensions,omitempty"`
+}
+
+// AuthInfo contains information that describes identity information.  This is use to tell the kubernetes cluster who you are.
+type AuthInfo struct {
+	// ClientCertificate is the path to a client cert file for TLS.
+	ClientCertificate string `json:"client-certificate,omitempty"`
+	// ClientCertificateData contains PEM-encoded data from a client cert file for TLS. Overrides ClientCertificate
+	ClientCertificateData []byte `json:"client-certificate-data,omitempty"`
+	// ClientKey is the path to a client key file for TLS.
+	ClientKey string `json:"client-key,omitempty"`
+	// ClientKeyData contains PEM-encoded data from a client key file for TLS. Overrides ClientKey
+	ClientKeyData []byte `json:"client-key-data,omitempty"`
+	// Token is the bearer token for authentication to the kubernetes cluster.
+	Token string `json:"token,omitempty"`
+	// Username is the username for basic authentication to the kubernetes cluster.
+	Username string `json:"username,omitempty"`
+	// Password is the password for basic authentication to the kubernetes cluster.
+	Password string `json:"password,omitempty"`
+	// Extensions holds additional information. This is useful for extenders so that reads and writes don't clobber unknown fields
+	Extensions []NamedExtension `json:"extensions,omitempty"`
+}
+
+// Context is a tuple of references to a cluster (how do I communicate with a kubernetes cluster), a user (how do I identify myself), and a namespace (what subset of resources do I want to work with)
+type Context struct {
+	// Cluster is the name of the cluster for this context
+	Cluster string `json:"cluster"`
+	// AuthInfo is the name of the authInfo for this context
+	AuthInfo string `json:"user"`
+	// Namespace is the default namespace to use on unspecified requests
+	Namespace string `json:"namespace,omitempty"`
+	// Extensions holds additional information. This is useful for extenders so that reads and writes don't clobber unknown fields
+	Extensions []NamedExtension `json:"extensions,omitempty"`
+}
+
+// NamedCluster relates nicknames to cluster information
+type NamedCluster struct {
+	// Name is the nickname for this Cluster
+	Name string `json:"name"`
+	// Cluster holds the cluster information
+	Cluster Cluster `json:"cluster"`
+}
+
+// NamedContext relates nicknames to context information
+type NamedContext struct {
+	// Name is the nickname for this Context
+	Name string `json:"name"`
+	// Context holds the context information
+	Context Context `json:"context"`
+}
+
+// NamedAuthInfo relates nicknames to auth information
+type NamedAuthInfo struct {
+	// Name is the nickname for this AuthInfo
+	Name string `json:"name"`
+	// AuthInfo holds the auth information
+	AuthInfo AuthInfo `json:"user"`
+}
+
+// NamedExtension relates nicknames to extension information
+type NamedExtension struct {
+	// Name is the nickname for this Extension
+	Name string `json:"name"`
+	// Extension holds the extension information
+	Extension runtime.RawExtension `json:"extension"`
+}

--- a/pkg/client/v1/clientcmd/auth_loaders.go
+++ b/pkg/client/v1/clientcmd/auth_loaders.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clientcmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+
+	clientauth "k8s.io/kubernetes/pkg/client/unversioned/auth"
+)
+
+// AuthLoaders are used to build clientauth.Info objects.
+type AuthLoader interface {
+	// LoadAuth takes a path to a config file and can then do anything it needs in order to return a valid clientauth.Info
+	LoadAuth(path string) (*clientauth.Info, error)
+}
+
+// default implementation of an AuthLoader
+type defaultAuthLoader struct{}
+
+// LoadAuth for defaultAuthLoader simply delegates to clientauth.LoadFromFile
+func (*defaultAuthLoader) LoadAuth(path string) (*clientauth.Info, error) {
+	return clientauth.LoadFromFile(path)
+}
+
+type PromptingAuthLoader struct {
+	reader io.Reader
+}
+
+// LoadAuth parses an AuthInfo object from a file path. It prompts user and creates file if it doesn't exist.
+func (a *PromptingAuthLoader) LoadAuth(path string) (*clientauth.Info, error) {
+	var auth clientauth.Info
+	// Prompt for user/pass and write a file if none exists.
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		auth = *a.Prompt()
+		data, err := json.Marshal(auth)
+		if err != nil {
+			return &auth, err
+		}
+		err = ioutil.WriteFile(path, data, 0600)
+		return &auth, err
+	}
+	authPtr, err := clientauth.LoadFromFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return authPtr, nil
+}
+
+// Prompt pulls the user and password from a reader
+func (a *PromptingAuthLoader) Prompt() *clientauth.Info {
+	auth := &clientauth.Info{}
+	auth.User = promptForString("Username", a.reader)
+	auth.Password = promptForString("Password", a.reader)
+
+	return auth
+}
+
+func promptForString(field string, r io.Reader) string {
+	fmt.Printf("Please enter %s: ", field)
+	var result string
+	fmt.Fscan(r, &result)
+	return result
+}
+
+// NewPromptingAuthLoader is an AuthLoader that parses an AuthInfo object from a file path. It prompts user and creates file if it doesn't exist.
+func NewPromptingAuthLoader(reader io.Reader) *PromptingAuthLoader {
+	return &PromptingAuthLoader{reader}
+}
+
+// NewDefaultAuthLoader returns a default implementation of an AuthLoader that only reads from a config file
+func NewDefaultAuthLoader() AuthLoader {
+	return &defaultAuthLoader{}
+}

--- a/pkg/client/v1/clientcmd/auth_loaders.go
+++ b/pkg/client/v1/clientcmd/auth_loaders.go
@@ -23,7 +23,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	clientauth "k8s.io/kubernetes/pkg/client/unversioned/auth"
+	clientauth "k8s.io/kubernetes/pkg/client/v1/auth"
 )
 
 // AuthLoaders are used to build clientauth.Info objects.

--- a/pkg/client/v1/clientcmd/client_config.go
+++ b/pkg/client/v1/clientcmd/client_config.go
@@ -1,0 +1,333 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clientcmd
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+
+	"github.com/imdario/mergo"
+
+	"k8s.io/kubernetes/pkg/api"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	clientauth "k8s.io/kubernetes/pkg/client/unversioned/auth"
+	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
+)
+
+var (
+	// DefaultCluster is the cluster config used when no other config is specified
+	// TODO: eventually apiserver should start on 443 and be secure by default
+	DefaultCluster = clientcmdapi.Cluster{Server: "http://localhost:8080"}
+
+	// EnvVarCluster allows overriding the DefaultCluster using an envvar for the server name
+	EnvVarCluster = clientcmdapi.Cluster{Server: os.Getenv("KUBERNETES_MASTER")}
+
+	DefaultClientConfig = DirectClientConfig{*clientcmdapi.NewConfig(), "", &ConfigOverrides{}, nil}
+)
+
+// ClientConfig is used to make it easy to get an api server client
+type ClientConfig interface {
+	// RawConfig returns the merged result of all overrides
+	RawConfig() (clientcmdapi.Config, error)
+	// ClientConfig returns a complete client config
+	ClientConfig() (*client.Config, error)
+	// Namespace returns the namespace resulting from the merged
+	// result of all overrides and a boolean indicating if it was
+	// overridden
+	Namespace() (string, bool, error)
+}
+
+// DirectClientConfig is a ClientConfig interface that is backed by a clientcmdapi.Config, options overrides, and an optional fallbackReader for auth information
+type DirectClientConfig struct {
+	config         clientcmdapi.Config
+	contextName    string
+	overrides      *ConfigOverrides
+	fallbackReader io.Reader
+}
+
+// NewDefaultClientConfig creates a DirectClientConfig using the config.CurrentContext as the context name
+func NewDefaultClientConfig(config clientcmdapi.Config, overrides *ConfigOverrides) ClientConfig {
+	return DirectClientConfig{config, config.CurrentContext, overrides, nil}
+}
+
+// NewNonInteractiveClientConfig creates a DirectClientConfig using the passed context name and does not have a fallback reader for auth information
+func NewNonInteractiveClientConfig(config clientcmdapi.Config, contextName string, overrides *ConfigOverrides) ClientConfig {
+	return DirectClientConfig{config, contextName, overrides, nil}
+}
+
+// NewInteractiveClientConfig creates a DirectClientConfig using the passed context name and a reader in case auth information is not provided via files or flags
+func NewInteractiveClientConfig(config clientcmdapi.Config, contextName string, overrides *ConfigOverrides, fallbackReader io.Reader) ClientConfig {
+	return DirectClientConfig{config, contextName, overrides, fallbackReader}
+}
+
+func (config DirectClientConfig) RawConfig() (clientcmdapi.Config, error) {
+	return config.config, nil
+}
+
+// ClientConfig implements ClientConfig
+func (config DirectClientConfig) ClientConfig() (*client.Config, error) {
+	if err := config.ConfirmUsable(); err != nil {
+		return nil, err
+	}
+
+	configAuthInfo := config.getAuthInfo()
+	configClusterInfo := config.getCluster()
+
+	clientConfig := &client.Config{}
+	clientConfig.Host = configClusterInfo.Server
+	if u, err := url.ParseRequestURI(clientConfig.Host); err == nil && u.Opaque == "" && len(u.Path) > 1 {
+		clientConfig.Prefix = u.Path
+		u.Path = ""
+		u.RawQuery = ""
+		u.Fragment = ""
+		clientConfig.Host = u.String()
+	}
+	clientConfig.Version = configClusterInfo.APIVersion
+
+	// only try to read the auth information if we are secure
+	if client.IsConfigTransportTLS(*clientConfig) {
+		var err error
+
+		// mergo is a first write wins for map value and a last writing wins for interface values
+		userAuthPartialConfig, err := getUserIdentificationPartialConfig(configAuthInfo, config.fallbackReader)
+		if err != nil {
+			return nil, err
+		}
+		mergo.Merge(clientConfig, userAuthPartialConfig)
+
+		serverAuthPartialConfig, err := getServerIdentificationPartialConfig(configAuthInfo, configClusterInfo)
+		if err != nil {
+			return nil, err
+		}
+		mergo.Merge(clientConfig, serverAuthPartialConfig)
+	}
+
+	return clientConfig, nil
+}
+
+// clientauth.Info object contain both user identification and server identification.  We want different precedence orders for
+// both, so we have to split the objects and merge them separately
+// we want this order of precedence for the server identification
+// 1.  configClusterInfo (the final result of command line flags and merged .kubeconfig files)
+// 2.  configAuthInfo.auth-path (this file can contain information that conflicts with #1, and we want #1 to win the priority)
+// 3.  load the ~/.kubernetes_auth file as a default
+func getServerIdentificationPartialConfig(configAuthInfo clientcmdapi.AuthInfo, configClusterInfo clientcmdapi.Cluster) (*client.Config, error) {
+	mergedConfig := &client.Config{}
+
+	// configClusterInfo holds the information identify the server provided by .kubeconfig
+	configClientConfig := &client.Config{}
+	configClientConfig.CAFile = configClusterInfo.CertificateAuthority
+	configClientConfig.CAData = configClusterInfo.CertificateAuthorityData
+	configClientConfig.Insecure = configClusterInfo.InsecureSkipTLSVerify
+	mergo.Merge(mergedConfig, configClientConfig)
+
+	return mergedConfig, nil
+}
+
+// clientauth.Info object contain both user identification and server identification.  We want different precedence orders for
+// both, so we have to split the objects and merge them separately
+// we want this order of precedence for user identifcation
+// 1.  configAuthInfo minus auth-path (the final result of command line flags and merged .kubeconfig files)
+// 2.  configAuthInfo.auth-path (this file can contain information that conflicts with #1, and we want #1 to win the priority)
+// 3.  if there is not enough information to idenfity the user, load try the ~/.kubernetes_auth file
+// 4.  if there is not enough information to identify the user, prompt if possible
+func getUserIdentificationPartialConfig(configAuthInfo clientcmdapi.AuthInfo, fallbackReader io.Reader) (*client.Config, error) {
+	mergedConfig := &client.Config{}
+
+	// blindly overwrite existing values based on precedence
+	if len(configAuthInfo.Token) > 0 {
+		mergedConfig.BearerToken = configAuthInfo.Token
+	}
+	if len(configAuthInfo.ClientCertificate) > 0 || len(configAuthInfo.ClientCertificateData) > 0 {
+		mergedConfig.CertFile = configAuthInfo.ClientCertificate
+		mergedConfig.CertData = configAuthInfo.ClientCertificateData
+		mergedConfig.KeyFile = configAuthInfo.ClientKey
+		mergedConfig.KeyData = configAuthInfo.ClientKeyData
+	}
+	if len(configAuthInfo.Username) > 0 || len(configAuthInfo.Password) > 0 {
+		mergedConfig.Username = configAuthInfo.Username
+		mergedConfig.Password = configAuthInfo.Password
+	}
+
+	// if there still isn't enough information to authenticate the user, try prompting
+	if !canIdentifyUser(*mergedConfig) && (fallbackReader != nil) {
+		prompter := NewPromptingAuthLoader(fallbackReader)
+		promptedAuthInfo := prompter.Prompt()
+
+		promptedConfig := makeUserIdentificationConfig(*promptedAuthInfo)
+		previouslyMergedConfig := mergedConfig
+		mergedConfig = &client.Config{}
+		mergo.Merge(mergedConfig, promptedConfig)
+		mergo.Merge(mergedConfig, previouslyMergedConfig)
+	}
+
+	return mergedConfig, nil
+}
+
+// makeUserIdentificationFieldsConfig returns a client.Config capable of being merged using mergo for only user identification information
+func makeUserIdentificationConfig(info clientauth.Info) *client.Config {
+	config := &client.Config{}
+	config.Username = info.User
+	config.Password = info.Password
+	config.CertFile = info.CertFile
+	config.KeyFile = info.KeyFile
+	config.BearerToken = info.BearerToken
+	return config
+}
+
+// makeUserIdentificationFieldsConfig returns a client.Config capable of being merged using mergo for only server identification information
+func makeServerIdentificationConfig(info clientauth.Info) client.Config {
+	config := client.Config{}
+	config.CAFile = info.CAFile
+	if info.Insecure != nil {
+		config.Insecure = *info.Insecure
+	}
+	return config
+}
+
+func canIdentifyUser(config client.Config) bool {
+	return len(config.Username) > 0 ||
+		(len(config.CertFile) > 0 || len(config.CertData) > 0) ||
+		len(config.BearerToken) > 0
+
+}
+
+// Namespace implements KubeConfig
+func (config DirectClientConfig) Namespace() (string, bool, error) {
+	if err := config.ConfirmUsable(); err != nil {
+		return "", false, err
+	}
+
+	configContext := config.getContext()
+
+	if len(configContext.Namespace) == 0 {
+		return api.NamespaceDefault, false, nil
+	}
+
+	overridden := false
+	if config.overrides != nil && config.overrides.Context.Namespace != "" {
+		overridden = true
+	}
+	return configContext.Namespace, overridden, nil
+}
+
+// ConfirmUsable looks a particular context and determines if that particular part of the config is useable.  There might still be errors in the config,
+// but no errors in the sections requested or referenced.  It does not return early so that it can find as many errors as possible.
+func (config DirectClientConfig) ConfirmUsable() error {
+	validationErrors := make([]error, 0)
+	validationErrors = append(validationErrors, validateAuthInfo(config.getAuthInfoName(), config.getAuthInfo())...)
+	validationErrors = append(validationErrors, validateClusterInfo(config.getClusterName(), config.getCluster())...)
+
+	return newErrConfigurationInvalid(validationErrors)
+}
+
+func (config DirectClientConfig) getContextName() string {
+	if len(config.overrides.CurrentContext) != 0 {
+		return config.overrides.CurrentContext
+	}
+	if len(config.contextName) != 0 {
+		return config.contextName
+	}
+
+	return config.config.CurrentContext
+}
+
+func (config DirectClientConfig) getAuthInfoName() string {
+	if len(config.overrides.Context.AuthInfo) != 0 {
+		return config.overrides.Context.AuthInfo
+	}
+	return config.getContext().AuthInfo
+}
+
+func (config DirectClientConfig) getClusterName() string {
+	if len(config.overrides.Context.Cluster) != 0 {
+		return config.overrides.Context.Cluster
+	}
+	return config.getContext().Cluster
+}
+
+func (config DirectClientConfig) getContext() clientcmdapi.Context {
+	contexts := config.config.Contexts
+	contextName := config.getContextName()
+
+	var mergedContext clientcmdapi.Context
+	if configContext, exists := contexts[contextName]; exists {
+		mergo.Merge(&mergedContext, configContext)
+	}
+	mergo.Merge(&mergedContext, config.overrides.Context)
+
+	return mergedContext
+}
+
+func (config DirectClientConfig) getAuthInfo() clientcmdapi.AuthInfo {
+	authInfos := config.config.AuthInfos
+	authInfoName := config.getAuthInfoName()
+
+	var mergedAuthInfo clientcmdapi.AuthInfo
+	if configAuthInfo, exists := authInfos[authInfoName]; exists {
+		mergo.Merge(&mergedAuthInfo, configAuthInfo)
+	}
+	mergo.Merge(&mergedAuthInfo, config.overrides.AuthInfo)
+
+	return mergedAuthInfo
+}
+
+func (config DirectClientConfig) getCluster() clientcmdapi.Cluster {
+	clusterInfos := config.config.Clusters
+	clusterInfoName := config.getClusterName()
+
+	var mergedClusterInfo clientcmdapi.Cluster
+	mergo.Merge(&mergedClusterInfo, DefaultCluster)
+	mergo.Merge(&mergedClusterInfo, EnvVarCluster)
+	if configClusterInfo, exists := clusterInfos[clusterInfoName]; exists {
+		mergo.Merge(&mergedClusterInfo, configClusterInfo)
+	}
+	mergo.Merge(&mergedClusterInfo, config.overrides.ClusterInfo)
+
+	return mergedClusterInfo
+}
+
+// inClusterClientConfig makes a config that will work from within a kubernetes cluster container environment.
+type inClusterClientConfig struct{}
+
+func (inClusterClientConfig) RawConfig() (clientcmdapi.Config, error) {
+	return clientcmdapi.Config{}, fmt.Errorf("inCluster environment config doesn't support multiple clusters")
+}
+
+func (inClusterClientConfig) ClientConfig() (*client.Config, error) {
+	return client.InClusterConfig()
+}
+
+func (inClusterClientConfig) Namespace() (string, error) {
+	// TODO: generic way to figure out what namespace you are running in?
+	// This way assumes you've set the POD_NAMESPACE environment variable
+	// using the downward API.
+	if ns := os.Getenv("POD_NAMESPACE"); ns != "" {
+		return ns, nil
+	}
+	return "default", nil
+}
+
+// Possible returns true if loading an inside-kubernetes-cluster is possible.
+func (inClusterClientConfig) Possible() bool {
+	fi, err := os.Stat("/var/run/secrets/kubernetes.io/serviceaccount/token")
+	return os.Getenv("KUBERNETES_SERVICE_HOST") != "" &&
+		os.Getenv("KUBERNETES_SERVICE_PORT") != "" &&
+		err == nil && !fi.IsDir()
+}

--- a/pkg/client/v1/clientcmd/client_config.go
+++ b/pkg/client/v1/clientcmd/client_config.go
@@ -25,9 +25,9 @@ import (
 	"github.com/imdario/mergo"
 
 	"k8s.io/kubernetes/pkg/api"
-	client "k8s.io/kubernetes/pkg/client/unversioned"
-	clientauth "k8s.io/kubernetes/pkg/client/unversioned/auth"
-	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
+	client "k8s.io/kubernetes/pkg/client/v1"
+	clientauth "k8s.io/kubernetes/pkg/client/v1/auth"
+	clientcmdapi "k8s.io/kubernetes/pkg/client/v1/clientcmd/api"
 )
 
 var (

--- a/pkg/client/v1/clientcmd/client_config_test.go
+++ b/pkg/client/v1/clientcmd/client_config_test.go
@@ -1,0 +1,254 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clientcmd
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api/testapi"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
+)
+
+func createValidTestConfig() *clientcmdapi.Config {
+	const (
+		server = "https://anything.com:8080"
+		token  = "the-token"
+	)
+
+	config := clientcmdapi.NewConfig()
+	config.Clusters["clean"] = &clientcmdapi.Cluster{
+		Server:     server,
+		APIVersion: testapi.Default.Version(),
+	}
+	config.AuthInfos["clean"] = &clientcmdapi.AuthInfo{
+		Token: token,
+	}
+	config.Contexts["clean"] = &clientcmdapi.Context{
+		Cluster:  "clean",
+		AuthInfo: "clean",
+	}
+	config.CurrentContext = "clean"
+
+	return config
+}
+
+func TestMergeContext(t *testing.T) {
+	const namespace = "overriden-namespace"
+
+	config := createValidTestConfig()
+	clientBuilder := NewNonInteractiveClientConfig(*config, "clean", &ConfigOverrides{})
+
+	_, overridden, err := clientBuilder.Namespace()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	if overridden {
+		t.Error("Expected namespace to not be overridden")
+	}
+
+	clientBuilder = NewNonInteractiveClientConfig(*config, "clean", &ConfigOverrides{
+		Context: clientcmdapi.Context{
+			Namespace: namespace,
+		},
+	})
+
+	actual, overridden, err := clientBuilder.Namespace()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	if !overridden {
+		t.Error("Expected namespace to be overridden")
+	}
+
+	matchStringArg(namespace, actual, t)
+}
+
+func TestCertificateData(t *testing.T) {
+	caData := []byte("ca-data")
+	certData := []byte("cert-data")
+	keyData := []byte("key-data")
+
+	config := clientcmdapi.NewConfig()
+	config.Clusters["clean"] = &clientcmdapi.Cluster{
+		Server:                   "https://localhost:8443",
+		APIVersion:               testapi.Default.Version(),
+		CertificateAuthorityData: caData,
+	}
+	config.AuthInfos["clean"] = &clientcmdapi.AuthInfo{
+		ClientCertificateData: certData,
+		ClientKeyData:         keyData,
+	}
+	config.Contexts["clean"] = &clientcmdapi.Context{
+		Cluster:  "clean",
+		AuthInfo: "clean",
+	}
+	config.CurrentContext = "clean"
+
+	clientBuilder := NewNonInteractiveClientConfig(*config, "clean", &ConfigOverrides{})
+
+	clientConfig, err := clientBuilder.ClientConfig()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Make sure cert data gets into config (will override file paths)
+	matchByteArg(caData, clientConfig.TLSClientConfig.CAData, t)
+	matchByteArg(certData, clientConfig.TLSClientConfig.CertData, t)
+	matchByteArg(keyData, clientConfig.TLSClientConfig.KeyData, t)
+}
+
+func TestBasicAuthData(t *testing.T) {
+	username := "myuser"
+	password := "mypass"
+
+	config := clientcmdapi.NewConfig()
+	config.Clusters["clean"] = &clientcmdapi.Cluster{
+		Server:     "https://localhost:8443",
+		APIVersion: testapi.Default.Version(),
+	}
+	config.AuthInfos["clean"] = &clientcmdapi.AuthInfo{
+		Username: username,
+		Password: password,
+	}
+	config.Contexts["clean"] = &clientcmdapi.Context{
+		Cluster:  "clean",
+		AuthInfo: "clean",
+	}
+	config.CurrentContext = "clean"
+
+	clientBuilder := NewNonInteractiveClientConfig(*config, "clean", &ConfigOverrides{})
+
+	clientConfig, err := clientBuilder.ClientConfig()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Make sure basic auth data gets into config
+	matchStringArg(username, clientConfig.Username, t)
+	matchStringArg(password, clientConfig.Password, t)
+}
+
+func TestCreateClean(t *testing.T) {
+	config := createValidTestConfig()
+	clientBuilder := NewNonInteractiveClientConfig(*config, "clean", &ConfigOverrides{})
+
+	clientConfig, err := clientBuilder.ClientConfig()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	matchStringArg(config.Clusters["clean"].Server, clientConfig.Host, t)
+	matchStringArg("", clientConfig.Prefix, t)
+	matchStringArg(config.Clusters["clean"].APIVersion, clientConfig.Version, t)
+	matchBoolArg(config.Clusters["clean"].InsecureSkipTLSVerify, clientConfig.Insecure, t)
+	matchStringArg(config.AuthInfos["clean"].Token, clientConfig.BearerToken, t)
+}
+
+func TestCreateCleanWithPrefix(t *testing.T) {
+	tt := []struct {
+		server string
+		host   string
+		prefix string
+	}{
+		{"https://anything.com:8080/foo/bar", "https://anything.com:8080", "/foo/bar"},
+		{"http://anything.com:8080/foo/bar", "http://anything.com:8080", "/foo/bar"},
+		{"http://anything.com:8080/foo/bar/", "http://anything.com:8080", "/foo/bar/"},
+		{"http://anything.com:8080/", "http://anything.com:8080/", ""},
+		{"http://anything.com:8080//", "http://anything.com:8080", "//"},
+		{"anything.com:8080/foo/bar", "anything.com:8080/foo/bar", ""},
+		{"anything.com:8080", "anything.com:8080", ""},
+		{"anything.com", "anything.com", ""},
+		{"anything", "anything", ""},
+	}
+
+	// WARNING: EnvVarCluster.Server is set during package loading time and can not be overriden by os.Setenv inside this test
+	EnvVarCluster.Server = ""
+	tt = append(tt, struct{ server, host, prefix string }{"", "http://localhost:8080", ""})
+
+	for _, tc := range tt {
+		config := createValidTestConfig()
+
+		cleanConfig := config.Clusters["clean"]
+		cleanConfig.Server = tc.server
+		config.Clusters["clean"] = cleanConfig
+
+		clientBuilder := NewNonInteractiveClientConfig(*config, "clean", &ConfigOverrides{})
+
+		clientConfig, err := clientBuilder.ClientConfig()
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		matchStringArg(tc.host, clientConfig.Host, t)
+		matchStringArg(tc.prefix, clientConfig.Prefix, t)
+	}
+}
+
+func TestCreateCleanDefault(t *testing.T) {
+	config := createValidTestConfig()
+	clientBuilder := NewDefaultClientConfig(*config, &ConfigOverrides{})
+
+	clientConfig, err := clientBuilder.ClientConfig()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	matchStringArg(config.Clusters["clean"].Server, clientConfig.Host, t)
+	matchStringArg(config.Clusters["clean"].APIVersion, clientConfig.Version, t)
+	matchBoolArg(config.Clusters["clean"].InsecureSkipTLSVerify, clientConfig.Insecure, t)
+	matchStringArg(config.AuthInfos["clean"].Token, clientConfig.BearerToken, t)
+}
+
+func TestCreateMissingContext(t *testing.T) {
+	const expectedErrorContains = "Context was not found for specified context"
+	config := createValidTestConfig()
+	clientBuilder := NewNonInteractiveClientConfig(*config, "not-present", &ConfigOverrides{})
+
+	clientConfig, err := clientBuilder.ClientConfig()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	expectedConfig := &client.Config{Host: clientConfig.Host}
+
+	if !reflect.DeepEqual(expectedConfig, clientConfig) {
+		t.Errorf("Expected %#v, got %#v", expectedConfig, clientConfig)
+	}
+
+}
+
+func matchBoolArg(expected, got bool, t *testing.T) {
+	if expected != got {
+		t.Errorf("Expected %v, got %v", expected, got)
+	}
+}
+
+func matchStringArg(expected, got string, t *testing.T) {
+	if expected != got {
+		t.Errorf("Expected %q, got %q", expected, got)
+	}
+}
+
+func matchByteArg(expected, got []byte, t *testing.T) {
+	if !reflect.DeepEqual(expected, got) {
+		t.Errorf("Expected %v, got %v", expected, got)
+	}
+}

--- a/pkg/client/v1/clientcmd/client_config_test.go
+++ b/pkg/client/v1/clientcmd/client_config_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api/testapi"
-	client "k8s.io/kubernetes/pkg/client/unversioned"
-	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
+	client "k8s.io/kubernetes/pkg/client/v1"
+	clientcmdapi "k8s.io/kubernetes/pkg/client/v1/clientcmd/api"
 )
 
 func createValidTestConfig() *clientcmdapi.Config {

--- a/pkg/client/v1/clientcmd/doc.go
+++ b/pkg/client/v1/clientcmd/doc.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package clientcmd provides one stop shopping for building a working client from a fixed config,
+from a .kubeconfig file, from command line flags, or from any merged combination.
+
+Sample usage from merged .kubeconfig files (local directory, home directory)
+	loadingRules := clientcmd.NewKubeConfigLoadingRules()
+	// if you want to change the loading rules (which files in which order), you can do so here
+
+	configOverrides := &clientcmd.ConfigOverrides{}
+	// if you want to change override values or bind them to flags, there are methods to help you
+
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingKubeConfig(loadingRules, configOverrides)
+	kubeConfig.Client()
+*/
+package clientcmd

--- a/pkg/client/v1/clientcmd/loader.go
+++ b/pkg/client/v1/clientcmd/loader.go
@@ -1,0 +1,449 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clientcmd
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/ghodss/yaml"
+	"github.com/imdario/mergo"
+
+	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
+	clientcmdlatest "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api/latest"
+	"k8s.io/kubernetes/pkg/util/errors"
+)
+
+const (
+	RecommendedConfigPathFlag   = "kubeconfig"
+	RecommendedConfigPathEnvVar = "KUBECONFIG"
+	RecommendedHomeFileName     = "/.kube/config"
+)
+
+var OldRecommendedHomeFile = path.Join(os.Getenv("HOME"), "/.kube/.kubeconfig")
+var RecommendedHomeFile = path.Join(os.Getenv("HOME"), RecommendedHomeFileName)
+
+// ClientConfigLoadingRules is an ExplicitPath and string slice of specific locations that are used for merging together a Config
+// Callers can put the chain together however they want, but we'd recommend:
+// EnvVarPathFiles if set (a list of files if set) OR the HomeDirectoryPath
+// ExplicitPath is special, because if a user specifically requests a certain file be used and error is reported if thie file is not present
+type ClientConfigLoadingRules struct {
+	ExplicitPath string
+	Precedence   []string
+
+	// MigrationRules is a map of destination files to source files.  If a destination file is not present, then the source file is checked.
+	// If the source file is present, then it is copied to the destination file BEFORE any further loading happens.
+	MigrationRules map[string]string
+
+	// DoNotResolvePaths indicates whether or not to resolve paths with respect to the originating files.  This is phrased as a negative so
+	// that a default object that doesn't set this will usually get the behavior it wants.
+	DoNotResolvePaths bool
+}
+
+// NewDefaultClientConfigLoadingRules returns a ClientConfigLoadingRules object with default fields filled in.  You are not required to
+// use this constructor
+func NewDefaultClientConfigLoadingRules() *ClientConfigLoadingRules {
+	chain := []string{}
+	migrationRules := map[string]string{}
+
+	envVarFiles := os.Getenv(RecommendedConfigPathEnvVar)
+	if len(envVarFiles) != 0 {
+		chain = append(chain, filepath.SplitList(envVarFiles)...)
+
+	} else {
+		chain = append(chain, RecommendedHomeFile)
+		migrationRules[RecommendedHomeFile] = OldRecommendedHomeFile
+
+	}
+
+	return &ClientConfigLoadingRules{
+		Precedence:     chain,
+		MigrationRules: migrationRules,
+	}
+}
+
+// Load starts by running the MigrationRules and then
+// takes the loading rules and returns a Config object based on following rules.
+//   if the ExplicitPath, return the unmerged explicit file
+//   Otherwise, return a merged config based on the Precedence slice
+// A missing ExplicitPath file produces an error. Empty filenames or other missing files are ignored.
+// Read errors or files with non-deserializable content produce errors.
+// The first file to set a particular map key wins and map key's value is never changed.
+// BUT, if you set a struct value that is NOT contained inside of map, the value WILL be changed.
+// This results in some odd looking logic to merge in one direction, merge in the other, and then merge the two.
+// It also means that if two files specify a "red-user", only values from the first file's red-user are used.  Even
+// non-conflicting entries from the second file's "red-user" are discarded.
+// Relative paths inside of the .kubeconfig files are resolved against the .kubeconfig file's parent folder
+// and only absolute file paths are returned.
+func (rules *ClientConfigLoadingRules) Load() (*clientcmdapi.Config, error) {
+	if err := rules.Migrate(); err != nil {
+		return nil, err
+	}
+
+	errlist := []error{}
+
+	kubeConfigFiles := []string{}
+
+	// Make sure a file we were explicitly told to use exists
+	if len(rules.ExplicitPath) > 0 {
+		if _, err := os.Stat(rules.ExplicitPath); os.IsNotExist(err) {
+			return nil, err
+		}
+		kubeConfigFiles = append(kubeConfigFiles, rules.ExplicitPath)
+
+	} else {
+		kubeConfigFiles = append(kubeConfigFiles, rules.Precedence...)
+
+	}
+
+	// first merge all of our maps
+	mapConfig := clientcmdapi.NewConfig()
+	for _, file := range kubeConfigFiles {
+		if err := mergeConfigWithFile(mapConfig, file); err != nil {
+			errlist = append(errlist, err)
+		}
+	}
+
+	// merge all of the struct values in the reverse order so that priority is given correctly
+	// errors are not added to the list the second time
+	nonMapConfig := clientcmdapi.NewConfig()
+	for i := len(kubeConfigFiles) - 1; i >= 0; i-- {
+		file := kubeConfigFiles[i]
+		mergeConfigWithFile(nonMapConfig, file)
+	}
+
+	// since values are overwritten, but maps values are not, we can merge the non-map config on top of the map config and
+	// get the values we expect.
+	config := clientcmdapi.NewConfig()
+	mergo.Merge(config, mapConfig)
+	mergo.Merge(config, nonMapConfig)
+
+	if rules.ResolvePaths() {
+		if err := ResolveLocalPaths(config); err != nil {
+			errlist = append(errlist, err)
+		}
+	}
+
+	return config, errors.NewAggregate(errlist)
+}
+
+// Migrate uses the MigrationRules map.  If a destination file is not present, then the source file is checked.
+// If the source file is present, then it is copied to the destination file BEFORE any further loading happens.
+func (rules *ClientConfigLoadingRules) Migrate() error {
+	if rules.MigrationRules == nil {
+		return nil
+	}
+
+	for destination, source := range rules.MigrationRules {
+		if _, err := os.Stat(destination); err == nil {
+			// if the destination already exists, do nothing
+			continue
+		} else if !os.IsNotExist(err) {
+			// if we had an error other than non-existence, fail
+			return err
+		}
+
+		if sourceInfo, err := os.Stat(source); err != nil {
+			if os.IsNotExist(err) {
+				// if the source file doesn't exist, there's no work to do.
+				continue
+			}
+
+			// if we had an error other than non-existence, fail
+			return err
+		} else if sourceInfo.IsDir() {
+			return fmt.Errorf("cannot migrate %v to %v because it is a directory", source, destination)
+		}
+
+		in, err := os.Open(source)
+		if err != nil {
+			return err
+		}
+		defer in.Close()
+		out, err := os.Create(destination)
+		if err != nil {
+			return err
+		}
+		defer out.Close()
+
+		if _, err = io.Copy(out, in); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func mergeConfigWithFile(startingConfig *clientcmdapi.Config, filename string) error {
+	if len(filename) == 0 {
+		// no work to do
+		return nil
+	}
+
+	config, err := LoadFromFile(filename)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("Error loading config file \"%s\": %v", filename, err)
+	}
+
+	mergo.Merge(startingConfig, config)
+
+	return nil
+}
+
+// LoadFromFile takes a filename and deserializes the contents into Config object
+func LoadFromFile(filename string) (*clientcmdapi.Config, error) {
+	kubeconfigBytes, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	config, err := Load(kubeconfigBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	// set LocationOfOrigin on every Cluster, User, and Context
+	for key, obj := range config.AuthInfos {
+		obj.LocationOfOrigin = filename
+		config.AuthInfos[key] = obj
+	}
+	for key, obj := range config.Clusters {
+		obj.LocationOfOrigin = filename
+		config.Clusters[key] = obj
+	}
+	for key, obj := range config.Contexts {
+		obj.LocationOfOrigin = filename
+		config.Contexts[key] = obj
+	}
+
+	return config, nil
+}
+
+// Load takes a byte slice and deserializes the contents into Config object.
+// Encapsulates deserialization without assuming the source is a file.
+func Load(data []byte) (*clientcmdapi.Config, error) {
+	config := clientcmdapi.NewConfig()
+	// if there's no data in a file, return the default object instead of failing (DecodeInto reject empty input)
+	if len(data) == 0 {
+		return config, nil
+	}
+
+	if err := clientcmdlatest.Codec.DecodeInto(data, config); err != nil {
+		return nil, err
+	}
+	return config, nil
+}
+
+// WriteToFile serializes the config to yaml and writes it out to a file.  If not present, it creates the file with the mode 0600.  If it is present
+// it stomps the contents
+func WriteToFile(config clientcmdapi.Config, filename string) error {
+	content, err := Write(config)
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(filename)
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		if err = os.MkdirAll(dir, 0755); err != nil {
+			return err
+		}
+	}
+	if err := ioutil.WriteFile(filename, content, 0600); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Write serializes the config to yaml.
+// Encapsulates serialization without assuming the destination is a file.
+func Write(config clientcmdapi.Config) ([]byte, error) {
+	json, err := clientcmdlatest.Codec.Encode(&config)
+	if err != nil {
+		return nil, err
+	}
+	content, err := yaml.JSONToYAML(json)
+	if err != nil {
+		return nil, err
+	}
+	return content, nil
+}
+
+func (rules ClientConfigLoadingRules) ResolvePaths() bool {
+	return !rules.DoNotResolvePaths
+}
+
+// ResolveLocalPaths resolves all relative paths in the config object with respect to the stanza's LocationOfOrigin
+// this cannot be done directly inside of LoadFromFile because doing so there would make it impossible to load a file without
+// modification of its contents.
+func ResolveLocalPaths(config *clientcmdapi.Config) error {
+	for _, cluster := range config.Clusters {
+		if len(cluster.LocationOfOrigin) == 0 {
+			continue
+		}
+		base, err := filepath.Abs(filepath.Dir(cluster.LocationOfOrigin))
+		if err != nil {
+			return fmt.Errorf("Could not determine the absolute path of config file %s: %v", cluster.LocationOfOrigin, err)
+		}
+
+		if err := ResolvePaths(GetClusterFileReferences(cluster), base); err != nil {
+			return err
+		}
+	}
+	for _, authInfo := range config.AuthInfos {
+		if len(authInfo.LocationOfOrigin) == 0 {
+			continue
+		}
+		base, err := filepath.Abs(filepath.Dir(authInfo.LocationOfOrigin))
+		if err != nil {
+			return fmt.Errorf("Could not determine the absolute path of config file %s: %v", authInfo.LocationOfOrigin, err)
+		}
+
+		if err := ResolvePaths(GetAuthInfoFileReferences(authInfo), base); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// RelativizeClusterLocalPaths first absolutizes the paths by calling ResolveLocalPaths.  This assumes that any NEW path is already
+// absolute, but any existing path will be resolved relative to LocationOfOrigin
+func RelativizeClusterLocalPaths(cluster *clientcmdapi.Cluster) error {
+	if len(cluster.LocationOfOrigin) == 0 {
+		return fmt.Errorf("no location of origin for %s", cluster.Server)
+	}
+	base, err := filepath.Abs(filepath.Dir(cluster.LocationOfOrigin))
+	if err != nil {
+		return fmt.Errorf("could not determine the absolute path of config file %s: %v", cluster.LocationOfOrigin, err)
+	}
+
+	if err := ResolvePaths(GetClusterFileReferences(cluster), base); err != nil {
+		return err
+	}
+	if err := RelativizePathWithNoBacksteps(GetClusterFileReferences(cluster), base); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// RelativizeAuthInfoLocalPaths first absolutizes the paths by calling ResolveLocalPaths.  This assumes that any NEW path is already
+// absolute, but any existing path will be resolved relative to LocationOfOrigin
+func RelativizeAuthInfoLocalPaths(authInfo *clientcmdapi.AuthInfo) error {
+	if len(authInfo.LocationOfOrigin) == 0 {
+		return fmt.Errorf("no location of origin for %v", authInfo)
+	}
+	base, err := filepath.Abs(filepath.Dir(authInfo.LocationOfOrigin))
+	if err != nil {
+		return fmt.Errorf("could not determine the absolute path of config file %s: %v", authInfo.LocationOfOrigin, err)
+	}
+
+	if err := ResolvePaths(GetAuthInfoFileReferences(authInfo), base); err != nil {
+		return err
+	}
+	if err := RelativizePathWithNoBacksteps(GetAuthInfoFileReferences(authInfo), base); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func RelativizeConfigPaths(config *clientcmdapi.Config, base string) error {
+	return RelativizePathWithNoBacksteps(GetConfigFileReferences(config), base)
+}
+
+func ResolveConfigPaths(config *clientcmdapi.Config, base string) error {
+	return ResolvePaths(GetConfigFileReferences(config), base)
+}
+
+func GetConfigFileReferences(config *clientcmdapi.Config) []*string {
+	refs := []*string{}
+
+	for _, cluster := range config.Clusters {
+		refs = append(refs, GetClusterFileReferences(cluster)...)
+	}
+	for _, authInfo := range config.AuthInfos {
+		refs = append(refs, GetAuthInfoFileReferences(authInfo)...)
+	}
+
+	return refs
+}
+
+func GetClusterFileReferences(cluster *clientcmdapi.Cluster) []*string {
+	return []*string{&cluster.CertificateAuthority}
+}
+
+func GetAuthInfoFileReferences(authInfo *clientcmdapi.AuthInfo) []*string {
+	return []*string{&authInfo.ClientCertificate, &authInfo.ClientKey}
+}
+
+// ResolvePaths updates the given refs to be absolute paths, relative to the given base directory
+func ResolvePaths(refs []*string, base string) error {
+	for _, ref := range refs {
+		// Don't resolve empty paths
+		if len(*ref) > 0 {
+			// Don't resolve absolute paths
+			if !filepath.IsAbs(*ref) {
+				*ref = filepath.Join(base, *ref)
+			}
+		}
+	}
+	return nil
+}
+
+// RelativizePathWithNoBacksteps updates the given refs to be relative paths, relative to the given base directory as long as they do not require backsteps.
+// Any path requiring a backstep is left as-is as long it is absolute.  Any non-absolute path that can't be relativized produces an error
+func RelativizePathWithNoBacksteps(refs []*string, base string) error {
+	for _, ref := range refs {
+		// Don't relativize empty paths
+		if len(*ref) > 0 {
+			rel, err := MakeRelative(*ref, base)
+			if err != nil {
+				return err
+			}
+
+			// if we have a backstep, don't mess with the path
+			if strings.HasPrefix(rel, "../") {
+				if filepath.IsAbs(*ref) {
+					continue
+				}
+
+				return fmt.Errorf("%v requires backsteps and is not absolute", *ref)
+			}
+
+			*ref = rel
+		}
+	}
+	return nil
+}
+
+func MakeRelative(path, base string) (string, error) {
+	if len(path) > 0 {
+		rel, err := filepath.Rel(base, path)
+		if err != nil {
+			return path, err
+		}
+		return rel, nil
+	}
+	return path, nil
+}

--- a/pkg/client/v1/clientcmd/loader.go
+++ b/pkg/client/v1/clientcmd/loader.go
@@ -28,8 +28,8 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/imdario/mergo"
 
-	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
-	clientcmdlatest "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api/latest"
+	clientcmdapi "k8s.io/kubernetes/pkg/client/v1/clientcmd/api"
+	clientcmdlatest "k8s.io/kubernetes/pkg/client/v1/clientcmd/api/latest"
 	"k8s.io/kubernetes/pkg/util/errors"
 )
 

--- a/pkg/client/v1/clientcmd/loader_test.go
+++ b/pkg/client/v1/clientcmd/loader_test.go
@@ -1,0 +1,535 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clientcmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/ghodss/yaml"
+
+	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
+	clientcmdlatest "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api/latest"
+)
+
+var (
+	testConfigAlfa = clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"red-user": {Token: "red-token"}},
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"cow-cluster": {Server: "http://cow.org:8080"}},
+		Contexts: map[string]*clientcmdapi.Context{
+			"federal-context": {AuthInfo: "red-user", Cluster: "cow-cluster", Namespace: "hammer-ns"}},
+	}
+	testConfigBravo = clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"black-user": {Token: "black-token"}},
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"pig-cluster": {Server: "http://pig.org:8080"}},
+		Contexts: map[string]*clientcmdapi.Context{
+			"queen-anne-context": {AuthInfo: "black-user", Cluster: "pig-cluster", Namespace: "saw-ns"}},
+	}
+	testConfigCharlie = clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"green-user": {Token: "green-token"}},
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"horse-cluster": {Server: "http://horse.org:8080"}},
+		Contexts: map[string]*clientcmdapi.Context{
+			"shaker-context": {AuthInfo: "green-user", Cluster: "horse-cluster", Namespace: "chisel-ns"}},
+	}
+	testConfigDelta = clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"blue-user": {Token: "blue-token"}},
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"chicken-cluster": {Server: "http://chicken.org:8080"}},
+		Contexts: map[string]*clientcmdapi.Context{
+			"gothic-context": {AuthInfo: "blue-user", Cluster: "chicken-cluster", Namespace: "plane-ns"}},
+	}
+
+	testConfigConflictAlfa = clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"red-user":    {Token: "a-different-red-token"},
+			"yellow-user": {Token: "yellow-token"}},
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"cow-cluster":    {Server: "http://a-different-cow.org:8080", InsecureSkipTLSVerify: true},
+			"donkey-cluster": {Server: "http://donkey.org:8080", InsecureSkipTLSVerify: true}},
+		CurrentContext: "federal-context",
+	}
+)
+
+func TestNonExistentCommandLineFile(t *testing.T) {
+	loadingRules := ClientConfigLoadingRules{
+		ExplicitPath: "bogus_file",
+	}
+
+	_, err := loadingRules.Load()
+	if err == nil {
+		t.Fatalf("Expected error for missing command-line file, got none")
+	}
+	if !strings.Contains(err.Error(), "bogus_file") {
+		t.Fatalf("Expected error about 'bogus_file', got %s", err.Error())
+	}
+}
+
+func TestToleratingMissingFiles(t *testing.T) {
+	loadingRules := ClientConfigLoadingRules{
+		Precedence: []string{"bogus1", "bogus2", "bogus3"},
+	}
+
+	_, err := loadingRules.Load()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}
+
+func TestErrorReadingFile(t *testing.T) {
+	commandLineFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(commandLineFile.Name())
+
+	if err := ioutil.WriteFile(commandLineFile.Name(), []byte("bogus value"), 0644); err != nil {
+		t.Fatalf("Error creating tempfile: %v", err)
+	}
+
+	loadingRules := ClientConfigLoadingRules{
+		ExplicitPath: commandLineFile.Name(),
+	}
+
+	_, err := loadingRules.Load()
+	if err == nil {
+		t.Fatalf("Expected error for unloadable file, got none")
+	}
+	if !strings.Contains(err.Error(), commandLineFile.Name()) {
+		t.Fatalf("Expected error about '%s', got %s", commandLineFile.Name(), err.Error())
+	}
+}
+
+func TestErrorReadingNonFile(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("Couldn't create tmpdir")
+	}
+	defer os.Remove(tmpdir)
+
+	loadingRules := ClientConfigLoadingRules{
+		ExplicitPath: tmpdir,
+	}
+
+	_, err = loadingRules.Load()
+	if err == nil {
+		t.Fatalf("Expected error for non-file, got none")
+	}
+	if !strings.Contains(err.Error(), tmpdir) {
+		t.Fatalf("Expected error about '%s', got %s", tmpdir, err.Error())
+	}
+}
+
+func TestConflictingCurrentContext(t *testing.T) {
+	commandLineFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(commandLineFile.Name())
+	envVarFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(envVarFile.Name())
+
+	mockCommandLineConfig := clientcmdapi.Config{
+		CurrentContext: "any-context-value",
+	}
+	mockEnvVarConfig := clientcmdapi.Config{
+		CurrentContext: "a-different-context",
+	}
+
+	WriteToFile(mockCommandLineConfig, commandLineFile.Name())
+	WriteToFile(mockEnvVarConfig, envVarFile.Name())
+
+	loadingRules := ClientConfigLoadingRules{
+		ExplicitPath: commandLineFile.Name(),
+		Precedence:   []string{envVarFile.Name()},
+	}
+
+	mergedConfig, err := loadingRules.Load()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	if mergedConfig.CurrentContext != mockCommandLineConfig.CurrentContext {
+		t.Errorf("expected %v, got %v", mockCommandLineConfig.CurrentContext, mergedConfig.CurrentContext)
+	}
+}
+
+func TestResolveRelativePaths(t *testing.T) {
+	pathResolutionConfig1 := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"relative-user-1": {ClientCertificate: "relative/client/cert", ClientKey: "../relative/client/key"},
+			"absolute-user-1": {ClientCertificate: "/absolute/client/cert", ClientKey: "/absolute/client/key"},
+		},
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"relative-server-1": {CertificateAuthority: "../relative/ca"},
+			"absolute-server-1": {CertificateAuthority: "/absolute/ca"},
+		},
+	}
+	pathResolutionConfig2 := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"relative-user-2": {ClientCertificate: "relative/client/cert2", ClientKey: "../relative/client/key2"},
+			"absolute-user-2": {ClientCertificate: "/absolute/client/cert2", ClientKey: "/absolute/client/key2"},
+		},
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"relative-server-2": {CertificateAuthority: "../relative/ca2"},
+			"absolute-server-2": {CertificateAuthority: "/absolute/ca2"},
+		},
+	}
+
+	configDir1, _ := ioutil.TempDir("", "")
+	configFile1 := path.Join(configDir1, ".kubeconfig")
+	configDir1, _ = filepath.Abs(configDir1)
+	defer os.Remove(configFile1)
+	configDir2, _ := ioutil.TempDir("", "")
+	configDir2, _ = ioutil.TempDir(configDir2, "")
+	configFile2 := path.Join(configDir2, ".kubeconfig")
+	configDir2, _ = filepath.Abs(configDir2)
+	defer os.Remove(configFile2)
+
+	WriteToFile(pathResolutionConfig1, configFile1)
+	WriteToFile(pathResolutionConfig2, configFile2)
+
+	loadingRules := ClientConfigLoadingRules{
+		Precedence: []string{configFile1, configFile2},
+	}
+
+	mergedConfig, err := loadingRules.Load()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	foundClusterCount := 0
+	for key, cluster := range mergedConfig.Clusters {
+		if key == "relative-server-1" {
+			foundClusterCount++
+			matchStringArg(path.Join(configDir1, pathResolutionConfig1.Clusters["relative-server-1"].CertificateAuthority), cluster.CertificateAuthority, t)
+		}
+		if key == "relative-server-2" {
+			foundClusterCount++
+			matchStringArg(path.Join(configDir2, pathResolutionConfig2.Clusters["relative-server-2"].CertificateAuthority), cluster.CertificateAuthority, t)
+		}
+		if key == "absolute-server-1" {
+			foundClusterCount++
+			matchStringArg(pathResolutionConfig1.Clusters["absolute-server-1"].CertificateAuthority, cluster.CertificateAuthority, t)
+		}
+		if key == "absolute-server-2" {
+			foundClusterCount++
+			matchStringArg(pathResolutionConfig2.Clusters["absolute-server-2"].CertificateAuthority, cluster.CertificateAuthority, t)
+		}
+	}
+	if foundClusterCount != 4 {
+		t.Errorf("Expected 4 clusters, found %v: %v", foundClusterCount, mergedConfig.Clusters)
+	}
+
+	foundAuthInfoCount := 0
+	for key, authInfo := range mergedConfig.AuthInfos {
+		if key == "relative-user-1" {
+			foundAuthInfoCount++
+			matchStringArg(path.Join(configDir1, pathResolutionConfig1.AuthInfos["relative-user-1"].ClientCertificate), authInfo.ClientCertificate, t)
+			matchStringArg(path.Join(configDir1, pathResolutionConfig1.AuthInfos["relative-user-1"].ClientKey), authInfo.ClientKey, t)
+		}
+		if key == "relative-user-2" {
+			foundAuthInfoCount++
+			matchStringArg(path.Join(configDir2, pathResolutionConfig2.AuthInfos["relative-user-2"].ClientCertificate), authInfo.ClientCertificate, t)
+			matchStringArg(path.Join(configDir2, pathResolutionConfig2.AuthInfos["relative-user-2"].ClientKey), authInfo.ClientKey, t)
+		}
+		if key == "absolute-user-1" {
+			foundAuthInfoCount++
+			matchStringArg(pathResolutionConfig1.AuthInfos["absolute-user-1"].ClientCertificate, authInfo.ClientCertificate, t)
+			matchStringArg(pathResolutionConfig1.AuthInfos["absolute-user-1"].ClientKey, authInfo.ClientKey, t)
+		}
+		if key == "absolute-user-2" {
+			foundAuthInfoCount++
+			matchStringArg(pathResolutionConfig2.AuthInfos["absolute-user-2"].ClientCertificate, authInfo.ClientCertificate, t)
+			matchStringArg(pathResolutionConfig2.AuthInfos["absolute-user-2"].ClientKey, authInfo.ClientKey, t)
+		}
+	}
+	if foundAuthInfoCount != 4 {
+		t.Errorf("Expected 4 users, found %v: %v", foundAuthInfoCount, mergedConfig.AuthInfos)
+	}
+
+}
+
+func TestMigratingFile(t *testing.T) {
+	sourceFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(sourceFile.Name())
+	destinationFile, _ := ioutil.TempFile("", "")
+	// delete the file so that we'll write to it
+	os.Remove(destinationFile.Name())
+
+	WriteToFile(testConfigAlfa, sourceFile.Name())
+
+	loadingRules := ClientConfigLoadingRules{
+		MigrationRules: map[string]string{destinationFile.Name(): sourceFile.Name()},
+	}
+
+	if _, err := loadingRules.Load(); err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+
+	// the load should have recreated this file
+	defer os.Remove(destinationFile.Name())
+
+	sourceContent, err := ioutil.ReadFile(sourceFile.Name())
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	destinationContent, err := ioutil.ReadFile(destinationFile.Name())
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+
+	if !reflect.DeepEqual(sourceContent, destinationContent) {
+		t.Errorf("source and destination do not match")
+	}
+}
+
+func TestMigratingFileLeaveExistingFileAlone(t *testing.T) {
+	sourceFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(sourceFile.Name())
+	destinationFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(destinationFile.Name())
+
+	WriteToFile(testConfigAlfa, sourceFile.Name())
+
+	loadingRules := ClientConfigLoadingRules{
+		MigrationRules: map[string]string{destinationFile.Name(): sourceFile.Name()},
+	}
+
+	if _, err := loadingRules.Load(); err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+
+	destinationContent, err := ioutil.ReadFile(destinationFile.Name())
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+
+	if len(destinationContent) > 0 {
+		t.Errorf("destination should not have been touched")
+	}
+}
+
+func TestMigratingFileSourceMissingSkip(t *testing.T) {
+	sourceFilename := "some-missing-file"
+	destinationFile, _ := ioutil.TempFile("", "")
+	// delete the file so that we'll write to it
+	os.Remove(destinationFile.Name())
+
+	loadingRules := ClientConfigLoadingRules{
+		MigrationRules: map[string]string{destinationFile.Name(): sourceFilename},
+	}
+
+	if _, err := loadingRules.Load(); err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+
+	if _, err := os.Stat(destinationFile.Name()); !os.IsNotExist(err) {
+		t.Errorf("destination should not exist")
+	}
+}
+
+func ExampleNoMergingOnExplicitPaths() {
+	commandLineFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(commandLineFile.Name())
+	envVarFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(envVarFile.Name())
+
+	WriteToFile(testConfigAlfa, commandLineFile.Name())
+	WriteToFile(testConfigConflictAlfa, envVarFile.Name())
+
+	loadingRules := ClientConfigLoadingRules{
+		ExplicitPath: commandLineFile.Name(),
+		Precedence:   []string{envVarFile.Name()},
+	}
+
+	mergedConfig, err := loadingRules.Load()
+
+	json, err := clientcmdlatest.Codec.Encode(mergedConfig)
+	if err != nil {
+		fmt.Printf("Unexpected error: %v", err)
+	}
+	output, err := yaml.JSONToYAML(json)
+	if err != nil {
+		fmt.Printf("Unexpected error: %v", err)
+	}
+
+	fmt.Printf("%v", string(output))
+	// Output:
+	// apiVersion: v1
+	// clusters:
+	// - cluster:
+	//     server: http://cow.org:8080
+	//   name: cow-cluster
+	// contexts:
+	// - context:
+	//     cluster: cow-cluster
+	//     namespace: hammer-ns
+	//     user: red-user
+	//   name: federal-context
+	// current-context: ""
+	// kind: Config
+	// preferences: {}
+	// users:
+	// - name: red-user
+	//   user:
+	//     token: red-token
+}
+
+func ExampleMergingSomeWithConflict() {
+	commandLineFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(commandLineFile.Name())
+	envVarFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(envVarFile.Name())
+
+	WriteToFile(testConfigAlfa, commandLineFile.Name())
+	WriteToFile(testConfigConflictAlfa, envVarFile.Name())
+
+	loadingRules := ClientConfigLoadingRules{
+		Precedence: []string{commandLineFile.Name(), envVarFile.Name()},
+	}
+
+	mergedConfig, err := loadingRules.Load()
+
+	json, err := clientcmdlatest.Codec.Encode(mergedConfig)
+	if err != nil {
+		fmt.Printf("Unexpected error: %v", err)
+	}
+	output, err := yaml.JSONToYAML(json)
+	if err != nil {
+		fmt.Printf("Unexpected error: %v", err)
+	}
+
+	fmt.Printf("%v", string(output))
+	// Output:
+	// apiVersion: v1
+	// clusters:
+	// - cluster:
+	//     server: http://cow.org:8080
+	//   name: cow-cluster
+	// - cluster:
+	//     insecure-skip-tls-verify: true
+	//     server: http://donkey.org:8080
+	//   name: donkey-cluster
+	// contexts:
+	// - context:
+	//     cluster: cow-cluster
+	//     namespace: hammer-ns
+	//     user: red-user
+	//   name: federal-context
+	// current-context: federal-context
+	// kind: Config
+	// preferences: {}
+	// users:
+	// - name: red-user
+	//   user:
+	//     token: red-token
+	// - name: yellow-user
+	//   user:
+	//     token: yellow-token
+}
+
+func ExampleMergingEverythingNoConflicts() {
+	commandLineFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(commandLineFile.Name())
+	envVarFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(envVarFile.Name())
+	currentDirFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(currentDirFile.Name())
+	homeDirFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(homeDirFile.Name())
+
+	WriteToFile(testConfigAlfa, commandLineFile.Name())
+	WriteToFile(testConfigBravo, envVarFile.Name())
+	WriteToFile(testConfigCharlie, currentDirFile.Name())
+	WriteToFile(testConfigDelta, homeDirFile.Name())
+
+	loadingRules := ClientConfigLoadingRules{
+		Precedence: []string{commandLineFile.Name(), envVarFile.Name(), currentDirFile.Name(), homeDirFile.Name()},
+	}
+
+	mergedConfig, err := loadingRules.Load()
+
+	json, err := clientcmdlatest.Codec.Encode(mergedConfig)
+	if err != nil {
+		fmt.Printf("Unexpected error: %v", err)
+	}
+	output, err := yaml.JSONToYAML(json)
+	if err != nil {
+		fmt.Printf("Unexpected error: %v", err)
+	}
+
+	fmt.Printf("%v", string(output))
+	// Output:
+	// 	apiVersion: v1
+	// clusters:
+	// - cluster:
+	//     server: http://chicken.org:8080
+	//   name: chicken-cluster
+	// - cluster:
+	//     server: http://cow.org:8080
+	//   name: cow-cluster
+	// - cluster:
+	//     server: http://horse.org:8080
+	//   name: horse-cluster
+	// - cluster:
+	//     server: http://pig.org:8080
+	//   name: pig-cluster
+	// contexts:
+	// - context:
+	//     cluster: cow-cluster
+	//     namespace: hammer-ns
+	//     user: red-user
+	//   name: federal-context
+	// - context:
+	//     cluster: chicken-cluster
+	//     namespace: plane-ns
+	//     user: blue-user
+	//   name: gothic-context
+	// - context:
+	//     cluster: pig-cluster
+	//     namespace: saw-ns
+	//     user: black-user
+	//   name: queen-anne-context
+	// - context:
+	//     cluster: horse-cluster
+	//     namespace: chisel-ns
+	//     user: green-user
+	//   name: shaker-context
+	// current-context: ""
+	// kind: Config
+	// preferences: {}
+	// users:
+	// - name: black-user
+	//   user:
+	//     token: black-token
+	// - name: blue-user
+	//   user:
+	//     token: blue-token
+	// - name: green-user
+	//   user:
+	//     token: green-token
+	// - name: red-user
+	//   user:
+	//     token: red-token
+}

--- a/pkg/client/v1/clientcmd/loader_test.go
+++ b/pkg/client/v1/clientcmd/loader_test.go
@@ -28,8 +28,8 @@ import (
 
 	"github.com/ghodss/yaml"
 
-	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
-	clientcmdlatest "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api/latest"
+	clientcmdapi "k8s.io/kubernetes/pkg/client/v1/clientcmd/api"
+	clientcmdlatest "k8s.io/kubernetes/pkg/client/v1/clientcmd/api/latest"
 )
 
 var (

--- a/pkg/client/v1/clientcmd/merged_client_builder.go
+++ b/pkg/client/v1/clientcmd/merged_client_builder.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clientcmd
+
+import (
+	"io"
+	"reflect"
+
+	"github.com/golang/glog"
+
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
+)
+
+// DeferredLoadingClientConfig is a ClientConfig interface that is backed by a set of loading rules
+// It is used in cases where the loading rules may change after you've instantiated them and you want to be sure that
+// the most recent rules are used.  This is useful in cases where you bind flags to loading rule parameters before
+// the parse happens and you want your calling code to be ignorant of how the values are being mutated to avoid
+// passing extraneous information down a call stack
+type DeferredLoadingClientConfig struct {
+	loadingRules   *ClientConfigLoadingRules
+	overrides      *ConfigOverrides
+	fallbackReader io.Reader
+}
+
+// NewNonInteractiveDeferredLoadingClientConfig creates a ConfigClientClientConfig using the passed context name
+func NewNonInteractiveDeferredLoadingClientConfig(loadingRules *ClientConfigLoadingRules, overrides *ConfigOverrides) ClientConfig {
+	return DeferredLoadingClientConfig{loadingRules, overrides, nil}
+}
+
+// NewInteractiveDeferredLoadingClientConfig creates a ConfigClientClientConfig using the passed context name and the fallback auth reader
+func NewInteractiveDeferredLoadingClientConfig(loadingRules *ClientConfigLoadingRules, overrides *ConfigOverrides, fallbackReader io.Reader) ClientConfig {
+	return DeferredLoadingClientConfig{loadingRules, overrides, fallbackReader}
+}
+
+func (config DeferredLoadingClientConfig) createClientConfig() (ClientConfig, error) {
+	mergedConfig, err := config.loadingRules.Load()
+	if err != nil {
+		return nil, err
+	}
+
+	var mergedClientConfig ClientConfig
+	if config.fallbackReader != nil {
+		mergedClientConfig = NewInteractiveClientConfig(*mergedConfig, config.overrides.CurrentContext, config.overrides, config.fallbackReader)
+	} else {
+		mergedClientConfig = NewNonInteractiveClientConfig(*mergedConfig, config.overrides.CurrentContext, config.overrides)
+	}
+
+	return mergedClientConfig, nil
+}
+
+func (config DeferredLoadingClientConfig) RawConfig() (clientcmdapi.Config, error) {
+	mergedConfig, err := config.createClientConfig()
+	if err != nil {
+		return clientcmdapi.Config{}, err
+	}
+
+	return mergedConfig.RawConfig()
+}
+
+// ClientConfig implements ClientConfig
+func (config DeferredLoadingClientConfig) ClientConfig() (*client.Config, error) {
+	mergedClientConfig, err := config.createClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	mergedConfig, err := mergedClientConfig.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	// Are we running in a cluster and were no other configs found? If so, use the in-cluster-config.
+	icc := inClusterClientConfig{}
+	defaultConfig, err := DefaultClientConfig.ClientConfig()
+	if icc.Possible() && err == nil && reflect.DeepEqual(mergedConfig, defaultConfig) {
+		glog.V(2).Info("no kubeconfig could be created, falling back to service account.")
+		return icc.ClientConfig()
+	}
+
+	return mergedConfig, nil
+}
+
+// Namespace implements KubeConfig
+func (config DeferredLoadingClientConfig) Namespace() (string, bool, error) {
+	mergedKubeConfig, err := config.createClientConfig()
+	if err != nil {
+		return "", false, err
+	}
+
+	return mergedKubeConfig.Namespace()
+}

--- a/pkg/client/v1/clientcmd/merged_client_builder.go
+++ b/pkg/client/v1/clientcmd/merged_client_builder.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/golang/glog"
 
-	client "k8s.io/kubernetes/pkg/client/unversioned"
-	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
+	client "k8s.io/kubernetes/pkg/client/v1"
+	clientcmdapi "k8s.io/kubernetes/pkg/client/v1/clientcmd/api"
 )
 
 // DeferredLoadingClientConfig is a ClientConfig interface that is backed by a set of loading rules

--- a/pkg/client/v1/clientcmd/overrides.go
+++ b/pkg/client/v1/clientcmd/overrides.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clientcmd
+
+import (
+	"strconv"
+
+	"github.com/spf13/pflag"
+
+	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
+)
+
+// ConfigOverrides holds values that should override whatever information is pulled from the actual Config object.  You can't
+// simply use an actual Config object, because Configs hold maps, but overrides are restricted to "at most one"
+type ConfigOverrides struct {
+	AuthInfo       clientcmdapi.AuthInfo
+	ClusterInfo    clientcmdapi.Cluster
+	Context        clientcmdapi.Context
+	CurrentContext string
+}
+
+// ConfigOverrideFlags holds the flag names to be used for binding command line flags.  Notice that this structure tightly
+// corresponds to ConfigOverrides
+type ConfigOverrideFlags struct {
+	AuthOverrideFlags    AuthOverrideFlags
+	ClusterOverrideFlags ClusterOverrideFlags
+	ContextOverrideFlags ContextOverrideFlags
+	CurrentContext       FlagInfo
+}
+
+// AuthOverrideFlags holds the flag names to be used for binding command line flags for AuthInfo objects
+type AuthOverrideFlags struct {
+	ClientCertificate FlagInfo
+	ClientKey         FlagInfo
+	Token             FlagInfo
+	Username          FlagInfo
+	Password          FlagInfo
+}
+
+// ContextOverrideFlags holds the flag names to be used for binding command line flags for Cluster objects
+type ContextOverrideFlags struct {
+	ClusterName  FlagInfo
+	AuthInfoName FlagInfo
+	Namespace    FlagInfo
+}
+
+// ClusterOverride holds the flag names to be used for binding command line flags for Cluster objects
+type ClusterOverrideFlags struct {
+	APIServer             FlagInfo
+	APIVersion            FlagInfo
+	CertificateAuthority  FlagInfo
+	InsecureSkipTLSVerify FlagInfo
+}
+
+// FlagInfo contains information about how to register a flag.  This struct is useful if you want to provide a way for an extender to
+// get back a set of recommended flag names, descriptions, and defaults, but allow for customization by an extender.  This makes for
+// coherent extension, without full prescription
+type FlagInfo struct {
+	// LongName is the long string for a flag.  If this is empty, then the flag will not be bound
+	LongName string
+	// ShortName is the single character for a flag.  If this is empty, then there will be no short flag
+	ShortName string
+	// Default is the default value for the flag
+	Default string
+	// Description is the description for the flag
+	Description string
+}
+
+// BindStringFlag binds the flag based on the provided info.  If LongName == "", nothing is registered
+func (f FlagInfo) BindStringFlag(flags *pflag.FlagSet, target *string) {
+	// you can't register a flag without a long name
+	if len(f.LongName) > 0 {
+		flags.StringVarP(target, f.LongName, f.ShortName, f.Default, f.Description)
+	}
+}
+
+// BindBoolFlag binds the flag based on the provided info.  If LongName == "", nothing is registered
+func (f FlagInfo) BindBoolFlag(flags *pflag.FlagSet, target *bool) {
+	// you can't register a flag without a long name
+	if len(f.LongName) > 0 {
+		// try to parse Default as a bool.  If it fails, assume false
+		boolVal, err := strconv.ParseBool(f.Default)
+		if err != nil {
+			boolVal = false
+		}
+
+		flags.BoolVarP(target, f.LongName, f.ShortName, boolVal, f.Description)
+	}
+}
+
+const (
+	FlagClusterName  = "cluster"
+	FlagAuthInfoName = "user"
+	FlagContext      = "context"
+	FlagNamespace    = "namespace"
+	FlagAPIServer    = "server"
+	FlagAPIVersion   = "api-version"
+	FlagInsecure     = "insecure-skip-tls-verify"
+	FlagCertFile     = "client-certificate"
+	FlagKeyFile      = "client-key"
+	FlagCAFile       = "certificate-authority"
+	FlagEmbedCerts   = "embed-certs"
+	FlagBearerToken  = "token"
+	FlagUsername     = "username"
+	FlagPassword     = "password"
+)
+
+// RecommendedAuthOverrideFlags is a convenience method to return recommended flag names prefixed with a string of your choosing
+func RecommendedAuthOverrideFlags(prefix string) AuthOverrideFlags {
+	return AuthOverrideFlags{
+		ClientCertificate: FlagInfo{prefix + FlagCertFile, "", "", "Path to a client key file for TLS."},
+		ClientKey:         FlagInfo{prefix + FlagKeyFile, "", "", "Path to a client key file for TLS."},
+		Token:             FlagInfo{prefix + FlagBearerToken, "", "", "Bearer token for authentication to the API server."},
+		Username:          FlagInfo{prefix + FlagUsername, "", "", "Username for basic authentication to the API server."},
+		Password:          FlagInfo{prefix + FlagPassword, "", "", "Password for basic authentication to the API server."},
+	}
+}
+
+// RecommendedClusterOverrideFlags is a convenience method to return recommended flag names prefixed with a string of your choosing
+func RecommendedClusterOverrideFlags(prefix string) ClusterOverrideFlags {
+	return ClusterOverrideFlags{
+		APIServer:             FlagInfo{prefix + FlagAPIServer, "", "", "The address and port of the Kubernetes API server"},
+		APIVersion:            FlagInfo{prefix + FlagAPIVersion, "", "", "The API version to use when talking to the server"},
+		CertificateAuthority:  FlagInfo{prefix + FlagCAFile, "", "", "Path to a cert. file for the certificate authority."},
+		InsecureSkipTLSVerify: FlagInfo{prefix + FlagInsecure, "", "false", "If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure."},
+	}
+}
+
+// RecommendedConfigOverrideFlags is a convenience method to return recommended flag names prefixed with a string of your choosing
+func RecommendedConfigOverrideFlags(prefix string) ConfigOverrideFlags {
+	return ConfigOverrideFlags{
+		AuthOverrideFlags:    RecommendedAuthOverrideFlags(prefix),
+		ClusterOverrideFlags: RecommendedClusterOverrideFlags(prefix),
+		ContextOverrideFlags: RecommendedContextOverrideFlags(prefix),
+		CurrentContext:       FlagInfo{prefix + FlagContext, "", "", "The name of the kubeconfig context to use"},
+	}
+}
+
+// RecommendedContextOverrideFlags is a convenience method to return recommended flag names prefixed with a string of your choosing
+func RecommendedContextOverrideFlags(prefix string) ContextOverrideFlags {
+	return ContextOverrideFlags{
+		ClusterName:  FlagInfo{prefix + FlagClusterName, "", "", "The name of the kubeconfig cluster to use"},
+		AuthInfoName: FlagInfo{prefix + FlagAuthInfoName, "", "", "The name of the kubeconfig user to use"},
+		Namespace:    FlagInfo{prefix + FlagNamespace, "", "", "If present, the namespace scope for this CLI request."},
+	}
+}
+
+// BindAuthInfoFlags is a convenience method to bind the specified flags to their associated variables
+func BindAuthInfoFlags(authInfo *clientcmdapi.AuthInfo, flags *pflag.FlagSet, flagNames AuthOverrideFlags) {
+	flagNames.ClientCertificate.BindStringFlag(flags, &authInfo.ClientCertificate)
+	flagNames.ClientKey.BindStringFlag(flags, &authInfo.ClientKey)
+	flagNames.Token.BindStringFlag(flags, &authInfo.Token)
+	flagNames.Username.BindStringFlag(flags, &authInfo.Username)
+	flagNames.Password.BindStringFlag(flags, &authInfo.Password)
+}
+
+// BindClusterFlags is a convenience method to bind the specified flags to their associated variables
+func BindClusterFlags(clusterInfo *clientcmdapi.Cluster, flags *pflag.FlagSet, flagNames ClusterOverrideFlags) {
+	flagNames.APIServer.BindStringFlag(flags, &clusterInfo.Server)
+	flagNames.APIVersion.BindStringFlag(flags, &clusterInfo.APIVersion)
+	flagNames.CertificateAuthority.BindStringFlag(flags, &clusterInfo.CertificateAuthority)
+	flagNames.InsecureSkipTLSVerify.BindBoolFlag(flags, &clusterInfo.InsecureSkipTLSVerify)
+}
+
+// BindOverrideFlags is a convenience method to bind the specified flags to their associated variables
+func BindOverrideFlags(overrides *ConfigOverrides, flags *pflag.FlagSet, flagNames ConfigOverrideFlags) {
+	BindAuthInfoFlags(&overrides.AuthInfo, flags, flagNames.AuthOverrideFlags)
+	BindClusterFlags(&overrides.ClusterInfo, flags, flagNames.ClusterOverrideFlags)
+	BindContextFlags(&overrides.Context, flags, flagNames.ContextOverrideFlags)
+	flagNames.CurrentContext.BindStringFlag(flags, &overrides.CurrentContext)
+}
+
+// BindFlags is a convenience method to bind the specified flags to their associated variables
+func BindContextFlags(contextInfo *clientcmdapi.Context, flags *pflag.FlagSet, flagNames ContextOverrideFlags) {
+	flagNames.ClusterName.BindStringFlag(flags, &contextInfo.Cluster)
+	flagNames.AuthInfoName.BindStringFlag(flags, &contextInfo.AuthInfo)
+	flagNames.Namespace.BindStringFlag(flags, &contextInfo.Namespace)
+}

--- a/pkg/client/v1/clientcmd/overrides.go
+++ b/pkg/client/v1/clientcmd/overrides.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/spf13/pflag"
 
-	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
+	clientcmdapi "k8s.io/kubernetes/pkg/client/v1/clientcmd/api"
 )
 
 // ConfigOverrides holds values that should override whatever information is pulled from the actual Config object.  You can't

--- a/pkg/client/v1/clientcmd/validation.go
+++ b/pkg/client/v1/clientcmd/validation.go
@@ -1,0 +1,240 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clientcmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
+	"k8s.io/kubernetes/pkg/util/validation"
+)
+
+var ErrNoContext = errors.New("no context chosen")
+
+type errContextNotFound struct {
+	ContextName string
+}
+
+func (e *errContextNotFound) Error() string {
+	return fmt.Sprintf("context was not found for specified context: %v", e.ContextName)
+}
+
+// IsContextNotFound returns a boolean indicating whether the error is known to
+// report that a context was not found
+func IsContextNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	if _, ok := err.(*errContextNotFound); ok || err == ErrNoContext {
+		return true
+	}
+	return strings.Contains(err.Error(), "context was not found for specified context")
+}
+
+// errConfigurationInvalid is a set of errors indicating the configuration is invalid.
+type errConfigurationInvalid []error
+
+// errConfigurationInvalid implements error and Aggregate
+var _ error = errConfigurationInvalid{}
+var _ utilerrors.Aggregate = errConfigurationInvalid{}
+
+func newErrConfigurationInvalid(errs []error) error {
+	switch len(errs) {
+	case 0:
+		return nil
+	default:
+		return errConfigurationInvalid(errs)
+	}
+}
+
+// Error implements the error interface
+func (e errConfigurationInvalid) Error() string {
+	return fmt.Sprintf("invalid configuration: %v", utilerrors.NewAggregate(e).Error())
+}
+
+// Errors implements the AggregateError interface
+func (e errConfigurationInvalid) Errors() []error {
+	return e
+}
+
+// IsConfigurationInvalid returns true if the provided error indicates the configuration is invalid.
+func IsConfigurationInvalid(err error) bool {
+	switch err.(type) {
+	case *errContextNotFound, errConfigurationInvalid:
+		return true
+	}
+	return IsContextNotFound(err)
+}
+
+// Validate checks for errors in the Config.  It does not return early so that it can find as many errors as possible.
+func Validate(config clientcmdapi.Config) error {
+	validationErrors := make([]error, 0)
+
+	if len(config.CurrentContext) != 0 {
+		if _, exists := config.Contexts[config.CurrentContext]; !exists {
+			validationErrors = append(validationErrors, &errContextNotFound{config.CurrentContext})
+		}
+	}
+
+	for contextName, context := range config.Contexts {
+		validationErrors = append(validationErrors, validateContext(contextName, *context, config)...)
+	}
+
+	for authInfoName, authInfo := range config.AuthInfos {
+		validationErrors = append(validationErrors, validateAuthInfo(authInfoName, *authInfo)...)
+	}
+
+	for clusterName, clusterInfo := range config.Clusters {
+		validationErrors = append(validationErrors, validateClusterInfo(clusterName, *clusterInfo)...)
+	}
+
+	return newErrConfigurationInvalid(validationErrors)
+}
+
+// ConfirmUsable looks a particular context and determines if that particular part of the config is useable.  There might still be errors in the config,
+// but no errors in the sections requested or referenced.  It does not return early so that it can find as many errors as possible.
+func ConfirmUsable(config clientcmdapi.Config, passedContextName string) error {
+	validationErrors := make([]error, 0)
+
+	var contextName string
+	if len(passedContextName) != 0 {
+		contextName = passedContextName
+	} else {
+		contextName = config.CurrentContext
+	}
+
+	if len(contextName) == 0 {
+		return ErrNoContext
+	}
+
+	context, exists := config.Contexts[contextName]
+	if !exists {
+		validationErrors = append(validationErrors, &errContextNotFound{contextName})
+	}
+
+	if exists {
+		validationErrors = append(validationErrors, validateContext(contextName, *context, config)...)
+		validationErrors = append(validationErrors, validateAuthInfo(context.AuthInfo, *config.AuthInfos[context.AuthInfo])...)
+		validationErrors = append(validationErrors, validateClusterInfo(context.Cluster, *config.Clusters[context.Cluster])...)
+	}
+
+	return newErrConfigurationInvalid(validationErrors)
+}
+
+// validateClusterInfo looks for conflicts and errors in the cluster info
+func validateClusterInfo(clusterName string, clusterInfo clientcmdapi.Cluster) []error {
+	validationErrors := make([]error, 0)
+
+	if len(clusterInfo.Server) == 0 {
+		if len(clusterName) == 0 {
+			validationErrors = append(validationErrors, fmt.Errorf("default cluster has no server defined"))
+		} else {
+			validationErrors = append(validationErrors, fmt.Errorf("no server found for cluster %q", clusterName))
+		}
+	}
+	// Make sure CA data and CA file aren't both specified
+	if len(clusterInfo.CertificateAuthority) != 0 && len(clusterInfo.CertificateAuthorityData) != 0 {
+		validationErrors = append(validationErrors, fmt.Errorf("certificate-authority-data and certificate-authority are both specified for %v. certificate-authority-data will override.", clusterName))
+	}
+	if len(clusterInfo.CertificateAuthority) != 0 {
+		clientCertCA, err := os.Open(clusterInfo.CertificateAuthority)
+		defer clientCertCA.Close()
+		if err != nil {
+			validationErrors = append(validationErrors, fmt.Errorf("unable to read certificate-authority %v for %v due to %v", clusterInfo.CertificateAuthority, clusterName, err))
+		}
+	}
+
+	return validationErrors
+}
+
+// validateAuthInfo looks for conflicts and errors in the auth info
+func validateAuthInfo(authInfoName string, authInfo clientcmdapi.AuthInfo) []error {
+	validationErrors := make([]error, 0)
+
+	usingAuthPath := false
+	methods := make([]string, 0, 3)
+	if len(authInfo.Token) != 0 {
+		methods = append(methods, "token")
+	}
+	if len(authInfo.Username) != 0 || len(authInfo.Password) != 0 {
+		methods = append(methods, "basicAuth")
+	}
+
+	if len(authInfo.ClientCertificate) != 0 || len(authInfo.ClientCertificateData) != 0 {
+		// Make sure cert data and file aren't both specified
+		if len(authInfo.ClientCertificate) != 0 && len(authInfo.ClientCertificateData) != 0 {
+			validationErrors = append(validationErrors, fmt.Errorf("client-cert-data and client-cert are both specified for %v. client-cert-data will override.", authInfoName))
+		}
+		// Make sure key data and file aren't both specified
+		if len(authInfo.ClientKey) != 0 && len(authInfo.ClientKeyData) != 0 {
+			validationErrors = append(validationErrors, fmt.Errorf("client-key-data and client-key are both specified for %v; client-key-data will override", authInfoName))
+		}
+		// Make sure a key is specified
+		if len(authInfo.ClientKey) == 0 && len(authInfo.ClientKeyData) == 0 {
+			validationErrors = append(validationErrors, fmt.Errorf("client-key-data or client-key must be specified for %v to use the clientCert authentication method.", authInfoName))
+		}
+
+		if len(authInfo.ClientCertificate) != 0 {
+			clientCertFile, err := os.Open(authInfo.ClientCertificate)
+			defer clientCertFile.Close()
+			if err != nil {
+				validationErrors = append(validationErrors, fmt.Errorf("unable to read client-cert %v for %v due to %v", authInfo.ClientCertificate, authInfoName, err))
+			}
+		}
+		if len(authInfo.ClientKey) != 0 {
+			clientKeyFile, err := os.Open(authInfo.ClientKey)
+			defer clientKeyFile.Close()
+			if err != nil {
+				validationErrors = append(validationErrors, fmt.Errorf("unable to read client-key %v for %v due to %v", authInfo.ClientKey, authInfoName, err))
+			}
+		}
+	}
+
+	// authPath also provides information for the client to identify the server, so allow multiple auth methods in that case
+	if (len(methods) > 1) && (!usingAuthPath) {
+		validationErrors = append(validationErrors, fmt.Errorf("more than one authentication method found for %v; found %v, only one is allowed", authInfoName, methods))
+	}
+
+	return validationErrors
+}
+
+// validateContext looks for errors in the context.  It is not transitive, so errors in the reference authInfo or cluster configs are not included in this return
+func validateContext(contextName string, context clientcmdapi.Context, config clientcmdapi.Config) []error {
+	validationErrors := make([]error, 0)
+
+	if len(context.AuthInfo) == 0 {
+		validationErrors = append(validationErrors, fmt.Errorf("user was not specified for context %q", contextName))
+	} else if _, exists := config.AuthInfos[context.AuthInfo]; !exists {
+		validationErrors = append(validationErrors, fmt.Errorf("user %q was not found for context %q", context.AuthInfo, contextName))
+	}
+
+	if len(context.Cluster) == 0 {
+		validationErrors = append(validationErrors, fmt.Errorf("cluster was not specified for context %q", contextName))
+	} else if _, exists := config.Clusters[context.Cluster]; !exists {
+		validationErrors = append(validationErrors, fmt.Errorf("cluster %q was not found for context %q", context.Cluster, contextName))
+	}
+
+	if (len(context.Namespace) != 0) && !validation.IsDNS952Label(context.Namespace) {
+		validationErrors = append(validationErrors, fmt.Errorf("namespace %q for context %q does not conform to the kubernetes DNS952 rules", context.Namespace, contextName))
+	}
+
+	return validationErrors
+}

--- a/pkg/client/v1/clientcmd/validation.go
+++ b/pkg/client/v1/clientcmd/validation.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"strings"
 
-	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
+	clientcmdapi "k8s.io/kubernetes/pkg/client/v1/clientcmd/api"
 	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/util/validation"
 )

--- a/pkg/client/v1/clientcmd/validation_test.go
+++ b/pkg/client/v1/clientcmd/validation_test.go
@@ -1,0 +1,419 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clientcmd
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
+	"k8s.io/kubernetes/pkg/util/errors"
+)
+
+func TestConfirmUsableBadInfoButOkConfig(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	config.Clusters["missing ca"] = &clientcmdapi.Cluster{
+		Server:               "anything",
+		CertificateAuthority: "missing",
+	}
+	config.AuthInfos["error"] = &clientcmdapi.AuthInfo{
+		Username: "anything",
+		Token:    "here",
+	}
+	config.Contexts["dirty"] = &clientcmdapi.Context{
+		Cluster:  "missing ca",
+		AuthInfo: "error",
+	}
+	config.Clusters["clean"] = &clientcmdapi.Cluster{
+		Server: "anything",
+	}
+	config.AuthInfos["clean"] = &clientcmdapi.AuthInfo{
+		Token: "here",
+	}
+	config.Contexts["clean"] = &clientcmdapi.Context{
+		Cluster:  "clean",
+		AuthInfo: "clean",
+	}
+
+	badValidation := configValidationTest{
+		config:                 config,
+		expectedErrorSubstring: []string{"unable to read certificate-authority"},
+	}
+	okTest := configValidationTest{
+		config: config,
+	}
+
+	okTest.testConfirmUsable("clean", t)
+	badValidation.testConfig(t)
+}
+func TestConfirmUsableBadInfoConfig(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	config.Clusters["missing ca"] = &clientcmdapi.Cluster{
+		Server:               "anything",
+		CertificateAuthority: "missing",
+	}
+	config.AuthInfos["error"] = &clientcmdapi.AuthInfo{
+		Username: "anything",
+		Token:    "here",
+	}
+	config.Contexts["first"] = &clientcmdapi.Context{
+		Cluster:  "missing ca",
+		AuthInfo: "error",
+	}
+	test := configValidationTest{
+		config:                 config,
+		expectedErrorSubstring: []string{"unable to read certificate-authority"},
+	}
+
+	test.testConfirmUsable("first", t)
+}
+func TestConfirmUsableEmptyConfig(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	test := configValidationTest{
+		config:                 config,
+		expectedErrorSubstring: []string{"no context chosen"},
+	}
+
+	test.testConfirmUsable("", t)
+}
+func TestConfirmUsableMissingConfig(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	test := configValidationTest{
+		config:                 config,
+		expectedErrorSubstring: []string{"context was not found for"},
+	}
+
+	test.testConfirmUsable("not-here", t)
+}
+func TestValidateEmptyConfig(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	test := configValidationTest{
+		config: config,
+	}
+
+	test.testConfig(t)
+}
+func TestValidateMissingCurrentContextConfig(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	config.CurrentContext = "anything"
+	test := configValidationTest{
+		config:                 config,
+		expectedErrorSubstring: []string{"context was not found for specified "},
+	}
+
+	test.testConfig(t)
+}
+func TestIsContextNotFound(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	config.CurrentContext = "anything"
+
+	err := Validate(*config)
+	if !IsContextNotFound(err) {
+		t.Errorf("Expected context not found, but got %v", err)
+	}
+	if !IsConfigurationInvalid(err) {
+		t.Errorf("Expected configuration invalid, but got %v", err)
+	}
+}
+
+func TestIsConfigurationInvalid(t *testing.T) {
+	if newErrConfigurationInvalid([]error{}) != nil {
+		t.Errorf("unexpected error")
+	}
+	if newErrConfigurationInvalid([]error{ErrNoContext}) == ErrNoContext {
+		t.Errorf("unexpected error")
+	}
+	if newErrConfigurationInvalid([]error{ErrNoContext, ErrNoContext}) == nil {
+		t.Errorf("unexpected error")
+	}
+	if !IsConfigurationInvalid(newErrConfigurationInvalid([]error{ErrNoContext, ErrNoContext})) {
+		t.Errorf("unexpected error")
+	}
+}
+
+func TestValidateMissingReferencesConfig(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	config.CurrentContext = "anything"
+	config.Contexts["anything"] = &clientcmdapi.Context{Cluster: "missing", AuthInfo: "missing"}
+	test := configValidationTest{
+		config:                 config,
+		expectedErrorSubstring: []string{"user \"missing\" was not found for context \"anything\"", "cluster \"missing\" was not found for context \"anything\""},
+	}
+
+	test.testContext("anything", t)
+	test.testConfig(t)
+}
+func TestValidateEmptyContext(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	config.CurrentContext = "anything"
+	config.Contexts["anything"] = &clientcmdapi.Context{}
+	test := configValidationTest{
+		config:                 config,
+		expectedErrorSubstring: []string{"user was not specified for context \"anything\"", "cluster was not specified for context \"anything\""},
+	}
+
+	test.testContext("anything", t)
+	test.testConfig(t)
+}
+
+func TestValidateEmptyClusterInfo(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	config.Clusters["empty"] = &clientcmdapi.Cluster{}
+	test := configValidationTest{
+		config:                 config,
+		expectedErrorSubstring: []string{"no server found for"},
+	}
+
+	test.testCluster("empty", t)
+	test.testConfig(t)
+}
+func TestValidateMissingCAFileClusterInfo(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	config.Clusters["missing ca"] = &clientcmdapi.Cluster{
+		Server:               "anything",
+		CertificateAuthority: "missing",
+	}
+	test := configValidationTest{
+		config:                 config,
+		expectedErrorSubstring: []string{"unable to read certificate-authority"},
+	}
+
+	test.testCluster("missing ca", t)
+	test.testConfig(t)
+}
+func TestValidateCleanClusterInfo(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	config.Clusters["clean"] = &clientcmdapi.Cluster{
+		Server: "anything",
+	}
+	test := configValidationTest{
+		config: config,
+	}
+
+	test.testCluster("clean", t)
+	test.testConfig(t)
+}
+func TestValidateCleanWithCAClusterInfo(t *testing.T) {
+	tempFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(tempFile.Name())
+
+	config := clientcmdapi.NewConfig()
+	config.Clusters["clean"] = &clientcmdapi.Cluster{
+		Server:               "anything",
+		CertificateAuthority: tempFile.Name(),
+	}
+	test := configValidationTest{
+		config: config,
+	}
+
+	test.testCluster("clean", t)
+	test.testConfig(t)
+}
+
+func TestValidateEmptyAuthInfo(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	config.AuthInfos["error"] = &clientcmdapi.AuthInfo{}
+	test := configValidationTest{
+		config: config,
+	}
+
+	test.testAuthInfo("error", t)
+	test.testConfig(t)
+}
+func TestValidateCertFilesNotFoundAuthInfo(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	config.AuthInfos["error"] = &clientcmdapi.AuthInfo{
+		ClientCertificate: "missing",
+		ClientKey:         "missing",
+	}
+	test := configValidationTest{
+		config:                 config,
+		expectedErrorSubstring: []string{"unable to read client-cert", "unable to read client-key"},
+	}
+
+	test.testAuthInfo("error", t)
+	test.testConfig(t)
+}
+func TestValidateCertDataOverridesFiles(t *testing.T) {
+	tempFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(tempFile.Name())
+
+	config := clientcmdapi.NewConfig()
+	config.AuthInfos["clean"] = &clientcmdapi.AuthInfo{
+		ClientCertificate:     tempFile.Name(),
+		ClientCertificateData: []byte("certdata"),
+		ClientKey:             tempFile.Name(),
+		ClientKeyData:         []byte("keydata"),
+	}
+	test := configValidationTest{
+		config:                 config,
+		expectedErrorSubstring: []string{"client-cert-data and client-cert are both specified", "client-key-data and client-key are both specified"},
+	}
+
+	test.testAuthInfo("clean", t)
+	test.testConfig(t)
+}
+func TestValidateCleanCertFilesAuthInfo(t *testing.T) {
+	tempFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(tempFile.Name())
+
+	config := clientcmdapi.NewConfig()
+	config.AuthInfos["clean"] = &clientcmdapi.AuthInfo{
+		ClientCertificate: tempFile.Name(),
+		ClientKey:         tempFile.Name(),
+	}
+	test := configValidationTest{
+		config: config,
+	}
+
+	test.testAuthInfo("clean", t)
+	test.testConfig(t)
+}
+func TestValidateCleanTokenAuthInfo(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	config.AuthInfos["clean"] = &clientcmdapi.AuthInfo{
+		Token: "any-value",
+	}
+	test := configValidationTest{
+		config: config,
+	}
+
+	test.testAuthInfo("clean", t)
+	test.testConfig(t)
+}
+
+func TestValidateMultipleMethodsAuthInfo(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	config.AuthInfos["error"] = &clientcmdapi.AuthInfo{
+		Token:    "token",
+		Username: "username",
+	}
+	test := configValidationTest{
+		config:                 config,
+		expectedErrorSubstring: []string{"more than one authentication method", "token", "basicAuth"},
+	}
+
+	test.testAuthInfo("error", t)
+	test.testConfig(t)
+}
+
+type configValidationTest struct {
+	config                 *clientcmdapi.Config
+	expectedErrorSubstring []string
+}
+
+func (c configValidationTest) testContext(contextName string, t *testing.T) {
+	errs := validateContext(contextName, *c.config.Contexts[contextName], *c.config)
+
+	if len(c.expectedErrorSubstring) != 0 {
+		if len(errs) == 0 {
+			t.Errorf("Expected error containing: %v", c.expectedErrorSubstring)
+		}
+		for _, curr := range c.expectedErrorSubstring {
+			if len(errs) != 0 && !strings.Contains(errors.NewAggregate(errs).Error(), curr) {
+				t.Errorf("Expected error containing: %v, but got %v", c.expectedErrorSubstring, errors.NewAggregate(errs))
+			}
+		}
+
+	} else {
+		if len(errs) != 0 {
+			t.Errorf("Unexpected error: %v", errors.NewAggregate(errs))
+		}
+	}
+}
+func (c configValidationTest) testConfirmUsable(contextName string, t *testing.T) {
+	err := ConfirmUsable(*c.config, contextName)
+
+	if len(c.expectedErrorSubstring) != 0 {
+		if err == nil {
+			t.Errorf("Expected error containing: %v", c.expectedErrorSubstring)
+		} else {
+			for _, curr := range c.expectedErrorSubstring {
+				if err != nil && !strings.Contains(err.Error(), curr) {
+					t.Errorf("Expected error containing: %v, but got %v", c.expectedErrorSubstring, err)
+				}
+			}
+		}
+	} else {
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	}
+}
+func (c configValidationTest) testConfig(t *testing.T) {
+	err := Validate(*c.config)
+
+	if len(c.expectedErrorSubstring) != 0 {
+		if err == nil {
+			t.Errorf("Expected error containing: %v", c.expectedErrorSubstring)
+		} else {
+			for _, curr := range c.expectedErrorSubstring {
+				if err != nil && !strings.Contains(err.Error(), curr) {
+					t.Errorf("Expected error containing: %v, but got %v", c.expectedErrorSubstring, err)
+				}
+			}
+			if !IsConfigurationInvalid(err) {
+				t.Errorf("all errors should be configuration invalid: %v", err)
+			}
+		}
+	} else {
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	}
+}
+func (c configValidationTest) testCluster(clusterName string, t *testing.T) {
+	errs := validateClusterInfo(clusterName, *c.config.Clusters[clusterName])
+
+	if len(c.expectedErrorSubstring) != 0 {
+		if len(errs) == 0 {
+			t.Errorf("Expected error containing: %v", c.expectedErrorSubstring)
+		}
+		for _, curr := range c.expectedErrorSubstring {
+			if len(errs) != 0 && !strings.Contains(errors.NewAggregate(errs).Error(), curr) {
+				t.Errorf("Expected error containing: %v, but got %v", c.expectedErrorSubstring, errors.NewAggregate(errs))
+			}
+		}
+
+	} else {
+		if len(errs) != 0 {
+			t.Errorf("Unexpected error: %v", errors.NewAggregate(errs))
+		}
+	}
+}
+
+func (c configValidationTest) testAuthInfo(authInfoName string, t *testing.T) {
+	errs := validateAuthInfo(authInfoName, *c.config.AuthInfos[authInfoName])
+
+	if len(c.expectedErrorSubstring) != 0 {
+		if len(errs) == 0 {
+			t.Errorf("Expected error containing: %v", c.expectedErrorSubstring)
+		}
+		for _, curr := range c.expectedErrorSubstring {
+			if len(errs) != 0 && !strings.Contains(errors.NewAggregate(errs).Error(), curr) {
+				t.Errorf("Expected error containing: %v, but got %v", c.expectedErrorSubstring, errors.NewAggregate(errs))
+			}
+		}
+
+	} else {
+		if len(errs) != 0 {
+			t.Errorf("Unexpected error: %v", errors.NewAggregate(errs))
+		}
+	}
+}

--- a/pkg/client/v1/clientcmd/validation_test.go
+++ b/pkg/client/v1/clientcmd/validation_test.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"testing"
 
-	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
+	clientcmdapi "k8s.io/kubernetes/pkg/client/v1/clientcmd/api"
 	"k8s.io/kubernetes/pkg/util/errors"
 )
 

--- a/pkg/client/v1/componentstatuses.go
+++ b/pkg/client/v1/componentstatuses.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+type ComponentStatusesInterface interface {
+	ComponentStatuses() ComponentStatusInterface
+}
+
+// ComponentStatusInterface contains methods to retrieve ComponentStatus
+type ComponentStatusInterface interface {
+	List(label labels.Selector, field fields.Selector) (*api.ComponentStatusList, error)
+	Get(name string) (*api.ComponentStatus, error)
+
+	// TODO: It'd be nice to have watch support at some point
+	//Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
+}
+
+// componentStatuses implements ComponentStatusesInterface
+type componentStatuses struct {
+	client *Client
+}
+
+func newComponentStatuses(c *Client) *componentStatuses {
+	return &componentStatuses{c}
+}
+
+func (c *componentStatuses) List(label labels.Selector, field fields.Selector) (result *api.ComponentStatusList, err error) {
+	result = &api.ComponentStatusList{}
+	err = c.client.Get().
+		Resource("componentStatuses").
+		LabelsSelectorParam(label).
+		FieldsSelectorParam(field).
+		Do().
+		Into(result)
+
+	return result, err
+}
+
+func (c *componentStatuses) Get(name string) (result *api.ComponentStatus, err error) {
+	result = &api.ComponentStatus{}
+	err = c.client.Get().Resource("componentStatuses").Name(name).Do().Into(result)
+	return
+}

--- a/pkg/client/v1/componentstatuses.go
+++ b/pkg/client/v1/componentstatuses.go
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
-	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 )
@@ -28,8 +28,8 @@ type ComponentStatusesInterface interface {
 
 // ComponentStatusInterface contains methods to retrieve ComponentStatus
 type ComponentStatusInterface interface {
-	List(label labels.Selector, field fields.Selector) (*api.ComponentStatusList, error)
-	Get(name string) (*api.ComponentStatus, error)
+	List(label labels.Selector, field fields.Selector) (*v1.ComponentStatusList, error)
+	Get(name string) (*v1.ComponentStatus, error)
 
 	// TODO: It'd be nice to have watch support at some point
 	//Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
@@ -44,8 +44,8 @@ func newComponentStatuses(c *Client) *componentStatuses {
 	return &componentStatuses{c}
 }
 
-func (c *componentStatuses) List(label labels.Selector, field fields.Selector) (result *api.ComponentStatusList, err error) {
-	result = &api.ComponentStatusList{}
+func (c *componentStatuses) List(label labels.Selector, field fields.Selector) (result *v1.ComponentStatusList, err error) {
+	result = &v1.ComponentStatusList{}
 	err = c.client.Get().
 		Resource("componentStatuses").
 		LabelsSelectorParam(label).
@@ -56,8 +56,8 @@ func (c *componentStatuses) List(label labels.Selector, field fields.Selector) (
 	return result, err
 }
 
-func (c *componentStatuses) Get(name string) (result *api.ComponentStatus, err error) {
-	result = &api.ComponentStatus{}
+func (c *componentStatuses) Get(name string) (result *v1.ComponentStatus, err error) {
+	result = &v1.ComponentStatus{}
 	err = c.client.Get().Resource("componentStatuses").Name(name).Do().Into(result)
 	return
 }

--- a/pkg/client/v1/conditions.go
+++ b/pkg/client/v1/conditions.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/util/wait"
+)
+
+// ControllerHasDesiredReplicas returns a condition that will be true if and only if
+// the desired replica count for a controller's ReplicaSelector equals the Replicas count.
+func ControllerHasDesiredReplicas(c Interface, controller *api.ReplicationController) wait.ConditionFunc {
+
+	// If we're given a controller where the status lags the spec, it either means that the controller is stale,
+	// or that the rc manager hasn't noticed the update yet. Polling status.Replicas is not safe in the latter case.
+	desiredGeneration := controller.Generation
+
+	return func() (bool, error) {
+		ctrl, err := c.ReplicationControllers(controller.Namespace).Get(controller.Name)
+		if err != nil {
+			return false, err
+		}
+		// There's a chance a concurrent update modifies the Spec.Replicas causing this check to pass,
+		// or, after this check has passed, a modification causes the rc manager to create more pods.
+		// This will not be an issue once we've implemented graceful delete for rcs, but till then
+		// concurrent stop operations on the same rc might have unintended side effects.
+		return ctrl.Status.ObservedGeneration >= desiredGeneration && ctrl.Status.Replicas == ctrl.Spec.Replicas, nil
+	}
+}

--- a/pkg/client/v1/conditions.go
+++ b/pkg/client/v1/conditions.go
@@ -14,16 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
-	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/util/wait"
 )
 
-// ControllerHasDesiredReplicas returns a condition that will be true if and only if
-// the desired replica count for a controller's ReplicaSelector equals the Replicas count.
-func ControllerHasDesiredReplicas(c Interface, controller *api.ReplicationController) wait.ConditionFunc {
+// ControllerHasDesiredReplicas returns a condition that will be true iff the desired replica count
+// for a controller's ReplicaSelector equals the Replicas count.
+func ControllerHasDesiredReplicas(c Interface, controller *v1.ReplicationController) wait.ConditionFunc {
 
 	// If we're given a controller where the status lags the spec, it either means that the controller is stale,
 	// or that the rc manager hasn't noticed the update yet. Polling status.Replicas is not safe in the latter case.
@@ -38,6 +38,6 @@ func ControllerHasDesiredReplicas(c Interface, controller *api.ReplicationContro
 		// or, after this check has passed, a modification causes the rc manager to create more pods.
 		// This will not be an issue once we've implemented graceful delete for rcs, but till then
 		// concurrent stop operations on the same rc might have unintended side effects.
-		return ctrl.Status.ObservedGeneration >= desiredGeneration && ctrl.Status.Replicas == ctrl.Spec.Replicas, nil
+		return ctrl.Status.ObservedGeneration >= desiredGeneration && ctrl.Status.Replicas == *ctrl.Spec.Replicas, nil
 	}
 }

--- a/pkg/client/v1/containerinfo.go
+++ b/pkg/client/v1/containerinfo.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+
+	cadvisorApi "github.com/google/cadvisor/info/v1"
+)
+
+type ContainerInfoGetter interface {
+	// GetContainerInfo returns information about a container.
+	GetContainerInfo(host, podID, containerID string, req *cadvisorApi.ContainerInfoRequest) (*cadvisorApi.ContainerInfo, error)
+	// GetRootInfo returns information about the root container on a machine.
+	GetRootInfo(host string, req *cadvisorApi.ContainerInfoRequest) (*cadvisorApi.ContainerInfo, error)
+	// GetMachineInfo returns the machine's information like number of cores, memory capacity.
+	GetMachineInfo(host string) (*cadvisorApi.MachineInfo, error)
+}
+
+type HTTPContainerInfoGetter struct {
+	Client *http.Client
+	Port   int
+}
+
+func (self *HTTPContainerInfoGetter) GetMachineInfo(host string) (*cadvisorApi.MachineInfo, error) {
+	request, err := http.NewRequest(
+		"GET",
+		fmt.Sprintf("http://%v/spec",
+			net.JoinHostPort(host, strconv.Itoa(self.Port)),
+		),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := self.Client.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("trying to get machine spec from %v; received status %v",
+			host, response.Status)
+	}
+	var minfo cadvisorApi.MachineInfo
+	err = json.NewDecoder(response.Body).Decode(&minfo)
+	if err != nil {
+		return nil, err
+	}
+	return &minfo, nil
+}
+
+func (self *HTTPContainerInfoGetter) getContainerInfo(host, path string, req *cadvisorApi.ContainerInfoRequest) (*cadvisorApi.ContainerInfo, error) {
+	var body io.Reader
+	if req != nil {
+		content, err := json.Marshal(req)
+		if err != nil {
+			return nil, err
+		}
+		body = bytes.NewBuffer(content)
+	}
+
+	request, err := http.NewRequest(
+		"GET",
+		fmt.Sprintf("http://%v/stats/%v",
+			net.JoinHostPort(host, strconv.Itoa(self.Port)),
+			path,
+		),
+		body,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := self.Client.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("trying to get info for %v from %v; received status %v",
+			path, host, response.Status)
+	}
+	var cinfo cadvisorApi.ContainerInfo
+	err = json.NewDecoder(response.Body).Decode(&cinfo)
+	if err != nil {
+		return nil, err
+	}
+	return &cinfo, nil
+}
+
+func (self *HTTPContainerInfoGetter) GetContainerInfo(host, podID, containerID string, req *cadvisorApi.ContainerInfoRequest) (*cadvisorApi.ContainerInfo, error) {
+	return self.getContainerInfo(
+		host,
+		fmt.Sprintf("%v/%v", podID, containerID),
+		req,
+	)
+}
+
+func (self *HTTPContainerInfoGetter) GetRootInfo(host string, req *cadvisorApi.ContainerInfoRequest) (*cadvisorApi.ContainerInfo, error) {
+	return self.getContainerInfo(host, "", req)
+}

--- a/pkg/client/v1/containerinfo.go
+++ b/pkg/client/v1/containerinfo.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"bytes"

--- a/pkg/client/v1/containerinfo_test.go
+++ b/pkg/client/v1/containerinfo_test.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	cadvisorApi "github.com/google/cadvisor/info/v1"
+	cadvisorApiTest "github.com/google/cadvisor/info/v1/test"
+)
+
+func testHTTPContainerInfoGetter(
+	req *cadvisorApi.ContainerInfoRequest,
+	cinfo *cadvisorApi.ContainerInfo,
+	podID string,
+	containerID string,
+	status int,
+	t *testing.T,
+) {
+	expectedPath := "/stats"
+	if len(podID) > 0 && len(containerID) > 0 {
+		expectedPath = path.Join(expectedPath, podID, containerID)
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if status != 0 {
+			w.WriteHeader(status)
+		}
+		if strings.TrimRight(r.URL.Path, "/") != strings.TrimRight(expectedPath, "/") {
+			t.Fatalf("Received request to an invalid path. Should be %v. got %v",
+				expectedPath, r.URL.Path)
+		}
+
+		var receivedReq cadvisorApi.ContainerInfoRequest
+		err := json.NewDecoder(r.Body).Decode(&receivedReq)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Note: This will not make a deep copy of req.
+		// So changing req after Get*Info would be a race.
+		expectedReq := req
+		// Fill any empty fields with default value
+		if !expectedReq.Equals(receivedReq) {
+			t.Errorf("received wrong request")
+		}
+		err = json.NewEncoder(w).Encode(cinfo)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}))
+	defer ts.Close()
+	hostURL, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parts := strings.Split(hostURL.Host, ":")
+
+	port, err := strconv.Atoi(parts[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	containerInfoGetter := &HTTPContainerInfoGetter{
+		Client: http.DefaultClient,
+		Port:   port,
+	}
+
+	var receivedContainerInfo *cadvisorApi.ContainerInfo
+	if len(podID) > 0 && len(containerID) > 0 {
+		receivedContainerInfo, err = containerInfoGetter.GetContainerInfo(parts[0], podID, containerID, req)
+	} else {
+		receivedContainerInfo, err = containerInfoGetter.GetRootInfo(parts[0], req)
+	}
+	if status == 0 || status == http.StatusOK {
+		if err != nil {
+			t.Errorf("received unexpected error: %v", err)
+		}
+
+		if !receivedContainerInfo.Eq(cinfo) {
+			t.Error("received unexpected container info")
+		}
+	} else {
+		if err == nil {
+			t.Error("did not receive expected error.")
+		}
+	}
+}
+
+func TestHTTPContainerInfoGetterGetContainerInfoSuccessfully(t *testing.T) {
+	req := &cadvisorApi.ContainerInfoRequest{
+		NumStats: 10,
+	}
+	cinfo := cadvisorApiTest.GenerateRandomContainerInfo(
+		"dockerIDWhichWillNotBeChecked", // docker ID
+		2, // Number of cores
+		req,
+		1*time.Second,
+	)
+	testHTTPContainerInfoGetter(req, cinfo, "somePodID", "containerNameInK8S", 0, t)
+}
+
+func TestHTTPContainerInfoGetterGetRootInfoSuccessfully(t *testing.T) {
+	req := &cadvisorApi.ContainerInfoRequest{
+		NumStats: 10,
+	}
+	cinfo := cadvisorApiTest.GenerateRandomContainerInfo(
+		"dockerIDWhichWillNotBeChecked", // docker ID
+		2, // Number of cores
+		req,
+		1*time.Second,
+	)
+	testHTTPContainerInfoGetter(req, cinfo, "", "", 0, t)
+}
+
+func TestHTTPContainerInfoGetterGetContainerInfoWithError(t *testing.T) {
+	req := &cadvisorApi.ContainerInfoRequest{
+		NumStats: 10,
+	}
+	cinfo := cadvisorApiTest.GenerateRandomContainerInfo(
+		"dockerIDWhichWillNotBeChecked", // docker ID
+		2, // Number of cores
+		req,
+		1*time.Second,
+	)
+	testHTTPContainerInfoGetter(req, cinfo, "somePodID", "containerNameInK8S", http.StatusNotFound, t)
+}
+
+func TestHTTPContainerInfoGetterGetRootInfoWithError(t *testing.T) {
+	req := &cadvisorApi.ContainerInfoRequest{
+		NumStats: 10,
+	}
+	cinfo := cadvisorApiTest.GenerateRandomContainerInfo(
+		"dockerIDWhichWillNotBeChecked", // docker ID
+		2, // Number of cores
+		req,
+		1*time.Second,
+	)
+	testHTTPContainerInfoGetter(req, cinfo, "", "", http.StatusNotFound, t)
+}
+
+func TestHTTPGetMachineInfo(t *testing.T) {
+	mspec := &cadvisorApi.MachineInfo{
+		NumCores:       4,
+		MemoryCapacity: 2048,
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := json.NewEncoder(w).Encode(mspec)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}))
+	defer ts.Close()
+	hostURL, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parts := strings.Split(hostURL.Host, ":")
+
+	port, err := strconv.Atoi(parts[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	containerInfoGetter := &HTTPContainerInfoGetter{
+		Client: http.DefaultClient,
+		Port:   port,
+	}
+
+	received, err := containerInfoGetter.GetMachineInfo(parts[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(received, mspec) {
+		t.Errorf("received wrong machine spec")
+	}
+}

--- a/pkg/client/v1/containerinfo_test.go
+++ b/pkg/client/v1/containerinfo_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"encoding/json"

--- a/pkg/client/v1/daemon_sets.go
+++ b/pkg/client/v1/daemon_sets.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"k8s.io/kubernetes/pkg/apis/experimental"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// DaemonsSetsNamespacer has methods to work with DaemonSet resources in a namespace
+type DaemonSetsNamespacer interface {
+	DaemonSets(namespace string) DaemonSetInterface
+}
+
+type DaemonSetInterface interface {
+	List(selector labels.Selector) (*experimental.DaemonSetList, error)
+	Get(name string) (*experimental.DaemonSet, error)
+	Create(ctrl *experimental.DaemonSet) (*experimental.DaemonSet, error)
+	Update(ctrl *experimental.DaemonSet) (*experimental.DaemonSet, error)
+	Delete(name string) error
+	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
+}
+
+// daemonSets implements DaemonsSetsNamespacer interface
+type daemonSets struct {
+	r  *ExperimentalClient
+	ns string
+}
+
+func newDaemonSets(c *ExperimentalClient, namespace string) *daemonSets {
+	return &daemonSets{c, namespace}
+}
+
+// Ensure statically that daemonSets implements DaemonSetsInterface.
+var _ DaemonSetInterface = &daemonSets{}
+
+func (c *daemonSets) List(selector labels.Selector) (result *experimental.DaemonSetList, err error) {
+	result = &experimental.DaemonSetList{}
+	err = c.r.Get().Namespace(c.ns).Resource("daemonsets").LabelsSelectorParam(selector).Do().Into(result)
+	return
+}
+
+// Get returns information about a particular daemon set.
+func (c *daemonSets) Get(name string) (result *experimental.DaemonSet, err error) {
+	result = &experimental.DaemonSet{}
+	err = c.r.Get().Namespace(c.ns).Resource("daemonsets").Name(name).Do().Into(result)
+	return
+}
+
+// Create creates a new daemon set.
+func (c *daemonSets) Create(daemon *experimental.DaemonSet) (result *experimental.DaemonSet, err error) {
+	result = &experimental.DaemonSet{}
+	err = c.r.Post().Namespace(c.ns).Resource("daemonsets").Body(daemon).Do().Into(result)
+	return
+}
+
+// Update updates an existing daemon set.
+func (c *daemonSets) Update(daemon *experimental.DaemonSet) (result *experimental.DaemonSet, err error) {
+	result = &experimental.DaemonSet{}
+	err = c.r.Put().Namespace(c.ns).Resource("daemonsets").Name(daemon.Name).Body(daemon).Do().Into(result)
+	return
+}
+
+// Delete deletes an existing daemon set.
+func (c *daemonSets) Delete(name string) error {
+	return c.r.Delete().Namespace(c.ns).Resource("daemonsets").Name(name).Do().Error()
+}
+
+// Watch returns a watch.Interface that watches the requested daemon sets.
+func (c *daemonSets) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.r.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("daemonsets").
+		Param("resourceVersion", resourceVersion).
+		LabelsSelectorParam(label).
+		FieldsSelectorParam(field).
+		Watch()
+}

--- a/pkg/client/v1/daemon_sets.go
+++ b/pkg/client/v1/daemon_sets.go
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
-	"k8s.io/kubernetes/pkg/apis/experimental"
+	experimental "k8s.io/kubernetes/pkg/apis/experimental/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/watch"

--- a/pkg/client/v1/daemon_sets_test.go
+++ b/pkg/client/v1/daemon_sets_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/apis/experimental"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func getDSResourceName() string {
+	return "daemonsets"
+}
+
+func TestListDaemonSets(t *testing.T) {
+	ns := api.NamespaceAll
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Experimental.ResourcePath(getDSResourceName(), ns, ""),
+		},
+		Response: Response{StatusCode: 200,
+			Body: &experimental.DaemonSetList{
+				Items: []experimental.DaemonSet{
+					{
+						ObjectMeta: api.ObjectMeta{
+							Name: "foo",
+							Labels: map[string]string{
+								"foo":  "bar",
+								"name": "baz",
+							},
+						},
+						Spec: experimental.DaemonSetSpec{
+							Template: &api.PodTemplateSpec{},
+						},
+					},
+				},
+			},
+		},
+	}
+	receivedDSs, err := c.Setup(t).Experimental().DaemonSets(ns).List(labels.Everything())
+	c.Validate(t, receivedDSs, err)
+
+}
+
+func TestGetDaemonSet(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request: testRequest{Method: "GET", Path: testapi.Experimental.ResourcePath(getDSResourceName(), ns, "foo"), Query: buildQueryValues(nil)},
+		Response: Response{
+			StatusCode: 200,
+			Body: &experimental.DaemonSet{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo":  "bar",
+						"name": "baz",
+					},
+				},
+				Spec: experimental.DaemonSetSpec{
+					Template: &api.PodTemplateSpec{},
+				},
+			},
+		},
+	}
+	receivedDaemonSet, err := c.Setup(t).Experimental().DaemonSets(ns).Get("foo")
+	c.Validate(t, receivedDaemonSet, err)
+}
+
+func TestGetDaemonSetWithNoName(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{Error: true}
+	receivedPod, err := c.Setup(t).Experimental().DaemonSets(ns).Get("")
+	if (err != nil) && (err.Error() != nameRequiredError) {
+		t.Errorf("Expected error: %v, but got %v", nameRequiredError, err)
+	}
+
+	c.Validate(t, receivedPod, err)
+}
+
+func TestUpdateDaemonSet(t *testing.T) {
+	ns := api.NamespaceDefault
+	requestDaemonSet := &experimental.DaemonSet{
+		ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "1"},
+	}
+	c := &testClient{
+		Request: testRequest{Method: "PUT", Path: testapi.Experimental.ResourcePath(getDSResourceName(), ns, "foo"), Query: buildQueryValues(nil)},
+		Response: Response{
+			StatusCode: 200,
+			Body: &experimental.DaemonSet{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo":  "bar",
+						"name": "baz",
+					},
+				},
+				Spec: experimental.DaemonSetSpec{
+					Template: &api.PodTemplateSpec{},
+				},
+			},
+		},
+	}
+	receivedDaemonSet, err := c.Setup(t).Experimental().DaemonSets(ns).Update(requestDaemonSet)
+	c.Validate(t, receivedDaemonSet, err)
+}
+
+func TestDeleteDaemon(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request:  testRequest{Method: "DELETE", Path: testapi.Experimental.ResourcePath(getDSResourceName(), ns, "foo"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200},
+	}
+	err := c.Setup(t).Experimental().DaemonSets(ns).Delete("foo")
+	c.Validate(t, nil, err)
+}
+
+func TestCreateDaemonSet(t *testing.T) {
+	ns := api.NamespaceDefault
+	requestDaemonSet := &experimental.DaemonSet{
+		ObjectMeta: api.ObjectMeta{Name: "foo"},
+	}
+	c := &testClient{
+		Request: testRequest{Method: "POST", Path: testapi.Experimental.ResourcePath(getDSResourceName(), ns, ""), Body: requestDaemonSet, Query: buildQueryValues(nil)},
+		Response: Response{
+			StatusCode: 200,
+			Body: &experimental.DaemonSet{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo":  "bar",
+						"name": "baz",
+					},
+				},
+				Spec: experimental.DaemonSetSpec{
+					Template: &api.PodTemplateSpec{},
+				},
+			},
+		},
+	}
+	receivedDaemonSet, err := c.Setup(t).Experimental().DaemonSets(ns).Create(requestDaemonSet)
+	c.Validate(t, receivedDaemonSet, err)
+}

--- a/pkg/client/v1/daemon_sets_test.go
+++ b/pkg/client/v1/daemon_sets_test.go
@@ -14,14 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"testing"
 
-	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
-	"k8s.io/kubernetes/pkg/apis/experimental"
+	"k8s.io/kubernetes/pkg/api/v1"
+	experimental "k8s.io/kubernetes/pkg/apis/experimental/v1"
 	"k8s.io/kubernetes/pkg/labels"
 )
 
@@ -30,7 +30,7 @@ func getDSResourceName() string {
 }
 
 func TestListDaemonSets(t *testing.T) {
-	ns := api.NamespaceAll
+	ns := v1.NamespaceAll
 	c := &testClient{
 		Request: testRequest{
 			Method: "GET",
@@ -40,7 +40,7 @@ func TestListDaemonSets(t *testing.T) {
 			Body: &experimental.DaemonSetList{
 				Items: []experimental.DaemonSet{
 					{
-						ObjectMeta: api.ObjectMeta{
+						ObjectMeta: v1.ObjectMeta{
 							Name: "foo",
 							Labels: map[string]string{
 								"foo":  "bar",
@@ -48,7 +48,7 @@ func TestListDaemonSets(t *testing.T) {
 							},
 						},
 						Spec: experimental.DaemonSetSpec{
-							Template: &api.PodTemplateSpec{},
+							Template: &v1.PodTemplateSpec{},
 						},
 					},
 				},
@@ -61,13 +61,13 @@ func TestListDaemonSets(t *testing.T) {
 }
 
 func TestGetDaemonSet(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	c := &testClient{
 		Request: testRequest{Method: "GET", Path: testapi.Experimental.ResourcePath(getDSResourceName(), ns, "foo"), Query: buildQueryValues(nil)},
 		Response: Response{
 			StatusCode: 200,
 			Body: &experimental.DaemonSet{
-				ObjectMeta: api.ObjectMeta{
+				ObjectMeta: v1.ObjectMeta{
 					Name: "foo",
 					Labels: map[string]string{
 						"foo":  "bar",
@@ -75,7 +75,7 @@ func TestGetDaemonSet(t *testing.T) {
 					},
 				},
 				Spec: experimental.DaemonSetSpec{
-					Template: &api.PodTemplateSpec{},
+					Template: &v1.PodTemplateSpec{},
 				},
 			},
 		},
@@ -85,7 +85,7 @@ func TestGetDaemonSet(t *testing.T) {
 }
 
 func TestGetDaemonSetWithNoName(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	c := &testClient{Error: true}
 	receivedPod, err := c.Setup(t).Experimental().DaemonSets(ns).Get("")
 	if (err != nil) && (err.Error() != nameRequiredError) {
@@ -96,16 +96,16 @@ func TestGetDaemonSetWithNoName(t *testing.T) {
 }
 
 func TestUpdateDaemonSet(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	requestDaemonSet := &experimental.DaemonSet{
-		ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "1"},
+		ObjectMeta: v1.ObjectMeta{Name: "foo", ResourceVersion: "1"},
 	}
 	c := &testClient{
 		Request: testRequest{Method: "PUT", Path: testapi.Experimental.ResourcePath(getDSResourceName(), ns, "foo"), Query: buildQueryValues(nil)},
 		Response: Response{
 			StatusCode: 200,
 			Body: &experimental.DaemonSet{
-				ObjectMeta: api.ObjectMeta{
+				ObjectMeta: v1.ObjectMeta{
 					Name: "foo",
 					Labels: map[string]string{
 						"foo":  "bar",
@@ -113,7 +113,7 @@ func TestUpdateDaemonSet(t *testing.T) {
 					},
 				},
 				Spec: experimental.DaemonSetSpec{
-					Template: &api.PodTemplateSpec{},
+					Template: &v1.PodTemplateSpec{},
 				},
 			},
 		},
@@ -123,7 +123,7 @@ func TestUpdateDaemonSet(t *testing.T) {
 }
 
 func TestDeleteDaemon(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	c := &testClient{
 		Request:  testRequest{Method: "DELETE", Path: testapi.Experimental.ResourcePath(getDSResourceName(), ns, "foo"), Query: buildQueryValues(nil)},
 		Response: Response{StatusCode: 200},
@@ -133,16 +133,16 @@ func TestDeleteDaemon(t *testing.T) {
 }
 
 func TestCreateDaemonSet(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	requestDaemonSet := &experimental.DaemonSet{
-		ObjectMeta: api.ObjectMeta{Name: "foo"},
+		ObjectMeta: v1.ObjectMeta{Name: "foo"},
 	}
 	c := &testClient{
 		Request: testRequest{Method: "POST", Path: testapi.Experimental.ResourcePath(getDSResourceName(), ns, ""), Body: requestDaemonSet, Query: buildQueryValues(nil)},
 		Response: Response{
 			StatusCode: 200,
 			Body: &experimental.DaemonSet{
-				ObjectMeta: api.ObjectMeta{
+				ObjectMeta: v1.ObjectMeta{
 					Name: "foo",
 					Labels: map[string]string{
 						"foo":  "bar",
@@ -150,7 +150,7 @@ func TestCreateDaemonSet(t *testing.T) {
 					},
 				},
 				Spec: experimental.DaemonSetSpec{
-					Template: &api.PodTemplateSpec{},
+					Template: &v1.PodTemplateSpec{},
 				},
 			},
 		},

--- a/pkg/client/v1/debugging.go
+++ b/pkg/client/v1/debugging.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/golang/glog"
+
+	"k8s.io/kubernetes/pkg/util/sets"
+)
+
+// RequestInfo keeps track of information about a request/response combination
+type RequestInfo struct {
+	RequestHeaders http.Header
+	RequestVerb    string
+	RequestURL     string
+
+	ResponseStatus  string
+	ResponseHeaders http.Header
+	ResponseErr     error
+
+	Duration time.Duration
+}
+
+// NewRequestInfo creates a new RequestInfo based on an http request
+func NewRequestInfo(req *http.Request) *RequestInfo {
+	reqInfo := &RequestInfo{}
+	reqInfo.RequestURL = req.URL.String()
+	reqInfo.RequestVerb = req.Method
+	reqInfo.RequestHeaders = req.Header
+
+	return reqInfo
+}
+
+// Complete adds information about the response to the RequestInfo
+func (r *RequestInfo) Complete(response *http.Response, err error) {
+	if err != nil {
+		r.ResponseErr = err
+		return
+	}
+	r.ResponseStatus = response.Status
+	r.ResponseHeaders = response.Header
+}
+
+// ToCurl returns a string that can be run as a command in a terminal (minus the body)
+func (r RequestInfo) ToCurl() string {
+	headers := ""
+	for key, values := range map[string][]string(r.RequestHeaders) {
+		for _, value := range values {
+			headers += fmt.Sprintf(` -H %q`, fmt.Sprintf("%s: %s", key, value))
+		}
+	}
+
+	return fmt.Sprintf("curl -k -v -X%s %s %s", r.RequestVerb, headers, r.RequestURL)
+}
+
+// DebuggingRoundTripper will display information about the requests passing through it based on what is configured
+type DebuggingRoundTripper struct {
+	delegatedRoundTripper http.RoundTripper
+
+	Levels sets.String
+}
+
+const (
+	JustURL         string = "url"
+	URLTiming       string = "urltiming"
+	CurlCommand     string = "curlcommand"
+	RequestHeaders  string = "requestheaders"
+	ResponseStatus  string = "responsestatus"
+	ResponseHeaders string = "responseheaders"
+)
+
+func NewDebuggingRoundTripper(rt http.RoundTripper, levels ...string) *DebuggingRoundTripper {
+	return &DebuggingRoundTripper{rt, sets.NewString(levels...)}
+}
+
+func (rt *DebuggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	reqInfo := NewRequestInfo(req)
+
+	if rt.Levels.Has(JustURL) {
+		glog.Infof("%s %s", reqInfo.RequestVerb, reqInfo.RequestURL)
+	}
+	if rt.Levels.Has(CurlCommand) {
+		glog.Infof("%s", reqInfo.ToCurl())
+
+	}
+	if rt.Levels.Has(RequestHeaders) {
+		glog.Infof("Request Headers:")
+		for key, values := range reqInfo.RequestHeaders {
+			for _, value := range values {
+				glog.Infof("    %s: %s", key, value)
+			}
+		}
+	}
+
+	startTime := time.Now()
+	response, err := rt.delegatedRoundTripper.RoundTrip(req)
+	reqInfo.Duration = time.Since(startTime)
+
+	reqInfo.Complete(response, err)
+
+	if rt.Levels.Has(URLTiming) {
+		glog.Infof("%s %s %s in %d milliseconds", reqInfo.RequestVerb, reqInfo.RequestURL, reqInfo.ResponseStatus, reqInfo.Duration.Nanoseconds()/int64(time.Millisecond))
+	}
+	if rt.Levels.Has(ResponseStatus) {
+		glog.Infof("Response Status: %s in %d milliseconds", reqInfo.ResponseStatus, reqInfo.Duration.Nanoseconds()/int64(time.Millisecond))
+	}
+	if rt.Levels.Has(ResponseHeaders) {
+		glog.Infof("Response Headers:")
+		for key, values := range reqInfo.ResponseHeaders {
+			for _, value := range values {
+				glog.Infof("    %s: %s", key, value)
+			}
+		}
+	}
+
+	return response, err
+}

--- a/pkg/client/v1/debugging.go
+++ b/pkg/client/v1/debugging.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"fmt"

--- a/pkg/client/v1/deployment.go
+++ b/pkg/client/v1/deployment.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/experimental"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// DeploymentsNamespacer has methods to work with Deployment resources in a namespace
+type DeploymentsNamespacer interface {
+	Deployments(namespace string) DeploymentInterface
+}
+
+// DeploymentInterface has methods to work with Deployment resources.
+type DeploymentInterface interface {
+	List(label labels.Selector, field fields.Selector) (*experimental.DeploymentList, error)
+	Get(name string) (*experimental.Deployment, error)
+	Delete(name string, options *api.DeleteOptions) error
+	Create(Deployment *experimental.Deployment) (*experimental.Deployment, error)
+	Update(Deployment *experimental.Deployment) (*experimental.Deployment, error)
+	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
+}
+
+// deployments implements DeploymentInterface
+type deployments struct {
+	client *ExperimentalClient
+	ns     string
+}
+
+// newDeployments returns a Deployments
+func newDeployments(c *ExperimentalClient, namespace string) *deployments {
+	return &deployments{
+		client: c,
+		ns:     namespace,
+	}
+}
+
+// List takes label and field selectors, and returns the list of Deployments that match those selectors.
+func (c *deployments) List(label labels.Selector, field fields.Selector) (result *experimental.DeploymentList, err error) {
+	result = &experimental.DeploymentList{}
+	err = c.client.Get().Namespace(c.ns).Resource("deployments").LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
+	return
+}
+
+// Get takes name of the deployment, and returns the corresponding deployment object, and an error if there is any.
+func (c *deployments) Get(name string) (result *experimental.Deployment, err error) {
+	result = &experimental.Deployment{}
+	err = c.client.Get().Namespace(c.ns).Resource("deployments").Name(name).Do().Into(result)
+	return
+}
+
+// Delete takes name of the deployment and deletes it. Returns an error if one occurs.
+func (c *deployments) Delete(name string, options *api.DeleteOptions) error {
+	if options == nil {
+		return c.client.Delete().Namespace(c.ns).Resource("deployments").Name(name).Do().Error()
+	}
+	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion())
+	if err != nil {
+		return err
+	}
+	return c.client.Delete().Namespace(c.ns).Resource("deployments").Name(name).Body(body).Do().Error()
+}
+
+// Create takes the representation of a deployment and creates it.  Returns the server's representation of the deployment, and an error, if there is any.
+func (c *deployments) Create(deployment *experimental.Deployment) (result *experimental.Deployment, err error) {
+	result = &experimental.Deployment{}
+	err = c.client.Post().Namespace(c.ns).Resource("deployments").Body(deployment).Do().Into(result)
+	return
+}
+
+// Update takes the representation of a deployment and updates it. Returns the server's representation of the deployment, and an error, if there is any.
+func (c *deployments) Update(deployment *experimental.Deployment) (result *experimental.Deployment, err error) {
+	result = &experimental.Deployment{}
+	err = c.client.Put().Namespace(c.ns).Resource("deployments").Name(deployment.Name).Body(deployment).Do().Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested deployments.
+func (c *deployments) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.client.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("deployments").
+		Param("resourceVersion", resourceVersion).
+		LabelsSelectorParam(label).
+		FieldsSelectorParam(field).
+		Watch()
+}

--- a/pkg/client/v1/deployment.go
+++ b/pkg/client/v1/deployment.go
@@ -14,11 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/apis/experimental"
+	"k8s.io/kubernetes/pkg/api/v1"
+	experimental "k8s.io/kubernetes/pkg/apis/experimental/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/watch"
@@ -33,7 +34,7 @@ type DeploymentsNamespacer interface {
 type DeploymentInterface interface {
 	List(label labels.Selector, field fields.Selector) (*experimental.DeploymentList, error)
 	Get(name string) (*experimental.Deployment, error)
-	Delete(name string, options *api.DeleteOptions) error
+	Delete(name string, options *v1.DeleteOptions) error
 	Create(Deployment *experimental.Deployment) (*experimental.Deployment, error)
 	Update(Deployment *experimental.Deployment) (*experimental.Deployment, error)
 	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
@@ -68,7 +69,7 @@ func (c *deployments) Get(name string) (result *experimental.Deployment, err err
 }
 
 // Delete takes name of the deployment and deletes it. Returns an error if one occurs.
-func (c *deployments) Delete(name string, options *api.DeleteOptions) error {
+func (c *deployments) Delete(name string, options *v1.DeleteOptions) error {
 	if options == nil {
 		return c.client.Delete().Namespace(c.ns).Resource("deployments").Name(name).Do().Error()
 	}

--- a/pkg/client/v1/deployment_test.go
+++ b/pkg/client/v1/deployment_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"net/url"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/apis/experimental"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func getDeploymentsResoureName() string {
+	return "deployments"
+}
+
+func TestDeploymentCreate(t *testing.T) {
+	ns := api.NamespaceDefault
+	deployment := experimental.Deployment{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "abc",
+			Namespace: ns,
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "POST",
+			Path:   testapi.Experimental.ResourcePath(getDeploymentsResoureName(), ns, ""),
+			Query:  buildQueryValues(nil),
+			Body:   &deployment,
+		},
+		Response: Response{StatusCode: 200, Body: &deployment},
+	}
+
+	response, err := c.Setup(t).Deployments(ns).Create(&deployment)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	c.Validate(t, response, err)
+}
+
+func TestDeploymentGet(t *testing.T) {
+	ns := api.NamespaceDefault
+	deployment := &experimental.Deployment{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "abc",
+			Namespace: ns,
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Experimental.ResourcePath(getDeploymentsResoureName(), ns, "abc"),
+			Query:  buildQueryValues(nil),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: deployment},
+	}
+
+	response, err := c.Setup(t).Deployments(ns).Get("abc")
+	c.Validate(t, response, err)
+}
+
+func TestDeploymentList(t *testing.T) {
+	ns := api.NamespaceDefault
+	deploymentList := &experimental.DeploymentList{
+		Items: []experimental.Deployment{
+			{
+				ObjectMeta: api.ObjectMeta{
+					Name:      "foo",
+					Namespace: ns,
+				},
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Experimental.ResourcePath(getDeploymentsResoureName(), ns, ""),
+			Query:  buildQueryValues(nil),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: deploymentList},
+	}
+	response, err := c.Setup(t).Deployments(ns).List(labels.Everything(), fields.Everything())
+	c.Validate(t, response, err)
+}
+
+func TestDeploymentUpdate(t *testing.T) {
+	ns := api.NamespaceDefault
+	deployment := &experimental.Deployment{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "abc",
+			Namespace:       ns,
+			ResourceVersion: "1",
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "PUT",
+			Path:   testapi.Experimental.ResourcePath(getDeploymentsResoureName(), ns, "abc"),
+			Query:  buildQueryValues(nil),
+		},
+		Response: Response{StatusCode: 200, Body: deployment},
+	}
+	response, err := c.Setup(t).Deployments(ns).Update(deployment)
+	c.Validate(t, response, err)
+}
+
+func TestDeploymentDelete(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request: testRequest{
+			Method: "DELETE",
+			Path:   testapi.Experimental.ResourcePath(getDeploymentsResoureName(), ns, "foo"),
+			Query:  buildQueryValues(nil),
+		},
+		Response: Response{StatusCode: 200},
+	}
+	err := c.Setup(t).Deployments(ns).Delete("foo", nil)
+	c.Validate(t, nil, err)
+}
+
+func TestDeploymentWatch(t *testing.T) {
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Experimental.ResourcePathWithPrefix("watch", getDeploymentsResoureName(), "", ""),
+			Query:  url.Values{"resourceVersion": []string{}},
+		},
+		Response: Response{StatusCode: 200},
+	}
+	_, err := c.Setup(t).Deployments(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), "")
+	c.Validate(t, nil, err)
+}

--- a/pkg/client/v1/deployment_test.go
+++ b/pkg/client/v1/deployment_test.go
@@ -14,15 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"net/url"
 	"testing"
 
-	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
-	"k8s.io/kubernetes/pkg/apis/experimental"
+	"k8s.io/kubernetes/pkg/api/v1"
+	experimental "k8s.io/kubernetes/pkg/apis/experimental/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 )
@@ -32,9 +32,9 @@ func getDeploymentsResoureName() string {
 }
 
 func TestDeploymentCreate(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	deployment := experimental.Deployment{
-		ObjectMeta: api.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "abc",
 			Namespace: ns,
 		},
@@ -57,9 +57,9 @@ func TestDeploymentCreate(t *testing.T) {
 }
 
 func TestDeploymentGet(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	deployment := &experimental.Deployment{
-		ObjectMeta: api.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "abc",
 			Namespace: ns,
 		},
@@ -79,11 +79,11 @@ func TestDeploymentGet(t *testing.T) {
 }
 
 func TestDeploymentList(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	deploymentList := &experimental.DeploymentList{
 		Items: []experimental.Deployment{
 			{
-				ObjectMeta: api.ObjectMeta{
+				ObjectMeta: v1.ObjectMeta{
 					Name:      "foo",
 					Namespace: ns,
 				},
@@ -104,9 +104,9 @@ func TestDeploymentList(t *testing.T) {
 }
 
 func TestDeploymentUpdate(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	deployment := &experimental.Deployment{
-		ObjectMeta: api.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:            "abc",
 			Namespace:       ns,
 			ResourceVersion: "1",
@@ -125,7 +125,7 @@ func TestDeploymentUpdate(t *testing.T) {
 }
 
 func TestDeploymentDelete(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	c := &testClient{
 		Request: testRequest{
 			Method: "DELETE",
@@ -147,6 +147,6 @@ func TestDeploymentWatch(t *testing.T) {
 		},
 		Response: Response{StatusCode: 200},
 	}
-	_, err := c.Setup(t).Deployments(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), "")
+	_, err := c.Setup(t).Deployments(v1.NamespaceAll).Watch(labels.Everything(), fields.Everything(), "")
 	c.Validate(t, nil, err)
 }

--- a/pkg/client/v1/doc.go
+++ b/pkg/client/v1/doc.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package client contains the implementation of the client side communication with the
+Kubernetes master. The Client class provides methods for reading, creating, updating,
+and deleting pods, replication controllers, daemons, services, and nodes.
+
+Most consumers should use the Config object to create a Client:
+
+    import (
+      "k8s.io/kubernetes/pkg/client"
+      "k8s.io/kubernetes/pkg/api"
+      "k8s.io/kubernetes/pkg/fields"
+      "k8s.io/kubernetes/pkg/labels"
+    )
+
+    [...]
+
+    config := &client.Config{
+      Host:     "http://localhost:8080",
+      Username: "test",
+      Password: "password",
+    }
+    client, err := client.New(config)
+    if err != nil {
+      // handle error
+    }
+    pods, err := client.Pods(api.NamespaceDefault).List(labels.Everything(), fields.Everything())
+    if err != nil {
+      // handle error
+    }
+
+More advanced consumers may wish to provide their own transport via a http.RoundTripper:
+
+    config := &client.Config{
+      Host:      "https://localhost:8080",
+      Transport: oauthclient.Transport(),
+    }
+    client, err := client.New(config)
+
+The RESTClient type implements the Kubernetes API conventions (see `docs/devel/api-conventions.md`)
+for a given API path and is intended for use by consumers implementing their own Kubernetes
+compatible APIs.
+*/
+package unversioned

--- a/pkg/client/v1/doc.go
+++ b/pkg/client/v1/doc.go
@@ -15,15 +15,15 @@ limitations under the License.
 */
 
 /*
-Package client contains the implementation of the client side communication with the
+Package v1 contains the implementation of the v1 client side communication with the
 Kubernetes master. The Client class provides methods for reading, creating, updating,
 and deleting pods, replication controllers, daemons, services, and nodes.
 
 Most consumers should use the Config object to create a Client:
 
     import (
-      "k8s.io/kubernetes/pkg/client"
-      "k8s.io/kubernetes/pkg/api"
+      client "k8s.io/kubernetes/pkg/client/v1"
+      api "k8s.io/kubernetes/pkg/api/v1"
       "k8s.io/kubernetes/pkg/fields"
       "k8s.io/kubernetes/pkg/labels"
     )
@@ -56,4 +56,4 @@ The RESTClient type implements the Kubernetes API conventions (see `docs/devel/a
 for a given API path and is intended for use by consumers implementing their own Kubernetes
 compatible APIs.
 */
-package unversioned
+package v1

--- a/pkg/client/v1/endpoints.go
+++ b/pkg/client/v1/endpoints.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// EndpointsNamespacer has methods to work with Endpoints resources in a namespace
+type EndpointsNamespacer interface {
+	Endpoints(namespace string) EndpointsInterface
+}
+
+// EndpointsInterface has methods to work with Endpoints resources
+type EndpointsInterface interface {
+	Create(endpoints *api.Endpoints) (*api.Endpoints, error)
+	List(selector labels.Selector) (*api.EndpointsList, error)
+	Get(name string) (*api.Endpoints, error)
+	Delete(name string) error
+	Update(endpoints *api.Endpoints) (*api.Endpoints, error)
+	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
+}
+
+// endpoints implements EndpointsInterface
+type endpoints struct {
+	r  *Client
+	ns string
+}
+
+// newEndpoints returns a endpoints
+func newEndpoints(c *Client, namespace string) *endpoints {
+	return &endpoints{c, namespace}
+}
+
+// Create creates a new endpoint.
+func (c *endpoints) Create(endpoints *api.Endpoints) (*api.Endpoints, error) {
+	result := &api.Endpoints{}
+	err := c.r.Post().Namespace(c.ns).Resource("endpoints").Body(endpoints).Do().Into(result)
+	return result, err
+}
+
+// List takes a selector, and returns the list of endpoints that match that selector
+func (c *endpoints) List(selector labels.Selector) (result *api.EndpointsList, err error) {
+	result = &api.EndpointsList{}
+	err = c.r.Get().
+		Namespace(c.ns).
+		Resource("endpoints").
+		LabelsSelectorParam(selector).
+		Do().
+		Into(result)
+	return
+}
+
+// Get returns information about the endpoints for a particular service.
+func (c *endpoints) Get(name string) (result *api.Endpoints, err error) {
+	result = &api.Endpoints{}
+	err = c.r.Get().Namespace(c.ns).Resource("endpoints").Name(name).Do().Into(result)
+	return
+}
+
+// Delete takes the name of the endpoint, and returns an error if one occurs
+func (c *endpoints) Delete(name string) error {
+	return c.r.Delete().Namespace(c.ns).Resource("endpoints").Name(name).Do().Error()
+}
+
+// Watch returns a watch.Interface that watches the requested endpoints for a service.
+func (c *endpoints) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.r.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("endpoints").
+		Param("resourceVersion", resourceVersion).
+		LabelsSelectorParam(label).
+		FieldsSelectorParam(field).
+		Watch()
+}
+
+func (c *endpoints) Update(endpoints *api.Endpoints) (*api.Endpoints, error) {
+	result := &api.Endpoints{}
+	if len(endpoints.ResourceVersion) == 0 {
+		return nil, fmt.Errorf("invalid update object, missing resource version: %v", endpoints)
+	}
+	err := c.r.Put().
+		Namespace(c.ns).
+		Resource("endpoints").
+		Name(endpoints.Name).
+		Body(endpoints).
+		Do().
+		Into(result)
+	return result, err
+}

--- a/pkg/client/v1/endpoints.go
+++ b/pkg/client/v1/endpoints.go
@@ -14,12 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"fmt"
 
-	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/watch"
@@ -32,11 +32,11 @@ type EndpointsNamespacer interface {
 
 // EndpointsInterface has methods to work with Endpoints resources
 type EndpointsInterface interface {
-	Create(endpoints *api.Endpoints) (*api.Endpoints, error)
-	List(selector labels.Selector) (*api.EndpointsList, error)
-	Get(name string) (*api.Endpoints, error)
+	Create(endpoints *v1.Endpoints) (*v1.Endpoints, error)
+	List(selector labels.Selector) (*v1.EndpointsList, error)
+	Get(name string) (*v1.Endpoints, error)
 	Delete(name string) error
-	Update(endpoints *api.Endpoints) (*api.Endpoints, error)
+	Update(endpoints *v1.Endpoints) (*v1.Endpoints, error)
 	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
 }
 
@@ -52,15 +52,15 @@ func newEndpoints(c *Client, namespace string) *endpoints {
 }
 
 // Create creates a new endpoint.
-func (c *endpoints) Create(endpoints *api.Endpoints) (*api.Endpoints, error) {
-	result := &api.Endpoints{}
+func (c *endpoints) Create(endpoints *v1.Endpoints) (*v1.Endpoints, error) {
+	result := &v1.Endpoints{}
 	err := c.r.Post().Namespace(c.ns).Resource("endpoints").Body(endpoints).Do().Into(result)
 	return result, err
 }
 
 // List takes a selector, and returns the list of endpoints that match that selector
-func (c *endpoints) List(selector labels.Selector) (result *api.EndpointsList, err error) {
-	result = &api.EndpointsList{}
+func (c *endpoints) List(selector labels.Selector) (result *v1.EndpointsList, err error) {
+	result = &v1.EndpointsList{}
 	err = c.r.Get().
 		Namespace(c.ns).
 		Resource("endpoints").
@@ -71,8 +71,8 @@ func (c *endpoints) List(selector labels.Selector) (result *api.EndpointsList, e
 }
 
 // Get returns information about the endpoints for a particular service.
-func (c *endpoints) Get(name string) (result *api.Endpoints, err error) {
-	result = &api.Endpoints{}
+func (c *endpoints) Get(name string) (result *v1.Endpoints, err error) {
+	result = &v1.Endpoints{}
 	err = c.r.Get().Namespace(c.ns).Resource("endpoints").Name(name).Do().Into(result)
 	return
 }
@@ -94,8 +94,8 @@ func (c *endpoints) Watch(label labels.Selector, field fields.Selector, resource
 		Watch()
 }
 
-func (c *endpoints) Update(endpoints *api.Endpoints) (*api.Endpoints, error) {
-	result := &api.Endpoints{}
+func (c *endpoints) Update(endpoints *v1.Endpoints) (*v1.Endpoints, error) {
+	result := &v1.Endpoints{}
 	if len(endpoints.ResourceVersion) == 0 {
 		return nil, fmt.Errorf("invalid update object, missing resource version: %v", endpoints)
 	}

--- a/pkg/client/v1/endpoints_test.go
+++ b/pkg/client/v1/endpoints_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func TestListEndpoints(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request: testRequest{Method: "GET", Path: testapi.Default.ResourcePath("endpoints", ns, ""), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200,
+			Body: &api.EndpointsList{
+				Items: []api.Endpoints{
+					{
+						ObjectMeta: api.ObjectMeta{Name: "endpoint-1"},
+						Subsets: []api.EndpointSubset{{
+							Addresses: []api.EndpointAddress{{IP: "10.245.1.2"}, {IP: "10.245.1.3"}},
+							Ports:     []api.EndpointPort{{Port: 8080}},
+						}},
+					},
+				},
+			},
+		},
+	}
+	receivedEndpointsList, err := c.Setup(t).Endpoints(ns).List(labels.Everything())
+	c.Validate(t, receivedEndpointsList, err)
+}
+
+func TestGetEndpoints(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request:  testRequest{Method: "GET", Path: testapi.Default.ResourcePath("endpoints", ns, "endpoint-1"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200, Body: &api.Endpoints{ObjectMeta: api.ObjectMeta{Name: "endpoint-1"}}},
+	}
+	response, err := c.Setup(t).Endpoints(ns).Get("endpoint-1")
+	c.Validate(t, response, err)
+}
+
+func TestGetEndpointWithNoName(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{Error: true}
+	receivedPod, err := c.Setup(t).Endpoints(ns).Get("")
+	if (err != nil) && (err.Error() != nameRequiredError) {
+		t.Errorf("Expected error: %v, but got %v", nameRequiredError, err)
+	}
+
+	c.Validate(t, receivedPod, err)
+}

--- a/pkg/client/v1/endpoints_test.go
+++ b/pkg/client/v1/endpoints_test.go
@@ -14,28 +14,28 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"testing"
 
-	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/labels"
 )
 
 func TestListEndpoints(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	c := &testClient{
 		Request: testRequest{Method: "GET", Path: testapi.Default.ResourcePath("endpoints", ns, ""), Query: buildQueryValues(nil)},
 		Response: Response{StatusCode: 200,
-			Body: &api.EndpointsList{
-				Items: []api.Endpoints{
+			Body: &v1.EndpointsList{
+				Items: []v1.Endpoints{
 					{
-						ObjectMeta: api.ObjectMeta{Name: "endpoint-1"},
-						Subsets: []api.EndpointSubset{{
-							Addresses: []api.EndpointAddress{{IP: "10.245.1.2"}, {IP: "10.245.1.3"}},
-							Ports:     []api.EndpointPort{{Port: 8080}},
+						ObjectMeta: v1.ObjectMeta{Name: "endpoint-1"},
+						Subsets: []v1.EndpointSubset{{
+							Addresses: []v1.EndpointAddress{{IP: "10.245.1.2"}, {IP: "10.245.1.3"}},
+							Ports:     []v1.EndpointPort{{Port: 8080}},
 						}},
 					},
 				},
@@ -47,17 +47,17 @@ func TestListEndpoints(t *testing.T) {
 }
 
 func TestGetEndpoints(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	c := &testClient{
 		Request:  testRequest{Method: "GET", Path: testapi.Default.ResourcePath("endpoints", ns, "endpoint-1"), Query: buildQueryValues(nil)},
-		Response: Response{StatusCode: 200, Body: &api.Endpoints{ObjectMeta: api.ObjectMeta{Name: "endpoint-1"}}},
+		Response: Response{StatusCode: 200, Body: &v1.Endpoints{ObjectMeta: v1.ObjectMeta{Name: "endpoint-1"}}},
 	}
 	response, err := c.Setup(t).Endpoints(ns).Get("endpoint-1")
 	c.Validate(t, response, err)
 }
 
 func TestGetEndpointWithNoName(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	c := &testClient{Error: true}
 	receivedPod, err := c.Setup(t).Endpoints(ns).Get("")
 	if (err != nil) && (err.Error() != nameRequiredError) {

--- a/pkg/client/v1/events.go
+++ b/pkg/client/v1/events.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// EventNamespacer can return an EventInterface for the given namespace.
+type EventNamespacer interface {
+	Events(namespace string) EventInterface
+}
+
+// EventInterface has methods to work with Event resources
+type EventInterface interface {
+	Create(event *api.Event) (*api.Event, error)
+	Update(event *api.Event) (*api.Event, error)
+	List(label labels.Selector, field fields.Selector) (*api.EventList, error)
+	Get(name string) (*api.Event, error)
+	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
+	// Search finds events about the specified object
+	Search(objOrRef runtime.Object) (*api.EventList, error)
+	Delete(name string) error
+	// Returns the appropriate field selector based on the API version being used to communicate with the server.
+	// The returned field selector can be used with List and Watch to filter desired events.
+	GetFieldSelector(involvedObjectName, involvedObjectNamespace, involvedObjectKind, involvedObjectUID *string) fields.Selector
+}
+
+// events implements Events interface
+type events struct {
+	client    *Client
+	namespace string
+}
+
+// newEvents returns a new events object.
+func newEvents(c *Client, ns string) *events {
+	return &events{
+		client:    c,
+		namespace: ns,
+	}
+}
+
+// Create makes a new event. Returns the copy of the event the server returns,
+// or an error. The namespace to create the event within is deduced from the
+// event; it must either match this event client's namespace, or this event
+// client must have been created with the "" namespace.
+func (e *events) Create(event *api.Event) (*api.Event, error) {
+	if e.namespace != "" && event.Namespace != e.namespace {
+		return nil, fmt.Errorf("can't create an event with namespace '%v' in namespace '%v'", event.Namespace, e.namespace)
+	}
+	result := &api.Event{}
+	err := e.client.Post().
+		NamespaceIfScoped(event.Namespace, len(event.Namespace) > 0).
+		Resource("events").
+		Body(event).
+		Do().
+		Into(result)
+	return result, err
+}
+
+// Update modifies an existing event. It returns the copy of the event that the server returns,
+// or an error. The namespace and key to update the event within is deduced from the event. The
+// namespace must either match this event client's namespace, or this event client must have been
+// created with the "" namespace. Update also requires the ResourceVersion to be set in the event
+// object.
+func (e *events) Update(event *api.Event) (*api.Event, error) {
+	if len(event.ResourceVersion) == 0 {
+		return nil, fmt.Errorf("invalid event update object, missing resource version: %#v", event)
+	}
+	result := &api.Event{}
+	err := e.client.Put().
+		NamespaceIfScoped(event.Namespace, len(event.Namespace) > 0).
+		Resource("events").
+		Name(event.Name).
+		Body(event).
+		Do().
+		Into(result)
+	return result, err
+}
+
+// List returns a list of events matching the selectors.
+func (e *events) List(label labels.Selector, field fields.Selector) (*api.EventList, error) {
+	result := &api.EventList{}
+	err := e.client.Get().
+		NamespaceIfScoped(e.namespace, len(e.namespace) > 0).
+		Resource("events").
+		LabelsSelectorParam(label).
+		FieldsSelectorParam(field).
+		Do().
+		Into(result)
+	return result, err
+}
+
+// Get returns the given event, or an error.
+func (e *events) Get(name string) (*api.Event, error) {
+	result := &api.Event{}
+	err := e.client.Get().
+		NamespaceIfScoped(e.namespace, len(e.namespace) > 0).
+		Resource("events").
+		Name(name).
+		Do().
+		Into(result)
+	return result, err
+}
+
+// Watch starts watching for events matching the given selectors.
+func (e *events) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return e.client.Get().
+		Prefix("watch").
+		NamespaceIfScoped(e.namespace, len(e.namespace) > 0).
+		Resource("events").
+		Param("resourceVersion", resourceVersion).
+		LabelsSelectorParam(label).
+		FieldsSelectorParam(field).
+		Watch()
+}
+
+// Search finds events about the specified object. The namespace of the
+// object must match this event's client namespace unless the event client
+// was made with the "" namespace.
+func (e *events) Search(objOrRef runtime.Object) (*api.EventList, error) {
+	ref, err := api.GetReference(objOrRef)
+	if err != nil {
+		return nil, err
+	}
+	if e.namespace != "" && ref.Namespace != e.namespace {
+		return nil, fmt.Errorf("won't be able to find any events of namespace '%v' in namespace '%v'", ref.Namespace, e.namespace)
+	}
+	stringRefKind := string(ref.Kind)
+	var refKind *string
+	if stringRefKind != "" {
+		refKind = &stringRefKind
+	}
+	stringRefUID := string(ref.UID)
+	var refUID *string
+	if stringRefUID != "" {
+		refUID = &stringRefUID
+	}
+	fieldSelector := e.GetFieldSelector(&ref.Name, &ref.Namespace, refKind, refUID)
+	return e.List(labels.Everything(), fieldSelector)
+}
+
+// Delete deletes an existing event.
+func (e *events) Delete(name string) error {
+	return e.client.Delete().
+		NamespaceIfScoped(e.namespace, len(e.namespace) > 0).
+		Resource("events").
+		Name(name).
+		Do().
+		Error()
+}
+
+// Returns the appropriate field selector based on the API version being used to communicate with the server.
+// The returned field selector can be used with List and Watch to filter desired events.
+func (e *events) GetFieldSelector(involvedObjectName, involvedObjectNamespace, involvedObjectKind, involvedObjectUID *string) fields.Selector {
+	apiVersion := e.client.APIVersion()
+	field := fields.Set{}
+	if involvedObjectName != nil {
+		field[getInvolvedObjectNameFieldLabel(apiVersion)] = *involvedObjectName
+	}
+	if involvedObjectNamespace != nil {
+		field["involvedObject.namespace"] = *involvedObjectNamespace
+	}
+	if involvedObjectKind != nil {
+		field["involvedObject.kind"] = *involvedObjectKind
+	}
+	if involvedObjectUID != nil {
+		field["involvedObject.uid"] = *involvedObjectUID
+	}
+	return field.AsSelector()
+}
+
+// Returns the appropriate field label to use for name of the involved object as per the given API version.
+func getInvolvedObjectNameFieldLabel(version string) string {
+	return "involvedObject.name"
+}

--- a/pkg/client/v1/events.go
+++ b/pkg/client/v1/events.go
@@ -14,12 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"fmt"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
@@ -33,13 +34,13 @@ type EventNamespacer interface {
 
 // EventInterface has methods to work with Event resources
 type EventInterface interface {
-	Create(event *api.Event) (*api.Event, error)
-	Update(event *api.Event) (*api.Event, error)
-	List(label labels.Selector, field fields.Selector) (*api.EventList, error)
-	Get(name string) (*api.Event, error)
+	Create(event *v1.Event) (*v1.Event, error)
+	Update(event *v1.Event) (*v1.Event, error)
+	List(label labels.Selector, field fields.Selector) (*v1.EventList, error)
+	Get(name string) (*v1.Event, error)
 	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
 	// Search finds events about the specified object
-	Search(objOrRef runtime.Object) (*api.EventList, error)
+	Search(objOrRef runtime.Object) (*v1.EventList, error)
 	Delete(name string) error
 	// Returns the appropriate field selector based on the API version being used to communicate with the server.
 	// The returned field selector can be used with List and Watch to filter desired events.
@@ -64,11 +65,11 @@ func newEvents(c *Client, ns string) *events {
 // or an error. The namespace to create the event within is deduced from the
 // event; it must either match this event client's namespace, or this event
 // client must have been created with the "" namespace.
-func (e *events) Create(event *api.Event) (*api.Event, error) {
+func (e *events) Create(event *v1.Event) (*v1.Event, error) {
 	if e.namespace != "" && event.Namespace != e.namespace {
 		return nil, fmt.Errorf("can't create an event with namespace '%v' in namespace '%v'", event.Namespace, e.namespace)
 	}
-	result := &api.Event{}
+	result := &v1.Event{}
 	err := e.client.Post().
 		NamespaceIfScoped(event.Namespace, len(event.Namespace) > 0).
 		Resource("events").
@@ -83,11 +84,11 @@ func (e *events) Create(event *api.Event) (*api.Event, error) {
 // namespace must either match this event client's namespace, or this event client must have been
 // created with the "" namespace. Update also requires the ResourceVersion to be set in the event
 // object.
-func (e *events) Update(event *api.Event) (*api.Event, error) {
+func (e *events) Update(event *v1.Event) (*v1.Event, error) {
 	if len(event.ResourceVersion) == 0 {
 		return nil, fmt.Errorf("invalid event update object, missing resource version: %#v", event)
 	}
-	result := &api.Event{}
+	result := &v1.Event{}
 	err := e.client.Put().
 		NamespaceIfScoped(event.Namespace, len(event.Namespace) > 0).
 		Resource("events").
@@ -99,8 +100,8 @@ func (e *events) Update(event *api.Event) (*api.Event, error) {
 }
 
 // List returns a list of events matching the selectors.
-func (e *events) List(label labels.Selector, field fields.Selector) (*api.EventList, error) {
-	result := &api.EventList{}
+func (e *events) List(label labels.Selector, field fields.Selector) (*v1.EventList, error) {
+	result := &v1.EventList{}
 	err := e.client.Get().
 		NamespaceIfScoped(e.namespace, len(e.namespace) > 0).
 		Resource("events").
@@ -112,8 +113,8 @@ func (e *events) List(label labels.Selector, field fields.Selector) (*api.EventL
 }
 
 // Get returns the given event, or an error.
-func (e *events) Get(name string) (*api.Event, error) {
-	result := &api.Event{}
+func (e *events) Get(name string) (*v1.Event, error) {
+	result := &v1.Event{}
 	err := e.client.Get().
 		NamespaceIfScoped(e.namespace, len(e.namespace) > 0).
 		Resource("events").
@@ -138,7 +139,7 @@ func (e *events) Watch(label labels.Selector, field fields.Selector, resourceVer
 // Search finds events about the specified object. The namespace of the
 // object must match this event's client namespace unless the event client
 // was made with the "" namespace.
-func (e *events) Search(objOrRef runtime.Object) (*api.EventList, error) {
+func (e *events) Search(objOrRef runtime.Object) (*v1.EventList, error) {
 	ref, err := api.GetReference(objOrRef)
 	if err != nil {
 		return nil, err

--- a/pkg/client/v1/events_test.go
+++ b/pkg/client/v1/events_test.go
@@ -1,0 +1,195 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"net/url"
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func TestEventSearch(t *testing.T) {
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath("events", "baz", ""),
+			Query: url.Values{
+				api.FieldSelectorQueryParam(testapi.Default.Version()): []string{
+					getInvolvedObjectNameFieldLabel(testapi.Default.Version()) + "=foo,",
+					"involvedObject.namespace=baz,",
+					"involvedObject.kind=Pod",
+				},
+				api.LabelSelectorQueryParam(testapi.Default.Version()): []string{},
+			},
+		},
+		Response: Response{StatusCode: 200, Body: &api.EventList{}},
+	}
+	eventList, err := c.Setup(t).Events("baz").Search(
+		&api.Pod{
+			ObjectMeta: api.ObjectMeta{
+				Name:      "foo",
+				Namespace: "baz",
+				SelfLink:  testapi.Default.SelfLink("pods", ""),
+			},
+		},
+	)
+	c.Validate(t, eventList, err)
+}
+
+func TestEventCreate(t *testing.T) {
+	objReference := &api.ObjectReference{
+		Kind:            "foo",
+		Namespace:       "nm",
+		Name:            "objref1",
+		UID:             "uid",
+		APIVersion:      "apiv1",
+		ResourceVersion: "1",
+	}
+	timeStamp := unversioned.Now()
+	event := &api.Event{
+		ObjectMeta: api.ObjectMeta{
+			Namespace: api.NamespaceDefault,
+		},
+		InvolvedObject: *objReference,
+		FirstTimestamp: timeStamp,
+		LastTimestamp:  timeStamp,
+		Count:          1,
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "POST",
+			Path:   testapi.Default.ResourcePath("events", api.NamespaceDefault, ""),
+			Body:   event,
+		},
+		Response: Response{StatusCode: 200, Body: event},
+	}
+
+	response, err := c.Setup(t).Events(api.NamespaceDefault).Create(event)
+
+	if err != nil {
+		t.Fatalf("%v should be nil.", err)
+	}
+
+	if e, a := *objReference, response.InvolvedObject; !reflect.DeepEqual(e, a) {
+		t.Errorf("%#v != %#v.", e, a)
+	}
+}
+
+func TestEventGet(t *testing.T) {
+	objReference := &api.ObjectReference{
+		Kind:            "foo",
+		Namespace:       "nm",
+		Name:            "objref1",
+		UID:             "uid",
+		APIVersion:      "apiv1",
+		ResourceVersion: "1",
+	}
+	timeStamp := unversioned.Now()
+	event := &api.Event{
+		ObjectMeta: api.ObjectMeta{
+			Namespace: "other",
+		},
+		InvolvedObject: *objReference,
+		FirstTimestamp: timeStamp,
+		LastTimestamp:  timeStamp,
+		Count:          1,
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath("events", "other", "1"),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: event},
+	}
+
+	response, err := c.Setup(t).Events("other").Get("1")
+
+	if err != nil {
+		t.Fatalf("%v should be nil.", err)
+	}
+
+	if e, r := event.InvolvedObject, response.InvolvedObject; !reflect.DeepEqual(e, r) {
+		t.Errorf("%#v != %#v.", e, r)
+	}
+}
+
+func TestEventList(t *testing.T) {
+	ns := api.NamespaceDefault
+	objReference := &api.ObjectReference{
+		Kind:            "foo",
+		Namespace:       ns,
+		Name:            "objref1",
+		UID:             "uid",
+		APIVersion:      "apiv1",
+		ResourceVersion: "1",
+	}
+	timeStamp := unversioned.Now()
+	eventList := &api.EventList{
+		Items: []api.Event{
+			{
+				InvolvedObject: *objReference,
+				FirstTimestamp: timeStamp,
+				LastTimestamp:  timeStamp,
+				Count:          1,
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath("events", ns, ""),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: eventList},
+	}
+	response, err := c.Setup(t).Events(ns).List(labels.Everything(),
+		fields.Everything())
+
+	if err != nil {
+		t.Errorf("%#v should be nil.", err)
+	}
+
+	if len(response.Items) != 1 {
+		t.Errorf("%#v response.Items should have len 1.", response.Items)
+	}
+
+	responseEvent := response.Items[0]
+	if e, r := eventList.Items[0].InvolvedObject,
+		responseEvent.InvolvedObject; !reflect.DeepEqual(e, r) {
+		t.Errorf("%#v != %#v.", e, r)
+	}
+}
+
+func TestEventDelete(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request: testRequest{
+			Method: "DELETE",
+			Path:   testapi.Default.ResourcePath("events", ns, "foo"),
+		},
+		Response: Response{StatusCode: 200},
+	}
+	err := c.Setup(t).Events(ns).Delete("foo")
+	c.Validate(t, nil, err)
+}

--- a/pkg/client/v1/events_test.go
+++ b/pkg/client/v1/events_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"net/url"
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 )
@@ -42,11 +43,11 @@ func TestEventSearch(t *testing.T) {
 				api.LabelSelectorQueryParam(testapi.Default.Version()): []string{},
 			},
 		},
-		Response: Response{StatusCode: 200, Body: &api.EventList{}},
+		Response: Response{StatusCode: 200, Body: &v1.EventList{}},
 	}
 	eventList, err := c.Setup(t).Events("baz").Search(
-		&api.Pod{
-			ObjectMeta: api.ObjectMeta{
+		&v1.Pod{
+			ObjectMeta: v1.ObjectMeta{
 				Name:      "foo",
 				Namespace: "baz",
 				SelfLink:  testapi.Default.SelfLink("pods", ""),
@@ -57,7 +58,7 @@ func TestEventSearch(t *testing.T) {
 }
 
 func TestEventCreate(t *testing.T) {
-	objReference := &api.ObjectReference{
+	objReference := &v1.ObjectReference{
 		Kind:            "foo",
 		Namespace:       "nm",
 		Name:            "objref1",
@@ -66,9 +67,9 @@ func TestEventCreate(t *testing.T) {
 		ResourceVersion: "1",
 	}
 	timeStamp := unversioned.Now()
-	event := &api.Event{
-		ObjectMeta: api.ObjectMeta{
-			Namespace: api.NamespaceDefault,
+	event := &v1.Event{
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: v1.NamespaceDefault,
 		},
 		InvolvedObject: *objReference,
 		FirstTimestamp: timeStamp,
@@ -78,13 +79,13 @@ func TestEventCreate(t *testing.T) {
 	c := &testClient{
 		Request: testRequest{
 			Method: "POST",
-			Path:   testapi.Default.ResourcePath("events", api.NamespaceDefault, ""),
+			Path:   testapi.Default.ResourcePath("events", v1.NamespaceDefault, ""),
 			Body:   event,
 		},
 		Response: Response{StatusCode: 200, Body: event},
 	}
 
-	response, err := c.Setup(t).Events(api.NamespaceDefault).Create(event)
+	response, err := c.Setup(t).Events(v1.NamespaceDefault).Create(event)
 
 	if err != nil {
 		t.Fatalf("%v should be nil.", err)
@@ -96,7 +97,7 @@ func TestEventCreate(t *testing.T) {
 }
 
 func TestEventGet(t *testing.T) {
-	objReference := &api.ObjectReference{
+	objReference := &v1.ObjectReference{
 		Kind:            "foo",
 		Namespace:       "nm",
 		Name:            "objref1",
@@ -105,8 +106,8 @@ func TestEventGet(t *testing.T) {
 		ResourceVersion: "1",
 	}
 	timeStamp := unversioned.Now()
-	event := &api.Event{
-		ObjectMeta: api.ObjectMeta{
+	event := &v1.Event{
+		ObjectMeta: v1.ObjectMeta{
 			Namespace: "other",
 		},
 		InvolvedObject: *objReference,
@@ -135,8 +136,8 @@ func TestEventGet(t *testing.T) {
 }
 
 func TestEventList(t *testing.T) {
-	ns := api.NamespaceDefault
-	objReference := &api.ObjectReference{
+	ns := v1.NamespaceDefault
+	objReference := &v1.ObjectReference{
 		Kind:            "foo",
 		Namespace:       ns,
 		Name:            "objref1",
@@ -145,8 +146,8 @@ func TestEventList(t *testing.T) {
 		ResourceVersion: "1",
 	}
 	timeStamp := unversioned.Now()
-	eventList := &api.EventList{
-		Items: []api.Event{
+	eventList := &v1.EventList{
+		Items: []v1.Event{
 			{
 				InvolvedObject: *objReference,
 				FirstTimestamp: timeStamp,
@@ -182,7 +183,7 @@ func TestEventList(t *testing.T) {
 }
 
 func TestEventDelete(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	c := &testClient{
 		Request: testRequest{
 			Method: "DELETE",

--- a/pkg/client/v1/experimental.go
+++ b/pkg/client/v1/experimental.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"encoding/json"

--- a/pkg/client/v1/experimental.go
+++ b/pkg/client/v1/experimental.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/latest"
+	"k8s.io/kubernetes/pkg/version"
+)
+
+// Interface holds the experimental methods for clients of Kubernetes
+// to allow mock testing.
+// Experimental features are not supported and may be changed or removed in
+// incompatible ways at any time.
+type ExperimentalInterface interface {
+	VersionInterface
+	HorizontalPodAutoscalersNamespacer
+	ScaleNamespacer
+	DaemonSetsNamespacer
+	DeploymentsNamespacer
+	JobsNamespacer
+}
+
+// ExperimentalClient is used to interact with experimental Kubernetes features.
+// Experimental features are not supported and may be changed or removed in
+// incompatible ways at any time.
+type ExperimentalClient struct {
+	*RESTClient
+}
+
+// ServerVersion retrieves and parses the server's version.
+func (c *ExperimentalClient) ServerVersion() (*version.Info, error) {
+	body, err := c.Get().AbsPath("/version").Do().Raw()
+	if err != nil {
+		return nil, err
+	}
+	var info version.Info
+	err = json.Unmarshal(body, &info)
+	if err != nil {
+		return nil, fmt.Errorf("got '%s': %v", string(body), err)
+	}
+	return &info, nil
+}
+
+// ServerAPIVersions retrieves and parses the list of experimental API versions the
+// server supports.
+func (c *ExperimentalClient) ServerAPIVersions() (*api.APIVersions, error) {
+	body, err := c.Get().UnversionedPath("").Do().Raw()
+	if err != nil {
+		return nil, err
+	}
+	var v api.APIVersions
+	err = json.Unmarshal(body, &v)
+	if err != nil {
+		return nil, fmt.Errorf("got '%s': %v", string(body), err)
+	}
+	return &v, nil
+}
+
+func (c *ExperimentalClient) HorizontalPodAutoscalers(namespace string) HorizontalPodAutoscalerInterface {
+	return newHorizontalPodAutoscalers(c, namespace)
+}
+
+func (c *ExperimentalClient) Scales(namespace string) ScaleInterface {
+	return newScales(c, namespace)
+}
+
+func (c *ExperimentalClient) DaemonSets(namespace string) DaemonSetInterface {
+	return newDaemonSets(c, namespace)
+}
+
+func (c *ExperimentalClient) Deployments(namespace string) DeploymentInterface {
+	return newDeployments(c, namespace)
+}
+
+func (c *ExperimentalClient) Jobs(namespace string) JobInterface {
+	return newJobs(c, namespace)
+}
+
+// NewExperimental creates a new ExperimentalClient for the given config. This client
+// provides access to experimental Kubernetes features.
+// Experimental features are not supported and may be changed or removed in
+// incompatible ways at any time.
+func NewExperimental(c *Config) (*ExperimentalClient, error) {
+	config := *c
+	if err := setExperimentalDefaults(&config); err != nil {
+		return nil, err
+	}
+	client, err := RESTClientFor(&config)
+	if err != nil {
+		return nil, err
+	}
+	return &ExperimentalClient{client}, nil
+}
+
+// NewExperimentalOrDie creates a new ExperimentalClient for the given config and
+// panics if there is an error in the config.
+// Experimental features are not supported and may be changed or removed in
+// incompatible ways at any time.
+func NewExperimentalOrDie(c *Config) *ExperimentalClient {
+	client, err := NewExperimental(c)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
+func setExperimentalDefaults(config *Config) error {
+	// if experimental group is not registered, return an error
+	g, err := latest.Group("experimental")
+	if err != nil {
+		return err
+	}
+	config.Prefix = "apis/" + g.Group
+	if config.UserAgent == "" {
+		config.UserAgent = DefaultKubernetesUserAgent()
+	}
+	if config.Version == "" {
+		config.Version = g.Version
+	}
+
+	versionInterfaces, err := g.InterfacesFor(config.Version)
+	if err != nil {
+		return fmt.Errorf("Experimental API version '%s' is not recognized (valid values: %s)",
+			config.Version, strings.Join(latest.GroupOrDie("experimental").Versions, ", "))
+	}
+	if config.Codec == nil {
+		config.Codec = versionInterfaces.Codec
+	}
+	if config.QPS == 0 {
+		config.QPS = 5
+	}
+	if config.Burst == 0 {
+		config.Burst = 10
+	}
+	return nil
+}

--- a/pkg/client/v1/fake/fake.go
+++ b/pkg/client/v1/fake/fake.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This is made a separate package and should only be imported by tests, because
+// it imports testapi
+package fake
+
+import (
+	"net/http"
+	"net/url"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+type HTTPClientFunc func(*http.Request) (*http.Response, error)
+
+func (f HTTPClientFunc) Do(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+// RESTClient provides a fake RESTClient interface.
+type RESTClient struct {
+	Client unversioned.HTTPClient
+	Codec  runtime.Codec
+	Req    *http.Request
+	Resp   *http.Response
+	Err    error
+}
+
+func (c *RESTClient) Get() *unversioned.Request {
+	return unversioned.NewRequest(c, "GET", &url.URL{Host: "localhost"}, testapi.Default.Version(), c.Codec)
+}
+
+func (c *RESTClient) Put() *unversioned.Request {
+	return unversioned.NewRequest(c, "PUT", &url.URL{Host: "localhost"}, testapi.Default.Version(), c.Codec)
+}
+
+func (c *RESTClient) Patch(_ api.PatchType) *unversioned.Request {
+	return unversioned.NewRequest(c, "PATCH", &url.URL{Host: "localhost"}, testapi.Default.Version(), c.Codec)
+}
+
+func (c *RESTClient) Post() *unversioned.Request {
+	return unversioned.NewRequest(c, "POST", &url.URL{Host: "localhost"}, testapi.Default.Version(), c.Codec)
+}
+
+func (c *RESTClient) Delete() *unversioned.Request {
+	return unversioned.NewRequest(c, "DELETE", &url.URL{Host: "localhost"}, testapi.Default.Version(), c.Codec)
+}
+
+func (c *RESTClient) Do(req *http.Request) (*http.Response, error) {
+	c.Req = req
+	if c.Client != unversioned.HTTPClient(nil) {
+		return c.Client.Do(req)
+	}
+	return c.Resp, c.Err
+}

--- a/pkg/client/v1/fake/fake.go
+++ b/pkg/client/v1/fake/fake.go
@@ -24,7 +24,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
-	"k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/client/v1"
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
@@ -36,36 +36,36 @@ func (f HTTPClientFunc) Do(req *http.Request) (*http.Response, error) {
 
 // RESTClient provides a fake RESTClient interface.
 type RESTClient struct {
-	Client unversioned.HTTPClient
+	Client v1.HTTPClient
 	Codec  runtime.Codec
 	Req    *http.Request
 	Resp   *http.Response
 	Err    error
 }
 
-func (c *RESTClient) Get() *unversioned.Request {
-	return unversioned.NewRequest(c, "GET", &url.URL{Host: "localhost"}, testapi.Default.Version(), c.Codec)
+func (c *RESTClient) Get() *v1.Request {
+	return v1.NewRequest(c, "GET", &url.URL{Host: "localhost"}, testapi.Default.Version(), c.Codec)
 }
 
-func (c *RESTClient) Put() *unversioned.Request {
-	return unversioned.NewRequest(c, "PUT", &url.URL{Host: "localhost"}, testapi.Default.Version(), c.Codec)
+func (c *RESTClient) Put() *v1.Request {
+	return v1.NewRequest(c, "PUT", &url.URL{Host: "localhost"}, testapi.Default.Version(), c.Codec)
 }
 
-func (c *RESTClient) Patch(_ api.PatchType) *unversioned.Request {
-	return unversioned.NewRequest(c, "PATCH", &url.URL{Host: "localhost"}, testapi.Default.Version(), c.Codec)
+func (c *RESTClient) Patch(_ api.PatchType) *v1.Request {
+	return v1.NewRequest(c, "PATCH", &url.URL{Host: "localhost"}, testapi.Default.Version(), c.Codec)
 }
 
-func (c *RESTClient) Post() *unversioned.Request {
-	return unversioned.NewRequest(c, "POST", &url.URL{Host: "localhost"}, testapi.Default.Version(), c.Codec)
+func (c *RESTClient) Post() *v1.Request {
+	return v1.NewRequest(c, "POST", &url.URL{Host: "localhost"}, testapi.Default.Version(), c.Codec)
 }
 
-func (c *RESTClient) Delete() *unversioned.Request {
-	return unversioned.NewRequest(c, "DELETE", &url.URL{Host: "localhost"}, testapi.Default.Version(), c.Codec)
+func (c *RESTClient) Delete() *v1.Request {
+	return v1.NewRequest(c, "DELETE", &url.URL{Host: "localhost"}, testapi.Default.Version(), c.Codec)
 }
 
 func (c *RESTClient) Do(req *http.Request) (*http.Response, error) {
 	c.Req = req
-	if c.Client != unversioned.HTTPClient(nil) {
+	if c.Client != v1.HTTPClient(nil) {
 		return c.Client.Do(req)
 	}
 	return c.Resp, c.Err

--- a/pkg/client/v1/flags.go
+++ b/pkg/client/v1/flags.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"time"
+)
+
+// FlagSet abstracts the flag interface for compatibility with both Golang "flag"
+// and cobra pflags (Posix style).
+type FlagSet interface {
+	StringVar(p *string, name, value, usage string)
+	BoolVar(p *bool, name string, value bool, usage string)
+	UintVar(p *uint, name string, value uint, usage string)
+	DurationVar(p *time.Duration, name string, value time.Duration, usage string)
+	IntVar(p *int, name string, value int, usage string)
+}

--- a/pkg/client/v1/flags.go
+++ b/pkg/client/v1/flags.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"time"

--- a/pkg/client/v1/flags_test.go
+++ b/pkg/client/v1/flags_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/kubernetes/pkg/util/sets"
+)
+
+type fakeFlagSet struct {
+	t   *testing.T
+	set sets.String
+}
+
+func (f *fakeFlagSet) StringVar(p *string, name, value, usage string) {
+	if p == nil {
+		f.t.Errorf("unexpected nil pointer")
+	}
+	if usage == "" {
+		f.t.Errorf("unexpected empty usage")
+	}
+	f.set.Insert(name)
+}
+
+func (f *fakeFlagSet) BoolVar(p *bool, name string, value bool, usage string) {
+	if p == nil {
+		f.t.Errorf("unexpected nil pointer")
+	}
+	if usage == "" {
+		f.t.Errorf("unexpected empty usage")
+	}
+	f.set.Insert(name)
+}
+
+func (f *fakeFlagSet) UintVar(p *uint, name string, value uint, usage string) {
+	if p == nil {
+		f.t.Errorf("unexpected nil pointer")
+	}
+	if usage == "" {
+		f.t.Errorf("unexpected empty usage")
+	}
+	f.set.Insert(name)
+}
+
+func (f *fakeFlagSet) DurationVar(p *time.Duration, name string, value time.Duration, usage string) {
+	if p == nil {
+		f.t.Errorf("unexpected nil pointer")
+	}
+	if usage == "" {
+		f.t.Errorf("unexpected empty usage")
+	}
+	f.set.Insert(name)
+}
+
+func (f *fakeFlagSet) IntVar(p *int, name string, value int, usage string) {
+	if p == nil {
+		f.t.Errorf("unexpected nil pointer")
+	}
+	if usage == "" {
+		f.t.Errorf("unexpected empty usage")
+	}
+	f.set.Insert(name)
+}

--- a/pkg/client/v1/flags_test.go
+++ b/pkg/client/v1/flags_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"testing"

--- a/pkg/client/v1/helper.go
+++ b/pkg/client/v1/helper.go
@@ -1,0 +1,568 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"reflect"
+	gruntime "runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/latest"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/version"
+)
+
+// Config holds the common attributes that can be passed to a Kubernetes client on
+// initialization.
+type Config struct {
+	// Host must be a host string, a host:port pair, or a URL to the base of the API.
+	Host string
+	// Prefix is the sub path of the server. If not specified, the client will set
+	// a default value.  Use "/" to indicate the server root should be used
+	Prefix string
+	// Version is the API version to talk to. Must be provided when initializing
+	// a RESTClient directly. When initializing a Client, will be set with the default
+	// code version.
+	Version string
+	// Codec specifies the encoding and decoding behavior for runtime.Objects passed
+	// to a RESTClient or Client. Required when initializing a RESTClient, optional
+	// when initializing a Client.
+	Codec runtime.Codec
+
+	// Server requires Basic authentication
+	Username string
+	Password string
+
+	// Server requires Bearer authentication. This client will not attempt to use
+	// refresh tokens for an OAuth2 flow.
+	// TODO: demonstrate an OAuth2 compatible client.
+	BearerToken string
+
+	// TLSClientConfig contains settings to enable transport layer security
+	TLSClientConfig
+
+	// Server should be accessed without verifying the TLS
+	// certificate. For testing only.
+	Insecure bool
+
+	// UserAgent is an optional field that specifies the caller of this request.
+	UserAgent string
+
+	// Transport may be used for custom HTTP behavior. This attribute may not
+	// be specified with the TLS client certificate options. Use WrapTransport
+	// for most client level operations.
+	Transport http.RoundTripper
+	// WrapTransport will be invoked for custom HTTP behavior after the underlying
+	// transport is initialized (either the transport created from TLSClientConfig,
+	// Transport, or http.DefaultTransport). The config may layer other RoundTrippers
+	// on top of the returned RoundTripper.
+	WrapTransport func(rt http.RoundTripper) http.RoundTripper
+
+	// QPS indicates the maximum QPS to the master from this client.  If zero, QPS is unlimited.
+	QPS float32
+
+	// Maximum burst for throttle
+	Burst int
+}
+
+type KubeletConfig struct {
+	// ToDo: Add support for different kubelet instances exposing different ports
+	Port        uint
+	EnableHttps bool
+
+	// TLSClientConfig contains settings to enable transport layer security
+	TLSClientConfig
+
+	// HTTPTimeout is used by the client to timeout http requests to Kubelet.
+	HTTPTimeout time.Duration
+
+	// Dial is a custom dialer used for the client
+	Dial func(net, addr string) (net.Conn, error)
+}
+
+// TLSClientConfig contains settings to enable transport layer security
+type TLSClientConfig struct {
+	// Server requires TLS client certificate authentication
+	CertFile string
+	// Server requires TLS client certificate authentication
+	KeyFile string
+	// Trusted root certificates for server
+	CAFile string
+
+	// CertData holds PEM-encoded bytes (typically read from a client certificate file).
+	// CertData takes precedence over CertFile
+	CertData []byte
+	// KeyData holds PEM-encoded bytes (typically read from a client certificate key file).
+	// KeyData takes precedence over KeyFile
+	KeyData []byte
+	// CAData holds PEM-encoded bytes (typically read from a root certificates bundle).
+	// CAData takes precedence over CAFile
+	CAData []byte
+}
+
+// New creates a Kubernetes client for the given config. This client works with pods,
+// replication controllers, daemons, and services. It allows operations such as list, get, update
+// and delete on these objects. An error is returned if the provided configuration
+// is not valid.
+func New(c *Config) (*Client, error) {
+	config := *c
+	if err := SetKubernetesDefaults(&config); err != nil {
+		return nil, err
+	}
+	client, err := RESTClientFor(&config)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := latest.Group("experimental"); err != nil {
+		return &Client{RESTClient: client, ExperimentalClient: nil}, nil
+	}
+	experimentalConfig := *c
+	experimentalClient, err := NewExperimental(&experimentalConfig)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{RESTClient: client, ExperimentalClient: experimentalClient}, nil
+}
+
+// MatchesServerVersion queries the server to compares the build version
+// (git hash) of the client with the server's build version. It returns an error
+// if it failed to contact the server or if the versions are not an exact match.
+func MatchesServerVersion(client *Client, c *Config) error {
+	var err error
+	if client == nil {
+		client, err = New(c)
+		if err != nil {
+			return err
+		}
+	}
+	clientVersion := version.Get()
+	serverVersion, err := client.ServerVersion()
+	if err != nil {
+		return fmt.Errorf("couldn't read version from server: %v\n", err)
+	}
+	if s := *serverVersion; !reflect.DeepEqual(clientVersion, s) {
+		return fmt.Errorf("server version (%#v) differs from client version (%#v)!\n", s, clientVersion)
+	}
+
+	return nil
+}
+
+// NegotiateVersion queries the server's supported api versions to find
+// a version that both client and server support.
+// - If no version is provided, try registered client versions in order of
+//   preference.
+// - If version is provided, but not default config (explicitly requested via
+//   commandline flag), and is unsupported by the server, print a warning to
+//   stderr and try client's registered versions in order of preference.
+// - If version is config default, and the server does not support it,
+//   return an error.
+func NegotiateVersion(client *Client, c *Config, version string, clientRegisteredVersions []string) (string, error) {
+	var err error
+	if client == nil {
+		client, err = New(c)
+		if err != nil {
+			return "", err
+		}
+	}
+	clientVersions := sets.String{}
+	for _, v := range clientRegisteredVersions {
+		clientVersions.Insert(v)
+	}
+	apiVersions, err := client.ServerAPIVersions()
+	if err != nil {
+		return "", fmt.Errorf("couldn't read version from server: %v", err)
+	}
+	serverVersions := sets.String{}
+	for _, v := range apiVersions.Versions {
+		serverVersions.Insert(v)
+	}
+	// If no version requested, use config version (may also be empty).
+	if len(version) == 0 {
+		version = c.Version
+	}
+	// If version explicitly requested verify that both client and server support it.
+	// If server does not support warn, but try to negotiate a lower version.
+	if len(version) != 0 {
+		if !clientVersions.Has(version) {
+			return "", fmt.Errorf("Client does not support API version '%s'. Client supported API versions: %v", version, clientVersions)
+
+		}
+		if serverVersions.Has(version) {
+			return version, nil
+		}
+		// If we are using an explicit config version the server does not support, fail.
+		if version == c.Version {
+			return "", fmt.Errorf("Server does not support API version '%s'.", version)
+		}
+	}
+
+	for _, clientVersion := range clientRegisteredVersions {
+		if serverVersions.Has(clientVersion) {
+			// Version was not explicitly requested in command config (--api-version).
+			// Ok to fall back to a supported version with a warning.
+			if len(version) != 0 {
+				glog.Warningf("Server does not support API version '%s'. Falling back to '%s'.", version, clientVersion)
+			}
+			return clientVersion, nil
+		}
+	}
+	return "", fmt.Errorf("Failed to negotiate an api version. Server supports: %v. Client supports: %v.",
+		serverVersions, clientRegisteredVersions)
+}
+
+// NewOrDie creates a Kubernetes client and panics if the provided API version is not recognized.
+func NewOrDie(c *Config) *Client {
+	client, err := New(c)
+	if err != nil {
+		panic(err)
+	}
+	return client
+}
+
+// InClusterConfig returns a config object which uses the service account
+// kubernetes gives to pods. It's intended for clients that expect to be
+// running inside a pod running on kuberenetes. It will return an error if
+// called from a process not running in a kubernetes environment.
+func InClusterConfig() (*Config, error) {
+	token, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/" + api.ServiceAccountTokenKey)
+	if err != nil {
+		return nil, err
+	}
+	tlsClientConfig := TLSClientConfig{}
+	rootCAFile := "/var/run/secrets/kubernetes.io/serviceaccount/" + api.ServiceAccountRootCAKey
+	if _, err := util.CertPoolFromFile(rootCAFile); err != nil {
+		glog.Errorf("expected to load root CA config from %s, but got err: %v", rootCAFile, err)
+	} else {
+		tlsClientConfig.CAFile = rootCAFile
+	}
+
+	return &Config{
+		// TODO: switch to using cluster DNS.
+		Host:            "https://" + net.JoinHostPort(os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT")),
+		BearerToken:     string(token),
+		TLSClientConfig: tlsClientConfig,
+	}, nil
+}
+
+// NewInCluster is a shortcut for calling InClusterConfig() and then New().
+func NewInCluster() (*Client, error) {
+	cc, err := InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+	return New(cc)
+}
+
+// SetKubernetesDefaults sets default values on the provided client config for accessing the
+// Kubernetes API or returns an error if any of the defaults are impossible or invalid.
+func SetKubernetesDefaults(config *Config) error {
+	if config.Prefix == "" {
+		config.Prefix = "/api"
+	}
+	if len(config.UserAgent) == 0 {
+		config.UserAgent = DefaultKubernetesUserAgent()
+	}
+	if len(config.Version) == 0 {
+		config.Version = defaultVersionFor(config)
+	}
+	version := config.Version
+	versionInterfaces, err := latest.GroupOrDie("").InterfacesFor(version)
+	if err != nil {
+		return fmt.Errorf("API version '%s' is not recognized (valid values: %s)", version, strings.Join(latest.GroupOrDie("").Versions, ", "))
+	}
+	if config.Codec == nil {
+		config.Codec = versionInterfaces.Codec
+	}
+	if config.QPS == 0.0 {
+		config.QPS = 5.0
+	}
+	if config.Burst == 0 {
+		config.Burst = 10
+	}
+	return nil
+}
+
+// RESTClientFor returns a RESTClient that satisfies the requested attributes on a client Config
+// object. Note that a RESTClient may require fields that are optional when initializing a Client.
+// A RESTClient created by this method is generic - it expects to operate on an API that follows
+// the Kubernetes conventions, but may not be the Kubernetes API.
+func RESTClientFor(config *Config) (*RESTClient, error) {
+	if len(config.Version) == 0 {
+		return nil, fmt.Errorf("version is required when initializing a RESTClient")
+	}
+	if config.Codec == nil {
+		return nil, fmt.Errorf("Codec is required when initializing a RESTClient")
+	}
+
+	baseURL, err := defaultServerUrlFor(config)
+	if err != nil {
+		return nil, err
+	}
+
+	client := NewRESTClient(baseURL, config.Version, config.Codec, config.QPS, config.Burst)
+
+	transport, err := TransportFor(config)
+	if err != nil {
+		return nil, err
+	}
+
+	if transport != http.DefaultTransport {
+		client.Client = &http.Client{Transport: transport}
+	}
+	return client, nil
+}
+
+var (
+	// tlsTransports stores reusable round trippers with custom TLSClientConfig options
+	tlsTransports = map[string]*http.Transport{}
+
+	// tlsTransportLock protects retrieval and storage of round trippers into the tlsTransports map
+	tlsTransportLock sync.Mutex
+)
+
+// tlsTransportFor returns a http.RoundTripper for the given config, or an error
+// The same RoundTripper will be returned for configs with identical TLS options
+// If the config has no custom TLS options, http.DefaultTransport is returned
+func tlsTransportFor(config *Config) (http.RoundTripper, error) {
+	// Get a unique key for the TLS options in the config
+	key, err := tlsConfigKey(config)
+	if err != nil {
+		return nil, err
+	}
+
+	// Ensure we only create a single transport for the given TLS options
+	tlsTransportLock.Lock()
+	defer tlsTransportLock.Unlock()
+
+	// See if we already have a custom transport for this config
+	if cachedTransport, ok := tlsTransports[key]; ok {
+		return cachedTransport, nil
+	}
+
+	// Get the TLS options for this client config
+	tlsConfig, err := TLSConfigFor(config)
+	if err != nil {
+		return nil, err
+	}
+	// The options didn't require a custom TLS config
+	if tlsConfig == nil {
+		return http.DefaultTransport, nil
+	}
+
+	// Cache a single transport for these options
+	tlsTransports[key] = &http.Transport{
+		TLSClientConfig: tlsConfig,
+		Proxy:           http.ProxyFromEnvironment,
+		Dial: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).Dial,
+		TLSHandshakeTimeout: 10 * time.Second,
+	}
+	return tlsTransports[key], nil
+}
+
+// TransportFor returns an http.RoundTripper that will provide the authentication
+// or transport level security defined by the provided Config. Will return the
+// default http.DefaultTransport if no special case behavior is needed.
+func TransportFor(config *Config) (http.RoundTripper, error) {
+	hasCA := len(config.CAFile) > 0 || len(config.CAData) > 0
+	hasCert := len(config.CertFile) > 0 || len(config.CertData) > 0
+
+	// Set transport level security
+	if config.Transport != nil && (hasCA || hasCert || config.Insecure) {
+		return nil, fmt.Errorf("using a custom transport with TLS certificate options or the insecure flag is not allowed")
+	}
+
+	var (
+		transport http.RoundTripper
+		err       error
+	)
+
+	if config.Transport != nil {
+		transport = config.Transport
+	} else {
+		transport, err = tlsTransportFor(config)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Call wrap prior to adding debugging wrappers
+	if config.WrapTransport != nil {
+		transport = config.WrapTransport(transport)
+	}
+
+	switch {
+	case bool(glog.V(9)):
+		transport = NewDebuggingRoundTripper(transport, CurlCommand, URLTiming, ResponseHeaders)
+	case bool(glog.V(8)):
+		transport = NewDebuggingRoundTripper(transport, JustURL, RequestHeaders, ResponseStatus, ResponseHeaders)
+	case bool(glog.V(7)):
+		transport = NewDebuggingRoundTripper(transport, JustURL, RequestHeaders, ResponseStatus)
+	case bool(glog.V(6)):
+		transport = NewDebuggingRoundTripper(transport, URLTiming)
+	}
+
+	transport, err = HTTPWrappersForConfig(config, transport)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: use the config context to wrap a transport
+
+	return transport, nil
+}
+
+// HTTPWrappersForConfig wraps a round tripper with any relevant layered behavior from the
+// config. Exposed to allow more clients that need HTTP-like behavior but then must hijack
+// the underlying connection (like WebSocket or HTTP2 clients). Pure HTTP clients should use
+// the higher level TransportFor or RESTClientFor methods.
+func HTTPWrappersForConfig(config *Config, rt http.RoundTripper) (http.RoundTripper, error) {
+	// Set authentication wrappers
+	hasBasicAuth := config.Username != "" || config.Password != ""
+	if hasBasicAuth && config.BearerToken != "" {
+		return nil, fmt.Errorf("username/password or bearer token may be set, but not both")
+	}
+	switch {
+	case config.BearerToken != "":
+		rt = NewBearerAuthRoundTripper(config.BearerToken, rt)
+	case hasBasicAuth:
+		rt = NewBasicAuthRoundTripper(config.Username, config.Password, rt)
+	}
+	if len(config.UserAgent) > 0 {
+		rt = NewUserAgentRoundTripper(config.UserAgent, rt)
+	}
+	return rt, nil
+}
+
+// DefaultServerURL converts a host, host:port, or URL string to the default base server API path
+// to use with a Client at a given API version following the standard conventions for a
+// Kubernetes API.
+func DefaultServerURL(host, prefix, version string, defaultTLS bool) (*url.URL, error) {
+	if host == "" {
+		return nil, fmt.Errorf("host must be a URL or a host:port pair")
+	}
+	if version == "" {
+		return nil, fmt.Errorf("version must be set")
+	}
+	base := host
+	hostURL, err := url.Parse(base)
+	if err != nil {
+		return nil, err
+	}
+	if hostURL.Scheme == "" {
+		scheme := "http://"
+		if defaultTLS {
+			scheme = "https://"
+		}
+		hostURL, err = url.Parse(scheme + base)
+		if err != nil {
+			return nil, err
+		}
+		if hostURL.Path != "" && hostURL.Path != "/" {
+			return nil, fmt.Errorf("host must be a URL or a host:port pair: %q", base)
+		}
+	}
+
+	// If the user specified a URL without a path component (http://server.com), automatically
+	// append the default prefix
+	if hostURL.Path == "" {
+		if prefix == "" {
+			prefix = "/"
+		}
+		hostURL.Path = prefix
+	}
+
+	// Add the version to the end of the path
+	hostURL.Path = path.Join(hostURL.Path, version)
+
+	return hostURL, nil
+}
+
+// IsConfigTransportTLS returns true if and only if the provided config will result in a protected
+// connection to the server when it is passed to client.New() or client.RESTClientFor().
+// Use to determine when to send credentials over the wire.
+//
+// Note: the Insecure flag is ignored when testing for this value, so MITM attacks are
+// still possible.
+func IsConfigTransportTLS(config Config) bool {
+	// determination of TLS transport does not logically require a version to be specified
+	// modify the copy of the config we got to satisfy preconditions for defaultServerUrlFor
+	config.Version = defaultVersionFor(&config)
+
+	baseURL, err := defaultServerUrlFor(&config)
+	if err != nil {
+		return false
+	}
+	return baseURL.Scheme == "https"
+}
+
+// defaultServerUrlFor is shared between IsConfigTransportTLS and RESTClientFor. It
+// requires Host and Version to be set prior to being called.
+func defaultServerUrlFor(config *Config) (*url.URL, error) {
+	// TODO: move the default to secure when the apiserver supports TLS by default
+	// config.Insecure is taken to mean "I want HTTPS but don't bother checking the certs against a CA."
+	hasCA := len(config.CAFile) != 0 || len(config.CAData) != 0
+	hasCert := len(config.CertFile) != 0 || len(config.CertData) != 0
+	defaultTLS := hasCA || hasCert || config.Insecure
+	host := config.Host
+	if host == "" {
+		host = "localhost"
+	}
+	return DefaultServerURL(host, config.Prefix, config.Version, defaultTLS)
+}
+
+// defaultVersionFor is shared between defaultServerUrlFor and RESTClientFor
+func defaultVersionFor(config *Config) string {
+	version := config.Version
+	if version == "" {
+		// Clients default to the preferred code API version
+		// TODO: implement version negotiation (highest version supported by server)
+		version = latest.GroupOrDie("").Version
+	}
+	return version
+}
+
+// DefaultKubernetesUserAgent returns the default user agent that clients can use.
+func DefaultKubernetesUserAgent() string {
+	commit := version.Get().GitCommit
+	if len(commit) > 7 {
+		commit = commit[:7]
+	}
+	if len(commit) == 0 {
+		commit = "unknown"
+	}
+	version := version.Get().GitVersion
+	seg := strings.SplitN(version, "-", 2)
+	version = seg[0]
+	return fmt.Sprintf("%s/%s (%s/%s) kubernetes/%s", path.Base(os.Args[0]), version, gruntime.GOOS, gruntime.GOARCH, commit)
+}

--- a/pkg/client/v1/helper.go
+++ b/pkg/client/v1/helper.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"fmt"
@@ -31,8 +31,8 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/latest"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/sets"
@@ -252,12 +252,12 @@ func NewOrDie(c *Config) *Client {
 // running inside a pod running on kuberenetes. It will return an error if
 // called from a process not running in a kubernetes environment.
 func InClusterConfig() (*Config, error) {
-	token, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/" + api.ServiceAccountTokenKey)
+	token, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/" + v1.ServiceAccountTokenKey)
 	if err != nil {
 		return nil, err
 	}
 	tlsClientConfig := TLSClientConfig{}
-	rootCAFile := "/var/run/secrets/kubernetes.io/serviceaccount/" + api.ServiceAccountRootCAKey
+	rootCAFile := "/var/run/secrets/kubernetes.io/serviceaccount/" + v1.ServiceAccountRootCAKey
 	if _, err := util.CertPoolFromFile(rootCAFile); err != nil {
 		glog.Errorf("expected to load root CA config from %s, but got err: %v", rootCAFile, err)
 	} else {

--- a/pkg/client/v1/helper_blackbox_test.go
+++ b/pkg/client/v1/helper_blackbox_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/client/unversioned/fake"
+)
+
+func objBody(object interface{}) io.ReadCloser {
+	output, err := json.MarshalIndent(object, "", "")
+	if err != nil {
+		panic(err)
+	}
+	return ioutil.NopCloser(bytes.NewReader([]byte(output)))
+}
+
+func TestNegotiateVersion(t *testing.T) {
+	tests := []struct {
+		name, version, expectedVersion string
+		serverVersions                 []string
+		clientVersions                 []string
+		config                         *unversioned.Config
+		expectErr                      bool
+	}{
+		{
+			name:            "server supports client default",
+			version:         "version1",
+			config:          &unversioned.Config{},
+			serverVersions:  []string{"version1", testapi.Default.Version()},
+			clientVersions:  []string{"version1", testapi.Default.Version()},
+			expectedVersion: "version1",
+			expectErr:       false,
+		},
+		{
+			name:            "server falls back to client supported",
+			version:         testapi.Default.Version(),
+			config:          &unversioned.Config{},
+			serverVersions:  []string{"version1"},
+			clientVersions:  []string{"version1", testapi.Default.Version()},
+			expectedVersion: "version1",
+			expectErr:       false,
+		},
+		{
+			name:            "explicit version supported",
+			version:         "",
+			config:          &unversioned.Config{Version: testapi.Default.Version()},
+			serverVersions:  []string{"version1", testapi.Default.Version()},
+			clientVersions:  []string{"version1", testapi.Default.Version()},
+			expectedVersion: testapi.Default.Version(),
+			expectErr:       false,
+		},
+		{
+			name:            "explicit version not supported",
+			version:         "",
+			config:          &unversioned.Config{Version: testapi.Default.Version()},
+			serverVersions:  []string{"version1"},
+			clientVersions:  []string{"version1", testapi.Default.Version()},
+			expectedVersion: "",
+			expectErr:       true,
+		},
+	}
+	codec := testapi.Default.Codec()
+
+	for _, test := range tests {
+		fakeClient := &fake.RESTClient{
+			Codec: codec,
+			Resp: &http.Response{
+				StatusCode: 200,
+				Body:       objBody(&api.APIVersions{Versions: test.serverVersions}),
+			},
+			Client: fake.HTTPClientFunc(func(req *http.Request) (*http.Response, error) {
+				return &http.Response{StatusCode: 200, Body: objBody(&api.APIVersions{Versions: test.serverVersions})}, nil
+			}),
+		}
+		c := unversioned.NewOrDie(test.config)
+		c.Client = fakeClient.Client
+		response, err := unversioned.NegotiateVersion(c, test.config, test.version, test.clientVersions)
+		if err == nil && test.expectErr {
+			t.Errorf("expected error, got nil for [%s].", test.name)
+		}
+		if err != nil && !test.expectErr {
+			t.Errorf("unexpected error for [%s]: %v.", test.name, err)
+		}
+		if response != test.expectedVersion {
+			t.Errorf("expected version %s, got %s.", test.expectedVersion, response)
+		}
+	}
+}

--- a/pkg/client/v1/helper_blackbox_test.go
+++ b/pkg/client/v1/helper_blackbox_test.go
@@ -26,8 +26,8 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
-	"k8s.io/kubernetes/pkg/client/unversioned"
-	"k8s.io/kubernetes/pkg/client/unversioned/fake"
+	"k8s.io/kubernetes/pkg/client/v1"
+	"k8s.io/kubernetes/pkg/client/v1/fake"
 )
 
 func objBody(object interface{}) io.ReadCloser {
@@ -43,13 +43,13 @@ func TestNegotiateVersion(t *testing.T) {
 		name, version, expectedVersion string
 		serverVersions                 []string
 		clientVersions                 []string
-		config                         *unversioned.Config
+		config                         *v1.Config
 		expectErr                      bool
 	}{
 		{
 			name:            "server supports client default",
 			version:         "version1",
-			config:          &unversioned.Config{},
+			config:          &v1.Config{},
 			serverVersions:  []string{"version1", testapi.Default.Version()},
 			clientVersions:  []string{"version1", testapi.Default.Version()},
 			expectedVersion: "version1",
@@ -58,7 +58,7 @@ func TestNegotiateVersion(t *testing.T) {
 		{
 			name:            "server falls back to client supported",
 			version:         testapi.Default.Version(),
-			config:          &unversioned.Config{},
+			config:          &v1.Config{},
 			serverVersions:  []string{"version1"},
 			clientVersions:  []string{"version1", testapi.Default.Version()},
 			expectedVersion: "version1",
@@ -67,7 +67,7 @@ func TestNegotiateVersion(t *testing.T) {
 		{
 			name:            "explicit version supported",
 			version:         "",
-			config:          &unversioned.Config{Version: testapi.Default.Version()},
+			config:          &v1.Config{Version: testapi.Default.Version()},
 			serverVersions:  []string{"version1", testapi.Default.Version()},
 			clientVersions:  []string{"version1", testapi.Default.Version()},
 			expectedVersion: testapi.Default.Version(),
@@ -76,7 +76,7 @@ func TestNegotiateVersion(t *testing.T) {
 		{
 			name:            "explicit version not supported",
 			version:         "",
-			config:          &unversioned.Config{Version: testapi.Default.Version()},
+			config:          &v1.Config{Version: testapi.Default.Version()},
 			serverVersions:  []string{"version1"},
 			clientVersions:  []string{"version1", testapi.Default.Version()},
 			expectedVersion: "",
@@ -96,9 +96,9 @@ func TestNegotiateVersion(t *testing.T) {
 				return &http.Response{StatusCode: 200, Body: objBody(&api.APIVersions{Versions: test.serverVersions})}, nil
 			}),
 		}
-		c := unversioned.NewOrDie(test.config)
+		c := v1.NewOrDie(test.config)
 		c.Client = fakeClient.Client
-		response, err := unversioned.NegotiateVersion(c, test.config, test.version, test.clientVersions)
+		response, err := v1.NegotiateVersion(c, test.config, test.version, test.clientVersions)
 		if err == nil && test.expectErr {
 			t.Errorf("expected error, got nil for [%s].", test.name)
 		}

--- a/pkg/client/v1/helper_blackbox_test.go
+++ b/pkg/client/v1/helper_blackbox_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned_test
+package v1_test
 
 import (
 	"bytes"

--- a/pkg/client/v1/helper_test.go
+++ b/pkg/client/v1/helper_test.go
@@ -1,0 +1,376 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api/testapi"
+)
+
+const (
+	rootCACert = `-----BEGIN CERTIFICATE-----
+MIIC4DCCAcqgAwIBAgIBATALBgkqhkiG9w0BAQswIzEhMB8GA1UEAwwYMTAuMTMu
+MTI5LjEwNkAxNDIxMzU5MDU4MB4XDTE1MDExNTIxNTczN1oXDTE2MDExNTIxNTcz
+OFowIzEhMB8GA1UEAwwYMTAuMTMuMTI5LjEwNkAxNDIxMzU5MDU4MIIBIjANBgkq
+hkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAunDRXGwsiYWGFDlWH6kjGun+PshDGeZX
+xtx9lUnL8pIRWH3wX6f13PO9sktaOWW0T0mlo6k2bMlSLlSZgG9H6og0W6gLS3vq
+s4VavZ6DbXIwemZG2vbRwsvR+t4G6Nbwelm6F8RFnA1Fwt428pavmNQ/wgYzo+T1
+1eS+HiN4ACnSoDSx3QRWcgBkB1g6VReofVjx63i0J+w8Q/41L9GUuLqquFxu6ZnH
+60vTB55lHgFiDLjA1FkEz2dGvGh/wtnFlRvjaPC54JH2K1mPYAUXTreoeJtLJKX0
+ycoiyB24+zGCniUmgIsmQWRPaOPircexCp1BOeze82BT1LCZNTVaxQIDAQABoyMw
+ITAOBgNVHQ8BAf8EBAMCAKQwDwYDVR0TAQH/BAUwAwEB/zALBgkqhkiG9w0BAQsD
+ggEBADMxsUuAFlsYDpF4fRCzXXwrhbtj4oQwcHpbu+rnOPHCZupiafzZpDu+rw4x
+YGPnCb594bRTQn4pAu3Ac18NbLD5pV3uioAkv8oPkgr8aUhXqiv7KdDiaWm6sbAL
+EHiXVBBAFvQws10HMqMoKtO8f1XDNAUkWduakR/U6yMgvOPwS7xl0eUTqyRB6zGb
+K55q2dejiFWaFqB/y78txzvz6UlOZKE44g2JAVoJVM6kGaxh33q8/FmrL4kuN3ut
+W+MmJCVDvd4eEqPwbp7146ZWTqpIJ8lvA6wuChtqV8lhAPka2hD/LMqY8iXNmfXD
+uml0obOEy+ON91k+SWTJ3ggmF/U=
+-----END CERTIFICATE-----`
+
+	certData = `-----BEGIN CERTIFICATE-----
+MIIC6jCCAdSgAwIBAgIBCzALBgkqhkiG9w0BAQswIzEhMB8GA1UEAwwYMTAuMTMu
+MTI5LjEwNkAxNDIxMzU5MDU4MB4XDTE1MDExNTIyMDEzMVoXDTE2MDExNTIyMDEz
+MlowGzEZMBcGA1UEAxMQb3BlbnNoaWZ0LWNsaWVudDCCASIwDQYJKoZIhvcNAQEB
+BQADggEPADCCAQoCggEBAKtdhz0+uCLXw5cSYns9rU/XifFSpb/x24WDdrm72S/v
+b9BPYsAStiP148buylr1SOuNi8sTAZmlVDDIpIVwMLff+o2rKYDicn9fjbrTxTOj
+lI4pHJBH+JU3AJ0tbajupioh70jwFS0oYpwtneg2zcnE2Z4l6mhrj2okrc5Q1/X2
+I2HChtIU4JYTisObtin10QKJX01CLfYXJLa8upWzKZ4/GOcHG+eAV3jXWoXidtjb
+1Usw70amoTZ6mIVCkiu1QwCoa8+ycojGfZhvqMsAp1536ZcCul+Na+AbCv4zKS7F
+kQQaImVrXdUiFansIoofGlw/JNuoKK6ssVpS5Ic3pgcCAwEAAaM1MDMwDgYDVR0P
+AQH/BAQDAgCgMBMGA1UdJQQMMAoGCCsGAQUFBwMCMAwGA1UdEwEB/wQCMAAwCwYJ
+KoZIhvcNAQELA4IBAQCKLREH7bXtXtZ+8vI6cjD7W3QikiArGqbl36bAhhWsJLp/
+p/ndKz39iFNaiZ3GlwIURWOOKx3y3GA0x9m8FR+Llthf0EQ8sUjnwaknWs0Y6DQ3
+jjPFZOpV3KPCFrdMJ3++E3MgwFC/Ih/N2ebFX9EcV9Vcc6oVWMdwT0fsrhu683rq
+6GSR/3iVX1G/pmOiuaR0fNUaCyCfYrnI4zHBDgSfnlm3vIvN2lrsR/DQBakNL8DJ
+HBgKxMGeUPoneBv+c8DMXIL0EhaFXRlBv9QW45/GiAIOuyFJ0i6hCtGZpJjq4OpQ
+BRjCI+izPzFTjsxD4aORE+WOkyWFCGPWKfNejfw0
+-----END CERTIFICATE-----`
+
+	keyData = `-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAq12HPT64ItfDlxJiez2tT9eJ8VKlv/HbhYN2ubvZL+9v0E9i
+wBK2I/Xjxu7KWvVI642LyxMBmaVUMMikhXAwt9/6jaspgOJyf1+NutPFM6OUjikc
+kEf4lTcAnS1tqO6mKiHvSPAVLShinC2d6DbNycTZniXqaGuPaiStzlDX9fYjYcKG
+0hTglhOKw5u2KfXRAolfTUIt9hcktry6lbMpnj8Y5wcb54BXeNdaheJ22NvVSzDv
+RqahNnqYhUKSK7VDAKhrz7JyiMZ9mG+oywCnXnfplwK6X41r4BsK/jMpLsWRBBoi
+ZWtd1SIVqewiih8aXD8k26gorqyxWlLkhzemBwIDAQABAoIBAD2XYRs3JrGHQUpU
+FkdbVKZkvrSY0vAZOqBTLuH0zUv4UATb8487anGkWBjRDLQCgxH+jucPTrztekQK
+aW94clo0S3aNtV4YhbSYIHWs1a0It0UdK6ID7CmdWkAj6s0T8W8lQT7C46mWYVLm
+5mFnCTHi6aB42jZrqmEpC7sivWwuU0xqj3Ml8kkxQCGmyc9JjmCB4OrFFC8NNt6M
+ObvQkUI6Z3nO4phTbpxkE1/9dT0MmPIF7GhHVzJMS+EyyRYUDllZ0wvVSOM3qZT0
+JMUaBerkNwm9foKJ1+dv2nMKZZbJajv7suUDCfU44mVeaEO+4kmTKSGCGjjTBGkr
+7L1ySDECgYEA5ElIMhpdBzIivCuBIH8LlUeuzd93pqssO1G2Xg0jHtfM4tz7fyeI
+cr90dc8gpli24dkSxzLeg3Tn3wIj/Bu64m2TpZPZEIlukYvgdgArmRIPQVxerYey
+OkrfTNkxU1HXsYjLCdGcGXs5lmb+K/kuTcFxaMOs7jZi7La+jEONwf8CgYEAwCs/
+rUOOA0klDsWWisbivOiNPII79c9McZCNBqncCBfMUoiGe8uWDEO4TFHN60vFuVk9
+8PkwpCfvaBUX+ajvbafIfHxsnfk1M04WLGCeqQ/ym5Q4sQoQOcC1b1y9qc/xEWfg
+nIUuia0ukYRpl7qQa3tNg+BNFyjypW8zukUAC/kCgYB1/Kojuxx5q5/oQVPrx73k
+2bevD+B3c+DYh9MJqSCNwFtUpYIWpggPxoQan4LwdsmO0PKzocb/ilyNFj4i/vII
+NToqSc/WjDFpaDIKyuu9oWfhECye45NqLWhb/6VOuu4QA/Nsj7luMhIBehnEAHW+
+GkzTKM8oD1PxpEG3nPKXYQKBgQC6AuMPRt3XBl1NkCrpSBy/uObFlFaP2Enpf39S
+3OZ0Gv0XQrnSaL1kP8TMcz68rMrGX8DaWYsgytstR4W+jyy7WvZwsUu+GjTJ5aMG
+77uEcEBpIi9CBzivfn7hPccE8ZgqPf+n4i6q66yxBJflW5xhvafJqDtW2LcPNbW/
+bvzdmQKBgExALRUXpq+5dbmkdXBHtvXdRDZ6rVmrnjy4nI5bPw+1GqQqk6uAR6B/
+F6NmLCQOO4PDG/cuatNHIr2FrwTmGdEL6ObLUGWn9Oer9gJhHVqqsY5I4sEPo4XX
+stR0Yiw0buV6DL/moUO0HIM9Bjh96HJp+LxiIS6UCdIhMPp5HoQa
+-----END RSA PRIVATE KEY-----`
+)
+
+func TestTransportFor(t *testing.T) {
+	testCases := map[string]struct {
+		Config  *Config
+		Err     bool
+		TLS     bool
+		Default bool
+	}{
+		"default transport": {
+			Default: true,
+			Config:  &Config{},
+		},
+
+		"ca transport": {
+			TLS: true,
+			Config: &Config{
+				TLSClientConfig: TLSClientConfig{
+					CAData: []byte(rootCACert),
+				},
+			},
+		},
+		"bad ca file transport": {
+			Err: true,
+			Config: &Config{
+				TLSClientConfig: TLSClientConfig{
+					CAFile: "invalid file",
+				},
+			},
+		},
+		"ca data overriding bad ca file transport": {
+			TLS: true,
+			Config: &Config{
+				TLSClientConfig: TLSClientConfig{
+					CAData: []byte(rootCACert),
+					CAFile: "invalid file",
+				},
+			},
+		},
+
+		"cert transport": {
+			TLS: true,
+			Config: &Config{
+				TLSClientConfig: TLSClientConfig{
+					CertData: []byte(certData),
+					KeyData:  []byte(keyData),
+					CAData:   []byte(rootCACert),
+				},
+			},
+		},
+		"bad cert data transport": {
+			Err: true,
+			Config: &Config{
+				TLSClientConfig: TLSClientConfig{
+					CertData: []byte(certData),
+					KeyData:  []byte("bad key data"),
+					CAData:   []byte(rootCACert),
+				},
+			},
+		},
+		"bad file cert transport": {
+			Err: true,
+			Config: &Config{
+				TLSClientConfig: TLSClientConfig{
+					CertData: []byte(certData),
+					KeyFile:  "invalid file",
+					CAData:   []byte(rootCACert),
+				},
+			},
+		},
+		"key data overriding bad file cert transport": {
+			TLS: true,
+			Config: &Config{
+				TLSClientConfig: TLSClientConfig{
+					CertData: []byte(certData),
+					KeyData:  []byte(keyData),
+					KeyFile:  "invalid file",
+					CAData:   []byte(rootCACert),
+				},
+			},
+		},
+	}
+	for k, testCase := range testCases {
+		transport, err := TransportFor(testCase.Config)
+		switch {
+		case testCase.Err && err == nil:
+			t.Errorf("%s: unexpected non-error", k)
+			continue
+		case !testCase.Err && err != nil:
+			t.Errorf("%s: unexpected error: %v", k, err)
+			continue
+		}
+
+		switch {
+		case testCase.Default && transport != http.DefaultTransport:
+			t.Errorf("%s: expected the default transport, got %#v", k, transport)
+			continue
+		case !testCase.Default && transport == http.DefaultTransport:
+			t.Errorf("%s: expected non-default transport, got %#v", k, transport)
+			continue
+		}
+
+		// We only know how to check TLSConfig on http.Transports
+		if transport, ok := transport.(*http.Transport); ok {
+			switch {
+			case testCase.TLS && transport.TLSClientConfig == nil:
+				t.Errorf("%s: expected TLSClientConfig, got %#v", k, transport)
+				continue
+			case !testCase.TLS && transport.TLSClientConfig != nil:
+				t.Errorf("%s: expected no TLSClientConfig, got %#v", k, transport)
+				continue
+			}
+		}
+	}
+}
+
+func TestTLSTransportCache(t *testing.T) {
+	// Empty the cache
+	tlsTransports = map[string]*http.Transport{}
+	// Construct several transports (Insecure=true to force a transport with custom tls settings)
+	identicalConfigurations := map[string]*Config{
+		"empty":          {Insecure: true},
+		"host":           {Insecure: true, Host: "foo"},
+		"prefix":         {Insecure: true, Prefix: "foo"},
+		"version":        {Insecure: true, Version: "foo"},
+		"codec":          {Insecure: true, Codec: testapi.Default.Codec()},
+		"basic":          {Insecure: true, Username: "bob", Password: "password"},
+		"bearer":         {Insecure: true, BearerToken: "token"},
+		"user agent":     {Insecure: true, UserAgent: "useragent"},
+		"wrap transport": {Insecure: true, WrapTransport: func(http.RoundTripper) http.RoundTripper { return nil }},
+		"qps/burst":      {Insecure: true, QPS: 1.0, Burst: 10},
+	}
+	for k, v := range identicalConfigurations {
+		if _, err := TransportFor(v); err != nil {
+			t.Errorf("Unexpected error for %q: %v", k, err)
+		}
+	}
+	if len(tlsTransports) != 1 {
+		t.Errorf("Expected 1 cached transport, got %d", len(tlsTransports))
+	}
+
+	// Empty the cache
+	tlsTransports = map[string]*http.Transport{}
+	// Construct several transports with custom TLS settings
+	// (no normalization is performed on ca/cert/key data, so appending a newline lets us test "different" content)
+	uniqueConfigurations := map[string]*Config{
+		"insecure":                {Insecure: true},
+		"cadata 1":                {TLSClientConfig: TLSClientConfig{CAData: []byte(rootCACert)}},
+		"cadata 2":                {TLSClientConfig: TLSClientConfig{CAData: []byte(rootCACert + "\n")}},
+		"cert 1, key 1":           {TLSClientConfig: TLSClientConfig{CertData: []byte(certData), KeyData: []byte(keyData)}},
+		"cert 1, key 2":           {TLSClientConfig: TLSClientConfig{CertData: []byte(certData), KeyData: []byte(keyData + "\n")}},
+		"cert 2, key 1":           {TLSClientConfig: TLSClientConfig{CertData: []byte(certData + "\n"), KeyData: []byte(keyData)}},
+		"cert 2, key 2":           {TLSClientConfig: TLSClientConfig{CertData: []byte(certData + "\n"), KeyData: []byte(keyData + "\n")}},
+		"cadata 1, cert 1, key 1": {TLSClientConfig: TLSClientConfig{CAData: []byte(rootCACert), CertData: []byte(certData), KeyData: []byte(keyData)}},
+	}
+	for k, v := range uniqueConfigurations {
+		if _, err := TransportFor(v); err != nil {
+			t.Errorf("Unexpected error for %q: %v", k, err)
+		}
+	}
+	// All custom configs should result in a cache entry
+	if len(tlsTransports) != len(uniqueConfigurations) {
+		t.Errorf("Expected %d cached transports, got %d", len(uniqueConfigurations), len(tlsTransports))
+	}
+
+	// Empty the cache
+	tlsTransports = map[string]*http.Transport{}
+	if _, err := TransportFor(&Config{}); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	// A client config with no TLS options should use http.DefaultTransport, not a cached custom transport
+	if len(tlsTransports) != 0 {
+		t.Errorf("Expected no cached transports, got %d", len(tlsTransports))
+	}
+}
+
+func TestIsConfigTransportTLS(t *testing.T) {
+	testCases := []struct {
+		Config       *Config
+		TransportTLS bool
+	}{
+		{
+			Config:       &Config{},
+			TransportTLS: false,
+		},
+		{
+			Config: &Config{
+				Host: "https://localhost",
+			},
+			TransportTLS: true,
+		},
+		{
+			Config: &Config{
+				Host: "localhost",
+				TLSClientConfig: TLSClientConfig{
+					CertFile: "foo",
+				},
+			},
+			TransportTLS: true,
+		},
+		{
+			Config: &Config{
+				Host: "///:://localhost",
+				TLSClientConfig: TLSClientConfig{
+					CertFile: "foo",
+				},
+			},
+			TransportTLS: false,
+		},
+		{
+			Config: &Config{
+				Host:     "1.2.3.4:567",
+				Insecure: true,
+			},
+			TransportTLS: true,
+		},
+	}
+	for _, testCase := range testCases {
+		if err := SetKubernetesDefaults(testCase.Config); err != nil {
+			t.Errorf("setting defaults failed for %#v: %v", testCase.Config, err)
+			continue
+		}
+		useTLS := IsConfigTransportTLS(*testCase.Config)
+		if testCase.TransportTLS != useTLS {
+			t.Errorf("expected %v for %#v", testCase.TransportTLS, testCase.Config)
+		}
+	}
+}
+
+func TestSetKubernetesDefaults(t *testing.T) {
+	testCases := []struct {
+		Config Config
+		After  Config
+		Err    bool
+	}{
+		{
+			Config{},
+			Config{
+				Prefix:  "/api",
+				Version: testapi.Default.Version(),
+				Codec:   testapi.Default.Codec(),
+				QPS:     5,
+				Burst:   10,
+			},
+			false,
+		},
+		{
+			Config{
+				Version: "not_an_api",
+			},
+			Config{},
+			true,
+		},
+	}
+	for _, testCase := range testCases {
+		val := &testCase.Config
+		err := SetKubernetesDefaults(val)
+		val.UserAgent = ""
+		switch {
+		case err == nil && testCase.Err:
+			t.Errorf("expected error but was nil")
+			continue
+		case err != nil && !testCase.Err:
+			t.Errorf("unexpected error %v", err)
+			continue
+		case err != nil:
+			continue
+		}
+		if !reflect.DeepEqual(*val, testCase.After) {
+			t.Errorf("unexpected result object: %#v", val)
+		}
+	}
+}
+
+func TestSetKubernetesDefaultsUserAgent(t *testing.T) {
+	config := &Config{}
+	if err := SetKubernetesDefaults(config); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !strings.Contains(config.UserAgent, "kubernetes/") {
+		t.Errorf("no user agent set: %#v", config)
+	}
+}

--- a/pkg/client/v1/helper_test.go
+++ b/pkg/client/v1/helper_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"net/http"

--- a/pkg/client/v1/horizontalpodautoscaler.go
+++ b/pkg/client/v1/horizontalpodautoscaler.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/experimental"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// HorizontalPodAutoscalersNamespacer has methods to work with HorizontalPodAutoscaler resources in a namespace
+type HorizontalPodAutoscalersNamespacer interface {
+	HorizontalPodAutoscalers(namespace string) HorizontalPodAutoscalerInterface
+}
+
+// HorizontalPodAutoscalerInterface has methods to work with HorizontalPodAutoscaler resources.
+type HorizontalPodAutoscalerInterface interface {
+	List(label labels.Selector, field fields.Selector) (*experimental.HorizontalPodAutoscalerList, error)
+	Get(name string) (*experimental.HorizontalPodAutoscaler, error)
+	Delete(name string, options *api.DeleteOptions) error
+	Create(horizontalPodAutoscaler *experimental.HorizontalPodAutoscaler) (*experimental.HorizontalPodAutoscaler, error)
+	Update(horizontalPodAutoscaler *experimental.HorizontalPodAutoscaler) (*experimental.HorizontalPodAutoscaler, error)
+	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
+}
+
+// horizontalPodAutoscalers implements HorizontalPodAutoscalersNamespacer interface
+type horizontalPodAutoscalers struct {
+	client *ExperimentalClient
+	ns     string
+}
+
+// newHorizontalPodAutoscalers returns a horizontalPodAutoscalers
+func newHorizontalPodAutoscalers(c *ExperimentalClient, namespace string) *horizontalPodAutoscalers {
+	return &horizontalPodAutoscalers{
+		client: c,
+		ns:     namespace,
+	}
+}
+
+// List takes label and field selectors, and returns the list of horizontalPodAutoscalers that match those selectors.
+func (c *horizontalPodAutoscalers) List(label labels.Selector, field fields.Selector) (result *experimental.HorizontalPodAutoscalerList, err error) {
+	result = &experimental.HorizontalPodAutoscalerList{}
+	err = c.client.Get().Namespace(c.ns).Resource("horizontalPodAutoscalers").LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
+	return
+}
+
+// Get takes the name of the horizontalPodAutoscaler, and returns the corresponding HorizontalPodAutoscaler object, and an error if it occurs
+func (c *horizontalPodAutoscalers) Get(name string) (result *experimental.HorizontalPodAutoscaler, err error) {
+	result = &experimental.HorizontalPodAutoscaler{}
+	err = c.client.Get().Namespace(c.ns).Resource("horizontalPodAutoscalers").Name(name).Do().Into(result)
+	return
+}
+
+// Delete takes the name of the horizontalPodAutoscaler and deletes it.  Returns an error if one occurs.
+func (c *horizontalPodAutoscalers) Delete(name string, options *api.DeleteOptions) error {
+	// TODO: to make this reusable in other client libraries
+	if options == nil {
+		return c.client.Delete().Namespace(c.ns).Resource("horizontalPodAutoscalers").Name(name).Do().Error()
+	}
+	body, err := api.Scheme.EncodeToVersion(options, c.client.APIVersion())
+	if err != nil {
+		return err
+	}
+	return c.client.Delete().Namespace(c.ns).Resource("horizontalPodAutoscalers").Name(name).Body(body).Do().Error()
+}
+
+// Create takes the representation of a horizontalPodAutoscaler and creates it.  Returns the server's representation of the horizontalPodAutoscaler, and an error, if it occurs.
+func (c *horizontalPodAutoscalers) Create(horizontalPodAutoscaler *experimental.HorizontalPodAutoscaler) (result *experimental.HorizontalPodAutoscaler, err error) {
+	result = &experimental.HorizontalPodAutoscaler{}
+	err = c.client.Post().Namespace(c.ns).Resource("horizontalPodAutoscalers").Body(horizontalPodAutoscaler).Do().Into(result)
+	return
+}
+
+// Update takes the representation of a horizontalPodAutoscaler and updates it.  Returns the server's representation of the horizontalPodAutoscaler, and an error, if it occurs.
+func (c *horizontalPodAutoscalers) Update(horizontalPodAutoscaler *experimental.HorizontalPodAutoscaler) (result *experimental.HorizontalPodAutoscaler, err error) {
+	result = &experimental.HorizontalPodAutoscaler{}
+	err = c.client.Put().Namespace(c.ns).Resource("horizontalPodAutoscalers").Name(horizontalPodAutoscaler.Name).Body(horizontalPodAutoscaler).Do().Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested horizontalPodAutoscalers.
+func (c *horizontalPodAutoscalers) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.client.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("horizontalPodAutoscalers").
+		Param("resourceVersion", resourceVersion).
+		LabelsSelectorParam(label).
+		FieldsSelectorParam(field).
+		Watch()
+}

--- a/pkg/client/v1/horizontalpodautoscaler.go
+++ b/pkg/client/v1/horizontalpodautoscaler.go
@@ -14,11 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/apis/experimental"
+	"k8s.io/kubernetes/pkg/api/v1"
+	experimental "k8s.io/kubernetes/pkg/apis/experimental/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/watch"
@@ -33,7 +34,7 @@ type HorizontalPodAutoscalersNamespacer interface {
 type HorizontalPodAutoscalerInterface interface {
 	List(label labels.Selector, field fields.Selector) (*experimental.HorizontalPodAutoscalerList, error)
 	Get(name string) (*experimental.HorizontalPodAutoscaler, error)
-	Delete(name string, options *api.DeleteOptions) error
+	Delete(name string, options *v1.DeleteOptions) error
 	Create(horizontalPodAutoscaler *experimental.HorizontalPodAutoscaler) (*experimental.HorizontalPodAutoscaler, error)
 	Update(horizontalPodAutoscaler *experimental.HorizontalPodAutoscaler) (*experimental.HorizontalPodAutoscaler, error)
 	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
@@ -68,7 +69,7 @@ func (c *horizontalPodAutoscalers) Get(name string) (result *experimental.Horizo
 }
 
 // Delete takes the name of the horizontalPodAutoscaler and deletes it.  Returns an error if one occurs.
-func (c *horizontalPodAutoscalers) Delete(name string, options *api.DeleteOptions) error {
+func (c *horizontalPodAutoscalers) Delete(name string, options *v1.DeleteOptions) error {
 	// TODO: to make this reusable in other client libraries
 	if options == nil {
 		return c.client.Delete().Namespace(c.ns).Resource("horizontalPodAutoscalers").Name(name).Do().Error()

--- a/pkg/client/v1/horizontalpodautoscaler_test.go
+++ b/pkg/client/v1/horizontalpodautoscaler_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"net/url"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/apis/experimental"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func getHorizontalPodAutoscalersResoureName() string {
+	return "horizontalpodautoscalers"
+}
+
+func TestHorizontalPodAutoscalerCreate(t *testing.T) {
+	ns := api.NamespaceDefault
+	horizontalPodAutoscaler := experimental.HorizontalPodAutoscaler{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "abc",
+			Namespace: ns,
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "POST",
+			Path:   testapi.Experimental.ResourcePath(getHorizontalPodAutoscalersResoureName(), ns, ""),
+			Query:  buildQueryValues(nil),
+			Body:   &horizontalPodAutoscaler,
+		},
+		Response: Response{StatusCode: 200, Body: &horizontalPodAutoscaler},
+	}
+
+	response, err := c.Setup(t).Experimental().HorizontalPodAutoscalers(ns).Create(&horizontalPodAutoscaler)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	c.Validate(t, response, err)
+}
+
+func TestHorizontalPodAutoscalerGet(t *testing.T) {
+	ns := api.NamespaceDefault
+	horizontalPodAutoscaler := &experimental.HorizontalPodAutoscaler{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "abc",
+			Namespace: ns,
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Experimental.ResourcePath(getHorizontalPodAutoscalersResoureName(), ns, "abc"),
+			Query:  buildQueryValues(nil),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: horizontalPodAutoscaler},
+	}
+
+	response, err := c.Setup(t).Experimental().HorizontalPodAutoscalers(ns).Get("abc")
+	c.Validate(t, response, err)
+}
+
+func TestHorizontalPodAutoscalerList(t *testing.T) {
+	ns := api.NamespaceDefault
+	horizontalPodAutoscalerList := &experimental.HorizontalPodAutoscalerList{
+		Items: []experimental.HorizontalPodAutoscaler{
+			{
+				ObjectMeta: api.ObjectMeta{
+					Name:      "foo",
+					Namespace: ns,
+				},
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Experimental.ResourcePath(getHorizontalPodAutoscalersResoureName(), ns, ""),
+			Query:  buildQueryValues(nil),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: horizontalPodAutoscalerList},
+	}
+	response, err := c.Setup(t).Experimental().HorizontalPodAutoscalers(ns).List(labels.Everything(), fields.Everything())
+	c.Validate(t, response, err)
+}
+
+func TestHorizontalPodAutoscalerUpdate(t *testing.T) {
+	ns := api.NamespaceDefault
+	horizontalPodAutoscaler := &experimental.HorizontalPodAutoscaler{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "abc",
+			Namespace:       ns,
+			ResourceVersion: "1",
+		},
+	}
+	c := &testClient{
+		Request:  testRequest{Method: "PUT", Path: testapi.Experimental.ResourcePath(getHorizontalPodAutoscalersResoureName(), ns, "abc"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200, Body: horizontalPodAutoscaler},
+	}
+	response, err := c.Setup(t).Experimental().HorizontalPodAutoscalers(ns).Update(horizontalPodAutoscaler)
+	c.Validate(t, response, err)
+}
+
+func TestHorizontalPodAutoscalerDelete(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request:  testRequest{Method: "DELETE", Path: testapi.Experimental.ResourcePath(getHorizontalPodAutoscalersResoureName(), ns, "foo"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200},
+	}
+	err := c.Setup(t).Experimental().HorizontalPodAutoscalers(ns).Delete("foo", nil)
+	c.Validate(t, nil, err)
+}
+
+func TestHorizontalPodAutoscalerWatch(t *testing.T) {
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Experimental.ResourcePathWithPrefix("watch", getHorizontalPodAutoscalersResoureName(), "", ""),
+			Query:  url.Values{"resourceVersion": []string{}}},
+		Response: Response{StatusCode: 200},
+	}
+	_, err := c.Setup(t).Experimental().HorizontalPodAutoscalers(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), "")
+	c.Validate(t, nil, err)
+}

--- a/pkg/client/v1/horizontalpodautoscaler_test.go
+++ b/pkg/client/v1/horizontalpodautoscaler_test.go
@@ -14,15 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"net/url"
 	"testing"
 
-	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
-	"k8s.io/kubernetes/pkg/apis/experimental"
+	"k8s.io/kubernetes/pkg/api/v1"
+	experimental "k8s.io/kubernetes/pkg/apis/experimental/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 )
@@ -32,9 +32,9 @@ func getHorizontalPodAutoscalersResoureName() string {
 }
 
 func TestHorizontalPodAutoscalerCreate(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	horizontalPodAutoscaler := experimental.HorizontalPodAutoscaler{
-		ObjectMeta: api.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "abc",
 			Namespace: ns,
 		},
@@ -57,9 +57,9 @@ func TestHorizontalPodAutoscalerCreate(t *testing.T) {
 }
 
 func TestHorizontalPodAutoscalerGet(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	horizontalPodAutoscaler := &experimental.HorizontalPodAutoscaler{
-		ObjectMeta: api.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "abc",
 			Namespace: ns,
 		},
@@ -79,11 +79,11 @@ func TestHorizontalPodAutoscalerGet(t *testing.T) {
 }
 
 func TestHorizontalPodAutoscalerList(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	horizontalPodAutoscalerList := &experimental.HorizontalPodAutoscalerList{
 		Items: []experimental.HorizontalPodAutoscaler{
 			{
-				ObjectMeta: api.ObjectMeta{
+				ObjectMeta: v1.ObjectMeta{
 					Name:      "foo",
 					Namespace: ns,
 				},
@@ -104,9 +104,9 @@ func TestHorizontalPodAutoscalerList(t *testing.T) {
 }
 
 func TestHorizontalPodAutoscalerUpdate(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	horizontalPodAutoscaler := &experimental.HorizontalPodAutoscaler{
-		ObjectMeta: api.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:            "abc",
 			Namespace:       ns,
 			ResourceVersion: "1",
@@ -121,7 +121,7 @@ func TestHorizontalPodAutoscalerUpdate(t *testing.T) {
 }
 
 func TestHorizontalPodAutoscalerDelete(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	c := &testClient{
 		Request:  testRequest{Method: "DELETE", Path: testapi.Experimental.ResourcePath(getHorizontalPodAutoscalersResoureName(), ns, "foo"), Query: buildQueryValues(nil)},
 		Response: Response{StatusCode: 200},
@@ -138,6 +138,6 @@ func TestHorizontalPodAutoscalerWatch(t *testing.T) {
 			Query:  url.Values{"resourceVersion": []string{}}},
 		Response: Response{StatusCode: 200},
 	}
-	_, err := c.Setup(t).Experimental().HorizontalPodAutoscalers(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), "")
+	_, err := c.Setup(t).Experimental().HorizontalPodAutoscalers(v1.NamespaceAll).Watch(labels.Everything(), fields.Everything(), "")
 	c.Validate(t, nil, err)
 }

--- a/pkg/client/v1/import_known_versions.go
+++ b/pkg/client/v1/import_known_versions.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+// These imports are the API groups the client will support.
+import (
+	_ "k8s.io/kubernetes/pkg/api/install"
+	_ "k8s.io/kubernetes/pkg/apis/experimental/install"
+)

--- a/pkg/client/v1/import_known_versions.go
+++ b/pkg/client/v1/import_known_versions.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 // These imports are the API groups the client will support.
 import (

--- a/pkg/client/v1/jobs.go
+++ b/pkg/client/v1/jobs.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/experimental"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// JobsNamespacer has methods to work with Job resources in a namespace
+type JobsNamespacer interface {
+	Jobs(namespace string) JobInterface
+}
+
+// JobInterface exposes methods to work on Job resources.
+type JobInterface interface {
+	List(label labels.Selector, field fields.Selector) (*experimental.JobList, error)
+	Get(name string) (*experimental.Job, error)
+	Create(job *experimental.Job) (*experimental.Job, error)
+	Update(job *experimental.Job) (*experimental.Job, error)
+	Delete(name string, options *api.DeleteOptions) error
+	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
+	UpdateStatus(job *experimental.Job) (*experimental.Job, error)
+}
+
+// jobs implements JobsNamespacer interface
+type jobs struct {
+	r  *ExperimentalClient
+	ns string
+}
+
+// newJobs returns a jobs
+func newJobs(c *ExperimentalClient, namespace string) *jobs {
+	return &jobs{c, namespace}
+}
+
+// List returns a list of jobs that match the label and field selectors.
+func (c *jobs) List(label labels.Selector, field fields.Selector) (result *experimental.JobList, err error) {
+	result = &experimental.JobList{}
+	err = c.r.Get().Namespace(c.ns).Resource("jobs").LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
+	return
+}
+
+// Get returns information about a particular job.
+func (c *jobs) Get(name string) (result *experimental.Job, err error) {
+	result = &experimental.Job{}
+	err = c.r.Get().Namespace(c.ns).Resource("jobs").Name(name).Do().Into(result)
+	return
+}
+
+// Create creates a new job.
+func (c *jobs) Create(job *experimental.Job) (result *experimental.Job, err error) {
+	result = &experimental.Job{}
+	err = c.r.Post().Namespace(c.ns).Resource("jobs").Body(job).Do().Into(result)
+	return
+}
+
+// Update updates an existing job.
+func (c *jobs) Update(job *experimental.Job) (result *experimental.Job, err error) {
+	result = &experimental.Job{}
+	err = c.r.Put().Namespace(c.ns).Resource("jobs").Name(job.Name).Body(job).Do().Into(result)
+	return
+}
+
+// Delete deletes a job, returns error if one occurs.
+func (c *jobs) Delete(name string, options *api.DeleteOptions) (err error) {
+	if options == nil {
+		return c.r.Delete().Namespace(c.ns).Resource("jobs").Name(name).Do().Error()
+	}
+
+	body, err := api.Scheme.EncodeToVersion(options, c.r.APIVersion())
+	if err != nil {
+		return err
+	}
+	return c.r.Delete().Namespace(c.ns).Resource("jobs").Name(name).Body(body).Do().Error()
+}
+
+// Watch returns a watch.Interface that watches the requested jobs.
+func (c *jobs) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.r.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("jobs").
+		Param("resourceVersion", resourceVersion).
+		LabelsSelectorParam(label).
+		FieldsSelectorParam(field).
+		Watch()
+}
+
+// UpdateStatus takes the name of the job and the new status.  Returns the server's representation of the job, and an error, if it occurs.
+func (c *jobs) UpdateStatus(job *experimental.Job) (result *experimental.Job, err error) {
+	result = &experimental.Job{}
+	err = c.r.Put().Namespace(c.ns).Resource("jobs").Name(job.Name).SubResource("status").Body(job).Do().Into(result)
+	return
+}

--- a/pkg/client/v1/jobs.go
+++ b/pkg/client/v1/jobs.go
@@ -14,11 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/apis/experimental"
+	"k8s.io/kubernetes/pkg/api/v1"
+	experimental "k8s.io/kubernetes/pkg/apis/experimental/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/watch"
@@ -35,7 +36,7 @@ type JobInterface interface {
 	Get(name string) (*experimental.Job, error)
 	Create(job *experimental.Job) (*experimental.Job, error)
 	Update(job *experimental.Job) (*experimental.Job, error)
-	Delete(name string, options *api.DeleteOptions) error
+	Delete(name string, options *v1.DeleteOptions) error
 	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
 	UpdateStatus(job *experimental.Job) (*experimental.Job, error)
 }
@@ -80,7 +81,7 @@ func (c *jobs) Update(job *experimental.Job) (result *experimental.Job, err erro
 }
 
 // Delete deletes a job, returns error if one occurs.
-func (c *jobs) Delete(name string, options *api.DeleteOptions) (err error) {
+func (c *jobs) Delete(name string, options *v1.DeleteOptions) (err error) {
 	if options == nil {
 		return c.r.Delete().Namespace(c.ns).Resource("jobs").Name(name).Do().Error()
 	}

--- a/pkg/client/v1/jobs_test.go
+++ b/pkg/client/v1/jobs_test.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/apis/experimental"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func getJobResourceName() string {
+	return "jobs"
+}
+
+func TestListJobs(t *testing.T) {
+	ns := api.NamespaceAll
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Experimental.ResourcePath(getJobResourceName(), ns, ""),
+		},
+		Response: Response{StatusCode: 200,
+			Body: &experimental.JobList{
+				Items: []experimental.Job{
+					{
+						ObjectMeta: api.ObjectMeta{
+							Name: "foo",
+							Labels: map[string]string{
+								"foo":  "bar",
+								"name": "baz",
+							},
+						},
+						Spec: experimental.JobSpec{
+							Template: &api.PodTemplateSpec{},
+						},
+					},
+				},
+			},
+		},
+	}
+	receivedJobList, err := c.Setup(t).Experimental().Jobs(ns).List(labels.Everything(), fields.Everything())
+	c.Validate(t, receivedJobList, err)
+}
+
+func TestGetJob(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Experimental.ResourcePath(getJobResourceName(), ns, "foo"),
+			Query:  buildQueryValues(nil),
+		},
+		Response: Response{
+			StatusCode: 200,
+			Body: &experimental.Job{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo":  "bar",
+						"name": "baz",
+					},
+				},
+				Spec: experimental.JobSpec{
+					Template: &api.PodTemplateSpec{},
+				},
+			},
+		},
+	}
+	receivedJob, err := c.Setup(t).Experimental().Jobs(ns).Get("foo")
+	c.Validate(t, receivedJob, err)
+}
+
+func TestGetJobWithNoName(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{Error: true}
+	receivedJob, err := c.Setup(t).Experimental().Jobs(ns).Get("")
+	if (err != nil) && (err.Error() != nameRequiredError) {
+		t.Errorf("Expected error: %v, but got %v", nameRequiredError, err)
+	}
+
+	c.Validate(t, receivedJob, err)
+}
+
+func TestUpdateJob(t *testing.T) {
+	ns := api.NamespaceDefault
+	requestJob := &experimental.Job{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "foo",
+			Namespace:       ns,
+			ResourceVersion: "1",
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "PUT",
+			Path:   testapi.Experimental.ResourcePath(getJobResourceName(), ns, "foo"),
+			Query:  buildQueryValues(nil),
+		},
+		Response: Response{
+			StatusCode: 200,
+			Body: &experimental.Job{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo":  "bar",
+						"name": "baz",
+					},
+				},
+				Spec: experimental.JobSpec{
+					Template: &api.PodTemplateSpec{},
+				},
+			},
+		},
+	}
+	receivedJob, err := c.Setup(t).Experimental().Jobs(ns).Update(requestJob)
+	c.Validate(t, receivedJob, err)
+}
+
+func TestUpdateJobStatus(t *testing.T) {
+	ns := api.NamespaceDefault
+	requestJob := &experimental.Job{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "foo",
+			Namespace:       ns,
+			ResourceVersion: "1",
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "PUT",
+			Path:   testapi.Experimental.ResourcePath(getJobResourceName(), ns, "foo") + "/status",
+			Query:  buildQueryValues(nil),
+		},
+		Response: Response{
+			StatusCode: 200,
+			Body: &experimental.Job{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo":  "bar",
+						"name": "baz",
+					},
+				},
+				Spec: experimental.JobSpec{
+					Template: &api.PodTemplateSpec{},
+				},
+				Status: experimental.JobStatus{
+					Active: 1,
+				},
+			},
+		},
+	}
+	receivedJob, err := c.Setup(t).Experimental().Jobs(ns).UpdateStatus(requestJob)
+	c.Validate(t, receivedJob, err)
+}
+
+func TestDeleteJob(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request: testRequest{
+			Method: "DELETE",
+			Path:   testapi.Experimental.ResourcePath(getJobResourceName(), ns, "foo"),
+			Query:  buildQueryValues(nil),
+		},
+		Response: Response{StatusCode: 200},
+	}
+	err := c.Setup(t).Experimental().Jobs(ns).Delete("foo", nil)
+	c.Validate(t, nil, err)
+}
+
+func TestCreateJob(t *testing.T) {
+	ns := api.NamespaceDefault
+	requestJob := &experimental.Job{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "foo",
+			Namespace: ns,
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "POST",
+			Path:   testapi.Experimental.ResourcePath(getJobResourceName(), ns, ""),
+			Body:   requestJob,
+			Query:  buildQueryValues(nil),
+		},
+		Response: Response{
+			StatusCode: 200,
+			Body: &experimental.Job{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo":  "bar",
+						"name": "baz",
+					},
+				},
+				Spec: experimental.JobSpec{
+					Template: &api.PodTemplateSpec{},
+				},
+			},
+		},
+	}
+	receivedJob, err := c.Setup(t).Experimental().Jobs(ns).Create(requestJob)
+	c.Validate(t, receivedJob, err)
+}

--- a/pkg/client/v1/jobs_test.go
+++ b/pkg/client/v1/jobs_test.go
@@ -14,14 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"testing"
 
-	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
-	"k8s.io/kubernetes/pkg/apis/experimental"
+	"k8s.io/kubernetes/pkg/api/v1"
+	experimental "k8s.io/kubernetes/pkg/apis/experimental/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 )
@@ -31,7 +31,7 @@ func getJobResourceName() string {
 }
 
 func TestListJobs(t *testing.T) {
-	ns := api.NamespaceAll
+	ns := v1.NamespaceAll
 	c := &testClient{
 		Request: testRequest{
 			Method: "GET",
@@ -41,7 +41,7 @@ func TestListJobs(t *testing.T) {
 			Body: &experimental.JobList{
 				Items: []experimental.Job{
 					{
-						ObjectMeta: api.ObjectMeta{
+						ObjectMeta: v1.ObjectMeta{
 							Name: "foo",
 							Labels: map[string]string{
 								"foo":  "bar",
@@ -49,7 +49,7 @@ func TestListJobs(t *testing.T) {
 							},
 						},
 						Spec: experimental.JobSpec{
-							Template: &api.PodTemplateSpec{},
+							Template: &v1.PodTemplateSpec{},
 						},
 					},
 				},
@@ -61,7 +61,7 @@ func TestListJobs(t *testing.T) {
 }
 
 func TestGetJob(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	c := &testClient{
 		Request: testRequest{
 			Method: "GET",
@@ -71,7 +71,7 @@ func TestGetJob(t *testing.T) {
 		Response: Response{
 			StatusCode: 200,
 			Body: &experimental.Job{
-				ObjectMeta: api.ObjectMeta{
+				ObjectMeta: v1.ObjectMeta{
 					Name: "foo",
 					Labels: map[string]string{
 						"foo":  "bar",
@@ -79,7 +79,7 @@ func TestGetJob(t *testing.T) {
 					},
 				},
 				Spec: experimental.JobSpec{
-					Template: &api.PodTemplateSpec{},
+					Template: &v1.PodTemplateSpec{},
 				},
 			},
 		},
@@ -89,7 +89,7 @@ func TestGetJob(t *testing.T) {
 }
 
 func TestGetJobWithNoName(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	c := &testClient{Error: true}
 	receivedJob, err := c.Setup(t).Experimental().Jobs(ns).Get("")
 	if (err != nil) && (err.Error() != nameRequiredError) {
@@ -100,9 +100,9 @@ func TestGetJobWithNoName(t *testing.T) {
 }
 
 func TestUpdateJob(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	requestJob := &experimental.Job{
-		ObjectMeta: api.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:            "foo",
 			Namespace:       ns,
 			ResourceVersion: "1",
@@ -117,7 +117,7 @@ func TestUpdateJob(t *testing.T) {
 		Response: Response{
 			StatusCode: 200,
 			Body: &experimental.Job{
-				ObjectMeta: api.ObjectMeta{
+				ObjectMeta: v1.ObjectMeta{
 					Name: "foo",
 					Labels: map[string]string{
 						"foo":  "bar",
@@ -125,7 +125,7 @@ func TestUpdateJob(t *testing.T) {
 					},
 				},
 				Spec: experimental.JobSpec{
-					Template: &api.PodTemplateSpec{},
+					Template: &v1.PodTemplateSpec{},
 				},
 			},
 		},
@@ -135,9 +135,9 @@ func TestUpdateJob(t *testing.T) {
 }
 
 func TestUpdateJobStatus(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	requestJob := &experimental.Job{
-		ObjectMeta: api.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:            "foo",
 			Namespace:       ns,
 			ResourceVersion: "1",
@@ -152,7 +152,7 @@ func TestUpdateJobStatus(t *testing.T) {
 		Response: Response{
 			StatusCode: 200,
 			Body: &experimental.Job{
-				ObjectMeta: api.ObjectMeta{
+				ObjectMeta: v1.ObjectMeta{
 					Name: "foo",
 					Labels: map[string]string{
 						"foo":  "bar",
@@ -160,7 +160,7 @@ func TestUpdateJobStatus(t *testing.T) {
 					},
 				},
 				Spec: experimental.JobSpec{
-					Template: &api.PodTemplateSpec{},
+					Template: &v1.PodTemplateSpec{},
 				},
 				Status: experimental.JobStatus{
 					Active: 1,
@@ -173,7 +173,7 @@ func TestUpdateJobStatus(t *testing.T) {
 }
 
 func TestDeleteJob(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	c := &testClient{
 		Request: testRequest{
 			Method: "DELETE",
@@ -187,9 +187,9 @@ func TestDeleteJob(t *testing.T) {
 }
 
 func TestCreateJob(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	requestJob := &experimental.Job{
-		ObjectMeta: api.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "foo",
 			Namespace: ns,
 		},
@@ -204,7 +204,7 @@ func TestCreateJob(t *testing.T) {
 		Response: Response{
 			StatusCode: 200,
 			Body: &experimental.Job{
-				ObjectMeta: api.ObjectMeta{
+				ObjectMeta: v1.ObjectMeta{
 					Name: "foo",
 					Labels: map[string]string{
 						"foo":  "bar",
@@ -212,7 +212,7 @@ func TestCreateJob(t *testing.T) {
 					},
 				},
 				Spec: experimental.JobSpec{
-					Template: &api.PodTemplateSpec{},
+					Template: &v1.PodTemplateSpec{},
 				},
 			},
 		},

--- a/pkg/client/v1/kubelet.go
+++ b/pkg/client/v1/kubelet.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"errors"
+	"net/http"
+)
+
+// KubeletClient is an interface for all kubelet functionality
+type KubeletClient interface {
+	ConnectionInfoGetter
+}
+
+type ConnectionInfoGetter interface {
+	GetConnectionInfo(host string) (scheme string, port uint, transport http.RoundTripper, err error)
+}
+
+// HTTPKubeletClient is the default implementation of KubeletHealthchecker, accesses the kubelet over HTTP.
+type HTTPKubeletClient struct {
+	Client *http.Client
+	Config *KubeletConfig
+}
+
+func MakeTransport(config *KubeletConfig) (http.RoundTripper, error) {
+	cfg := &Config{TLSClientConfig: config.TLSClientConfig}
+	if config.EnableHttps {
+		hasCA := len(config.CAFile) > 0 || len(config.CAData) > 0
+		if !hasCA {
+			cfg.Insecure = true
+		}
+	}
+	tlsConfig, err := TLSConfigFor(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if config.Dial != nil || tlsConfig != nil {
+		return &http.Transport{
+			Dial:            config.Dial,
+			TLSClientConfig: tlsConfig,
+		}, nil
+	} else {
+		return http.DefaultTransport, nil
+	}
+}
+
+// TODO: this structure is questionable, it should be using client.Config and overriding defaults.
+func NewKubeletClient(config *KubeletConfig) (KubeletClient, error) {
+	transport, err := MakeTransport(config)
+	if err != nil {
+		return nil, err
+	}
+	c := &http.Client{
+		Transport: transport,
+		Timeout:   config.HTTPTimeout,
+	}
+	return &HTTPKubeletClient{
+		Client: c,
+		Config: config,
+	}, nil
+}
+
+func (c *HTTPKubeletClient) GetConnectionInfo(host string) (string, uint, http.RoundTripper, error) {
+	scheme := "http"
+	if c.Config.EnableHttps {
+		scheme = "https"
+	}
+	return scheme, c.Config.Port, c.Client.Transport, nil
+}
+
+// FakeKubeletClient is a fake implementation of KubeletClient which returns an error
+// when called.  It is useful to pass to the master in a test configuration with
+// no kubelets.
+type FakeKubeletClient struct{}
+
+func (c FakeKubeletClient) GetConnectionInfo(host string) (string, uint, http.RoundTripper, error) {
+	return "", 0, nil, errors.New("Not Implemented")
+}

--- a/pkg/client/v1/kubelet.go
+++ b/pkg/client/v1/kubelet.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"errors"

--- a/pkg/client/v1/kubelet_test.go
+++ b/pkg/client/v1/kubelet_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/probe"
+	"k8s.io/kubernetes/pkg/util"
+)
+
+func TestHTTPKubeletClient(t *testing.T) {
+	expectObj := probe.Success
+	body, err := json.Marshal(expectObj)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	fakeHandler := util.FakeHandler{
+		StatusCode:   200,
+		ResponseBody: string(body),
+	}
+	testServer := httptest.NewServer(&fakeHandler)
+	defer testServer.Close()
+
+	_, err = url.Parse(testServer.URL)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNewKubeletClient(t *testing.T) {
+	config := &KubeletConfig{
+		EnableHttps: false,
+	}
+
+	client, err := NewKubeletClient(config)
+	if err != nil {
+		t.Errorf("Error while trying to create a client: %v", err)
+	}
+	if client == nil {
+		t.Error("client is nil.")
+	}
+}
+
+func TestNewKubeletClientTLSInvalid(t *testing.T) {
+	config := &KubeletConfig{
+		EnableHttps: true,
+		//Invalid certificate and key path
+		TLSClientConfig: TLSClientConfig{
+			CertFile: "../testdata/mycertinvalid.cer",
+			KeyFile:  "../testdata/mycertinvalid.key",
+			CAFile:   "../testdata/myCA.cer",
+		},
+	}
+
+	client, err := NewKubeletClient(config)
+	if err == nil {
+		t.Errorf("Expected an error")
+	}
+	if client != nil {
+		t.Error("client should be nil as we provided invalid cert file")
+	}
+}
+
+func TestNewKubeletClientTLSValid(t *testing.T) {
+	config := &KubeletConfig{
+		EnableHttps: true,
+		TLSClientConfig: TLSClientConfig{
+			CertFile: "../testdata/mycertvalid.cer",
+			// TLS Configuration, only applies if EnableHttps is true.
+			KeyFile: "../testdata/mycertvalid.key",
+			// TLS Configuration, only applies if EnableHttps is true.
+			CAFile: "../testdata/myCA.cer",
+		},
+	}
+
+	client, err := NewKubeletClient(config)
+	if err != nil {
+		t.Errorf("Not expecting an error #%v", err)
+	}
+	if client == nil {
+		t.Error("client should not be nil")
+	}
+}

--- a/pkg/client/v1/kubelet_test.go
+++ b/pkg/client/v1/kubelet_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"encoding/json"

--- a/pkg/client/v1/limit_ranges.go
+++ b/pkg/client/v1/limit_ranges.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// LimitRangesNamespacer has methods to work with LimitRange resources in a namespace
+type LimitRangesNamespacer interface {
+	LimitRanges(namespace string) LimitRangeInterface
+}
+
+// LimitRangeInterface has methods to work with LimitRange resources.
+type LimitRangeInterface interface {
+	List(selector labels.Selector) (*api.LimitRangeList, error)
+	Get(name string) (*api.LimitRange, error)
+	Delete(name string) error
+	Create(limitRange *api.LimitRange) (*api.LimitRange, error)
+	Update(limitRange *api.LimitRange) (*api.LimitRange, error)
+	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
+}
+
+// limitRanges implements LimitRangesNamespacer interface
+type limitRanges struct {
+	r  *Client
+	ns string
+}
+
+// newLimitRanges returns a limitRanges
+func newLimitRanges(c *Client, namespace string) *limitRanges {
+	return &limitRanges{
+		r:  c,
+		ns: namespace,
+	}
+}
+
+// List takes a selector, and returns the list of limitRanges that match that selector.
+func (c *limitRanges) List(selector labels.Selector) (result *api.LimitRangeList, err error) {
+	result = &api.LimitRangeList{}
+	err = c.r.Get().Namespace(c.ns).Resource("limitRanges").LabelsSelectorParam(selector).Do().Into(result)
+	return
+}
+
+// Get takes the name of the limitRange, and returns the corresponding Pod object, and an error if it occurs
+func (c *limitRanges) Get(name string) (result *api.LimitRange, err error) {
+	result = &api.LimitRange{}
+	err = c.r.Get().Namespace(c.ns).Resource("limitRanges").Name(name).Do().Into(result)
+	return
+}
+
+// Delete takes the name of the limitRange, and returns an error if one occurs
+func (c *limitRanges) Delete(name string) error {
+	return c.r.Delete().Namespace(c.ns).Resource("limitRanges").Name(name).Do().Error()
+}
+
+// Create takes the representation of a limitRange.  Returns the server's representation of the limitRange, and an error, if it occurs.
+func (c *limitRanges) Create(limitRange *api.LimitRange) (result *api.LimitRange, err error) {
+	result = &api.LimitRange{}
+	err = c.r.Post().Namespace(c.ns).Resource("limitRanges").Body(limitRange).Do().Into(result)
+	return
+}
+
+// Update takes the representation of a limitRange to update.  Returns the server's representation of the limitRange, and an error, if it occurs.
+func (c *limitRanges) Update(limitRange *api.LimitRange) (result *api.LimitRange, err error) {
+	result = &api.LimitRange{}
+	if len(limitRange.ResourceVersion) == 0 {
+		err = fmt.Errorf("invalid update object, missing resource version: %v", limitRange)
+		return
+	}
+	err = c.r.Put().Namespace(c.ns).Resource("limitRanges").Name(limitRange.Name).Body(limitRange).Do().Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested resource
+func (c *limitRanges) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.r.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("limitRanges").
+		Param("resourceVersion", resourceVersion).
+		LabelsSelectorParam(label).
+		FieldsSelectorParam(field).
+		Watch()
+}

--- a/pkg/client/v1/limit_ranges.go
+++ b/pkg/client/v1/limit_ranges.go
@@ -14,12 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"fmt"
 
-	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/watch"
@@ -32,11 +32,11 @@ type LimitRangesNamespacer interface {
 
 // LimitRangeInterface has methods to work with LimitRange resources.
 type LimitRangeInterface interface {
-	List(selector labels.Selector) (*api.LimitRangeList, error)
-	Get(name string) (*api.LimitRange, error)
+	List(selector labels.Selector) (*v1.LimitRangeList, error)
+	Get(name string) (*v1.LimitRange, error)
 	Delete(name string) error
-	Create(limitRange *api.LimitRange) (*api.LimitRange, error)
-	Update(limitRange *api.LimitRange) (*api.LimitRange, error)
+	Create(limitRange *v1.LimitRange) (*v1.LimitRange, error)
+	Update(limitRange *v1.LimitRange) (*v1.LimitRange, error)
 	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
 }
 
@@ -55,15 +55,15 @@ func newLimitRanges(c *Client, namespace string) *limitRanges {
 }
 
 // List takes a selector, and returns the list of limitRanges that match that selector.
-func (c *limitRanges) List(selector labels.Selector) (result *api.LimitRangeList, err error) {
-	result = &api.LimitRangeList{}
+func (c *limitRanges) List(selector labels.Selector) (result *v1.LimitRangeList, err error) {
+	result = &v1.LimitRangeList{}
 	err = c.r.Get().Namespace(c.ns).Resource("limitRanges").LabelsSelectorParam(selector).Do().Into(result)
 	return
 }
 
 // Get takes the name of the limitRange, and returns the corresponding Pod object, and an error if it occurs
-func (c *limitRanges) Get(name string) (result *api.LimitRange, err error) {
-	result = &api.LimitRange{}
+func (c *limitRanges) Get(name string) (result *v1.LimitRange, err error) {
+	result = &v1.LimitRange{}
 	err = c.r.Get().Namespace(c.ns).Resource("limitRanges").Name(name).Do().Into(result)
 	return
 }
@@ -74,15 +74,15 @@ func (c *limitRanges) Delete(name string) error {
 }
 
 // Create takes the representation of a limitRange.  Returns the server's representation of the limitRange, and an error, if it occurs.
-func (c *limitRanges) Create(limitRange *api.LimitRange) (result *api.LimitRange, err error) {
-	result = &api.LimitRange{}
+func (c *limitRanges) Create(limitRange *v1.LimitRange) (result *v1.LimitRange, err error) {
+	result = &v1.LimitRange{}
 	err = c.r.Post().Namespace(c.ns).Resource("limitRanges").Body(limitRange).Do().Into(result)
 	return
 }
 
 // Update takes the representation of a limitRange to update.  Returns the server's representation of the limitRange, and an error, if it occurs.
-func (c *limitRanges) Update(limitRange *api.LimitRange) (result *api.LimitRange, err error) {
-	result = &api.LimitRange{}
+func (c *limitRanges) Update(limitRange *v1.LimitRange) (result *v1.LimitRange, err error) {
+	result = &v1.LimitRange{}
 	if len(limitRange.ResourceVersion) == 0 {
 		err = fmt.Errorf("invalid update object, missing resource version: %v", limitRange)
 		return

--- a/pkg/client/v1/limit_ranges_test.go
+++ b/pkg/client/v1/limit_ranges_test.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"net/url"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func getLimitRangesResourceName() string {
+	return "limitranges"
+}
+
+func TestLimitRangeCreate(t *testing.T) {
+	ns := api.NamespaceDefault
+	limitRange := &api.LimitRange{
+		ObjectMeta: api.ObjectMeta{
+			Name: "abc",
+		},
+		Spec: api.LimitRangeSpec{
+			Limits: []api.LimitRangeItem{
+				{
+					Type: api.LimitTypePod,
+					Max: api.ResourceList{
+						api.ResourceCPU:    resource.MustParse("100"),
+						api.ResourceMemory: resource.MustParse("10000"),
+					},
+					Min: api.ResourceList{
+						api.ResourceCPU:    resource.MustParse("0"),
+						api.ResourceMemory: resource.MustParse("100"),
+					},
+				},
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "POST",
+			Path:   testapi.Default.ResourcePath(getLimitRangesResourceName(), ns, ""),
+			Query:  buildQueryValues(nil),
+			Body:   limitRange,
+		},
+		Response: Response{StatusCode: 200, Body: limitRange},
+	}
+
+	response, err := c.Setup(t).LimitRanges(ns).Create(limitRange)
+	c.Validate(t, response, err)
+}
+
+func TestLimitRangeGet(t *testing.T) {
+	ns := api.NamespaceDefault
+	limitRange := &api.LimitRange{
+		ObjectMeta: api.ObjectMeta{
+			Name: "abc",
+		},
+		Spec: api.LimitRangeSpec{
+			Limits: []api.LimitRangeItem{
+				{
+					Type: api.LimitTypePod,
+					Max: api.ResourceList{
+						api.ResourceCPU:    resource.MustParse("100"),
+						api.ResourceMemory: resource.MustParse("10000"),
+					},
+					Min: api.ResourceList{
+						api.ResourceCPU:    resource.MustParse("0"),
+						api.ResourceMemory: resource.MustParse("100"),
+					},
+				},
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath(getLimitRangesResourceName(), ns, "abc"),
+			Query:  buildQueryValues(nil),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: limitRange},
+	}
+
+	response, err := c.Setup(t).LimitRanges(ns).Get("abc")
+	c.Validate(t, response, err)
+}
+
+func TestLimitRangeList(t *testing.T) {
+	ns := api.NamespaceDefault
+
+	limitRangeList := &api.LimitRangeList{
+		Items: []api.LimitRange{
+			{
+				ObjectMeta: api.ObjectMeta{Name: "foo"},
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath(getLimitRangesResourceName(), ns, ""),
+			Query:  buildQueryValues(nil),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: limitRangeList},
+	}
+	response, err := c.Setup(t).LimitRanges(ns).List(labels.Everything())
+	c.Validate(t, response, err)
+}
+
+func TestLimitRangeUpdate(t *testing.T) {
+	ns := api.NamespaceDefault
+	limitRange := &api.LimitRange{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "abc",
+			ResourceVersion: "1",
+		},
+		Spec: api.LimitRangeSpec{
+			Limits: []api.LimitRangeItem{
+				{
+					Type: api.LimitTypePod,
+					Max: api.ResourceList{
+						api.ResourceCPU:    resource.MustParse("100"),
+						api.ResourceMemory: resource.MustParse("10000"),
+					},
+					Min: api.ResourceList{
+						api.ResourceCPU:    resource.MustParse("0"),
+						api.ResourceMemory: resource.MustParse("100"),
+					},
+				},
+			},
+		},
+	}
+	c := &testClient{
+		Request:  testRequest{Method: "PUT", Path: testapi.Default.ResourcePath(getLimitRangesResourceName(), ns, "abc"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200, Body: limitRange},
+	}
+	response, err := c.Setup(t).LimitRanges(ns).Update(limitRange)
+	c.Validate(t, response, err)
+}
+
+func TestInvalidLimitRangeUpdate(t *testing.T) {
+	ns := api.NamespaceDefault
+	limitRange := &api.LimitRange{
+		ObjectMeta: api.ObjectMeta{
+			Name: "abc",
+		},
+		Spec: api.LimitRangeSpec{
+			Limits: []api.LimitRangeItem{
+				{
+					Type: api.LimitTypePod,
+					Max: api.ResourceList{
+						api.ResourceCPU:    resource.MustParse("100"),
+						api.ResourceMemory: resource.MustParse("10000"),
+					},
+					Min: api.ResourceList{
+						api.ResourceCPU:    resource.MustParse("0"),
+						api.ResourceMemory: resource.MustParse("100"),
+					},
+				},
+			},
+		},
+	}
+	c := &testClient{
+		Request:  testRequest{Method: "PUT", Path: testapi.Default.ResourcePath(getLimitRangesResourceName(), ns, "abc"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200, Body: limitRange},
+	}
+	_, err := c.Setup(t).LimitRanges(ns).Update(limitRange)
+	if err == nil {
+		t.Errorf("Expected an error due to missing ResourceVersion")
+	}
+}
+
+func TestLimitRangeDelete(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request:  testRequest{Method: "DELETE", Path: testapi.Default.ResourcePath(getLimitRangesResourceName(), ns, "foo"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200},
+	}
+	err := c.Setup(t).LimitRanges(ns).Delete("foo")
+	c.Validate(t, nil, err)
+}
+
+func TestLimitRangeWatch(t *testing.T) {
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePathWithPrefix("watch", getLimitRangesResourceName(), "", ""),
+			Query:  url.Values{"resourceVersion": []string{}}},
+		Response: Response{StatusCode: 200},
+	}
+	_, err := c.Setup(t).LimitRanges(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), "")
+	c.Validate(t, nil, err)
+}

--- a/pkg/client/v1/limit_ranges_test.go
+++ b/pkg/client/v1/limit_ranges_test.go
@@ -14,15 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"net/url"
 	"testing"
 
-	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 )
@@ -32,22 +32,22 @@ func getLimitRangesResourceName() string {
 }
 
 func TestLimitRangeCreate(t *testing.T) {
-	ns := api.NamespaceDefault
-	limitRange := &api.LimitRange{
-		ObjectMeta: api.ObjectMeta{
+	ns := v1.NamespaceDefault
+	limitRange := &v1.LimitRange{
+		ObjectMeta: v1.ObjectMeta{
 			Name: "abc",
 		},
-		Spec: api.LimitRangeSpec{
-			Limits: []api.LimitRangeItem{
+		Spec: v1.LimitRangeSpec{
+			Limits: []v1.LimitRangeItem{
 				{
-					Type: api.LimitTypePod,
-					Max: api.ResourceList{
-						api.ResourceCPU:    resource.MustParse("100"),
-						api.ResourceMemory: resource.MustParse("10000"),
+					Type: v1.LimitTypePod,
+					Max: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("100"),
+						v1.ResourceMemory: resource.MustParse("10000"),
 					},
-					Min: api.ResourceList{
-						api.ResourceCPU:    resource.MustParse("0"),
-						api.ResourceMemory: resource.MustParse("100"),
+					Min: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("0"),
+						v1.ResourceMemory: resource.MustParse("100"),
 					},
 				},
 			},
@@ -68,22 +68,22 @@ func TestLimitRangeCreate(t *testing.T) {
 }
 
 func TestLimitRangeGet(t *testing.T) {
-	ns := api.NamespaceDefault
-	limitRange := &api.LimitRange{
-		ObjectMeta: api.ObjectMeta{
+	ns := v1.NamespaceDefault
+	limitRange := &v1.LimitRange{
+		ObjectMeta: v1.ObjectMeta{
 			Name: "abc",
 		},
-		Spec: api.LimitRangeSpec{
-			Limits: []api.LimitRangeItem{
+		Spec: v1.LimitRangeSpec{
+			Limits: []v1.LimitRangeItem{
 				{
-					Type: api.LimitTypePod,
-					Max: api.ResourceList{
-						api.ResourceCPU:    resource.MustParse("100"),
-						api.ResourceMemory: resource.MustParse("10000"),
+					Type: v1.LimitTypePod,
+					Max: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("100"),
+						v1.ResourceMemory: resource.MustParse("10000"),
 					},
-					Min: api.ResourceList{
-						api.ResourceCPU:    resource.MustParse("0"),
-						api.ResourceMemory: resource.MustParse("100"),
+					Min: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("0"),
+						v1.ResourceMemory: resource.MustParse("100"),
 					},
 				},
 			},
@@ -104,12 +104,12 @@ func TestLimitRangeGet(t *testing.T) {
 }
 
 func TestLimitRangeList(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 
-	limitRangeList := &api.LimitRangeList{
-		Items: []api.LimitRange{
+	limitRangeList := &v1.LimitRangeList{
+		Items: []v1.LimitRange{
 			{
-				ObjectMeta: api.ObjectMeta{Name: "foo"},
+				ObjectMeta: v1.ObjectMeta{Name: "foo"},
 			},
 		},
 	}
@@ -127,23 +127,23 @@ func TestLimitRangeList(t *testing.T) {
 }
 
 func TestLimitRangeUpdate(t *testing.T) {
-	ns := api.NamespaceDefault
-	limitRange := &api.LimitRange{
-		ObjectMeta: api.ObjectMeta{
+	ns := v1.NamespaceDefault
+	limitRange := &v1.LimitRange{
+		ObjectMeta: v1.ObjectMeta{
 			Name:            "abc",
 			ResourceVersion: "1",
 		},
-		Spec: api.LimitRangeSpec{
-			Limits: []api.LimitRangeItem{
+		Spec: v1.LimitRangeSpec{
+			Limits: []v1.LimitRangeItem{
 				{
-					Type: api.LimitTypePod,
-					Max: api.ResourceList{
-						api.ResourceCPU:    resource.MustParse("100"),
-						api.ResourceMemory: resource.MustParse("10000"),
+					Type: v1.LimitTypePod,
+					Max: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("100"),
+						v1.ResourceMemory: resource.MustParse("10000"),
 					},
-					Min: api.ResourceList{
-						api.ResourceCPU:    resource.MustParse("0"),
-						api.ResourceMemory: resource.MustParse("100"),
+					Min: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("0"),
+						v1.ResourceMemory: resource.MustParse("100"),
 					},
 				},
 			},
@@ -158,22 +158,22 @@ func TestLimitRangeUpdate(t *testing.T) {
 }
 
 func TestInvalidLimitRangeUpdate(t *testing.T) {
-	ns := api.NamespaceDefault
-	limitRange := &api.LimitRange{
-		ObjectMeta: api.ObjectMeta{
+	ns := v1.NamespaceDefault
+	limitRange := &v1.LimitRange{
+		ObjectMeta: v1.ObjectMeta{
 			Name: "abc",
 		},
-		Spec: api.LimitRangeSpec{
-			Limits: []api.LimitRangeItem{
+		Spec: v1.LimitRangeSpec{
+			Limits: []v1.LimitRangeItem{
 				{
-					Type: api.LimitTypePod,
-					Max: api.ResourceList{
-						api.ResourceCPU:    resource.MustParse("100"),
-						api.ResourceMemory: resource.MustParse("10000"),
+					Type: v1.LimitTypePod,
+					Max: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("100"),
+						v1.ResourceMemory: resource.MustParse("10000"),
 					},
-					Min: api.ResourceList{
-						api.ResourceCPU:    resource.MustParse("0"),
-						api.ResourceMemory: resource.MustParse("100"),
+					Min: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("0"),
+						v1.ResourceMemory: resource.MustParse("100"),
 					},
 				},
 			},
@@ -190,7 +190,7 @@ func TestInvalidLimitRangeUpdate(t *testing.T) {
 }
 
 func TestLimitRangeDelete(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	c := &testClient{
 		Request:  testRequest{Method: "DELETE", Path: testapi.Default.ResourcePath(getLimitRangesResourceName(), ns, "foo"), Query: buildQueryValues(nil)},
 		Response: Response{StatusCode: 200},
@@ -207,6 +207,6 @@ func TestLimitRangeWatch(t *testing.T) {
 			Query:  url.Values{"resourceVersion": []string{}}},
 		Response: Response{StatusCode: 200},
 	}
-	_, err := c.Setup(t).LimitRanges(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), "")
+	_, err := c.Setup(t).LimitRanges(v1.NamespaceAll).Watch(labels.Everything(), fields.Everything(), "")
 	c.Validate(t, nil, err)
 }

--- a/pkg/client/v1/namespaces.go
+++ b/pkg/client/v1/namespaces.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+type NamespacesInterface interface {
+	Namespaces() NamespaceInterface
+}
+
+type NamespaceInterface interface {
+	Create(item *api.Namespace) (*api.Namespace, error)
+	Get(name string) (result *api.Namespace, err error)
+	List(label labels.Selector, field fields.Selector) (*api.NamespaceList, error)
+	Delete(name string) error
+	Update(item *api.Namespace) (*api.Namespace, error)
+	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
+	Finalize(item *api.Namespace) (*api.Namespace, error)
+	Status(item *api.Namespace) (*api.Namespace, error)
+}
+
+// namespaces implements NamespacesInterface
+type namespaces struct {
+	r *Client
+}
+
+// newNamespaces returns a namespaces object.
+func newNamespaces(c *Client) *namespaces {
+	return &namespaces{r: c}
+}
+
+// Create creates a new namespace.
+func (c *namespaces) Create(namespace *api.Namespace) (*api.Namespace, error) {
+	result := &api.Namespace{}
+	err := c.r.Post().Resource("namespaces").Body(namespace).Do().Into(result)
+	return result, err
+}
+
+// List lists all the namespaces in the cluster.
+func (c *namespaces) List(label labels.Selector, field fields.Selector) (*api.NamespaceList, error) {
+	result := &api.NamespaceList{}
+	err := c.r.Get().
+		Resource("namespaces").
+		LabelsSelectorParam(label).
+		FieldsSelectorParam(field).
+		Do().Into(result)
+	return result, err
+}
+
+// Update takes the representation of a namespace to update.  Returns the server's representation of the namespace, and an error, if it occurs.
+func (c *namespaces) Update(namespace *api.Namespace) (result *api.Namespace, err error) {
+	result = &api.Namespace{}
+	if len(namespace.ResourceVersion) == 0 {
+		err = fmt.Errorf("invalid update object, missing resource version: %v", namespace)
+		return
+	}
+	err = c.r.Put().Resource("namespaces").Name(namespace.Name).Body(namespace).Do().Into(result)
+	return
+}
+
+// Finalize takes the representation of a namespace to update.  Returns the server's representation of the namespace, and an error, if it occurs.
+func (c *namespaces) Finalize(namespace *api.Namespace) (result *api.Namespace, err error) {
+	result = &api.Namespace{}
+	if len(namespace.ResourceVersion) == 0 {
+		err = fmt.Errorf("invalid update object, missing resource version: %v", namespace)
+		return
+	}
+	err = c.r.Put().Resource("namespaces").Name(namespace.Name).SubResource("finalize").Body(namespace).Do().Into(result)
+	return
+}
+
+// Status takes the representation of a namespace to update.  Returns the server's representation of the namespace, and an error, if it occurs.
+func (c *namespaces) Status(namespace *api.Namespace) (result *api.Namespace, err error) {
+	result = &api.Namespace{}
+	if len(namespace.ResourceVersion) == 0 {
+		err = fmt.Errorf("invalid update object, missing resource version: %v", namespace)
+		return
+	}
+	err = c.r.Put().Resource("namespaces").Name(namespace.Name).SubResource("status").Body(namespace).Do().Into(result)
+	return
+}
+
+// Get gets an existing namespace
+func (c *namespaces) Get(name string) (*api.Namespace, error) {
+	result := &api.Namespace{}
+	err := c.r.Get().Resource("namespaces").Name(name).Do().Into(result)
+	return result, err
+}
+
+// Delete deletes an existing namespace.
+func (c *namespaces) Delete(name string) error {
+	return c.r.Delete().Resource("namespaces").Name(name).Do().Error()
+}
+
+// Watch returns a watch.Interface that watches the requested namespaces.
+func (c *namespaces) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.r.Get().
+		Prefix("watch").
+		Resource("namespaces").
+		Param("resourceVersion", resourceVersion).
+		LabelsSelectorParam(label).
+		FieldsSelectorParam(field).
+		Watch()
+}

--- a/pkg/client/v1/namespaces.go
+++ b/pkg/client/v1/namespaces.go
@@ -14,12 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"fmt"
 
-	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/watch"
@@ -30,14 +30,14 @@ type NamespacesInterface interface {
 }
 
 type NamespaceInterface interface {
-	Create(item *api.Namespace) (*api.Namespace, error)
-	Get(name string) (result *api.Namespace, err error)
-	List(label labels.Selector, field fields.Selector) (*api.NamespaceList, error)
+	Create(item *v1.Namespace) (*v1.Namespace, error)
+	Get(name string) (result *v1.Namespace, err error)
+	List(label labels.Selector, field fields.Selector) (*v1.NamespaceList, error)
 	Delete(name string) error
-	Update(item *api.Namespace) (*api.Namespace, error)
+	Update(item *v1.Namespace) (*v1.Namespace, error)
 	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
-	Finalize(item *api.Namespace) (*api.Namespace, error)
-	Status(item *api.Namespace) (*api.Namespace, error)
+	Finalize(item *v1.Namespace) (*v1.Namespace, error)
+	Status(item *v1.Namespace) (*v1.Namespace, error)
 }
 
 // namespaces implements NamespacesInterface
@@ -51,15 +51,15 @@ func newNamespaces(c *Client) *namespaces {
 }
 
 // Create creates a new namespace.
-func (c *namespaces) Create(namespace *api.Namespace) (*api.Namespace, error) {
-	result := &api.Namespace{}
+func (c *namespaces) Create(namespace *v1.Namespace) (*v1.Namespace, error) {
+	result := &v1.Namespace{}
 	err := c.r.Post().Resource("namespaces").Body(namespace).Do().Into(result)
 	return result, err
 }
 
 // List lists all the namespaces in the cluster.
-func (c *namespaces) List(label labels.Selector, field fields.Selector) (*api.NamespaceList, error) {
-	result := &api.NamespaceList{}
+func (c *namespaces) List(label labels.Selector, field fields.Selector) (*v1.NamespaceList, error) {
+	result := &v1.NamespaceList{}
 	err := c.r.Get().
 		Resource("namespaces").
 		LabelsSelectorParam(label).
@@ -69,8 +69,8 @@ func (c *namespaces) List(label labels.Selector, field fields.Selector) (*api.Na
 }
 
 // Update takes the representation of a namespace to update.  Returns the server's representation of the namespace, and an error, if it occurs.
-func (c *namespaces) Update(namespace *api.Namespace) (result *api.Namespace, err error) {
-	result = &api.Namespace{}
+func (c *namespaces) Update(namespace *v1.Namespace) (result *v1.Namespace, err error) {
+	result = &v1.Namespace{}
 	if len(namespace.ResourceVersion) == 0 {
 		err = fmt.Errorf("invalid update object, missing resource version: %v", namespace)
 		return
@@ -80,8 +80,8 @@ func (c *namespaces) Update(namespace *api.Namespace) (result *api.Namespace, er
 }
 
 // Finalize takes the representation of a namespace to update.  Returns the server's representation of the namespace, and an error, if it occurs.
-func (c *namespaces) Finalize(namespace *api.Namespace) (result *api.Namespace, err error) {
-	result = &api.Namespace{}
+func (c *namespaces) Finalize(namespace *v1.Namespace) (result *v1.Namespace, err error) {
+	result = &v1.Namespace{}
 	if len(namespace.ResourceVersion) == 0 {
 		err = fmt.Errorf("invalid update object, missing resource version: %v", namespace)
 		return
@@ -91,8 +91,8 @@ func (c *namespaces) Finalize(namespace *api.Namespace) (result *api.Namespace, 
 }
 
 // Status takes the representation of a namespace to update.  Returns the server's representation of the namespace, and an error, if it occurs.
-func (c *namespaces) Status(namespace *api.Namespace) (result *api.Namespace, err error) {
-	result = &api.Namespace{}
+func (c *namespaces) Status(namespace *v1.Namespace) (result *v1.Namespace, err error) {
+	result = &v1.Namespace{}
 	if len(namespace.ResourceVersion) == 0 {
 		err = fmt.Errorf("invalid update object, missing resource version: %v", namespace)
 		return
@@ -102,8 +102,8 @@ func (c *namespaces) Status(namespace *api.Namespace) (result *api.Namespace, er
 }
 
 // Get gets an existing namespace
-func (c *namespaces) Get(name string) (*api.Namespace, error) {
-	result := &api.Namespace{}
+func (c *namespaces) Get(name string) (*v1.Namespace, error) {
+	result := &v1.Namespace{}
 	err := c.r.Get().Resource("namespaces").Name(name).Do().Into(result)
 	return result, err
 }

--- a/pkg/client/v1/namespaces_test.go
+++ b/pkg/client/v1/namespaces_test.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"net/url"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func TestNamespaceCreate(t *testing.T) {
+	// we create a namespace relative to another namespace
+	namespace := &api.Namespace{
+		ObjectMeta: api.ObjectMeta{Name: "foo"},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "POST",
+			Path:   testapi.Default.ResourcePath("namespaces", "", ""),
+			Body:   namespace,
+		},
+		Response: Response{StatusCode: 200, Body: namespace},
+	}
+
+	// from the source ns, provision a new global namespace "foo"
+	response, err := c.Setup(t).Namespaces().Create(namespace)
+
+	if err != nil {
+		t.Errorf("%#v should be nil.", err)
+	}
+
+	if e, a := response.Name, namespace.Name; e != a {
+		t.Errorf("%#v != %#v.", e, a)
+	}
+}
+
+func TestNamespaceGet(t *testing.T) {
+	namespace := &api.Namespace{
+		ObjectMeta: api.ObjectMeta{Name: "foo"},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath("namespaces", "", "foo"),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: namespace},
+	}
+
+	response, err := c.Setup(t).Namespaces().Get("foo")
+
+	if err != nil {
+		t.Errorf("%#v should be nil.", err)
+	}
+
+	if e, r := response.Name, namespace.Name; e != r {
+		t.Errorf("%#v != %#v.", e, r)
+	}
+}
+
+func TestNamespaceList(t *testing.T) {
+	namespaceList := &api.NamespaceList{
+		Items: []api.Namespace{
+			{
+				ObjectMeta: api.ObjectMeta{Name: "foo"},
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath("namespaces", "", ""),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: namespaceList},
+	}
+	response, err := c.Setup(t).Namespaces().List(labels.Everything(), fields.Everything())
+
+	if err != nil {
+		t.Errorf("%#v should be nil.", err)
+	}
+
+	if len(response.Items) != 1 {
+		t.Errorf("%#v response.Items should have len 1.", response.Items)
+	}
+
+	responseNamespace := response.Items[0]
+	if e, r := responseNamespace.Name, "foo"; e != r {
+		t.Errorf("%#v != %#v.", e, r)
+	}
+}
+
+func TestNamespaceUpdate(t *testing.T) {
+	requestNamespace := &api.Namespace{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "foo",
+			ResourceVersion: "1",
+			Labels: map[string]string{
+				"foo":  "bar",
+				"name": "baz",
+			},
+		},
+		Spec: api.NamespaceSpec{
+			Finalizers: []api.FinalizerName{api.FinalizerKubernetes},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "PUT",
+			Path:   testapi.Default.ResourcePath("namespaces", "", "foo")},
+		Response: Response{StatusCode: 200, Body: requestNamespace},
+	}
+	receivedNamespace, err := c.Setup(t).Namespaces().Update(requestNamespace)
+	c.Validate(t, receivedNamespace, err)
+}
+
+func TestNamespaceFinalize(t *testing.T) {
+	requestNamespace := &api.Namespace{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "foo",
+			ResourceVersion: "1",
+			Labels: map[string]string{
+				"foo":  "bar",
+				"name": "baz",
+			},
+		},
+		Spec: api.NamespaceSpec{
+			Finalizers: []api.FinalizerName{api.FinalizerKubernetes},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "PUT",
+			Path:   testapi.Default.ResourcePath("namespaces", "", "foo") + "/finalize",
+		},
+		Response: Response{StatusCode: 200, Body: requestNamespace},
+	}
+	receivedNamespace, err := c.Setup(t).Namespaces().Finalize(requestNamespace)
+	c.Validate(t, receivedNamespace, err)
+}
+
+func TestNamespaceDelete(t *testing.T) {
+	c := &testClient{
+		Request:  testRequest{Method: "DELETE", Path: testapi.Default.ResourcePath("namespaces", "", "foo")},
+		Response: Response{StatusCode: 200},
+	}
+	err := c.Setup(t).Namespaces().Delete("foo")
+	c.Validate(t, nil, err)
+}
+
+func TestNamespaceWatch(t *testing.T) {
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePathWithPrefix("watch", "namespaces", "", ""),
+			Query:  url.Values{"resourceVersion": []string{}}},
+		Response: Response{StatusCode: 200},
+	}
+	_, err := c.Setup(t).Namespaces().Watch(labels.Everything(), fields.Everything(), "")
+	c.Validate(t, nil, err)
+}

--- a/pkg/client/v1/namespaces_test.go
+++ b/pkg/client/v1/namespaces_test.go
@@ -14,22 +14,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"net/url"
 	"testing"
 
-	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 )
 
 func TestNamespaceCreate(t *testing.T) {
 	// we create a namespace relative to another namespace
-	namespace := &api.Namespace{
-		ObjectMeta: api.ObjectMeta{Name: "foo"},
+	namespace := &v1.Namespace{
+		ObjectMeta: v1.ObjectMeta{Name: "foo"},
 	}
 	c := &testClient{
 		Request: testRequest{
@@ -53,8 +53,8 @@ func TestNamespaceCreate(t *testing.T) {
 }
 
 func TestNamespaceGet(t *testing.T) {
-	namespace := &api.Namespace{
-		ObjectMeta: api.ObjectMeta{Name: "foo"},
+	namespace := &v1.Namespace{
+		ObjectMeta: v1.ObjectMeta{Name: "foo"},
 	}
 	c := &testClient{
 		Request: testRequest{
@@ -77,10 +77,10 @@ func TestNamespaceGet(t *testing.T) {
 }
 
 func TestNamespaceList(t *testing.T) {
-	namespaceList := &api.NamespaceList{
-		Items: []api.Namespace{
+	namespaceList := &v1.NamespaceList{
+		Items: []v1.Namespace{
 			{
-				ObjectMeta: api.ObjectMeta{Name: "foo"},
+				ObjectMeta: v1.ObjectMeta{Name: "foo"},
 			},
 		},
 	}
@@ -109,8 +109,8 @@ func TestNamespaceList(t *testing.T) {
 }
 
 func TestNamespaceUpdate(t *testing.T) {
-	requestNamespace := &api.Namespace{
-		ObjectMeta: api.ObjectMeta{
+	requestNamespace := &v1.Namespace{
+		ObjectMeta: v1.ObjectMeta{
 			Name:            "foo",
 			ResourceVersion: "1",
 			Labels: map[string]string{
@@ -118,8 +118,8 @@ func TestNamespaceUpdate(t *testing.T) {
 				"name": "baz",
 			},
 		},
-		Spec: api.NamespaceSpec{
-			Finalizers: []api.FinalizerName{api.FinalizerKubernetes},
+		Spec: v1.NamespaceSpec{
+			Finalizers: []v1.FinalizerName{v1.FinalizerKubernetes},
 		},
 	}
 	c := &testClient{
@@ -133,8 +133,8 @@ func TestNamespaceUpdate(t *testing.T) {
 }
 
 func TestNamespaceFinalize(t *testing.T) {
-	requestNamespace := &api.Namespace{
-		ObjectMeta: api.ObjectMeta{
+	requestNamespace := &v1.Namespace{
+		ObjectMeta: v1.ObjectMeta{
 			Name:            "foo",
 			ResourceVersion: "1",
 			Labels: map[string]string{
@@ -142,8 +142,8 @@ func TestNamespaceFinalize(t *testing.T) {
 				"name": "baz",
 			},
 		},
-		Spec: api.NamespaceSpec{
-			Finalizers: []api.FinalizerName{api.FinalizerKubernetes},
+		Spec: v1.NamespaceSpec{
+			Finalizers: []v1.FinalizerName{v1.FinalizerKubernetes},
 		},
 	}
 	c := &testClient{

--- a/pkg/client/v1/nodes.go
+++ b/pkg/client/v1/nodes.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+type NodesInterface interface {
+	Nodes() NodeInterface
+}
+
+type NodeInterface interface {
+	Get(name string) (result *api.Node, err error)
+	Create(node *api.Node) (*api.Node, error)
+	List(label labels.Selector, field fields.Selector) (*api.NodeList, error)
+	Delete(name string) error
+	Update(*api.Node) (*api.Node, error)
+	UpdateStatus(*api.Node) (*api.Node, error)
+	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
+}
+
+// nodes implements NodesInterface
+type nodes struct {
+	r *Client
+}
+
+// newNodes returns a nodes object.
+func newNodes(c *Client) *nodes {
+	return &nodes{c}
+}
+
+// resourceName returns node's URL resource name.
+func (c *nodes) resourceName() string {
+	return "nodes"
+}
+
+// Create creates a new node.
+func (c *nodes) Create(node *api.Node) (*api.Node, error) {
+	result := &api.Node{}
+	err := c.r.Post().Resource(c.resourceName()).Body(node).Do().Into(result)
+	return result, err
+}
+
+// List takes a selector, and returns the list of nodes that match that selector in the cluster.
+func (c *nodes) List(label labels.Selector, field fields.Selector) (*api.NodeList, error) {
+	result := &api.NodeList{}
+	err := c.r.Get().Resource(c.resourceName()).LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
+	return result, err
+}
+
+// Get gets an existing node.
+func (c *nodes) Get(name string) (*api.Node, error) {
+	result := &api.Node{}
+	err := c.r.Get().Resource(c.resourceName()).Name(name).Do().Into(result)
+	return result, err
+}
+
+// Delete deletes an existing node.
+func (c *nodes) Delete(name string) error {
+	return c.r.Delete().Resource(c.resourceName()).Name(name).Do().Error()
+}
+
+// Update updates an existing node.
+func (c *nodes) Update(node *api.Node) (*api.Node, error) {
+	result := &api.Node{}
+	if len(node.ResourceVersion) == 0 {
+		err := fmt.Errorf("invalid update object, missing resource version: %v", node)
+		return nil, err
+	}
+	err := c.r.Put().Resource(c.resourceName()).Name(node.Name).Body(node).Do().Into(result)
+	return result, err
+}
+
+func (c *nodes) UpdateStatus(node *api.Node) (*api.Node, error) {
+	result := &api.Node{}
+	if len(node.ResourceVersion) == 0 {
+		err := fmt.Errorf("invalid update object, missing resource version: %v", node)
+		return nil, err
+	}
+	err := c.r.Put().Resource(c.resourceName()).Name(node.Name).SubResource("status").Body(node).Do().Into(result)
+	return result, err
+}
+
+// Watch returns a watch.Interface that watches the requested nodes.
+func (c *nodes) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.r.Get().
+		Prefix("watch").
+		Namespace(api.NamespaceAll).
+		Resource(c.resourceName()).
+		Param("resourceVersion", resourceVersion).
+		LabelsSelectorParam(label).
+		FieldsSelectorParam(field).
+		Watch()
+}

--- a/pkg/client/v1/nodes.go
+++ b/pkg/client/v1/nodes.go
@@ -14,12 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"fmt"
 
-	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/watch"
@@ -30,12 +30,12 @@ type NodesInterface interface {
 }
 
 type NodeInterface interface {
-	Get(name string) (result *api.Node, err error)
-	Create(node *api.Node) (*api.Node, error)
-	List(label labels.Selector, field fields.Selector) (*api.NodeList, error)
+	Get(name string) (result *v1.Node, err error)
+	Create(node *v1.Node) (*v1.Node, error)
+	List(label labels.Selector, field fields.Selector) (*v1.NodeList, error)
 	Delete(name string) error
-	Update(*api.Node) (*api.Node, error)
-	UpdateStatus(*api.Node) (*api.Node, error)
+	Update(*v1.Node) (*v1.Node, error)
+	UpdateStatus(*v1.Node) (*v1.Node, error)
 	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
 }
 
@@ -55,22 +55,22 @@ func (c *nodes) resourceName() string {
 }
 
 // Create creates a new node.
-func (c *nodes) Create(node *api.Node) (*api.Node, error) {
-	result := &api.Node{}
+func (c *nodes) Create(node *v1.Node) (*v1.Node, error) {
+	result := &v1.Node{}
 	err := c.r.Post().Resource(c.resourceName()).Body(node).Do().Into(result)
 	return result, err
 }
 
 // List takes a selector, and returns the list of nodes that match that selector in the cluster.
-func (c *nodes) List(label labels.Selector, field fields.Selector) (*api.NodeList, error) {
-	result := &api.NodeList{}
+func (c *nodes) List(label labels.Selector, field fields.Selector) (*v1.NodeList, error) {
+	result := &v1.NodeList{}
 	err := c.r.Get().Resource(c.resourceName()).LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
 	return result, err
 }
 
 // Get gets an existing node.
-func (c *nodes) Get(name string) (*api.Node, error) {
-	result := &api.Node{}
+func (c *nodes) Get(name string) (*v1.Node, error) {
+	result := &v1.Node{}
 	err := c.r.Get().Resource(c.resourceName()).Name(name).Do().Into(result)
 	return result, err
 }
@@ -81,8 +81,8 @@ func (c *nodes) Delete(name string) error {
 }
 
 // Update updates an existing node.
-func (c *nodes) Update(node *api.Node) (*api.Node, error) {
-	result := &api.Node{}
+func (c *nodes) Update(node *v1.Node) (*v1.Node, error) {
+	result := &v1.Node{}
 	if len(node.ResourceVersion) == 0 {
 		err := fmt.Errorf("invalid update object, missing resource version: %v", node)
 		return nil, err
@@ -91,8 +91,8 @@ func (c *nodes) Update(node *api.Node) (*api.Node, error) {
 	return result, err
 }
 
-func (c *nodes) UpdateStatus(node *api.Node) (*api.Node, error) {
-	result := &api.Node{}
+func (c *nodes) UpdateStatus(node *v1.Node) (*v1.Node, error) {
+	result := &v1.Node{}
 	if len(node.ResourceVersion) == 0 {
 		err := fmt.Errorf("invalid update object, missing resource version: %v", node)
 		return nil, err
@@ -105,7 +105,7 @@ func (c *nodes) UpdateStatus(node *api.Node) (*api.Node, error) {
 func (c *nodes) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
 	return c.r.Get().
 		Prefix("watch").
-		Namespace(api.NamespaceAll).
+		Namespace(v1.NamespaceAll).
 		Resource(c.resourceName()).
 		Param("resourceVersion", resourceVersion).
 		LabelsSelectorParam(label).

--- a/pkg/client/v1/nodes_test.go
+++ b/pkg/client/v1/nodes_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"net/url"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func getNodesResourceName() string {
+	return "nodes"
+}
+
+func TestListNodes(t *testing.T) {
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath(getNodesResourceName(), "", ""),
+		},
+		Response: Response{StatusCode: 200, Body: &api.NodeList{ListMeta: unversioned.ListMeta{ResourceVersion: "1"}}},
+	}
+	response, err := c.Setup(t).Nodes().List(labels.Everything(), fields.Everything())
+	c.Validate(t, response, err)
+}
+
+func TestListNodesLabels(t *testing.T) {
+	labelSelectorQueryParamName := api.LabelSelectorQueryParam(testapi.Default.Version())
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath(getNodesResourceName(), "", ""),
+			Query:  buildQueryValues(url.Values{labelSelectorQueryParamName: []string{"foo=bar,name=baz"}})},
+		Response: Response{
+			StatusCode: 200,
+			Body: &api.NodeList{
+				Items: []api.Node{
+					{
+						ObjectMeta: api.ObjectMeta{
+							Labels: map[string]string{
+								"foo":  "bar",
+								"name": "baz",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	c.Setup(t)
+	c.QueryValidator[labelSelectorQueryParamName] = validateLabels
+	selector := labels.Set{"foo": "bar", "name": "baz"}.AsSelector()
+	receivedNodeList, err := c.Nodes().List(selector, fields.Everything())
+	c.Validate(t, receivedNodeList, err)
+}
+
+func TestGetNode(t *testing.T) {
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath(getNodesResourceName(), "", "1"),
+		},
+		Response: Response{StatusCode: 200, Body: &api.Node{ObjectMeta: api.ObjectMeta{Name: "node-1"}}},
+	}
+	response, err := c.Setup(t).Nodes().Get("1")
+	c.Validate(t, response, err)
+}
+
+func TestGetNodeWithNoName(t *testing.T) {
+	c := &testClient{Error: true}
+	receivedNode, err := c.Setup(t).Nodes().Get("")
+	if (err != nil) && (err.Error() != nameRequiredError) {
+		t.Errorf("Expected error: %v, but got %v", nameRequiredError, err)
+	}
+
+	c.Validate(t, receivedNode, err)
+}
+
+func TestCreateNode(t *testing.T) {
+	requestNode := &api.Node{
+		ObjectMeta: api.ObjectMeta{
+			Name: "node-1",
+		},
+		Status: api.NodeStatus{
+			Capacity: api.ResourceList{
+				api.ResourceCPU:    resource.MustParse("1000m"),
+				api.ResourceMemory: resource.MustParse("1Mi"),
+			},
+		},
+		Spec: api.NodeSpec{
+			Unschedulable: false,
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "POST",
+			Path:   testapi.Default.ResourcePath(getNodesResourceName(), "", ""),
+			Body:   requestNode},
+		Response: Response{
+			StatusCode: 200,
+			Body:       requestNode,
+		},
+	}
+	receivedNode, err := c.Setup(t).Nodes().Create(requestNode)
+	c.Validate(t, receivedNode, err)
+}
+
+func TestDeleteNode(t *testing.T) {
+	c := &testClient{
+		Request: testRequest{
+			Method: "DELETE",
+			Path:   testapi.Default.ResourcePath(getNodesResourceName(), "", "foo"),
+		},
+		Response: Response{StatusCode: 200},
+	}
+	err := c.Setup(t).Nodes().Delete("foo")
+	c.Validate(t, nil, err)
+}
+
+func TestUpdateNode(t *testing.T) {
+	requestNode := &api.Node{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "foo",
+			ResourceVersion: "1",
+		},
+		Status: api.NodeStatus{
+			Capacity: api.ResourceList{
+				api.ResourceCPU:    resource.MustParse("1000m"),
+				api.ResourceMemory: resource.MustParse("1Mi"),
+			},
+		},
+		Spec: api.NodeSpec{
+			Unschedulable: true,
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "PUT",
+			Path:   testapi.Default.ResourcePath(getNodesResourceName(), "", "foo"),
+		},
+		Response: Response{StatusCode: 200, Body: requestNode},
+	}
+	response, err := c.Setup(t).Nodes().Update(requestNode)
+	c.Validate(t, response, err)
+}

--- a/pkg/client/v1/nodes_test.go
+++ b/pkg/client/v1/nodes_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"net/url"
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 )
@@ -38,7 +39,7 @@ func TestListNodes(t *testing.T) {
 			Method: "GET",
 			Path:   testapi.Default.ResourcePath(getNodesResourceName(), "", ""),
 		},
-		Response: Response{StatusCode: 200, Body: &api.NodeList{ListMeta: unversioned.ListMeta{ResourceVersion: "1"}}},
+		Response: Response{StatusCode: 200, Body: &v1.NodeList{ListMeta: unversioned.ListMeta{ResourceVersion: "1"}}},
 	}
 	response, err := c.Setup(t).Nodes().List(labels.Everything(), fields.Everything())
 	c.Validate(t, response, err)
@@ -53,10 +54,10 @@ func TestListNodesLabels(t *testing.T) {
 			Query:  buildQueryValues(url.Values{labelSelectorQueryParamName: []string{"foo=bar,name=baz"}})},
 		Response: Response{
 			StatusCode: 200,
-			Body: &api.NodeList{
-				Items: []api.Node{
+			Body: &v1.NodeList{
+				Items: []v1.Node{
 					{
-						ObjectMeta: api.ObjectMeta{
+						ObjectMeta: v1.ObjectMeta{
 							Labels: map[string]string{
 								"foo":  "bar",
 								"name": "baz",
@@ -80,7 +81,7 @@ func TestGetNode(t *testing.T) {
 			Method: "GET",
 			Path:   testapi.Default.ResourcePath(getNodesResourceName(), "", "1"),
 		},
-		Response: Response{StatusCode: 200, Body: &api.Node{ObjectMeta: api.ObjectMeta{Name: "node-1"}}},
+		Response: Response{StatusCode: 200, Body: &v1.Node{ObjectMeta: v1.ObjectMeta{Name: "node-1"}}},
 	}
 	response, err := c.Setup(t).Nodes().Get("1")
 	c.Validate(t, response, err)
@@ -97,17 +98,17 @@ func TestGetNodeWithNoName(t *testing.T) {
 }
 
 func TestCreateNode(t *testing.T) {
-	requestNode := &api.Node{
-		ObjectMeta: api.ObjectMeta{
+	requestNode := &v1.Node{
+		ObjectMeta: v1.ObjectMeta{
 			Name: "node-1",
 		},
-		Status: api.NodeStatus{
-			Capacity: api.ResourceList{
-				api.ResourceCPU:    resource.MustParse("1000m"),
-				api.ResourceMemory: resource.MustParse("1Mi"),
+		Status: v1.NodeStatus{
+			Capacity: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1000m"),
+				v1.ResourceMemory: resource.MustParse("1Mi"),
 			},
 		},
-		Spec: api.NodeSpec{
+		Spec: v1.NodeSpec{
 			Unschedulable: false,
 		},
 	}
@@ -138,18 +139,18 @@ func TestDeleteNode(t *testing.T) {
 }
 
 func TestUpdateNode(t *testing.T) {
-	requestNode := &api.Node{
-		ObjectMeta: api.ObjectMeta{
+	requestNode := &v1.Node{
+		ObjectMeta: v1.ObjectMeta{
 			Name:            "foo",
 			ResourceVersion: "1",
 		},
-		Status: api.NodeStatus{
-			Capacity: api.ResourceList{
-				api.ResourceCPU:    resource.MustParse("1000m"),
-				api.ResourceMemory: resource.MustParse("1Mi"),
+		Status: v1.NodeStatus{
+			Capacity: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1000m"),
+				v1.ResourceMemory: resource.MustParse("1Mi"),
 			},
 		},
-		Spec: api.NodeSpec{
+		Spec: v1.NodeSpec{
 			Unschedulable: true,
 		},
 	}

--- a/pkg/client/v1/persistentvolume_test.go
+++ b/pkg/client/v1/persistentvolume_test.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"net/url"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func getPersistentVolumesResoureName() string {
+	return "persistentvolumes"
+}
+
+func TestPersistentVolumeCreate(t *testing.T) {
+	pv := &api.PersistentVolume{
+		ObjectMeta: api.ObjectMeta{
+			Name: "abc",
+		},
+		Spec: api.PersistentVolumeSpec{
+			Capacity: api.ResourceList{
+				api.ResourceName(api.ResourceStorage): resource.MustParse("10G"),
+			},
+			PersistentVolumeSource: api.PersistentVolumeSource{
+				HostPath: &api.HostPathVolumeSource{Path: "/foo"},
+			},
+		},
+	}
+
+	c := &testClient{
+		Request: testRequest{
+			Method: "POST",
+			Path:   testapi.Default.ResourcePath(getPersistentVolumesResoureName(), "", ""),
+			Query:  buildQueryValues(nil),
+			Body:   pv,
+		},
+		Response: Response{StatusCode: 200, Body: pv},
+	}
+
+	response, err := c.Setup(t).PersistentVolumes().Create(pv)
+	c.Validate(t, response, err)
+}
+
+func TestPersistentVolumeGet(t *testing.T) {
+	persistentVolume := &api.PersistentVolume{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "abc",
+			Namespace: "foo",
+		},
+		Spec: api.PersistentVolumeSpec{
+			Capacity: api.ResourceList{
+				api.ResourceName(api.ResourceStorage): resource.MustParse("10G"),
+			},
+			PersistentVolumeSource: api.PersistentVolumeSource{
+				HostPath: &api.HostPathVolumeSource{Path: "/foo"},
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath(getPersistentVolumesResoureName(), "", "abc"),
+			Query:  buildQueryValues(nil),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: persistentVolume},
+	}
+
+	response, err := c.Setup(t).PersistentVolumes().Get("abc")
+	c.Validate(t, response, err)
+}
+
+func TestPersistentVolumeList(t *testing.T) {
+	persistentVolumeList := &api.PersistentVolumeList{
+		Items: []api.PersistentVolume{
+			{
+				ObjectMeta: api.ObjectMeta{Name: "foo"},
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath(getPersistentVolumesResoureName(), "", ""),
+			Query:  buildQueryValues(nil),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: persistentVolumeList},
+	}
+	response, err := c.Setup(t).PersistentVolumes().List(labels.Everything(), fields.Everything())
+	c.Validate(t, response, err)
+}
+
+func TestPersistentVolumeUpdate(t *testing.T) {
+	persistentVolume := &api.PersistentVolume{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "abc",
+			ResourceVersion: "1",
+		},
+		Spec: api.PersistentVolumeSpec{
+			Capacity: api.ResourceList{
+				api.ResourceName(api.ResourceStorage): resource.MustParse("10G"),
+			},
+			PersistentVolumeSource: api.PersistentVolumeSource{
+				HostPath: &api.HostPathVolumeSource{Path: "/foo"},
+			},
+		},
+	}
+	c := &testClient{
+		Request:  testRequest{Method: "PUT", Path: testapi.Default.ResourcePath(getPersistentVolumesResoureName(), "", "abc"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200, Body: persistentVolume},
+	}
+	response, err := c.Setup(t).PersistentVolumes().Update(persistentVolume)
+	c.Validate(t, response, err)
+}
+
+func TestPersistentVolumeStatusUpdate(t *testing.T) {
+	persistentVolume := &api.PersistentVolume{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "abc",
+			ResourceVersion: "1",
+		},
+		Spec: api.PersistentVolumeSpec{
+			Capacity: api.ResourceList{
+				api.ResourceName(api.ResourceStorage): resource.MustParse("10G"),
+			},
+			PersistentVolumeSource: api.PersistentVolumeSource{
+				HostPath: &api.HostPathVolumeSource{Path: "/foo"},
+			},
+		},
+		Status: api.PersistentVolumeStatus{
+			Phase:   api.VolumeBound,
+			Message: "foo",
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "PUT",
+			Path:   testapi.Default.ResourcePath(getPersistentVolumesResoureName(), "", "abc") + "/status",
+			Query:  buildQueryValues(nil)},
+		Response: Response{StatusCode: 200, Body: persistentVolume},
+	}
+	response, err := c.Setup(t).PersistentVolumes().UpdateStatus(persistentVolume)
+	c.Validate(t, response, err)
+}
+
+func TestPersistentVolumeDelete(t *testing.T) {
+	c := &testClient{
+		Request:  testRequest{Method: "DELETE", Path: testapi.Default.ResourcePath(getPersistentVolumesResoureName(), "", "foo"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200},
+	}
+	err := c.Setup(t).PersistentVolumes().Delete("foo")
+	c.Validate(t, nil, err)
+}
+
+func TestPersistentVolumeWatch(t *testing.T) {
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePathWithPrefix("watch", getPersistentVolumesResoureName(), "", ""),
+			Query:  url.Values{"resourceVersion": []string{}}},
+		Response: Response{StatusCode: 200},
+	}
+	_, err := c.Setup(t).PersistentVolumes().Watch(labels.Everything(), fields.Everything(), "")
+	c.Validate(t, nil, err)
+}

--- a/pkg/client/v1/persistentvolume_test.go
+++ b/pkg/client/v1/persistentvolume_test.go
@@ -14,15 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"net/url"
 	"testing"
 
-	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 )
@@ -32,16 +32,16 @@ func getPersistentVolumesResoureName() string {
 }
 
 func TestPersistentVolumeCreate(t *testing.T) {
-	pv := &api.PersistentVolume{
-		ObjectMeta: api.ObjectMeta{
+	pv := &v1.PersistentVolume{
+		ObjectMeta: v1.ObjectMeta{
 			Name: "abc",
 		},
-		Spec: api.PersistentVolumeSpec{
-			Capacity: api.ResourceList{
-				api.ResourceName(api.ResourceStorage): resource.MustParse("10G"),
+		Spec: v1.PersistentVolumeSpec{
+			Capacity: v1.ResourceList{
+				v1.ResourceName(v1.ResourceStorage): resource.MustParse("10G"),
 			},
-			PersistentVolumeSource: api.PersistentVolumeSource{
-				HostPath: &api.HostPathVolumeSource{Path: "/foo"},
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				HostPath: &v1.HostPathVolumeSource{Path: "/foo"},
 			},
 		},
 	}
@@ -61,17 +61,17 @@ func TestPersistentVolumeCreate(t *testing.T) {
 }
 
 func TestPersistentVolumeGet(t *testing.T) {
-	persistentVolume := &api.PersistentVolume{
-		ObjectMeta: api.ObjectMeta{
+	persistentVolume := &v1.PersistentVolume{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "abc",
 			Namespace: "foo",
 		},
-		Spec: api.PersistentVolumeSpec{
-			Capacity: api.ResourceList{
-				api.ResourceName(api.ResourceStorage): resource.MustParse("10G"),
+		Spec: v1.PersistentVolumeSpec{
+			Capacity: v1.ResourceList{
+				v1.ResourceName(v1.ResourceStorage): resource.MustParse("10G"),
 			},
-			PersistentVolumeSource: api.PersistentVolumeSource{
-				HostPath: &api.HostPathVolumeSource{Path: "/foo"},
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				HostPath: &v1.HostPathVolumeSource{Path: "/foo"},
 			},
 		},
 	}
@@ -90,10 +90,10 @@ func TestPersistentVolumeGet(t *testing.T) {
 }
 
 func TestPersistentVolumeList(t *testing.T) {
-	persistentVolumeList := &api.PersistentVolumeList{
-		Items: []api.PersistentVolume{
+	persistentVolumeList := &v1.PersistentVolumeList{
+		Items: []v1.PersistentVolume{
 			{
-				ObjectMeta: api.ObjectMeta{Name: "foo"},
+				ObjectMeta: v1.ObjectMeta{Name: "foo"},
 			},
 		},
 	}
@@ -111,17 +111,17 @@ func TestPersistentVolumeList(t *testing.T) {
 }
 
 func TestPersistentVolumeUpdate(t *testing.T) {
-	persistentVolume := &api.PersistentVolume{
-		ObjectMeta: api.ObjectMeta{
+	persistentVolume := &v1.PersistentVolume{
+		ObjectMeta: v1.ObjectMeta{
 			Name:            "abc",
 			ResourceVersion: "1",
 		},
-		Spec: api.PersistentVolumeSpec{
-			Capacity: api.ResourceList{
-				api.ResourceName(api.ResourceStorage): resource.MustParse("10G"),
+		Spec: v1.PersistentVolumeSpec{
+			Capacity: v1.ResourceList{
+				v1.ResourceName(v1.ResourceStorage): resource.MustParse("10G"),
 			},
-			PersistentVolumeSource: api.PersistentVolumeSource{
-				HostPath: &api.HostPathVolumeSource{Path: "/foo"},
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				HostPath: &v1.HostPathVolumeSource{Path: "/foo"},
 			},
 		},
 	}
@@ -134,21 +134,21 @@ func TestPersistentVolumeUpdate(t *testing.T) {
 }
 
 func TestPersistentVolumeStatusUpdate(t *testing.T) {
-	persistentVolume := &api.PersistentVolume{
-		ObjectMeta: api.ObjectMeta{
+	persistentVolume := &v1.PersistentVolume{
+		ObjectMeta: v1.ObjectMeta{
 			Name:            "abc",
 			ResourceVersion: "1",
 		},
-		Spec: api.PersistentVolumeSpec{
-			Capacity: api.ResourceList{
-				api.ResourceName(api.ResourceStorage): resource.MustParse("10G"),
+		Spec: v1.PersistentVolumeSpec{
+			Capacity: v1.ResourceList{
+				v1.ResourceName(v1.ResourceStorage): resource.MustParse("10G"),
 			},
-			PersistentVolumeSource: api.PersistentVolumeSource{
-				HostPath: &api.HostPathVolumeSource{Path: "/foo"},
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				HostPath: &v1.HostPathVolumeSource{Path: "/foo"},
 			},
 		},
-		Status: api.PersistentVolumeStatus{
-			Phase:   api.VolumeBound,
+		Status: v1.PersistentVolumeStatus{
+			Phase:   v1.VolumeBound,
 			Message: "foo",
 		},
 	}

--- a/pkg/client/v1/persistentvolumeclaim.go
+++ b/pkg/client/v1/persistentvolumeclaim.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// PersistentVolumeClaimsNamespacer has methods to work with PersistentVolumeClaim resources in a namespace
+type PersistentVolumeClaimsNamespacer interface {
+	PersistentVolumeClaims(namespace string) PersistentVolumeClaimInterface
+}
+
+// PersistentVolumeClaimInterface has methods to work with PersistentVolumeClaim resources.
+type PersistentVolumeClaimInterface interface {
+	List(label labels.Selector, field fields.Selector) (*api.PersistentVolumeClaimList, error)
+	Get(name string) (*api.PersistentVolumeClaim, error)
+	Create(claim *api.PersistentVolumeClaim) (*api.PersistentVolumeClaim, error)
+	Update(claim *api.PersistentVolumeClaim) (*api.PersistentVolumeClaim, error)
+	UpdateStatus(claim *api.PersistentVolumeClaim) (*api.PersistentVolumeClaim, error)
+	Delete(name string) error
+	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
+}
+
+// persistentVolumeClaims implements PersistentVolumeClaimsNamespacer interface
+type persistentVolumeClaims struct {
+	client    *Client
+	namespace string
+}
+
+// newPersistentVolumeClaims returns a PodsClient
+func newPersistentVolumeClaims(c *Client, namespace string) *persistentVolumeClaims {
+	return &persistentVolumeClaims{c, namespace}
+}
+
+func (c *persistentVolumeClaims) List(label labels.Selector, field fields.Selector) (result *api.PersistentVolumeClaimList, err error) {
+	result = &api.PersistentVolumeClaimList{}
+
+	err = c.client.Get().
+		Namespace(c.namespace).
+		Resource("persistentVolumeClaims").
+		LabelsSelectorParam(label).
+		FieldsSelectorParam(field).
+		Do().
+		Into(result)
+
+	return result, err
+}
+
+func (c *persistentVolumeClaims) Get(name string) (result *api.PersistentVolumeClaim, err error) {
+	result = &api.PersistentVolumeClaim{}
+	err = c.client.Get().Namespace(c.namespace).Resource("persistentVolumeClaims").Name(name).Do().Into(result)
+	return
+}
+
+func (c *persistentVolumeClaims) Create(claim *api.PersistentVolumeClaim) (result *api.PersistentVolumeClaim, err error) {
+	result = &api.PersistentVolumeClaim{}
+	err = c.client.Post().Namespace(c.namespace).Resource("persistentVolumeClaims").Body(claim).Do().Into(result)
+	return
+}
+
+func (c *persistentVolumeClaims) Update(claim *api.PersistentVolumeClaim) (result *api.PersistentVolumeClaim, err error) {
+	result = &api.PersistentVolumeClaim{}
+	if len(claim.ResourceVersion) == 0 {
+		err = fmt.Errorf("invalid update object, missing resource version: %v", claim)
+		return
+	}
+	err = c.client.Put().Namespace(c.namespace).Resource("persistentVolumeClaims").Name(claim.Name).Body(claim).Do().Into(result)
+	return
+}
+
+func (c *persistentVolumeClaims) UpdateStatus(claim *api.PersistentVolumeClaim) (result *api.PersistentVolumeClaim, err error) {
+	result = &api.PersistentVolumeClaim{}
+	err = c.client.Put().Namespace(c.namespace).Resource("persistentVolumeClaims").Name(claim.Name).SubResource("status").Body(claim).Do().Into(result)
+	return
+}
+
+func (c *persistentVolumeClaims) Delete(name string) error {
+	return c.client.Delete().Namespace(c.namespace).Resource("persistentVolumeClaims").Name(name).Do().Error()
+}
+
+func (c *persistentVolumeClaims) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.client.Get().
+		Prefix("watch").
+		Namespace(c.namespace).
+		Resource("persistentVolumeClaims").
+		Param("resourceVersion", resourceVersion).
+		LabelsSelectorParam(label).
+		FieldsSelectorParam(field).
+		Watch()
+}

--- a/pkg/client/v1/persistentvolumeclaim.go
+++ b/pkg/client/v1/persistentvolumeclaim.go
@@ -14,12 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"fmt"
 
-	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/watch"
@@ -32,11 +32,11 @@ type PersistentVolumeClaimsNamespacer interface {
 
 // PersistentVolumeClaimInterface has methods to work with PersistentVolumeClaim resources.
 type PersistentVolumeClaimInterface interface {
-	List(label labels.Selector, field fields.Selector) (*api.PersistentVolumeClaimList, error)
-	Get(name string) (*api.PersistentVolumeClaim, error)
-	Create(claim *api.PersistentVolumeClaim) (*api.PersistentVolumeClaim, error)
-	Update(claim *api.PersistentVolumeClaim) (*api.PersistentVolumeClaim, error)
-	UpdateStatus(claim *api.PersistentVolumeClaim) (*api.PersistentVolumeClaim, error)
+	List(label labels.Selector, field fields.Selector) (*v1.PersistentVolumeClaimList, error)
+	Get(name string) (*v1.PersistentVolumeClaim, error)
+	Create(claim *v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaim, error)
+	Update(claim *v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaim, error)
+	UpdateStatus(claim *v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaim, error)
 	Delete(name string) error
 	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
 }
@@ -52,8 +52,8 @@ func newPersistentVolumeClaims(c *Client, namespace string) *persistentVolumeCla
 	return &persistentVolumeClaims{c, namespace}
 }
 
-func (c *persistentVolumeClaims) List(label labels.Selector, field fields.Selector) (result *api.PersistentVolumeClaimList, err error) {
-	result = &api.PersistentVolumeClaimList{}
+func (c *persistentVolumeClaims) List(label labels.Selector, field fields.Selector) (result *v1.PersistentVolumeClaimList, err error) {
+	result = &v1.PersistentVolumeClaimList{}
 
 	err = c.client.Get().
 		Namespace(c.namespace).
@@ -66,20 +66,20 @@ func (c *persistentVolumeClaims) List(label labels.Selector, field fields.Select
 	return result, err
 }
 
-func (c *persistentVolumeClaims) Get(name string) (result *api.PersistentVolumeClaim, err error) {
-	result = &api.PersistentVolumeClaim{}
+func (c *persistentVolumeClaims) Get(name string) (result *v1.PersistentVolumeClaim, err error) {
+	result = &v1.PersistentVolumeClaim{}
 	err = c.client.Get().Namespace(c.namespace).Resource("persistentVolumeClaims").Name(name).Do().Into(result)
 	return
 }
 
-func (c *persistentVolumeClaims) Create(claim *api.PersistentVolumeClaim) (result *api.PersistentVolumeClaim, err error) {
-	result = &api.PersistentVolumeClaim{}
+func (c *persistentVolumeClaims) Create(claim *v1.PersistentVolumeClaim) (result *v1.PersistentVolumeClaim, err error) {
+	result = &v1.PersistentVolumeClaim{}
 	err = c.client.Post().Namespace(c.namespace).Resource("persistentVolumeClaims").Body(claim).Do().Into(result)
 	return
 }
 
-func (c *persistentVolumeClaims) Update(claim *api.PersistentVolumeClaim) (result *api.PersistentVolumeClaim, err error) {
-	result = &api.PersistentVolumeClaim{}
+func (c *persistentVolumeClaims) Update(claim *v1.PersistentVolumeClaim) (result *v1.PersistentVolumeClaim, err error) {
+	result = &v1.PersistentVolumeClaim{}
 	if len(claim.ResourceVersion) == 0 {
 		err = fmt.Errorf("invalid update object, missing resource version: %v", claim)
 		return
@@ -88,8 +88,8 @@ func (c *persistentVolumeClaims) Update(claim *api.PersistentVolumeClaim) (resul
 	return
 }
 
-func (c *persistentVolumeClaims) UpdateStatus(claim *api.PersistentVolumeClaim) (result *api.PersistentVolumeClaim, err error) {
-	result = &api.PersistentVolumeClaim{}
+func (c *persistentVolumeClaims) UpdateStatus(claim *v1.PersistentVolumeClaim) (result *v1.PersistentVolumeClaim, err error) {
+	result = &v1.PersistentVolumeClaim{}
 	err = c.client.Put().Namespace(c.namespace).Resource("persistentVolumeClaims").Name(claim.Name).SubResource("status").Body(claim).Do().Into(result)
 	return
 }

--- a/pkg/client/v1/persistentvolumeclaim_test.go
+++ b/pkg/client/v1/persistentvolumeclaim_test.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"net/url"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func getPersistentVolumeClaimsResoureName() string {
+	return "persistentvolumeclaims"
+}
+
+func TestPersistentVolumeClaimCreate(t *testing.T) {
+	ns := api.NamespaceDefault
+	pv := &api.PersistentVolumeClaim{
+		ObjectMeta: api.ObjectMeta{
+			Name: "abc",
+		},
+		Spec: api.PersistentVolumeClaimSpec{
+			AccessModes: []api.PersistentVolumeAccessMode{
+				api.ReadWriteOnce,
+				api.ReadOnlyMany,
+			},
+			Resources: api.ResourceRequirements{
+				Requests: api.ResourceList{
+					api.ResourceName(api.ResourceStorage): resource.MustParse("10G"),
+				},
+			},
+		},
+	}
+
+	c := &testClient{
+		Request: testRequest{
+			Method: "POST",
+			Path:   testapi.Default.ResourcePath(getPersistentVolumeClaimsResoureName(), ns, ""),
+			Query:  buildQueryValues(nil),
+			Body:   pv,
+		},
+		Response: Response{StatusCode: 200, Body: pv},
+	}
+
+	response, err := c.Setup(t).PersistentVolumeClaims(ns).Create(pv)
+	c.Validate(t, response, err)
+}
+
+func TestPersistentVolumeClaimGet(t *testing.T) {
+	ns := api.NamespaceDefault
+	persistentVolumeClaim := &api.PersistentVolumeClaim{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "abc",
+			Namespace: "foo",
+		},
+		Spec: api.PersistentVolumeClaimSpec{
+			AccessModes: []api.PersistentVolumeAccessMode{
+				api.ReadWriteOnce,
+				api.ReadOnlyMany,
+			},
+			Resources: api.ResourceRequirements{
+				Requests: api.ResourceList{
+					api.ResourceName(api.ResourceStorage): resource.MustParse("10G"),
+				},
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath(getPersistentVolumeClaimsResoureName(), ns, "abc"),
+			Query:  buildQueryValues(nil),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: persistentVolumeClaim},
+	}
+
+	response, err := c.Setup(t).PersistentVolumeClaims(ns).Get("abc")
+	c.Validate(t, response, err)
+}
+
+func TestPersistentVolumeClaimList(t *testing.T) {
+	ns := api.NamespaceDefault
+	persistentVolumeList := &api.PersistentVolumeClaimList{
+		Items: []api.PersistentVolumeClaim{
+			{
+				ObjectMeta: api.ObjectMeta{Name: "foo", Namespace: "ns"},
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath(getPersistentVolumeClaimsResoureName(), ns, ""),
+			Query:  buildQueryValues(nil),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: persistentVolumeList},
+	}
+	response, err := c.Setup(t).PersistentVolumeClaims(ns).List(labels.Everything(), fields.Everything())
+	c.Validate(t, response, err)
+}
+
+func TestPersistentVolumeClaimUpdate(t *testing.T) {
+	ns := api.NamespaceDefault
+	persistentVolumeClaim := &api.PersistentVolumeClaim{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "abc",
+			ResourceVersion: "1",
+		},
+		Spec: api.PersistentVolumeClaimSpec{
+			AccessModes: []api.PersistentVolumeAccessMode{
+				api.ReadWriteOnce,
+				api.ReadOnlyMany,
+			},
+			Resources: api.ResourceRequirements{
+				Requests: api.ResourceList{
+					api.ResourceName(api.ResourceStorage): resource.MustParse("10G"),
+				},
+			},
+		},
+	}
+	c := &testClient{
+		Request:  testRequest{Method: "PUT", Path: testapi.Default.ResourcePath(getPersistentVolumeClaimsResoureName(), ns, "abc"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200, Body: persistentVolumeClaim},
+	}
+	response, err := c.Setup(t).PersistentVolumeClaims(ns).Update(persistentVolumeClaim)
+	c.Validate(t, response, err)
+}
+
+func TestPersistentVolumeClaimStatusUpdate(t *testing.T) {
+	ns := api.NamespaceDefault
+	persistentVolumeClaim := &api.PersistentVolumeClaim{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "abc",
+			ResourceVersion: "1",
+		},
+		Spec: api.PersistentVolumeClaimSpec{
+			AccessModes: []api.PersistentVolumeAccessMode{
+				api.ReadWriteOnce,
+				api.ReadOnlyMany,
+			},
+			Resources: api.ResourceRequirements{
+				Requests: api.ResourceList{
+					api.ResourceName(api.ResourceStorage): resource.MustParse("10G"),
+				},
+			},
+		},
+		Status: api.PersistentVolumeClaimStatus{
+			Phase: api.ClaimBound,
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "PUT",
+			Path:   testapi.Default.ResourcePath(getPersistentVolumeClaimsResoureName(), ns, "abc") + "/status",
+			Query:  buildQueryValues(nil)},
+		Response: Response{StatusCode: 200, Body: persistentVolumeClaim},
+	}
+	response, err := c.Setup(t).PersistentVolumeClaims(ns).UpdateStatus(persistentVolumeClaim)
+	c.Validate(t, response, err)
+}
+
+func TestPersistentVolumeClaimDelete(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request:  testRequest{Method: "DELETE", Path: testapi.Default.ResourcePath(getPersistentVolumeClaimsResoureName(), ns, "foo"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200},
+	}
+	err := c.Setup(t).PersistentVolumeClaims(ns).Delete("foo")
+	c.Validate(t, nil, err)
+}
+
+func TestPersistentVolumeClaimWatch(t *testing.T) {
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePathWithPrefix("watch", getPersistentVolumeClaimsResoureName(), "", ""),
+			Query:  url.Values{"resourceVersion": []string{}}},
+		Response: Response{StatusCode: 200},
+	}
+	_, err := c.Setup(t).PersistentVolumeClaims(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), "")
+	c.Validate(t, nil, err)
+}

--- a/pkg/client/v1/persistentvolumeclaim_test.go
+++ b/pkg/client/v1/persistentvolumeclaim_test.go
@@ -14,15 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"net/url"
 	"testing"
 
-	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 )
@@ -32,19 +32,19 @@ func getPersistentVolumeClaimsResoureName() string {
 }
 
 func TestPersistentVolumeClaimCreate(t *testing.T) {
-	ns := api.NamespaceDefault
-	pv := &api.PersistentVolumeClaim{
-		ObjectMeta: api.ObjectMeta{
+	ns := v1.NamespaceDefault
+	pv := &v1.PersistentVolumeClaim{
+		ObjectMeta: v1.ObjectMeta{
 			Name: "abc",
 		},
-		Spec: api.PersistentVolumeClaimSpec{
-			AccessModes: []api.PersistentVolumeAccessMode{
-				api.ReadWriteOnce,
-				api.ReadOnlyMany,
+		Spec: v1.PersistentVolumeClaimSpec{
+			AccessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadWriteOnce,
+				v1.ReadOnlyMany,
 			},
-			Resources: api.ResourceRequirements{
-				Requests: api.ResourceList{
-					api.ResourceName(api.ResourceStorage): resource.MustParse("10G"),
+			Resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceName(v1.ResourceStorage): resource.MustParse("10G"),
 				},
 			},
 		},
@@ -65,20 +65,20 @@ func TestPersistentVolumeClaimCreate(t *testing.T) {
 }
 
 func TestPersistentVolumeClaimGet(t *testing.T) {
-	ns := api.NamespaceDefault
-	persistentVolumeClaim := &api.PersistentVolumeClaim{
-		ObjectMeta: api.ObjectMeta{
+	ns := v1.NamespaceDefault
+	persistentVolumeClaim := &v1.PersistentVolumeClaim{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "abc",
 			Namespace: "foo",
 		},
-		Spec: api.PersistentVolumeClaimSpec{
-			AccessModes: []api.PersistentVolumeAccessMode{
-				api.ReadWriteOnce,
-				api.ReadOnlyMany,
+		Spec: v1.PersistentVolumeClaimSpec{
+			AccessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadWriteOnce,
+				v1.ReadOnlyMany,
 			},
-			Resources: api.ResourceRequirements{
-				Requests: api.ResourceList{
-					api.ResourceName(api.ResourceStorage): resource.MustParse("10G"),
+			Resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceName(v1.ResourceStorage): resource.MustParse("10G"),
 				},
 			},
 		},
@@ -98,11 +98,11 @@ func TestPersistentVolumeClaimGet(t *testing.T) {
 }
 
 func TestPersistentVolumeClaimList(t *testing.T) {
-	ns := api.NamespaceDefault
-	persistentVolumeList := &api.PersistentVolumeClaimList{
-		Items: []api.PersistentVolumeClaim{
+	ns := v1.NamespaceDefault
+	persistentVolumeList := &v1.PersistentVolumeClaimList{
+		Items: []v1.PersistentVolumeClaim{
 			{
-				ObjectMeta: api.ObjectMeta{Name: "foo", Namespace: "ns"},
+				ObjectMeta: v1.ObjectMeta{Name: "foo", Namespace: "ns"},
 			},
 		},
 	}
@@ -120,20 +120,20 @@ func TestPersistentVolumeClaimList(t *testing.T) {
 }
 
 func TestPersistentVolumeClaimUpdate(t *testing.T) {
-	ns := api.NamespaceDefault
-	persistentVolumeClaim := &api.PersistentVolumeClaim{
-		ObjectMeta: api.ObjectMeta{
+	ns := v1.NamespaceDefault
+	persistentVolumeClaim := &v1.PersistentVolumeClaim{
+		ObjectMeta: v1.ObjectMeta{
 			Name:            "abc",
 			ResourceVersion: "1",
 		},
-		Spec: api.PersistentVolumeClaimSpec{
-			AccessModes: []api.PersistentVolumeAccessMode{
-				api.ReadWriteOnce,
-				api.ReadOnlyMany,
+		Spec: v1.PersistentVolumeClaimSpec{
+			AccessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadWriteOnce,
+				v1.ReadOnlyMany,
 			},
-			Resources: api.ResourceRequirements{
-				Requests: api.ResourceList{
-					api.ResourceName(api.ResourceStorage): resource.MustParse("10G"),
+			Resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceName(v1.ResourceStorage): resource.MustParse("10G"),
 				},
 			},
 		},
@@ -147,25 +147,25 @@ func TestPersistentVolumeClaimUpdate(t *testing.T) {
 }
 
 func TestPersistentVolumeClaimStatusUpdate(t *testing.T) {
-	ns := api.NamespaceDefault
-	persistentVolumeClaim := &api.PersistentVolumeClaim{
-		ObjectMeta: api.ObjectMeta{
+	ns := v1.NamespaceDefault
+	persistentVolumeClaim := &v1.PersistentVolumeClaim{
+		ObjectMeta: v1.ObjectMeta{
 			Name:            "abc",
 			ResourceVersion: "1",
 		},
-		Spec: api.PersistentVolumeClaimSpec{
-			AccessModes: []api.PersistentVolumeAccessMode{
-				api.ReadWriteOnce,
-				api.ReadOnlyMany,
+		Spec: v1.PersistentVolumeClaimSpec{
+			AccessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadWriteOnce,
+				v1.ReadOnlyMany,
 			},
-			Resources: api.ResourceRequirements{
-				Requests: api.ResourceList{
-					api.ResourceName(api.ResourceStorage): resource.MustParse("10G"),
+			Resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceName(v1.ResourceStorage): resource.MustParse("10G"),
 				},
 			},
 		},
-		Status: api.PersistentVolumeClaimStatus{
-			Phase: api.ClaimBound,
+		Status: v1.PersistentVolumeClaimStatus{
+			Phase: v1.ClaimBound,
 		},
 	}
 	c := &testClient{
@@ -180,7 +180,7 @@ func TestPersistentVolumeClaimStatusUpdate(t *testing.T) {
 }
 
 func TestPersistentVolumeClaimDelete(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	c := &testClient{
 		Request:  testRequest{Method: "DELETE", Path: testapi.Default.ResourcePath(getPersistentVolumeClaimsResoureName(), ns, "foo"), Query: buildQueryValues(nil)},
 		Response: Response{StatusCode: 200},
@@ -197,6 +197,6 @@ func TestPersistentVolumeClaimWatch(t *testing.T) {
 			Query:  url.Values{"resourceVersion": []string{}}},
 		Response: Response{StatusCode: 200},
 	}
-	_, err := c.Setup(t).PersistentVolumeClaims(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), "")
+	_, err := c.Setup(t).PersistentVolumeClaims(v1.NamespaceAll).Watch(labels.Everything(), fields.Everything(), "")
 	c.Validate(t, nil, err)
 }

--- a/pkg/client/v1/persistentvolumes.go
+++ b/pkg/client/v1/persistentvolumes.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+type PersistentVolumesInterface interface {
+	PersistentVolumes() PersistentVolumeInterface
+}
+
+// PersistentVolumeInterface has methods to work with PersistentVolume resources.
+type PersistentVolumeInterface interface {
+	List(label labels.Selector, field fields.Selector) (*api.PersistentVolumeList, error)
+	Get(name string) (*api.PersistentVolume, error)
+	Create(volume *api.PersistentVolume) (*api.PersistentVolume, error)
+	Update(volume *api.PersistentVolume) (*api.PersistentVolume, error)
+	UpdateStatus(persistentVolume *api.PersistentVolume) (*api.PersistentVolume, error)
+	Delete(name string) error
+	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
+}
+
+// persistentVolumes implements PersistentVolumesInterface
+type persistentVolumes struct {
+	client *Client
+}
+
+func newPersistentVolumes(c *Client) *persistentVolumes {
+	return &persistentVolumes{c}
+}
+
+func (c *persistentVolumes) List(label labels.Selector, field fields.Selector) (result *api.PersistentVolumeList, err error) {
+	result = &api.PersistentVolumeList{}
+	err = c.client.Get().
+		Resource("persistentVolumes").
+		LabelsSelectorParam(label).
+		FieldsSelectorParam(field).
+		Do().
+		Into(result)
+
+	return result, err
+}
+
+func (c *persistentVolumes) Get(name string) (result *api.PersistentVolume, err error) {
+	result = &api.PersistentVolume{}
+	err = c.client.Get().Resource("persistentVolumes").Name(name).Do().Into(result)
+	return
+}
+
+func (c *persistentVolumes) Create(volume *api.PersistentVolume) (result *api.PersistentVolume, err error) {
+	result = &api.PersistentVolume{}
+	err = c.client.Post().Resource("persistentVolumes").Body(volume).Do().Into(result)
+	return
+}
+
+func (c *persistentVolumes) Update(volume *api.PersistentVolume) (result *api.PersistentVolume, err error) {
+	result = &api.PersistentVolume{}
+	if len(volume.ResourceVersion) == 0 {
+		err = fmt.Errorf("invalid update object, missing resource version: %v", volume)
+		return
+	}
+	err = c.client.Put().Resource("persistentVolumes").Name(volume.Name).Body(volume).Do().Into(result)
+	return
+}
+
+func (c *persistentVolumes) UpdateStatus(volume *api.PersistentVolume) (result *api.PersistentVolume, err error) {
+	result = &api.PersistentVolume{}
+	err = c.client.Put().Resource("persistentVolumes").Name(volume.Name).SubResource("status").Body(volume).Do().Into(result)
+	return
+}
+
+func (c *persistentVolumes) Delete(name string) error {
+	return c.client.Delete().Resource("persistentVolumes").Name(name).Do().Error()
+}
+
+func (c *persistentVolumes) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.client.Get().
+		Prefix("watch").
+		Resource("persistentVolumes").
+		Param("resourceVersion", resourceVersion).
+		LabelsSelectorParam(label).
+		FieldsSelectorParam(field).
+		Watch()
+}

--- a/pkg/client/v1/persistentvolumes.go
+++ b/pkg/client/v1/persistentvolumes.go
@@ -14,12 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"fmt"
 
-	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/watch"
@@ -31,11 +31,11 @@ type PersistentVolumesInterface interface {
 
 // PersistentVolumeInterface has methods to work with PersistentVolume resources.
 type PersistentVolumeInterface interface {
-	List(label labels.Selector, field fields.Selector) (*api.PersistentVolumeList, error)
-	Get(name string) (*api.PersistentVolume, error)
-	Create(volume *api.PersistentVolume) (*api.PersistentVolume, error)
-	Update(volume *api.PersistentVolume) (*api.PersistentVolume, error)
-	UpdateStatus(persistentVolume *api.PersistentVolume) (*api.PersistentVolume, error)
+	List(label labels.Selector, field fields.Selector) (*v1.PersistentVolumeList, error)
+	Get(name string) (*v1.PersistentVolume, error)
+	Create(volume *v1.PersistentVolume) (*v1.PersistentVolume, error)
+	Update(volume *v1.PersistentVolume) (*v1.PersistentVolume, error)
+	UpdateStatus(persistentVolume *v1.PersistentVolume) (*v1.PersistentVolume, error)
 	Delete(name string) error
 	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
 }
@@ -49,8 +49,8 @@ func newPersistentVolumes(c *Client) *persistentVolumes {
 	return &persistentVolumes{c}
 }
 
-func (c *persistentVolumes) List(label labels.Selector, field fields.Selector) (result *api.PersistentVolumeList, err error) {
-	result = &api.PersistentVolumeList{}
+func (c *persistentVolumes) List(label labels.Selector, field fields.Selector) (result *v1.PersistentVolumeList, err error) {
+	result = &v1.PersistentVolumeList{}
 	err = c.client.Get().
 		Resource("persistentVolumes").
 		LabelsSelectorParam(label).
@@ -61,20 +61,20 @@ func (c *persistentVolumes) List(label labels.Selector, field fields.Selector) (
 	return result, err
 }
 
-func (c *persistentVolumes) Get(name string) (result *api.PersistentVolume, err error) {
-	result = &api.PersistentVolume{}
+func (c *persistentVolumes) Get(name string) (result *v1.PersistentVolume, err error) {
+	result = &v1.PersistentVolume{}
 	err = c.client.Get().Resource("persistentVolumes").Name(name).Do().Into(result)
 	return
 }
 
-func (c *persistentVolumes) Create(volume *api.PersistentVolume) (result *api.PersistentVolume, err error) {
-	result = &api.PersistentVolume{}
+func (c *persistentVolumes) Create(volume *v1.PersistentVolume) (result *v1.PersistentVolume, err error) {
+	result = &v1.PersistentVolume{}
 	err = c.client.Post().Resource("persistentVolumes").Body(volume).Do().Into(result)
 	return
 }
 
-func (c *persistentVolumes) Update(volume *api.PersistentVolume) (result *api.PersistentVolume, err error) {
-	result = &api.PersistentVolume{}
+func (c *persistentVolumes) Update(volume *v1.PersistentVolume) (result *v1.PersistentVolume, err error) {
+	result = &v1.PersistentVolume{}
 	if len(volume.ResourceVersion) == 0 {
 		err = fmt.Errorf("invalid update object, missing resource version: %v", volume)
 		return
@@ -83,8 +83,8 @@ func (c *persistentVolumes) Update(volume *api.PersistentVolume) (result *api.Pe
 	return
 }
 
-func (c *persistentVolumes) UpdateStatus(volume *api.PersistentVolume) (result *api.PersistentVolume, err error) {
-	result = &api.PersistentVolume{}
+func (c *persistentVolumes) UpdateStatus(volume *v1.PersistentVolume) (result *v1.PersistentVolume, err error) {
+	result = &v1.PersistentVolume{}
 	err = c.client.Put().Resource("persistentVolumes").Name(volume.Name).SubResource("status").Body(volume).Do().Into(result)
 	return
 }

--- a/pkg/client/v1/pod_templates.go
+++ b/pkg/client/v1/pod_templates.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// PodTemplatesNamespacer has methods to work with PodTemplate resources in a namespace
+type PodTemplatesNamespacer interface {
+	PodTemplates(namespace string) PodTemplateInterface
+}
+
+// PodTemplateInterface has methods to work with PodTemplate resources.
+type PodTemplateInterface interface {
+	List(label labels.Selector, field fields.Selector) (*api.PodTemplateList, error)
+	Get(name string) (*api.PodTemplate, error)
+	Delete(name string, options *api.DeleteOptions) error
+	Create(podTemplate *api.PodTemplate) (*api.PodTemplate, error)
+	Update(podTemplate *api.PodTemplate) (*api.PodTemplate, error)
+	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
+}
+
+// podTemplates implements PodTemplatesNamespacer interface
+type podTemplates struct {
+	r  *Client
+	ns string
+}
+
+// newPodTemplates returns a podTemplates
+func newPodTemplates(c *Client, namespace string) *podTemplates {
+	return &podTemplates{
+		r:  c,
+		ns: namespace,
+	}
+}
+
+// List takes label and field selectors, and returns the list of podTemplates that match those selectors.
+func (c *podTemplates) List(label labels.Selector, field fields.Selector) (result *api.PodTemplateList, err error) {
+	result = &api.PodTemplateList{}
+	err = c.r.Get().Namespace(c.ns).Resource("podTemplates").LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
+	return
+}
+
+// Get takes the name of the podTemplate, and returns the corresponding PodTemplate object, and an error if it occurs
+func (c *podTemplates) Get(name string) (result *api.PodTemplate, err error) {
+	result = &api.PodTemplate{}
+	err = c.r.Get().Namespace(c.ns).Resource("podTemplates").Name(name).Do().Into(result)
+	return
+}
+
+// Delete takes the name of the podTemplate, and returns an error if one occurs
+func (c *podTemplates) Delete(name string, options *api.DeleteOptions) error {
+	// TODO: to make this reusable in other client libraries
+	if options == nil {
+		return c.r.Delete().Namespace(c.ns).Resource("podTemplates").Name(name).Do().Error()
+	}
+	body, err := api.Scheme.EncodeToVersion(options, c.r.APIVersion())
+	if err != nil {
+		return err
+	}
+	return c.r.Delete().Namespace(c.ns).Resource("podTemplates").Name(name).Body(body).Do().Error()
+}
+
+// Create takes the representation of a podTemplate.  Returns the server's representation of the podTemplate, and an error, if it occurs.
+func (c *podTemplates) Create(podTemplate *api.PodTemplate) (result *api.PodTemplate, err error) {
+	result = &api.PodTemplate{}
+	err = c.r.Post().Namespace(c.ns).Resource("podTemplates").Body(podTemplate).Do().Into(result)
+	return
+}
+
+// Update takes the representation of a podTemplate to update.  Returns the server's representation of the podTemplate, and an error, if it occurs.
+func (c *podTemplates) Update(podTemplate *api.PodTemplate) (result *api.PodTemplate, err error) {
+	result = &api.PodTemplate{}
+	err = c.r.Put().Namespace(c.ns).Resource("podTemplates").Name(podTemplate.Name).Body(podTemplate).Do().Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested podTemplates.
+func (c *podTemplates) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.r.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("podTemplates").
+		Param("resourceVersion", resourceVersion).
+		LabelsSelectorParam(label).
+		FieldsSelectorParam(field).
+		Watch()
+}

--- a/pkg/client/v1/pod_templates.go
+++ b/pkg/client/v1/pod_templates.go
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/watch"
@@ -30,11 +31,11 @@ type PodTemplatesNamespacer interface {
 
 // PodTemplateInterface has methods to work with PodTemplate resources.
 type PodTemplateInterface interface {
-	List(label labels.Selector, field fields.Selector) (*api.PodTemplateList, error)
-	Get(name string) (*api.PodTemplate, error)
-	Delete(name string, options *api.DeleteOptions) error
-	Create(podTemplate *api.PodTemplate) (*api.PodTemplate, error)
-	Update(podTemplate *api.PodTemplate) (*api.PodTemplate, error)
+	List(label labels.Selector, field fields.Selector) (*v1.PodTemplateList, error)
+	Get(name string) (*v1.PodTemplate, error)
+	Delete(name string, options *v1.DeleteOptions) error
+	Create(podTemplate *v1.PodTemplate) (*v1.PodTemplate, error)
+	Update(podTemplate *v1.PodTemplate) (*v1.PodTemplate, error)
 	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
 }
 
@@ -53,21 +54,21 @@ func newPodTemplates(c *Client, namespace string) *podTemplates {
 }
 
 // List takes label and field selectors, and returns the list of podTemplates that match those selectors.
-func (c *podTemplates) List(label labels.Selector, field fields.Selector) (result *api.PodTemplateList, err error) {
-	result = &api.PodTemplateList{}
+func (c *podTemplates) List(label labels.Selector, field fields.Selector) (result *v1.PodTemplateList, err error) {
+	result = &v1.PodTemplateList{}
 	err = c.r.Get().Namespace(c.ns).Resource("podTemplates").LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
 	return
 }
 
 // Get takes the name of the podTemplate, and returns the corresponding PodTemplate object, and an error if it occurs
-func (c *podTemplates) Get(name string) (result *api.PodTemplate, err error) {
-	result = &api.PodTemplate{}
+func (c *podTemplates) Get(name string) (result *v1.PodTemplate, err error) {
+	result = &v1.PodTemplate{}
 	err = c.r.Get().Namespace(c.ns).Resource("podTemplates").Name(name).Do().Into(result)
 	return
 }
 
 // Delete takes the name of the podTemplate, and returns an error if one occurs
-func (c *podTemplates) Delete(name string, options *api.DeleteOptions) error {
+func (c *podTemplates) Delete(name string, options *v1.DeleteOptions) error {
 	// TODO: to make this reusable in other client libraries
 	if options == nil {
 		return c.r.Delete().Namespace(c.ns).Resource("podTemplates").Name(name).Do().Error()
@@ -80,15 +81,15 @@ func (c *podTemplates) Delete(name string, options *api.DeleteOptions) error {
 }
 
 // Create takes the representation of a podTemplate.  Returns the server's representation of the podTemplate, and an error, if it occurs.
-func (c *podTemplates) Create(podTemplate *api.PodTemplate) (result *api.PodTemplate, err error) {
-	result = &api.PodTemplate{}
+func (c *podTemplates) Create(podTemplate *v1.PodTemplate) (result *v1.PodTemplate, err error) {
+	result = &v1.PodTemplate{}
 	err = c.r.Post().Namespace(c.ns).Resource("podTemplates").Body(podTemplate).Do().Into(result)
 	return
 }
 
 // Update takes the representation of a podTemplate to update.  Returns the server's representation of the podTemplate, and an error, if it occurs.
-func (c *podTemplates) Update(podTemplate *api.PodTemplate) (result *api.PodTemplate, err error) {
-	result = &api.PodTemplate{}
+func (c *podTemplates) Update(podTemplate *v1.PodTemplate) (result *v1.PodTemplate, err error) {
+	result = &v1.PodTemplate{}
 	err = c.r.Put().Namespace(c.ns).Resource("podTemplates").Name(podTemplate.Name).Body(podTemplate).Do().Into(result)
 	return
 }

--- a/pkg/client/v1/pod_templates_test.go
+++ b/pkg/client/v1/pod_templates_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"net/url"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func getPodTemplatesResoureName() string {
+	return "podtemplates"
+}
+
+func TestPodTemplateCreate(t *testing.T) {
+	ns := api.NamespaceDefault
+	podTemplate := api.PodTemplate{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "abc",
+			Namespace: ns,
+		},
+		Template: api.PodTemplateSpec{},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "POST",
+			Path:   testapi.Default.ResourcePath(getPodTemplatesResoureName(), ns, ""),
+			Query:  buildQueryValues(nil),
+			Body:   &podTemplate,
+		},
+		Response: Response{StatusCode: 200, Body: &podTemplate},
+	}
+
+	response, err := c.Setup(t).PodTemplates(ns).Create(&podTemplate)
+	c.Validate(t, response, err)
+}
+
+func TestPodTemplateGet(t *testing.T) {
+	ns := api.NamespaceDefault
+	podTemplate := &api.PodTemplate{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "abc",
+			Namespace: ns,
+		},
+		Template: api.PodTemplateSpec{},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath(getPodTemplatesResoureName(), ns, "abc"),
+			Query:  buildQueryValues(nil),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: podTemplate},
+	}
+
+	response, err := c.Setup(t).PodTemplates(ns).Get("abc")
+	c.Validate(t, response, err)
+}
+
+func TestPodTemplateList(t *testing.T) {
+	ns := api.NamespaceDefault
+	podTemplateList := &api.PodTemplateList{
+		Items: []api.PodTemplate{
+			{
+				ObjectMeta: api.ObjectMeta{
+					Name:      "foo",
+					Namespace: ns,
+				},
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath(getPodTemplatesResoureName(), ns, ""),
+			Query:  buildQueryValues(nil),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: podTemplateList},
+	}
+	response, err := c.Setup(t).PodTemplates(ns).List(labels.Everything(), fields.Everything())
+	c.Validate(t, response, err)
+}
+
+func TestPodTemplateUpdate(t *testing.T) {
+	ns := api.NamespaceDefault
+	podTemplate := &api.PodTemplate{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "abc",
+			Namespace:       ns,
+			ResourceVersion: "1",
+		},
+		Template: api.PodTemplateSpec{},
+	}
+	c := &testClient{
+		Request:  testRequest{Method: "PUT", Path: testapi.Default.ResourcePath(getPodTemplatesResoureName(), ns, "abc"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200, Body: podTemplate},
+	}
+	response, err := c.Setup(t).PodTemplates(ns).Update(podTemplate)
+	c.Validate(t, response, err)
+}
+
+func TestPodTemplateDelete(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request:  testRequest{Method: "DELETE", Path: testapi.Default.ResourcePath(getPodTemplatesResoureName(), ns, "foo"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200},
+	}
+	err := c.Setup(t).PodTemplates(ns).Delete("foo", nil)
+	c.Validate(t, nil, err)
+}
+
+func TestPodTemplateWatch(t *testing.T) {
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePathWithPrefix("watch", getPodTemplatesResoureName(), "", ""),
+			Query:  url.Values{"resourceVersion": []string{}}},
+		Response: Response{StatusCode: 200},
+	}
+	_, err := c.Setup(t).PodTemplates(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), "")
+	c.Validate(t, nil, err)
+}

--- a/pkg/client/v1/pod_templates_test.go
+++ b/pkg/client/v1/pod_templates_test.go
@@ -14,14 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"net/url"
 	"testing"
 
-	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 )
@@ -31,13 +31,13 @@ func getPodTemplatesResoureName() string {
 }
 
 func TestPodTemplateCreate(t *testing.T) {
-	ns := api.NamespaceDefault
-	podTemplate := api.PodTemplate{
-		ObjectMeta: api.ObjectMeta{
+	ns := v1.NamespaceDefault
+	podTemplate := v1.PodTemplate{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "abc",
 			Namespace: ns,
 		},
-		Template: api.PodTemplateSpec{},
+		Template: v1.PodTemplateSpec{},
 	}
 	c := &testClient{
 		Request: testRequest{
@@ -54,13 +54,13 @@ func TestPodTemplateCreate(t *testing.T) {
 }
 
 func TestPodTemplateGet(t *testing.T) {
-	ns := api.NamespaceDefault
-	podTemplate := &api.PodTemplate{
-		ObjectMeta: api.ObjectMeta{
+	ns := v1.NamespaceDefault
+	podTemplate := &v1.PodTemplate{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "abc",
 			Namespace: ns,
 		},
-		Template: api.PodTemplateSpec{},
+		Template: v1.PodTemplateSpec{},
 	}
 	c := &testClient{
 		Request: testRequest{
@@ -77,11 +77,11 @@ func TestPodTemplateGet(t *testing.T) {
 }
 
 func TestPodTemplateList(t *testing.T) {
-	ns := api.NamespaceDefault
-	podTemplateList := &api.PodTemplateList{
-		Items: []api.PodTemplate{
+	ns := v1.NamespaceDefault
+	podTemplateList := &v1.PodTemplateList{
+		Items: []v1.PodTemplate{
 			{
-				ObjectMeta: api.ObjectMeta{
+				ObjectMeta: v1.ObjectMeta{
 					Name:      "foo",
 					Namespace: ns,
 				},
@@ -102,14 +102,14 @@ func TestPodTemplateList(t *testing.T) {
 }
 
 func TestPodTemplateUpdate(t *testing.T) {
-	ns := api.NamespaceDefault
-	podTemplate := &api.PodTemplate{
-		ObjectMeta: api.ObjectMeta{
+	ns := v1.NamespaceDefault
+	podTemplate := &v1.PodTemplate{
+		ObjectMeta: v1.ObjectMeta{
 			Name:            "abc",
 			Namespace:       ns,
 			ResourceVersion: "1",
 		},
-		Template: api.PodTemplateSpec{},
+		Template: v1.PodTemplateSpec{},
 	}
 	c := &testClient{
 		Request:  testRequest{Method: "PUT", Path: testapi.Default.ResourcePath(getPodTemplatesResoureName(), ns, "abc"), Query: buildQueryValues(nil)},
@@ -120,7 +120,7 @@ func TestPodTemplateUpdate(t *testing.T) {
 }
 
 func TestPodTemplateDelete(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	c := &testClient{
 		Request:  testRequest{Method: "DELETE", Path: testapi.Default.ResourcePath(getPodTemplatesResoureName(), ns, "foo"), Query: buildQueryValues(nil)},
 		Response: Response{StatusCode: 200},
@@ -137,6 +137,6 @@ func TestPodTemplateWatch(t *testing.T) {
 			Query:  url.Values{"resourceVersion": []string{}}},
 		Response: Response{StatusCode: 200},
 	}
-	_, err := c.Setup(t).PodTemplates(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), "")
+	_, err := c.Setup(t).PodTemplates(v1.NamespaceAll).Watch(labels.Everything(), fields.Everything(), "")
 	c.Validate(t, nil, err)
 }

--- a/pkg/client/v1/pods.go
+++ b/pkg/client/v1/pods.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// PodsNamespacer has methods to work with Pod resources in a namespace
+type PodsNamespacer interface {
+	Pods(namespace string) PodInterface
+}
+
+// PodInterface has methods to work with Pod resources.
+type PodInterface interface {
+	List(label labels.Selector, field fields.Selector) (*api.PodList, error)
+	Get(name string) (*api.Pod, error)
+	Delete(name string, options *api.DeleteOptions) error
+	Create(pod *api.Pod) (*api.Pod, error)
+	Update(pod *api.Pod) (*api.Pod, error)
+	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
+	Bind(binding *api.Binding) error
+	UpdateStatus(pod *api.Pod) (*api.Pod, error)
+}
+
+// pods implements PodsNamespacer interface
+type pods struct {
+	r  *Client
+	ns string
+}
+
+// newPods returns a pods
+func newPods(c *Client, namespace string) *pods {
+	return &pods{
+		r:  c,
+		ns: namespace,
+	}
+}
+
+// List takes label and field selectors, and returns the list of pods that match those selectors.
+func (c *pods) List(label labels.Selector, field fields.Selector) (result *api.PodList, err error) {
+	result = &api.PodList{}
+	err = c.r.Get().Namespace(c.ns).Resource("pods").LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
+	return
+}
+
+// Get takes the name of the pod, and returns the corresponding Pod object, and an error if it occurs
+func (c *pods) Get(name string) (result *api.Pod, err error) {
+	result = &api.Pod{}
+	err = c.r.Get().Namespace(c.ns).Resource("pods").Name(name).Do().Into(result)
+	return
+}
+
+// Delete takes the name of the pod, and returns an error if one occurs
+func (c *pods) Delete(name string, options *api.DeleteOptions) error {
+	// TODO: to make this reusable in other client libraries
+	if options == nil {
+		return c.r.Delete().Namespace(c.ns).Resource("pods").Name(name).Do().Error()
+	}
+	body, err := api.Scheme.EncodeToVersion(options, c.r.APIVersion())
+	if err != nil {
+		return err
+	}
+	return c.r.Delete().Namespace(c.ns).Resource("pods").Name(name).Body(body).Do().Error()
+}
+
+// Create takes the representation of a pod.  Returns the server's representation of the pod, and an error, if it occurs.
+func (c *pods) Create(pod *api.Pod) (result *api.Pod, err error) {
+	result = &api.Pod{}
+	err = c.r.Post().Namespace(c.ns).Resource("pods").Body(pod).Do().Into(result)
+	return
+}
+
+// Update takes the representation of a pod to update.  Returns the server's representation of the pod, and an error, if it occurs.
+func (c *pods) Update(pod *api.Pod) (result *api.Pod, err error) {
+	result = &api.Pod{}
+	err = c.r.Put().Namespace(c.ns).Resource("pods").Name(pod.Name).Body(pod).Do().Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested pods.
+func (c *pods) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.r.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("pods").
+		Param("resourceVersion", resourceVersion).
+		LabelsSelectorParam(label).
+		FieldsSelectorParam(field).
+		Watch()
+}
+
+// Bind applies the provided binding to the named pod in the current namespace (binding.Namespace is ignored).
+func (c *pods) Bind(binding *api.Binding) error {
+	return c.r.Post().Namespace(c.ns).Resource("pods").Name(binding.Name).SubResource("binding").Body(binding).Do().Error()
+}
+
+// UpdateStatus takes the name of the pod and the new status.  Returns the server's representation of the pod, and an error, if it occurs.
+func (c *pods) UpdateStatus(pod *api.Pod) (result *api.Pod, err error) {
+	result = &api.Pod{}
+	err = c.r.Put().Namespace(c.ns).Resource("pods").Name(pod.Name).SubResource("status").Body(pod).Do().Into(result)
+	return
+}

--- a/pkg/client/v1/pods.go
+++ b/pkg/client/v1/pods.go
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/watch"
@@ -30,14 +31,14 @@ type PodsNamespacer interface {
 
 // PodInterface has methods to work with Pod resources.
 type PodInterface interface {
-	List(label labels.Selector, field fields.Selector) (*api.PodList, error)
-	Get(name string) (*api.Pod, error)
-	Delete(name string, options *api.DeleteOptions) error
-	Create(pod *api.Pod) (*api.Pod, error)
-	Update(pod *api.Pod) (*api.Pod, error)
+	List(label labels.Selector, field fields.Selector) (*v1.PodList, error)
+	Get(name string) (*v1.Pod, error)
+	Delete(name string, options *v1.DeleteOptions) error
+	Create(pod *v1.Pod) (*v1.Pod, error)
+	Update(pod *v1.Pod) (*v1.Pod, error)
 	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
-	Bind(binding *api.Binding) error
-	UpdateStatus(pod *api.Pod) (*api.Pod, error)
+	Bind(binding *v1.Binding) error
+	UpdateStatus(pod *v1.Pod) (*v1.Pod, error)
 }
 
 // pods implements PodsNamespacer interface
@@ -55,21 +56,21 @@ func newPods(c *Client, namespace string) *pods {
 }
 
 // List takes label and field selectors, and returns the list of pods that match those selectors.
-func (c *pods) List(label labels.Selector, field fields.Selector) (result *api.PodList, err error) {
-	result = &api.PodList{}
+func (c *pods) List(label labels.Selector, field fields.Selector) (result *v1.PodList, err error) {
+	result = &v1.PodList{}
 	err = c.r.Get().Namespace(c.ns).Resource("pods").LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
 	return
 }
 
 // Get takes the name of the pod, and returns the corresponding Pod object, and an error if it occurs
-func (c *pods) Get(name string) (result *api.Pod, err error) {
-	result = &api.Pod{}
+func (c *pods) Get(name string) (result *v1.Pod, err error) {
+	result = &v1.Pod{}
 	err = c.r.Get().Namespace(c.ns).Resource("pods").Name(name).Do().Into(result)
 	return
 }
 
 // Delete takes the name of the pod, and returns an error if one occurs
-func (c *pods) Delete(name string, options *api.DeleteOptions) error {
+func (c *pods) Delete(name string, options *v1.DeleteOptions) error {
 	// TODO: to make this reusable in other client libraries
 	if options == nil {
 		return c.r.Delete().Namespace(c.ns).Resource("pods").Name(name).Do().Error()
@@ -82,15 +83,15 @@ func (c *pods) Delete(name string, options *api.DeleteOptions) error {
 }
 
 // Create takes the representation of a pod.  Returns the server's representation of the pod, and an error, if it occurs.
-func (c *pods) Create(pod *api.Pod) (result *api.Pod, err error) {
-	result = &api.Pod{}
+func (c *pods) Create(pod *v1.Pod) (result *v1.Pod, err error) {
+	result = &v1.Pod{}
 	err = c.r.Post().Namespace(c.ns).Resource("pods").Body(pod).Do().Into(result)
 	return
 }
 
 // Update takes the representation of a pod to update.  Returns the server's representation of the pod, and an error, if it occurs.
-func (c *pods) Update(pod *api.Pod) (result *api.Pod, err error) {
-	result = &api.Pod{}
+func (c *pods) Update(pod *v1.Pod) (result *v1.Pod, err error) {
+	result = &v1.Pod{}
 	err = c.r.Put().Namespace(c.ns).Resource("pods").Name(pod.Name).Body(pod).Do().Into(result)
 	return
 }
@@ -108,13 +109,13 @@ func (c *pods) Watch(label labels.Selector, field fields.Selector, resourceVersi
 }
 
 // Bind applies the provided binding to the named pod in the current namespace (binding.Namespace is ignored).
-func (c *pods) Bind(binding *api.Binding) error {
+func (c *pods) Bind(binding *v1.Binding) error {
 	return c.r.Post().Namespace(c.ns).Resource("pods").Name(binding.Name).SubResource("binding").Body(binding).Do().Error()
 }
 
 // UpdateStatus takes the name of the pod and the new status.  Returns the server's representation of the pod, and an error, if it occurs.
-func (c *pods) UpdateStatus(pod *api.Pod) (result *api.Pod, err error) {
-	result = &api.Pod{}
+func (c *pods) UpdateStatus(pod *v1.Pod) (result *v1.Pod, err error) {
+	result = &v1.Pod{}
 	err = c.r.Put().Namespace(c.ns).Resource("pods").Name(pod.Name).SubResource("status").Body(pod).Do().Into(result)
 	return
 }

--- a/pkg/client/v1/pods_test.go
+++ b/pkg/client/v1/pods_test.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"net/url"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func TestListEmptyPods(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request:  testRequest{Method: "GET", Path: testapi.Default.ResourcePath("pods", ns, ""), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200, Body: &api.PodList{}},
+	}
+	podList, err := c.Setup(t).Pods(ns).List(labels.Everything(), fields.Everything())
+	c.Validate(t, podList, err)
+}
+
+func TestListPods(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request: testRequest{Method: "GET", Path: testapi.Default.ResourcePath("pods", ns, ""), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200,
+			Body: &api.PodList{
+				Items: []api.Pod{
+					{
+						Status: api.PodStatus{
+							Phase: api.PodRunning,
+						},
+						ObjectMeta: api.ObjectMeta{
+							Labels: map[string]string{
+								"foo":  "bar",
+								"name": "baz",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	receivedPodList, err := c.Setup(t).Pods(ns).List(labels.Everything(), fields.Everything())
+	c.Validate(t, receivedPodList, err)
+}
+
+func TestListPodsLabels(t *testing.T) {
+	ns := api.NamespaceDefault
+	labelSelectorQueryParamName := api.LabelSelectorQueryParam(testapi.Default.Version())
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath("pods", ns, ""),
+			Query:  buildQueryValues(url.Values{labelSelectorQueryParamName: []string{"foo=bar,name=baz"}})},
+		Response: Response{
+			StatusCode: 200,
+			Body: &api.PodList{
+				Items: []api.Pod{
+					{
+						Status: api.PodStatus{
+							Phase: api.PodRunning,
+						},
+						ObjectMeta: api.ObjectMeta{
+							Labels: map[string]string{
+								"foo":  "bar",
+								"name": "baz",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	c.Setup(t)
+	c.QueryValidator[labelSelectorQueryParamName] = validateLabels
+	selector := labels.Set{"foo": "bar", "name": "baz"}.AsSelector()
+	receivedPodList, err := c.Pods(ns).List(selector, fields.Everything())
+	c.Validate(t, receivedPodList, err)
+}
+
+func TestGetPod(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request: testRequest{Method: "GET", Path: testapi.Default.ResourcePath("pods", ns, "foo"), Query: buildQueryValues(nil)},
+		Response: Response{
+			StatusCode: 200,
+			Body: &api.Pod{
+				Status: api.PodStatus{
+					Phase: api.PodRunning,
+				},
+				ObjectMeta: api.ObjectMeta{
+					Labels: map[string]string{
+						"foo":  "bar",
+						"name": "baz",
+					},
+				},
+			},
+		},
+	}
+	receivedPod, err := c.Setup(t).Pods(ns).Get("foo")
+	c.Validate(t, receivedPod, err)
+}
+
+func TestGetPodWithNoName(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{Error: true}
+	receivedPod, err := c.Setup(t).Pods(ns).Get("")
+	if (err != nil) && (err.Error() != nameRequiredError) {
+		t.Errorf("Expected error: %v, but got %v", nameRequiredError, err)
+	}
+
+	c.Validate(t, receivedPod, err)
+}
+
+func TestDeletePod(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request:  testRequest{Method: "DELETE", Path: testapi.Default.ResourcePath("pods", ns, "foo"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200},
+	}
+	err := c.Setup(t).Pods(ns).Delete("foo", nil)
+	c.Validate(t, nil, err)
+}
+
+func TestCreatePod(t *testing.T) {
+	ns := api.NamespaceDefault
+	requestPod := &api.Pod{
+		Status: api.PodStatus{
+			Phase: api.PodRunning,
+		},
+		ObjectMeta: api.ObjectMeta{
+			Labels: map[string]string{
+				"foo":  "bar",
+				"name": "baz",
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{Method: "POST", Path: testapi.Default.ResourcePath("pods", ns, ""), Query: buildQueryValues(nil), Body: requestPod},
+		Response: Response{
+			StatusCode: 200,
+			Body:       requestPod,
+		},
+	}
+	receivedPod, err := c.Setup(t).Pods(ns).Create(requestPod)
+	c.Validate(t, receivedPod, err)
+}
+
+func TestUpdatePod(t *testing.T) {
+	ns := api.NamespaceDefault
+	requestPod := &api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "foo",
+			ResourceVersion: "1",
+			Labels: map[string]string{
+				"foo":  "bar",
+				"name": "baz",
+			},
+		},
+		Status: api.PodStatus{
+			Phase: api.PodRunning,
+		},
+	}
+	c := &testClient{
+		Request:  testRequest{Method: "PUT", Path: testapi.Default.ResourcePath("pods", ns, "foo"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200, Body: requestPod},
+	}
+	receivedPod, err := c.Setup(t).Pods(ns).Update(requestPod)
+	c.Validate(t, receivedPod, err)
+}

--- a/pkg/client/v1/pods_test.go
+++ b/pkg/client/v1/pods_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"net/url"
@@ -22,32 +22,33 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 )
 
 func TestListEmptyPods(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	c := &testClient{
 		Request:  testRequest{Method: "GET", Path: testapi.Default.ResourcePath("pods", ns, ""), Query: buildQueryValues(nil)},
-		Response: Response{StatusCode: 200, Body: &api.PodList{}},
+		Response: Response{StatusCode: 200, Body: &v1.PodList{}},
 	}
 	podList, err := c.Setup(t).Pods(ns).List(labels.Everything(), fields.Everything())
 	c.Validate(t, podList, err)
 }
 
 func TestListPods(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	c := &testClient{
 		Request: testRequest{Method: "GET", Path: testapi.Default.ResourcePath("pods", ns, ""), Query: buildQueryValues(nil)},
 		Response: Response{StatusCode: 200,
-			Body: &api.PodList{
-				Items: []api.Pod{
+			Body: &v1.PodList{
+				Items: []v1.Pod{
 					{
-						Status: api.PodStatus{
-							Phase: api.PodRunning,
+						Status: v1.PodStatus{
+							Phase: v1.PodRunning,
 						},
-						ObjectMeta: api.ObjectMeta{
+						ObjectMeta: v1.ObjectMeta{
 							Labels: map[string]string{
 								"foo":  "bar",
 								"name": "baz",
@@ -63,7 +64,7 @@ func TestListPods(t *testing.T) {
 }
 
 func TestListPodsLabels(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	labelSelectorQueryParamName := api.LabelSelectorQueryParam(testapi.Default.Version())
 	c := &testClient{
 		Request: testRequest{
@@ -72,13 +73,13 @@ func TestListPodsLabels(t *testing.T) {
 			Query:  buildQueryValues(url.Values{labelSelectorQueryParamName: []string{"foo=bar,name=baz"}})},
 		Response: Response{
 			StatusCode: 200,
-			Body: &api.PodList{
-				Items: []api.Pod{
+			Body: &v1.PodList{
+				Items: []v1.Pod{
 					{
-						Status: api.PodStatus{
-							Phase: api.PodRunning,
+						Status: v1.PodStatus{
+							Phase: v1.PodRunning,
 						},
-						ObjectMeta: api.ObjectMeta{
+						ObjectMeta: v1.ObjectMeta{
 							Labels: map[string]string{
 								"foo":  "bar",
 								"name": "baz",
@@ -97,16 +98,16 @@ func TestListPodsLabels(t *testing.T) {
 }
 
 func TestGetPod(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	c := &testClient{
 		Request: testRequest{Method: "GET", Path: testapi.Default.ResourcePath("pods", ns, "foo"), Query: buildQueryValues(nil)},
 		Response: Response{
 			StatusCode: 200,
-			Body: &api.Pod{
-				Status: api.PodStatus{
-					Phase: api.PodRunning,
+			Body: &v1.Pod{
+				Status: v1.PodStatus{
+					Phase: v1.PodRunning,
 				},
-				ObjectMeta: api.ObjectMeta{
+				ObjectMeta: v1.ObjectMeta{
 					Labels: map[string]string{
 						"foo":  "bar",
 						"name": "baz",
@@ -120,7 +121,7 @@ func TestGetPod(t *testing.T) {
 }
 
 func TestGetPodWithNoName(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	c := &testClient{Error: true}
 	receivedPod, err := c.Setup(t).Pods(ns).Get("")
 	if (err != nil) && (err.Error() != nameRequiredError) {
@@ -131,7 +132,7 @@ func TestGetPodWithNoName(t *testing.T) {
 }
 
 func TestDeletePod(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	c := &testClient{
 		Request:  testRequest{Method: "DELETE", Path: testapi.Default.ResourcePath("pods", ns, "foo"), Query: buildQueryValues(nil)},
 		Response: Response{StatusCode: 200},
@@ -141,12 +142,12 @@ func TestDeletePod(t *testing.T) {
 }
 
 func TestCreatePod(t *testing.T) {
-	ns := api.NamespaceDefault
-	requestPod := &api.Pod{
-		Status: api.PodStatus{
-			Phase: api.PodRunning,
+	ns := v1.NamespaceDefault
+	requestPod := &v1.Pod{
+		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
 		},
-		ObjectMeta: api.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			Labels: map[string]string{
 				"foo":  "bar",
 				"name": "baz",
@@ -165,9 +166,9 @@ func TestCreatePod(t *testing.T) {
 }
 
 func TestUpdatePod(t *testing.T) {
-	ns := api.NamespaceDefault
-	requestPod := &api.Pod{
-		ObjectMeta: api.ObjectMeta{
+	ns := v1.NamespaceDefault
+	requestPod := &v1.Pod{
+		ObjectMeta: v1.ObjectMeta{
 			Name:            "foo",
 			ResourceVersion: "1",
 			Labels: map[string]string{
@@ -175,8 +176,8 @@ func TestUpdatePod(t *testing.T) {
 				"name": "baz",
 			},
 		},
-		Status: api.PodStatus{
-			Phase: api.PodRunning,
+		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
 		},
 	}
 	c := &testClient{

--- a/pkg/client/v1/portforward/doc.go
+++ b/pkg/client/v1/portforward/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package portforward adds support for SSH-like port forwarding from the client's
+// local host to remote containers.
+package portforward

--- a/pkg/client/v1/portforward/portforward.go
+++ b/pkg/client/v1/portforward/portforward.go
@@ -1,0 +1,324 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portforward
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/api"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/util/httpstream"
+	"k8s.io/kubernetes/pkg/util/httpstream/spdy"
+)
+
+type upgrader interface {
+	upgrade(*client.Request, *client.Config) (httpstream.Connection, error)
+}
+
+type defaultUpgrader struct{}
+
+func (u *defaultUpgrader) upgrade(req *client.Request, config *client.Config) (httpstream.Connection, error) {
+	return req.Upgrade(config, spdy.NewRoundTripper)
+}
+
+// PortForwarder knows how to listen for local connections and forward them to
+// a remote pod via an upgraded HTTP request.
+type PortForwarder struct {
+	req      *client.Request
+	config   *client.Config
+	ports    []ForwardedPort
+	stopChan <-chan struct{}
+
+	streamConn httpstream.Connection
+	listeners  []io.Closer
+	upgrader   upgrader
+	Ready      chan struct{}
+}
+
+// ForwardedPort contains a Local:Remote port pairing.
+type ForwardedPort struct {
+	Local  uint16
+	Remote uint16
+}
+
+/*
+	valid port specifications:
+
+	5000
+	- forwards from localhost:5000 to pod:5000
+
+	8888:5000
+	- forwards from localhost:8888 to pod:5000
+
+	0:5000
+	:5000
+	- selects a random available local port,
+	  forwards from localhost:<random port> to pod:5000
+*/
+func parsePorts(ports []string) ([]ForwardedPort, error) {
+	var forwards []ForwardedPort
+	for _, portString := range ports {
+		parts := strings.Split(portString, ":")
+		var localString, remoteString string
+		if len(parts) == 1 {
+			localString = parts[0]
+			remoteString = parts[0]
+		} else if len(parts) == 2 {
+			localString = parts[0]
+			if localString == "" {
+				// support :5000
+				localString = "0"
+			}
+			remoteString = parts[1]
+		} else {
+			return nil, fmt.Errorf("Invalid port format '%s'", portString)
+		}
+
+		localPort, err := strconv.ParseUint(localString, 10, 16)
+		if err != nil {
+			return nil, fmt.Errorf("Error parsing local port '%s': %s", localString, err)
+		}
+
+		remotePort, err := strconv.ParseUint(remoteString, 10, 16)
+		if err != nil {
+			return nil, fmt.Errorf("Error parsing remote port '%s': %s", remoteString, err)
+		}
+		if remotePort == 0 {
+			return nil, fmt.Errorf("Remote port must be > 0")
+		}
+
+		forwards = append(forwards, ForwardedPort{uint16(localPort), uint16(remotePort)})
+	}
+
+	return forwards, nil
+}
+
+// New creates a new PortForwarder.
+func New(req *client.Request, config *client.Config, ports []string, stopChan <-chan struct{}) (*PortForwarder, error) {
+	if len(ports) == 0 {
+		return nil, errors.New("You must specify at least 1 port")
+	}
+	parsedPorts, err := parsePorts(ports)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PortForwarder{
+		req:      req,
+		config:   config,
+		ports:    parsedPorts,
+		stopChan: stopChan,
+		Ready:    make(chan struct{}),
+	}, nil
+}
+
+// ForwardPorts formats and executes a port forwarding request. The connection will remain
+// open until stopChan is closed.
+func (pf *PortForwarder) ForwardPorts() error {
+	defer pf.Close()
+
+	if pf.upgrader == nil {
+		pf.upgrader = &defaultUpgrader{}
+	}
+	var err error
+	pf.streamConn, err = pf.upgrader.upgrade(pf.req, pf.config)
+	if err != nil {
+		return fmt.Errorf("Error upgrading connection: %s", err)
+	}
+	defer pf.streamConn.Close()
+
+	return pf.forward()
+}
+
+// forward dials the remote host specific in req, upgrades the request, starts
+// listeners for each port specified in ports, and forwards local connections
+// to the remote host via streams.
+func (pf *PortForwarder) forward() error {
+	var err error
+
+	listenSuccess := false
+	for _, port := range pf.ports {
+		err = pf.listenOnPort(&port)
+		switch {
+		case err == nil:
+			listenSuccess = true
+		default:
+			glog.Warningf("Unable to listen on port %d: %v", port.Local, err)
+		}
+	}
+
+	if !listenSuccess {
+		return fmt.Errorf("Unable to listen on any of the requested ports: %v", pf.ports)
+	}
+
+	close(pf.Ready)
+
+	// wait for interrupt or conn closure
+	select {
+	case <-pf.stopChan:
+	case <-pf.streamConn.CloseChan():
+		glog.Errorf("Lost connection to pod")
+	}
+
+	return nil
+}
+
+// listenOnPort delegates tcp4 and tcp6 listener creation and waits for connections on both of these addresses.
+// If both listener creation fail, an error is raised.
+func (pf *PortForwarder) listenOnPort(port *ForwardedPort) error {
+	errTcp4 := pf.listenOnPortAndAddress(port, "tcp4", "127.0.0.1")
+	errTcp6 := pf.listenOnPortAndAddress(port, "tcp6", "[::1]")
+	if errTcp4 != nil && errTcp6 != nil {
+		return fmt.Errorf("All listeners failed to create with the following errors: %s, %s", errTcp4, errTcp6)
+	}
+	return nil
+}
+
+// listenOnPortAndAddress delegates listener creation and waits for new connections
+// in the background f
+func (pf *PortForwarder) listenOnPortAndAddress(port *ForwardedPort, protocol string, address string) error {
+	listener, err := pf.getListener(protocol, address, port)
+	if err != nil {
+		return err
+	}
+	pf.listeners = append(pf.listeners, listener)
+	go pf.waitForConnection(listener, *port)
+	return nil
+}
+
+// getListener creates a listener on the interface targeted by the given hostname on the given port with
+// the given protocol. protocol is in net.Listen style which basically admits values like tcp, tcp4, tcp6
+func (pf *PortForwarder) getListener(protocol string, hostname string, port *ForwardedPort) (net.Listener, error) {
+	listener, err := net.Listen(protocol, fmt.Sprintf("%s:%d", hostname, port.Local))
+	if err != nil {
+		glog.Errorf("Unable to create listener: Error %s", err)
+		return nil, err
+	}
+	listenerAddress := listener.Addr().String()
+	host, localPort, _ := net.SplitHostPort(listenerAddress)
+	localPortUInt, err := strconv.ParseUint(localPort, 10, 16)
+
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing local port: %s from %s (%s)", err, listenerAddress, host)
+	}
+	port.Local = uint16(localPortUInt)
+	glog.Infof("Forwarding from %s:%d -> %d", hostname, localPortUInt, port.Remote)
+
+	return listener, nil
+}
+
+// waitForConnection waits for new connections to listener and handles them in
+// the background.
+func (pf *PortForwarder) waitForConnection(listener net.Listener, port ForwardedPort) {
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			// TODO consider using something like https://github.com/hydrogen18/stoppableListener?
+			if !strings.Contains(strings.ToLower(err.Error()), "use of closed network connection") {
+				glog.Errorf("Error accepting connection on port %d: %v", port.Local, err)
+			}
+			return
+		}
+		go pf.handleConnection(conn, port)
+	}
+}
+
+// handleConnection copies data between the local connection and the stream to
+// the remote server.
+func (pf *PortForwarder) handleConnection(conn net.Conn, port ForwardedPort) {
+	defer conn.Close()
+
+	glog.Infof("Handling connection for %d", port.Local)
+
+	errorChan := make(chan error)
+	doneChan := make(chan struct{}, 2)
+
+	// create error stream
+	headers := http.Header{}
+	headers.Set(api.StreamType, api.StreamTypeError)
+	headers.Set(api.PortHeader, fmt.Sprintf("%d", port.Remote))
+	errorStream, err := pf.streamConn.CreateStream(headers)
+	if err != nil {
+		glog.Errorf("Error creating error stream for port %d -> %d: %v", port.Local, port.Remote, err)
+		return
+	}
+	defer errorStream.Reset()
+	go func() {
+		message, err := ioutil.ReadAll(errorStream)
+		if err != nil && err != io.EOF {
+			errorChan <- fmt.Errorf("Error reading from error stream for port %d -> %d: %v", port.Local, port.Remote, err)
+		}
+		if len(message) > 0 {
+			errorChan <- fmt.Errorf("An error occurred forwarding %d -> %d: %v", port.Local, port.Remote, string(message))
+		}
+	}()
+
+	// create data stream
+	headers.Set(api.StreamType, api.StreamTypeData)
+	dataStream, err := pf.streamConn.CreateStream(headers)
+	if err != nil {
+		glog.Errorf("Error creating forwarding stream for port %d -> %d: %v", port.Local, port.Remote, err)
+		return
+	}
+	// Send a Reset when this function exits to completely tear down the stream here
+	// and in the remote server.
+	defer dataStream.Reset()
+
+	go func() {
+		// Copy from the remote side to the local port. We won't get an EOF from
+		// the server as it has no way of knowing when to close the stream.  We'll
+		// take care of closing both ends of the stream with the call to
+		// stream.Reset() when this function exits.
+		if _, err := io.Copy(conn, dataStream); err != nil && err != io.EOF && !strings.Contains(err.Error(), "use of closed network connection") {
+			glog.Errorf("Error copying from remote stream to local connection: %v", err)
+		}
+		doneChan <- struct{}{}
+	}()
+
+	go func() {
+		// Copy from the local port to the remote side. Here we will be able to know
+		// when the Copy gets an EOF from conn, as that will happen as soon as conn is
+		// closed (i.e. client disconnected).
+		if _, err := io.Copy(dataStream, conn); err != nil && err != io.EOF && !strings.Contains(err.Error(), "use of closed network connection") {
+			glog.Errorf("Error copying from local connection to remote stream: %v", err)
+		}
+		doneChan <- struct{}{}
+	}()
+
+	select {
+	case err := <-errorChan:
+		glog.Error(err)
+	case <-doneChan:
+	}
+}
+
+func (pf *PortForwarder) Close() {
+	// stop all listeners
+	for _, l := range pf.listeners {
+		if err := l.Close(); err != nil {
+			glog.Errorf("Error closing listener: %v", err)
+		}
+	}
+}

--- a/pkg/client/v1/portforward/portforward.go
+++ b/pkg/client/v1/portforward/portforward.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
-	client "k8s.io/kubernetes/pkg/client/unversioned"
+	client "k8s.io/kubernetes/pkg/client/v1"
 	"k8s.io/kubernetes/pkg/util/httpstream"
 	"k8s.io/kubernetes/pkg/util/httpstream/spdy"
 )

--- a/pkg/client/v1/portforward/portforward_test.go
+++ b/pkg/client/v1/portforward/portforward_test.go
@@ -1,0 +1,426 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portforward
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"k8s.io/kubernetes/pkg/api"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/util/httpstream"
+)
+
+func TestParsePortsAndNew(t *testing.T) {
+	tests := []struct {
+		input            []string
+		expected         []ForwardedPort
+		expectParseError bool
+		expectNewError   bool
+	}{
+		{input: []string{}, expectNewError: true},
+		{input: []string{"a"}, expectParseError: true, expectNewError: true},
+		{input: []string{":a"}, expectParseError: true, expectNewError: true},
+		{input: []string{"-1"}, expectParseError: true, expectNewError: true},
+		{input: []string{"65536"}, expectParseError: true, expectNewError: true},
+		{input: []string{"0"}, expectParseError: true, expectNewError: true},
+		{input: []string{"0:0"}, expectParseError: true, expectNewError: true},
+		{input: []string{"a:5000"}, expectParseError: true, expectNewError: true},
+		{input: []string{"5000:a"}, expectParseError: true, expectNewError: true},
+		{
+			input: []string{"5000", "5000:5000", "8888:5000", "5000:8888", ":5000", "0:5000"},
+			expected: []ForwardedPort{
+				{5000, 5000},
+				{5000, 5000},
+				{8888, 5000},
+				{5000, 8888},
+				{0, 5000},
+				{0, 5000},
+			},
+		},
+	}
+
+	for i, test := range tests {
+		parsed, err := parsePorts(test.input)
+		haveError := err != nil
+		if e, a := test.expectParseError, haveError; e != a {
+			t.Fatalf("%d: parsePorts: error expected=%t, got %t: %s", i, e, a, err)
+		}
+
+		expectedRequest := &client.Request{}
+		expectedConfig := &client.Config{}
+		expectedStopChan := make(chan struct{})
+		pf, err := New(expectedRequest, expectedConfig, test.input, expectedStopChan)
+		haveError = err != nil
+		if e, a := test.expectNewError, haveError; e != a {
+			t.Fatalf("%d: New: error expected=%t, got %t: %s", i, e, a, err)
+		}
+
+		if test.expectParseError || test.expectNewError {
+			continue
+		}
+
+		for pi, expectedPort := range test.expected {
+			if e, a := expectedPort.Local, parsed[pi].Local; e != a {
+				t.Fatalf("%d: local expected: %d, got: %d", i, e, a)
+			}
+			if e, a := expectedPort.Remote, parsed[pi].Remote; e != a {
+				t.Fatalf("%d: remote expected: %d, got: %d", i, e, a)
+			}
+		}
+
+		if e, a := expectedRequest, pf.req; e != a {
+			t.Fatalf("%d: req: expected %#v, got %#v", i, e, a)
+		}
+		if e, a := expectedConfig, pf.config; e != a {
+			t.Fatalf("%d: config: expected %#v, got %#v", i, e, a)
+		}
+		if e, a := test.expected, pf.ports; !reflect.DeepEqual(e, a) {
+			t.Fatalf("%d: ports: expected %#v, got %#v", i, e, a)
+		}
+		if e, a := expectedStopChan, pf.stopChan; e != a {
+			t.Fatalf("%d: stopChan: expected %#v, got %#v", i, e, a)
+		}
+		if pf.Ready == nil {
+			t.Fatalf("%d: Ready should be non-nil", i)
+		}
+	}
+}
+
+type fakeUpgrader struct {
+	conn *fakeUpgradeConnection
+	err  error
+}
+
+func (u *fakeUpgrader) upgrade(req *client.Request, config *client.Config) (httpstream.Connection, error) {
+	return u.conn, u.err
+}
+
+type fakeUpgradeConnection struct {
+	closeCalled bool
+	lock        sync.Mutex
+	streams     map[string]*fakeUpgradeStream
+	portData    map[string]string
+}
+
+func newFakeUpgradeConnection() *fakeUpgradeConnection {
+	return &fakeUpgradeConnection{
+		streams:  make(map[string]*fakeUpgradeStream),
+		portData: make(map[string]string),
+	}
+}
+
+func (c *fakeUpgradeConnection) CreateStream(headers http.Header) (httpstream.Stream, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	stream := &fakeUpgradeStream{}
+	c.streams[headers.Get(api.PortHeader)] = stream
+	// only simulate data on the data stream for now, not the error stream
+	if headers.Get(api.StreamType) == api.StreamTypeData {
+		stream.data = c.portData[headers.Get(api.PortHeader)]
+	}
+
+	return stream, nil
+}
+
+func (c *fakeUpgradeConnection) Close() error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	c.closeCalled = true
+	return nil
+}
+
+func (c *fakeUpgradeConnection) CloseChan() <-chan bool {
+	return make(chan bool)
+}
+
+func (c *fakeUpgradeConnection) SetIdleTimeout(timeout time.Duration) {
+}
+
+type fakeUpgradeStream struct {
+	readCalled  bool
+	writeCalled bool
+	dataWritten []byte
+	closeCalled bool
+	resetCalled bool
+	data        string
+	lock        sync.Mutex
+}
+
+func (s *fakeUpgradeStream) Read(p []byte) (int, error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.readCalled = true
+	b := []byte(s.data)
+	n := copy(p, b)
+	// Indicate we returned all the data, and have no more data (EOF)
+	// Returning an EOF here will cause the port forwarder to immediately terminate, which is correct when we have no more data to send
+	return n, io.EOF
+}
+
+func (s *fakeUpgradeStream) Write(p []byte) (int, error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.writeCalled = true
+	s.dataWritten = append(s.dataWritten, p...)
+	// Indicate the stream accepted all the data, and can accept more (no err)
+	// Returning an EOF here will cause the port forwarder to immediately terminate, which is incorrect, in case someone writes more data
+	return len(p), nil
+}
+
+func (s *fakeUpgradeStream) Close() error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.closeCalled = true
+	return nil
+}
+
+func (s *fakeUpgradeStream) Reset() error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.resetCalled = true
+	return nil
+}
+
+func (s *fakeUpgradeStream) Headers() http.Header {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	return http.Header{}
+}
+
+type GetListenerTestCase struct {
+	Hostname                string
+	Protocol                string
+	ShouldRaiseError        bool
+	ExpectedListenerAddress string
+}
+
+func TestGetListener(t *testing.T) {
+	var pf PortForwarder
+	testCases := []GetListenerTestCase{
+		{
+			Hostname:                "localhost",
+			Protocol:                "tcp4",
+			ShouldRaiseError:        false,
+			ExpectedListenerAddress: "127.0.0.1",
+		},
+		{
+			Hostname:                "127.0.0.1",
+			Protocol:                "tcp4",
+			ShouldRaiseError:        false,
+			ExpectedListenerAddress: "127.0.0.1",
+		},
+		{
+			Hostname:                "[::1]",
+			Protocol:                "tcp6",
+			ShouldRaiseError:        false,
+			ExpectedListenerAddress: "::1",
+		},
+		{
+			Hostname:         "[::1]",
+			Protocol:         "tcp4",
+			ShouldRaiseError: true,
+		},
+		{
+			Hostname:         "127.0.0.1",
+			Protocol:         "tcp6",
+			ShouldRaiseError: true,
+		},
+		{
+			// IPv6 address must be put into brackets. This test reveals this.
+			Hostname:         "::1",
+			Protocol:         "tcp6",
+			ShouldRaiseError: true,
+		},
+	}
+
+	for i, testCase := range testCases {
+		expectedListenerPort := "12345"
+		listener, err := pf.getListener(testCase.Protocol, testCase.Hostname, &ForwardedPort{12345, 12345})
+		if err != nil && strings.Contains(err.Error(), "cannot assign requested address") {
+			t.Logf("Can't test #%d: %v", i, err)
+			continue
+		}
+		errorRaised := err != nil
+
+		if testCase.ShouldRaiseError != errorRaised {
+			t.Errorf("Test case #%d failed: Data %v an error has been raised(%t) where it should not (or reciprocally): %v", i, testCase, testCase.ShouldRaiseError, err)
+			continue
+		}
+		if errorRaised {
+			continue
+		}
+
+		if listener == nil {
+			t.Errorf("Test case #%d did not raise an error but failed in initializing listener", i)
+			continue
+		}
+
+		host, port, _ := net.SplitHostPort(listener.Addr().String())
+		t.Logf("Asked a %s forward for: %s:%v, got listener %s:%s, expected: %s", testCase.Protocol, testCase.Hostname, 12345, host, port, expectedListenerPort)
+		if host != testCase.ExpectedListenerAddress {
+			t.Errorf("Test case #%d failed: Listener does not listen on exepected address: asked %v got %v", i, testCase.ExpectedListenerAddress, host)
+		}
+		if port != expectedListenerPort {
+			t.Errorf("Test case #%d failed: Listener does not listen on exepected port: asked %v got %v", i, expectedListenerPort, port)
+
+		}
+		listener.Close()
+
+	}
+}
+
+func TestForwardPorts(t *testing.T) {
+	testCases := []struct {
+		Upgrader *fakeUpgrader
+		Ports    []string
+		Send     map[uint16]string
+		Receive  map[uint16]string
+		Err      bool
+	}{
+		{
+			Upgrader: &fakeUpgrader{err: errors.New("bail")},
+			Err:      true,
+		},
+		{
+			Upgrader: &fakeUpgrader{conn: newFakeUpgradeConnection()},
+			Ports:    []string{"5000"},
+		},
+		{
+			Upgrader: &fakeUpgrader{conn: newFakeUpgradeConnection()},
+			Ports:    []string{"5001", "6000"},
+			Send: map[uint16]string{
+				5001: "abcd",
+				6000: "ghij",
+			},
+			Receive: map[uint16]string{
+				5001: "1234",
+				6000: "5678",
+			},
+		},
+	}
+
+	for i, testCase := range testCases {
+		stopChan := make(chan struct{}, 1)
+
+		pf, err := New(&client.Request{}, &client.Config{}, testCase.Ports, stopChan)
+		hasErr := err != nil
+		if hasErr != testCase.Err {
+			t.Fatalf("%d: New: expected %t, got %t: %v", i, testCase.Err, hasErr, err)
+		}
+		if pf == nil {
+			continue
+		}
+		pf.upgrader = testCase.Upgrader
+		if testCase.Upgrader.err != nil {
+			err := pf.ForwardPorts()
+			hasErr := err != nil
+			if hasErr != testCase.Err {
+				t.Fatalf("%d: ForwardPorts: expected %t, got %t: %v", i, testCase.Err, hasErr, err)
+			}
+			continue
+		}
+
+		doneChan := make(chan error)
+		go func() {
+			doneChan <- pf.ForwardPorts()
+		}()
+		<-pf.Ready
+
+		conn := testCase.Upgrader.conn
+
+		for port, data := range testCase.Send {
+			conn.lock.Lock()
+			conn.portData[fmt.Sprintf("%d", port)] = testCase.Receive[port]
+			conn.lock.Unlock()
+
+			clientConn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", port))
+			if err != nil {
+				t.Fatalf("%d: error dialing %d: %s", i, port, err)
+			}
+			defer clientConn.Close()
+
+			n, err := clientConn.Write([]byte(data))
+			if err != nil && err != io.EOF {
+				t.Fatalf("%d: Error sending data '%s': %s", i, data, err)
+			}
+			if n == 0 {
+				t.Fatalf("%d: unexpected write of 0 bytes", i)
+			}
+			b := make([]byte, 4)
+			n, err = clientConn.Read(b)
+			if err != nil && err != io.EOF {
+				t.Fatalf("%d: Error reading data: %s", i, err)
+			}
+			if !bytes.Equal([]byte(testCase.Receive[port]), b) {
+				t.Fatalf("%d: expected to read '%s', got '%s'", i, testCase.Receive[port], b)
+			}
+		}
+
+		// tell r.ForwardPorts to stop
+		close(stopChan)
+
+		// wait for r.ForwardPorts to actually return
+		err = <-doneChan
+		if err != nil {
+			t.Fatalf("%d: unexpected error: %s", i, err)
+		}
+
+		if e, a := len(testCase.Send), len(conn.streams); e != a {
+			t.Fatalf("%d: expected %d streams to be created, got %d", i, e, a)
+		}
+
+		if !conn.closeCalled {
+			t.Fatalf("%d: expected conn closure", i)
+		}
+	}
+
+}
+
+func TestForwardPortsReturnsErrorWhenAllBindsFailed(t *testing.T) {
+	stopChan1 := make(chan struct{}, 1)
+	defer close(stopChan1)
+
+	pf1, err := New(&client.Request{}, &client.Config{}, []string{"5555"}, stopChan1)
+	if err != nil {
+		t.Fatalf("error creating pf1: %v", err)
+	}
+	pf1.upgrader = &fakeUpgrader{conn: newFakeUpgradeConnection()}
+	go pf1.ForwardPorts()
+	<-pf1.Ready
+
+	stopChan2 := make(chan struct{}, 1)
+	pf2, err := New(&client.Request{}, &client.Config{}, []string{"5555"}, stopChan2)
+	if err != nil {
+		t.Fatalf("error creating pf2: %v", err)
+	}
+	pf2.upgrader = &fakeUpgrader{conn: newFakeUpgradeConnection()}
+	if err := pf2.ForwardPorts(); err == nil {
+		t.Fatal("expected non-nil error for pf2.ForwardPorts")
+	}
+}

--- a/pkg/client/v1/portforward/portforward_test.go
+++ b/pkg/client/v1/portforward/portforward_test.go
@@ -30,7 +30,7 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
-	client "k8s.io/kubernetes/pkg/client/unversioned"
+	client "k8s.io/kubernetes/pkg/client/v1"
 	"k8s.io/kubernetes/pkg/util/httpstream"
 )
 

--- a/pkg/client/v1/remotecommand/doc.go
+++ b/pkg/client/v1/remotecommand/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package remotecommand adds support for executing commands in containers,
+// with support for separate stdin, stdout, and stderr streams, as well as
+// TTY.
+package remotecommand

--- a/pkg/client/v1/remotecommand/remotecommand.go
+++ b/pkg/client/v1/remotecommand/remotecommand.go
@@ -1,0 +1,265 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remotecommand
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"sync"
+
+	"k8s.io/kubernetes/pkg/api"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/conversion/queryparams"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/httpstream"
+	"k8s.io/kubernetes/pkg/util/httpstream/spdy"
+)
+
+type upgrader interface {
+	upgrade(*client.Request, *client.Config) (httpstream.Connection, error)
+}
+
+type defaultUpgrader struct{}
+
+func (u *defaultUpgrader) upgrade(req *client.Request, config *client.Config) (httpstream.Connection, error) {
+	return req.Upgrade(config, spdy.NewRoundTripper)
+}
+
+type Streamer struct {
+	req    *client.Request
+	config *client.Config
+	stdin  io.Reader
+	stdout io.Writer
+	stderr io.Writer
+	tty    bool
+
+	upgrader upgrader
+}
+
+// Executor executes a command on a pod container
+type Executor struct {
+	Streamer
+	command []string
+}
+
+// New creates a new RemoteCommandExecutor
+func New(req *client.Request, config *client.Config, command []string, stdin io.Reader, stdout, stderr io.Writer, tty bool) *Executor {
+	return &Executor{
+		command: command,
+		Streamer: Streamer{
+			req:    req,
+			config: config,
+			stdin:  stdin,
+			stdout: stdout,
+			stderr: stderr,
+			tty:    tty,
+		},
+	}
+}
+
+type Attach struct {
+	Streamer
+}
+
+// NewAttach creates a new RemoteAttach
+func NewAttach(req *client.Request, config *client.Config, stdin io.Reader, stdout, stderr io.Writer, tty bool) *Attach {
+	return &Attach{
+		Streamer: Streamer{
+			req:    req,
+			config: config,
+			stdin:  stdin,
+			stdout: stdout,
+			stderr: stderr,
+			tty:    tty,
+		},
+	}
+}
+
+// Execute sends a remote command execution request, upgrading the
+// connection and creating streams to represent stdin/stdout/stderr. Data is
+// copied between these streams and the supplied stdin/stdout/stderr parameters.
+func (e *Attach) Execute() error {
+	opts := api.PodAttachOptions{
+		Stdin:  (e.stdin != nil),
+		Stdout: (e.stdout != nil),
+		Stderr: (!e.tty && e.stderr != nil),
+		TTY:    e.tty,
+	}
+
+	if err := e.setupRequestParameters(&opts); err != nil {
+		return err
+	}
+
+	return e.doStream()
+}
+
+// Execute sends a remote command execution request, upgrading the
+// connection and creating streams to represent stdin/stdout/stderr. Data is
+// copied between these streams and the supplied stdin/stdout/stderr parameters.
+func (e *Executor) Execute() error {
+	opts := api.PodExecOptions{
+		Stdin:   (e.stdin != nil),
+		Stdout:  (e.stdout != nil),
+		Stderr:  (!e.tty && e.stderr != nil),
+		TTY:     e.tty,
+		Command: e.command,
+	}
+
+	if err := e.setupRequestParameters(&opts); err != nil {
+		return err
+	}
+
+	return e.doStream()
+}
+
+func (e *Streamer) setupRequestParameters(obj runtime.Object) error {
+	versioned, err := api.Scheme.ConvertToVersion(obj, e.config.Version)
+	if err != nil {
+		return err
+	}
+	params, err := queryparams.Convert(versioned)
+	if err != nil {
+		return err
+	}
+	for k, v := range params {
+		for _, vv := range v {
+			e.req.Param(k, vv)
+		}
+	}
+	return nil
+}
+
+func (e *Streamer) doStream() error {
+	if e.upgrader == nil {
+		e.upgrader = &defaultUpgrader{}
+	}
+	conn, err := e.upgrader.upgrade(e.req, e.config)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	headers := http.Header{}
+
+	// set up error stream
+	errorChan := make(chan error)
+	headers.Set(api.StreamType, api.StreamTypeError)
+	errorStream, err := conn.CreateStream(headers)
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		message, err := ioutil.ReadAll(errorStream)
+		switch {
+		case err != nil && err != io.EOF:
+			errorChan <- fmt.Errorf("error reading from error stream: %s", err)
+		case len(message) > 0:
+			errorChan <- fmt.Errorf("error executing remote command: %s", message)
+		default:
+			errorChan <- nil
+		}
+		close(errorChan)
+	}()
+
+	var wg sync.WaitGroup
+	var once sync.Once
+
+	// set up stdin stream
+	if e.stdin != nil {
+		headers.Set(api.StreamType, api.StreamTypeStdin)
+		remoteStdin, err := conn.CreateStream(headers)
+		if err != nil {
+			return err
+		}
+
+		// copy from client's stdin to container's stdin
+		go func() {
+			// if e.stdin is noninteractive, e.g. `echo abc | kubectl exec -i <pod> -- cat`, make sure
+			// we close remoteStdin as soon as the copy from e.stdin to remoteStdin finishes. Otherwise
+			// the executed command will remain running.
+			defer once.Do(func() { remoteStdin.Close() })
+
+			if _, err := io.Copy(remoteStdin, e.stdin); err != nil {
+				util.HandleError(err)
+			}
+		}()
+
+		// read from remoteStdin until the stream is closed. this is essential to
+		// be able to exit interactive sessions cleanly and not leak goroutines or
+		// hang the client's terminal.
+		//
+		// go-dockerclient's current hijack implementation
+		// (https://github.com/fsouza/go-dockerclient/blob/89f3d56d93788dfe85f864a44f85d9738fca0670/client.go#L564)
+		// waits for all three streams (stdin/stdout/stderr) to finish copying
+		// before returning. When hijack finishes copying stdout/stderr, it calls
+		// Close() on its side of remoteStdin, which allows this copy to complete.
+		// When that happens, we must Close() on our side of remoteStdin, to
+		// allow the copy in hijack to complete, and hijack to return.
+		go func() {
+			defer once.Do(func() { remoteStdin.Close() })
+			// this "copy" doesn't actually read anything - it's just here to wait for
+			// the server to close remoteStdin.
+			if _, err := io.Copy(ioutil.Discard, remoteStdin); err != nil {
+				util.HandleError(err)
+			}
+		}()
+	}
+
+	// set up stdout stream
+	if e.stdout != nil {
+		headers.Set(api.StreamType, api.StreamTypeStdout)
+		remoteStdout, err := conn.CreateStream(headers)
+		if err != nil {
+			return err
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := io.Copy(e.stdout, remoteStdout); err != nil {
+				util.HandleError(err)
+			}
+		}()
+	}
+
+	// set up stderr stream
+	if e.stderr != nil && !e.tty {
+		headers.Set(api.StreamType, api.StreamTypeStderr)
+		remoteStderr, err := conn.CreateStream(headers)
+		if err != nil {
+			return err
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := io.Copy(e.stderr, remoteStderr); err != nil {
+				util.HandleError(err)
+			}
+		}()
+	}
+
+	// we're waiting for stdout/stderr to finish copying
+	wg.Wait()
+
+	// waits for errorStream to finish reading with an error or nil
+	return <-errorChan
+}

--- a/pkg/client/v1/remotecommand/remotecommand.go
+++ b/pkg/client/v1/remotecommand/remotecommand.go
@@ -24,7 +24,7 @@ import (
 	"sync"
 
 	"k8s.io/kubernetes/pkg/api"
-	client "k8s.io/kubernetes/pkg/client/unversioned"
+	client "k8s.io/kubernetes/pkg/client/v1"
 	"k8s.io/kubernetes/pkg/conversion/queryparams"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"

--- a/pkg/client/v1/remotecommand/remotecommand_test.go
+++ b/pkg/client/v1/remotecommand/remotecommand_test.go
@@ -1,0 +1,303 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remotecommand
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/util/httpstream"
+	"k8s.io/kubernetes/pkg/util/httpstream/spdy"
+)
+
+func fakeExecServer(t *testing.T, i int, stdinData, stdoutData, stderrData, errorData string, tty bool, messageCount int) http.HandlerFunc {
+	// error + stdin + stdout
+	expectedStreams := 3
+	if !tty {
+		// stderr
+		expectedStreams++
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		streamCh := make(chan httpstream.Stream)
+
+		upgrader := spdy.NewResponseUpgrader()
+		conn := upgrader.UpgradeResponse(w, req, func(stream httpstream.Stream) error {
+			streamCh <- stream
+			return nil
+		})
+		// from this point on, we can no longer call methods on w
+		if conn == nil {
+			// The upgrader is responsible for notifying the client of any errors that
+			// occurred during upgrading. All we can do is return here at this point
+			// if we weren't successful in upgrading.
+			return
+		}
+		defer conn.Close()
+
+		var errorStream, stdinStream, stdoutStream, stderrStream httpstream.Stream
+		receivedStreams := 0
+	WaitForStreams:
+		for {
+			select {
+			case stream := <-streamCh:
+				streamType := stream.Headers().Get(api.StreamType)
+				switch streamType {
+				case api.StreamTypeError:
+					errorStream = stream
+					receivedStreams++
+				case api.StreamTypeStdin:
+					stdinStream = stream
+					receivedStreams++
+				case api.StreamTypeStdout:
+					stdoutStream = stream
+					receivedStreams++
+				case api.StreamTypeStderr:
+					stderrStream = stream
+					receivedStreams++
+				default:
+					t.Errorf("%d: unexpected stream type: %q", i, streamType)
+				}
+
+				if receivedStreams == expectedStreams {
+					break WaitForStreams
+				}
+			}
+		}
+
+		if len(errorData) > 0 {
+			n, err := fmt.Fprint(errorStream, errorData)
+			if err != nil {
+				t.Errorf("%d: error writing to errorStream: %v", i, err)
+			}
+			if e, a := len(errorData), n; e != a {
+				t.Errorf("%d: expected to write %d bytes to errorStream, but only wrote %d", i, e, a)
+			}
+			errorStream.Close()
+		}
+
+		if len(stdoutData) > 0 {
+			for j := 0; j < messageCount; j++ {
+				n, err := fmt.Fprint(stdoutStream, stdoutData)
+				if err != nil {
+					t.Errorf("%d: error writing to stdoutStream: %v", i, err)
+				}
+				if e, a := len(stdoutData), n; e != a {
+					t.Errorf("%d: expected to write %d bytes to stdoutStream, but only wrote %d", i, e, a)
+				}
+			}
+			stdoutStream.Close()
+		}
+		if len(stderrData) > 0 {
+			for j := 0; j < messageCount; j++ {
+				n, err := fmt.Fprint(stderrStream, stderrData)
+				if err != nil {
+					t.Errorf("%d: error writing to stderrStream: %v", i, err)
+				}
+				if e, a := len(stderrData), n; e != a {
+					t.Errorf("%d: expected to write %d bytes to stderrStream, but only wrote %d", i, e, a)
+				}
+			}
+			stderrStream.Close()
+		}
+		if len(stdinData) > 0 {
+			data := make([]byte, len(stdinData))
+			for j := 0; j < messageCount; j++ {
+				n, err := io.ReadFull(stdinStream, data)
+				if err != nil {
+					t.Errorf("%d: error reading stdin stream: %v", i, err)
+				}
+				if e, a := len(stdinData), n; e != a {
+					t.Errorf("%d: expected to read %d bytes from stdinStream, but only read %d", i, e, a)
+				}
+				if e, a := stdinData, string(data); e != a {
+					t.Errorf("%d: stdin: expected %q, got %q", i, e, a)
+				}
+			}
+			stdinStream.Close()
+		}
+	})
+}
+
+func TestRequestExecuteRemoteCommand(t *testing.T) {
+	testCases := []struct {
+		Stdin        string
+		Stdout       string
+		Stderr       string
+		Error        string
+		Tty          bool
+		MessageCount int
+	}{
+		{
+			Error: "bail",
+		},
+		{
+			Stdin:  "a",
+			Stdout: "b",
+			Stderr: "c",
+			// TODO bump this to a larger number such as 100 once
+			// https://github.com/docker/spdystream/issues/55 is fixed and the Godep
+			// is bumped. Sending multiple messages over stdin/stdout/stderr results
+			// in more frames being spread across multiple spdystream frame workers.
+			// This makes it more likely that the spdystream bug will be encountered,
+			// where streams are closed as soon as a goaway frame is received, and
+			// any pending frames that haven't been processed yet may not be
+			// delivered (it's a race).
+			MessageCount: 1,
+		},
+		{
+			Stdin:  "a",
+			Stdout: "b",
+			Tty:    true,
+		},
+	}
+
+	for i, testCase := range testCases {
+		localOut := &bytes.Buffer{}
+		localErr := &bytes.Buffer{}
+
+		server := httptest.NewServer(fakeExecServer(t, i, testCase.Stdin, testCase.Stdout, testCase.Stderr, testCase.Error, testCase.Tty, testCase.MessageCount))
+
+		url, _ := url.ParseRequestURI(server.URL)
+		c := client.NewRESTClient(url, "x", nil, -1, -1)
+		req := c.Post().Resource("testing")
+
+		conf := &client.Config{
+			Host: server.URL,
+		}
+		e := New(req, conf, []string{"ls", "/"}, strings.NewReader(strings.Repeat(testCase.Stdin, testCase.MessageCount)), localOut, localErr, testCase.Tty)
+		err := e.Execute()
+		hasErr := err != nil
+
+		if len(testCase.Error) > 0 {
+			if !hasErr {
+				t.Errorf("%d: expected an error", i)
+			} else {
+				if e, a := testCase.Error, err.Error(); !strings.Contains(a, e) {
+					t.Errorf("%d: expected error stream read '%v', got '%v'", i, e, a)
+				}
+			}
+
+			server.Close()
+			continue
+		}
+
+		if hasErr {
+			t.Errorf("%d: unexpected error: %v", i, err)
+			server.Close()
+			continue
+		}
+
+		if len(testCase.Stdout) > 0 {
+			if e, a := strings.Repeat(testCase.Stdout, testCase.MessageCount), localOut; e != a.String() {
+				t.Errorf("%d: expected stdout data '%s', got '%s'", i, e, a)
+			}
+		}
+
+		if testCase.Stderr != "" {
+			if e, a := strings.Repeat(testCase.Stderr, testCase.MessageCount), localErr; e != a.String() {
+				t.Errorf("%d: expected stderr data '%s', got '%s'", i, e, a)
+			}
+		}
+
+		server.Close()
+	}
+}
+
+// TODO: this test is largely cut and paste, refactor to share code
+func TestRequestAttachRemoteCommand(t *testing.T) {
+	testCases := []struct {
+		Stdin  string
+		Stdout string
+		Stderr string
+		Error  string
+		Tty    bool
+	}{
+		{
+			Error: "bail",
+		},
+		{
+			Stdin:  "a",
+			Stdout: "b",
+			Stderr: "c",
+		},
+		{
+			Stdin:  "a",
+			Stdout: "b",
+			Tty:    true,
+		},
+	}
+
+	for i, testCase := range testCases {
+		localOut := &bytes.Buffer{}
+		localErr := &bytes.Buffer{}
+
+		server := httptest.NewServer(fakeExecServer(t, i, testCase.Stdin, testCase.Stdout, testCase.Stderr, testCase.Error, testCase.Tty, 1))
+
+		url, _ := url.ParseRequestURI(server.URL)
+		c := client.NewRESTClient(url, "x", nil, -1, -1)
+		req := c.Post().Resource("testing")
+
+		conf := &client.Config{
+			Host: server.URL,
+		}
+		e := NewAttach(req, conf, strings.NewReader(testCase.Stdin), localOut, localErr, testCase.Tty)
+		err := e.Execute()
+		hasErr := err != nil
+
+		if len(testCase.Error) > 0 {
+			if !hasErr {
+				t.Errorf("%d: expected an error", i)
+			} else {
+				if e, a := testCase.Error, err.Error(); !strings.Contains(a, e) {
+					t.Errorf("%d: expected error stream read '%v', got '%v'", i, e, a)
+				}
+			}
+
+			server.Close()
+			continue
+		}
+
+		if hasErr {
+			t.Errorf("%d: unexpected error: %v", i, err)
+			server.Close()
+			continue
+		}
+
+		if len(testCase.Stdout) > 0 {
+			if e, a := testCase.Stdout, localOut; e != a.String() {
+				t.Errorf("%d: expected stdout data '%s', got '%s'", i, e, a)
+			}
+		}
+
+		if testCase.Stderr != "" {
+			if e, a := testCase.Stderr, localErr; e != a.String() {
+				t.Errorf("%d: expected stderr data '%s', got '%s'", i, e, a)
+			}
+		}
+
+		server.Close()
+	}
+}

--- a/pkg/client/v1/remotecommand/remotecommand_test.go
+++ b/pkg/client/v1/remotecommand/remotecommand_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
-	client "k8s.io/kubernetes/pkg/client/unversioned"
+	client "k8s.io/kubernetes/pkg/client/v1"
 	"k8s.io/kubernetes/pkg/util/httpstream"
 	"k8s.io/kubernetes/pkg/util/httpstream/spdy"
 )

--- a/pkg/client/v1/replication_controllers.go
+++ b/pkg/client/v1/replication_controllers.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// ReplicationControllersNamespacer has methods to work with ReplicationController resources in a namespace
+type ReplicationControllersNamespacer interface {
+	ReplicationControllers(namespace string) ReplicationControllerInterface
+}
+
+// ReplicationControllerInterface has methods to work with ReplicationController resources.
+type ReplicationControllerInterface interface {
+	List(selector labels.Selector) (*api.ReplicationControllerList, error)
+	Get(name string) (*api.ReplicationController, error)
+	Create(ctrl *api.ReplicationController) (*api.ReplicationController, error)
+	Update(ctrl *api.ReplicationController) (*api.ReplicationController, error)
+	Delete(name string) error
+	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
+}
+
+// replicationControllers implements ReplicationControllersNamespacer interface
+type replicationControllers struct {
+	r  *Client
+	ns string
+}
+
+// newReplicationControllers returns a PodsClient
+func newReplicationControllers(c *Client, namespace string) *replicationControllers {
+	return &replicationControllers{c, namespace}
+}
+
+// List takes a selector, and returns the list of replication controllers that match that selector.
+func (c *replicationControllers) List(selector labels.Selector) (result *api.ReplicationControllerList, err error) {
+	result = &api.ReplicationControllerList{}
+	err = c.r.Get().Namespace(c.ns).Resource("replicationControllers").LabelsSelectorParam(selector).Do().Into(result)
+	return
+}
+
+// Get returns information about a particular replication controller.
+func (c *replicationControllers) Get(name string) (result *api.ReplicationController, err error) {
+	result = &api.ReplicationController{}
+	err = c.r.Get().Namespace(c.ns).Resource("replicationControllers").Name(name).Do().Into(result)
+	return
+}
+
+// Create creates a new replication controller.
+func (c *replicationControllers) Create(controller *api.ReplicationController) (result *api.ReplicationController, err error) {
+	result = &api.ReplicationController{}
+	err = c.r.Post().Namespace(c.ns).Resource("replicationControllers").Body(controller).Do().Into(result)
+	return
+}
+
+// Update updates an existing replication controller.
+func (c *replicationControllers) Update(controller *api.ReplicationController) (result *api.ReplicationController, err error) {
+	result = &api.ReplicationController{}
+	err = c.r.Put().Namespace(c.ns).Resource("replicationControllers").Name(controller.Name).Body(controller).Do().Into(result)
+	return
+}
+
+// Delete deletes an existing replication controller.
+func (c *replicationControllers) Delete(name string) error {
+	return c.r.Delete().Namespace(c.ns).Resource("replicationControllers").Name(name).Do().Error()
+}
+
+// Watch returns a watch.Interface that watches the requested controllers.
+func (c *replicationControllers) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.r.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("replicationControllers").
+		Param("resourceVersion", resourceVersion).
+		LabelsSelectorParam(label).
+		FieldsSelectorParam(field).
+		Watch()
+}

--- a/pkg/client/v1/replication_controllers.go
+++ b/pkg/client/v1/replication_controllers.go
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
-	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/watch"
@@ -30,10 +30,10 @@ type ReplicationControllersNamespacer interface {
 
 // ReplicationControllerInterface has methods to work with ReplicationController resources.
 type ReplicationControllerInterface interface {
-	List(selector labels.Selector) (*api.ReplicationControllerList, error)
-	Get(name string) (*api.ReplicationController, error)
-	Create(ctrl *api.ReplicationController) (*api.ReplicationController, error)
-	Update(ctrl *api.ReplicationController) (*api.ReplicationController, error)
+	List(selector labels.Selector) (*v1.ReplicationControllerList, error)
+	Get(name string) (*v1.ReplicationController, error)
+	Create(ctrl *v1.ReplicationController) (*v1.ReplicationController, error)
+	Update(ctrl *v1.ReplicationController) (*v1.ReplicationController, error)
 	Delete(name string) error
 	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
 }
@@ -50,29 +50,29 @@ func newReplicationControllers(c *Client, namespace string) *replicationControll
 }
 
 // List takes a selector, and returns the list of replication controllers that match that selector.
-func (c *replicationControllers) List(selector labels.Selector) (result *api.ReplicationControllerList, err error) {
-	result = &api.ReplicationControllerList{}
+func (c *replicationControllers) List(selector labels.Selector) (result *v1.ReplicationControllerList, err error) {
+	result = &v1.ReplicationControllerList{}
 	err = c.r.Get().Namespace(c.ns).Resource("replicationControllers").LabelsSelectorParam(selector).Do().Into(result)
 	return
 }
 
 // Get returns information about a particular replication controller.
-func (c *replicationControllers) Get(name string) (result *api.ReplicationController, err error) {
-	result = &api.ReplicationController{}
+func (c *replicationControllers) Get(name string) (result *v1.ReplicationController, err error) {
+	result = &v1.ReplicationController{}
 	err = c.r.Get().Namespace(c.ns).Resource("replicationControllers").Name(name).Do().Into(result)
 	return
 }
 
 // Create creates a new replication controller.
-func (c *replicationControllers) Create(controller *api.ReplicationController) (result *api.ReplicationController, err error) {
-	result = &api.ReplicationController{}
+func (c *replicationControllers) Create(controller *v1.ReplicationController) (result *v1.ReplicationController, err error) {
+	result = &v1.ReplicationController{}
 	err = c.r.Post().Namespace(c.ns).Resource("replicationControllers").Body(controller).Do().Into(result)
 	return
 }
 
 // Update updates an existing replication controller.
-func (c *replicationControllers) Update(controller *api.ReplicationController) (result *api.ReplicationController, err error) {
-	result = &api.ReplicationController{}
+func (c *replicationControllers) Update(controller *v1.ReplicationController) (result *v1.ReplicationController, err error) {
+	result = &v1.ReplicationController{}
 	err = c.r.Put().Namespace(c.ns).Resource("replicationControllers").Name(controller.Name).Body(controller).Do().Into(result)
 	return
 }

--- a/pkg/client/v1/replication_controllers_test.go
+++ b/pkg/client/v1/replication_controllers_test.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func getRCResourceName() string {
+	return "replicationcontrollers"
+}
+
+func TestListControllers(t *testing.T) {
+	ns := api.NamespaceAll
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath(getRCResourceName(), ns, ""),
+		},
+		Response: Response{StatusCode: 200,
+			Body: &api.ReplicationControllerList{
+				Items: []api.ReplicationController{
+					{
+						ObjectMeta: api.ObjectMeta{
+							Name: "foo",
+							Labels: map[string]string{
+								"foo":  "bar",
+								"name": "baz",
+							},
+						},
+						Spec: api.ReplicationControllerSpec{
+							Replicas: 2,
+							Template: &api.PodTemplateSpec{},
+						},
+					},
+				},
+			},
+		},
+	}
+	receivedControllerList, err := c.Setup(t).ReplicationControllers(ns).List(labels.Everything())
+	c.Validate(t, receivedControllerList, err)
+
+}
+
+func TestGetController(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request: testRequest{Method: "GET", Path: testapi.Default.ResourcePath(getRCResourceName(), ns, "foo"), Query: buildQueryValues(nil)},
+		Response: Response{
+			StatusCode: 200,
+			Body: &api.ReplicationController{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo":  "bar",
+						"name": "baz",
+					},
+				},
+				Spec: api.ReplicationControllerSpec{
+					Replicas: 2,
+					Template: &api.PodTemplateSpec{},
+				},
+			},
+		},
+	}
+	receivedController, err := c.Setup(t).ReplicationControllers(ns).Get("foo")
+	c.Validate(t, receivedController, err)
+}
+
+func TestGetControllerWithNoName(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{Error: true}
+	receivedPod, err := c.Setup(t).ReplicationControllers(ns).Get("")
+	if (err != nil) && (err.Error() != nameRequiredError) {
+		t.Errorf("Expected error: %v, but got %v", nameRequiredError, err)
+	}
+
+	c.Validate(t, receivedPod, err)
+}
+
+func TestUpdateController(t *testing.T) {
+	ns := api.NamespaceDefault
+	requestController := &api.ReplicationController{
+		ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "1"},
+	}
+	c := &testClient{
+		Request: testRequest{Method: "PUT", Path: testapi.Default.ResourcePath(getRCResourceName(), ns, "foo"), Query: buildQueryValues(nil)},
+		Response: Response{
+			StatusCode: 200,
+			Body: &api.ReplicationController{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo":  "bar",
+						"name": "baz",
+					},
+				},
+				Spec: api.ReplicationControllerSpec{
+					Replicas: 2,
+					Template: &api.PodTemplateSpec{},
+				},
+			},
+		},
+	}
+	receivedController, err := c.Setup(t).ReplicationControllers(ns).Update(requestController)
+	c.Validate(t, receivedController, err)
+}
+
+func TestDeleteController(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request:  testRequest{Method: "DELETE", Path: testapi.Default.ResourcePath(getRCResourceName(), ns, "foo"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200},
+	}
+	err := c.Setup(t).ReplicationControllers(ns).Delete("foo")
+	c.Validate(t, nil, err)
+}
+
+func TestCreateController(t *testing.T) {
+	ns := api.NamespaceDefault
+	requestController := &api.ReplicationController{
+		ObjectMeta: api.ObjectMeta{Name: "foo"},
+	}
+	c := &testClient{
+		Request: testRequest{Method: "POST", Path: testapi.Default.ResourcePath(getRCResourceName(), ns, ""), Body: requestController, Query: buildQueryValues(nil)},
+		Response: Response{
+			StatusCode: 200,
+			Body: &api.ReplicationController{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo":  "bar",
+						"name": "baz",
+					},
+				},
+				Spec: api.ReplicationControllerSpec{
+					Replicas: 2,
+					Template: &api.PodTemplateSpec{},
+				},
+			},
+		},
+	}
+	receivedController, err := c.Setup(t).ReplicationControllers(ns).Create(requestController)
+	c.Validate(t, receivedController, err)
+}

--- a/pkg/client/v1/replication_controllers_test.go
+++ b/pkg/client/v1/replication_controllers_test.go
@@ -14,13 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"testing"
 
-	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/labels"
 )
 
@@ -29,26 +29,26 @@ func getRCResourceName() string {
 }
 
 func TestListControllers(t *testing.T) {
-	ns := api.NamespaceAll
+	ns := v1.NamespaceAll
 	c := &testClient{
 		Request: testRequest{
 			Method: "GET",
 			Path:   testapi.Default.ResourcePath(getRCResourceName(), ns, ""),
 		},
 		Response: Response{StatusCode: 200,
-			Body: &api.ReplicationControllerList{
-				Items: []api.ReplicationController{
+			Body: &v1.ReplicationControllerList{
+				Items: []v1.ReplicationController{
 					{
-						ObjectMeta: api.ObjectMeta{
+						ObjectMeta: v1.ObjectMeta{
 							Name: "foo",
 							Labels: map[string]string{
 								"foo":  "bar",
 								"name": "baz",
 							},
 						},
-						Spec: api.ReplicationControllerSpec{
-							Replicas: 2,
-							Template: &api.PodTemplateSpec{},
+						Spec: v1.ReplicationControllerSpec{
+							Replicas: intPointer(2),
+							Template: &v1.PodTemplateSpec{},
 						},
 					},
 				},
@@ -61,22 +61,22 @@ func TestListControllers(t *testing.T) {
 }
 
 func TestGetController(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	c := &testClient{
 		Request: testRequest{Method: "GET", Path: testapi.Default.ResourcePath(getRCResourceName(), ns, "foo"), Query: buildQueryValues(nil)},
 		Response: Response{
 			StatusCode: 200,
-			Body: &api.ReplicationController{
-				ObjectMeta: api.ObjectMeta{
+			Body: &v1.ReplicationController{
+				ObjectMeta: v1.ObjectMeta{
 					Name: "foo",
 					Labels: map[string]string{
 						"foo":  "bar",
 						"name": "baz",
 					},
 				},
-				Spec: api.ReplicationControllerSpec{
-					Replicas: 2,
-					Template: &api.PodTemplateSpec{},
+				Spec: v1.ReplicationControllerSpec{
+					Replicas: intPointer(2),
+					Template: &v1.PodTemplateSpec{},
 				},
 			},
 		},
@@ -86,7 +86,7 @@ func TestGetController(t *testing.T) {
 }
 
 func TestGetControllerWithNoName(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	c := &testClient{Error: true}
 	receivedPod, err := c.Setup(t).ReplicationControllers(ns).Get("")
 	if (err != nil) && (err.Error() != nameRequiredError) {
@@ -97,25 +97,25 @@ func TestGetControllerWithNoName(t *testing.T) {
 }
 
 func TestUpdateController(t *testing.T) {
-	ns := api.NamespaceDefault
-	requestController := &api.ReplicationController{
-		ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "1"},
+	ns := v1.NamespaceDefault
+	requestController := &v1.ReplicationController{
+		ObjectMeta: v1.ObjectMeta{Name: "foo", ResourceVersion: "1"},
 	}
 	c := &testClient{
 		Request: testRequest{Method: "PUT", Path: testapi.Default.ResourcePath(getRCResourceName(), ns, "foo"), Query: buildQueryValues(nil)},
 		Response: Response{
 			StatusCode: 200,
-			Body: &api.ReplicationController{
-				ObjectMeta: api.ObjectMeta{
+			Body: &v1.ReplicationController{
+				ObjectMeta: v1.ObjectMeta{
 					Name: "foo",
 					Labels: map[string]string{
 						"foo":  "bar",
 						"name": "baz",
 					},
 				},
-				Spec: api.ReplicationControllerSpec{
-					Replicas: 2,
-					Template: &api.PodTemplateSpec{},
+				Spec: v1.ReplicationControllerSpec{
+					Replicas: intPointer(2),
+					Template: &v1.PodTemplateSpec{},
 				},
 			},
 		},
@@ -125,7 +125,7 @@ func TestUpdateController(t *testing.T) {
 }
 
 func TestDeleteController(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	c := &testClient{
 		Request:  testRequest{Method: "DELETE", Path: testapi.Default.ResourcePath(getRCResourceName(), ns, "foo"), Query: buildQueryValues(nil)},
 		Response: Response{StatusCode: 200},
@@ -135,25 +135,25 @@ func TestDeleteController(t *testing.T) {
 }
 
 func TestCreateController(t *testing.T) {
-	ns := api.NamespaceDefault
-	requestController := &api.ReplicationController{
-		ObjectMeta: api.ObjectMeta{Name: "foo"},
+	ns := v1.NamespaceDefault
+	requestController := &v1.ReplicationController{
+		ObjectMeta: v1.ObjectMeta{Name: "foo"},
 	}
 	c := &testClient{
 		Request: testRequest{Method: "POST", Path: testapi.Default.ResourcePath(getRCResourceName(), ns, ""), Body: requestController, Query: buildQueryValues(nil)},
 		Response: Response{
 			StatusCode: 200,
-			Body: &api.ReplicationController{
-				ObjectMeta: api.ObjectMeta{
+			Body: &v1.ReplicationController{
+				ObjectMeta: v1.ObjectMeta{
 					Name: "foo",
 					Labels: map[string]string{
 						"foo":  "bar",
 						"name": "baz",
 					},
 				},
-				Spec: api.ReplicationControllerSpec{
-					Replicas: 2,
-					Template: &api.PodTemplateSpec{},
+				Spec: v1.ReplicationControllerSpec{
+					Replicas: intPointer(2),
+					Template: &v1.PodTemplateSpec{},
 				},
 			},
 		},
@@ -161,3 +161,5 @@ func TestCreateController(t *testing.T) {
 	receivedController, err := c.Setup(t).ReplicationControllers(ns).Create(requestController)
 	c.Validate(t, receivedController, err)
 }
+
+func intPointer(x int) *int { return &x }

--- a/pkg/client/v1/request.go
+++ b/pkg/client/v1/request.go
@@ -1,0 +1,906 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"mime"
+	"net/http"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/client/metrics"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/httpstream"
+	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/watch"
+	watchjson "k8s.io/kubernetes/pkg/watch/json"
+)
+
+// specialParams lists parameters that are handled specially and which users of Request
+// are therefore not allowed to set manually.
+var specialParams = sets.NewString("timeout")
+
+// HTTPClient is an interface for testing a request object.
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// ResponseWrapper is an interface for getting a response.
+// The response may be either accessed as a raw data (the whole output is put into memory) or as a stream.
+type ResponseWrapper interface {
+	DoRaw() ([]byte, error)
+	Stream() (io.ReadCloser, error)
+}
+
+// RequestConstructionError is returned when there's an error assembling a request.
+type RequestConstructionError struct {
+	Err error
+}
+
+// Error returns a textual description of 'r'.
+func (r *RequestConstructionError) Error() string {
+	return fmt.Sprintf("request construction error: '%v'", r.Err)
+}
+
+// Request allows for building up a request to a server in a chained fashion.
+// Any errors are stored until the end of your call, so you only have to
+// check once.
+type Request struct {
+	// required
+	client  HTTPClient
+	verb    string
+	baseURL *url.URL
+	codec   runtime.Codec
+
+	// generic components accessible via method setters
+	path    string
+	subpath string
+	params  url.Values
+	headers http.Header
+
+	// structural elements of the request that are part of the Kubernetes API conventions
+	namespace    string
+	namespaceSet bool
+	resource     string
+	resourceName string
+	subresource  string
+	selector     labels.Selector
+	timeout      time.Duration
+
+	apiVersion string
+
+	// output
+	err  error
+	body io.Reader
+
+	// The constructed request and the response
+	req  *http.Request
+	resp *http.Response
+}
+
+// NewRequest creates a new request helper object for accessing runtime.Objects on a server.
+func NewRequest(client HTTPClient, verb string, baseURL *url.URL, apiVersion string,
+	codec runtime.Codec) *Request {
+	metrics.Register()
+	return &Request{
+		client:     client,
+		verb:       verb,
+		baseURL:    baseURL,
+		path:       baseURL.Path,
+		apiVersion: apiVersion,
+		codec:      codec,
+	}
+}
+
+// Prefix adds segments to the relative beginning to the request path. These
+// items will be placed before the optional Namespace, Resource, or Name sections.
+// Setting AbsPath will clear any previously set Prefix segments
+func (r *Request) Prefix(segments ...string) *Request {
+	if r.err != nil {
+		return r
+	}
+	r.path = path.Join(r.path, path.Join(segments...))
+	return r
+}
+
+// Suffix appends segments to the end of the path. These items will be placed after the prefix and optional
+// Namespace, Resource, or Name sections.
+func (r *Request) Suffix(segments ...string) *Request {
+	if r.err != nil {
+		return r
+	}
+	r.subpath = path.Join(r.subpath, path.Join(segments...))
+	return r
+}
+
+// Resource sets the resource to access (<resource>/[ns/<namespace>/]<name>)
+func (r *Request) Resource(resource string) *Request {
+	if r.err != nil {
+		return r
+	}
+	if len(r.resource) != 0 {
+		r.err = fmt.Errorf("resource already set to %q, cannot change to %q", r.resource, resource)
+		return r
+	}
+	r.resource = resource
+	return r
+}
+
+// SubResource sets a sub-resource path which can be multiple segments segment after the resource
+// name but before the suffix.
+func (r *Request) SubResource(subresources ...string) *Request {
+	if r.err != nil {
+		return r
+	}
+	subresource := path.Join(subresources...)
+	if len(r.subresource) != 0 {
+		r.err = fmt.Errorf("subresource already set to %q, cannot change to %q", r.resource, subresource)
+		return r
+	}
+	r.subresource = subresource
+	return r
+}
+
+// Name sets the name of a resource to access (<resource>/[ns/<namespace>/]<name>)
+func (r *Request) Name(resourceName string) *Request {
+	if r.err != nil {
+		return r
+	}
+	if len(resourceName) == 0 {
+		r.err = fmt.Errorf("resource name may not be empty")
+		return r
+	}
+	if len(r.resourceName) != 0 {
+		r.err = fmt.Errorf("resource name already set to %q, cannot change to %q", r.resourceName, resourceName)
+		return r
+	}
+	r.resourceName = resourceName
+	return r
+}
+
+// Namespace applies the namespace scope to a request (<resource>/[ns/<namespace>/]<name>)
+func (r *Request) Namespace(namespace string) *Request {
+	if r.err != nil {
+		return r
+	}
+	if r.namespaceSet {
+		r.err = fmt.Errorf("namespace already set to %q, cannot change to %q", r.namespace, namespace)
+		return r
+	}
+	r.namespaceSet = true
+	r.namespace = namespace
+	return r
+}
+
+// NamespaceIfScoped is a convenience function to set a namespace if scoped is true
+func (r *Request) NamespaceIfScoped(namespace string, scoped bool) *Request {
+	if scoped {
+		return r.Namespace(namespace)
+	}
+	return r
+}
+
+// UnversionedPath strips the apiVersion from the baseURL before appending segments.
+func (r *Request) UnversionedPath(segments ...string) *Request {
+	if r.err != nil {
+		return r
+	}
+	upath := path.Clean(r.baseURL.Path)
+	//TODO(jdef) this is a pretty hackish version test
+	if strings.HasPrefix(path.Base(upath), "v") {
+		upath = path.Dir(upath)
+		if upath == "." {
+			upath = "/"
+		}
+	}
+	r.path = path.Join(append([]string{upath}, segments...)...)
+	return r
+}
+
+// AbsPath overwrites an existing path with the segments provided. Trailing slashes are preserved
+// when a single segment is passed.
+func (r *Request) AbsPath(segments ...string) *Request {
+	if r.err != nil {
+		return r
+	}
+	if len(segments) == 1 {
+		// preserve any trailing slashes for legacy behavior
+		r.path = segments[0]
+	} else {
+		r.path = path.Join(segments...)
+	}
+	return r
+}
+
+// RequestURI overwrites existing path and parameters with the value of the provided server relative
+// URI. Some parameters (those in specialParameters) cannot be overwritten.
+func (r *Request) RequestURI(uri string) *Request {
+	if r.err != nil {
+		return r
+	}
+	locator, err := url.Parse(uri)
+	if err != nil {
+		r.err = err
+		return r
+	}
+	r.path = locator.Path
+	if len(locator.Query()) > 0 {
+		if r.params == nil {
+			r.params = make(url.Values)
+		}
+		for k, v := range locator.Query() {
+			r.params[k] = v
+		}
+	}
+	return r
+}
+
+const (
+	// A constant that clients can use to refer in a field selector to the object name field.
+	// Will be automatically emitted as the correct name for the API version.
+	NodeUnschedulable = "spec.unschedulable"
+	ObjectNameField   = "metadata.name"
+	PodHost           = "spec.nodeName"
+	PodStatus         = "status.phase"
+	SecretType        = "type"
+
+	EventReason                  = "reason"
+	EventSource                  = "source"
+	EventInvolvedKind            = "involvedObject.kind"
+	EventInvolvedNamespace       = "involvedObject.namespace"
+	EventInvolvedName            = "involvedObject.name"
+	EventInvolvedUID             = "involvedObject.uid"
+	EventInvolvedAPIVersion      = "involvedObject.apiVersion"
+	EventInvolvedResourceVersion = "involvedObject.resourceVersion"
+	EventInvolvedFieldPath       = "involvedObject.fieldPath"
+)
+
+type clientFieldNameToAPIVersionFieldName map[string]string
+
+func (c clientFieldNameToAPIVersionFieldName) filterField(field, value string) (newField, newValue string, err error) {
+	newFieldName, ok := c[field]
+	if !ok {
+		return "", "", fmt.Errorf("%v - %v - no field mapping defined", field, value)
+	}
+	return newFieldName, value, nil
+}
+
+type resourceTypeToFieldMapping map[string]clientFieldNameToAPIVersionFieldName
+
+func (r resourceTypeToFieldMapping) filterField(resourceType, field, value string) (newField, newValue string, err error) {
+	fMapping, ok := r[resourceType]
+	if !ok {
+		return "", "", fmt.Errorf("%v - %v - %v - no field mapping defined", resourceType, field, value)
+	}
+	return fMapping.filterField(field, value)
+}
+
+type versionToResourceToFieldMapping map[string]resourceTypeToFieldMapping
+
+func (v versionToResourceToFieldMapping) filterField(apiVersion, resourceType, field, value string) (newField, newValue string, err error) {
+	rMapping, ok := v[apiVersion]
+	if !ok {
+		glog.Warningf("field selector: %v - %v - %v - %v: need to check if this is versioned correctly.", apiVersion, resourceType, field, value)
+		return field, value, nil
+	}
+	newField, newValue, err = rMapping.filterField(resourceType, field, value)
+	if err != nil {
+		// This is only a warning until we find and fix all of the client's usages.
+		glog.Warningf("field selector: %v - %v - %v - %v: need to check if this is versioned correctly.", apiVersion, resourceType, field, value)
+		return field, value, nil
+	}
+	return newField, newValue, nil
+}
+
+var fieldMappings = versionToResourceToFieldMapping{
+	"v1": resourceTypeToFieldMapping{
+		"nodes": clientFieldNameToAPIVersionFieldName{
+			ObjectNameField:   "metadata.name",
+			NodeUnschedulable: "spec.unschedulable",
+		},
+		"pods": clientFieldNameToAPIVersionFieldName{
+			PodHost:   "spec.nodeName",
+			PodStatus: "status.phase",
+		},
+		"secrets": clientFieldNameToAPIVersionFieldName{
+			SecretType: "type",
+		},
+		"serviceAccounts": clientFieldNameToAPIVersionFieldName{
+			ObjectNameField: "metadata.name",
+		},
+		"endpoints": clientFieldNameToAPIVersionFieldName{
+			ObjectNameField: "metadata.name",
+		},
+		"events": clientFieldNameToAPIVersionFieldName{
+			ObjectNameField:              "metadata.name",
+			EventReason:                  "reason",
+			EventSource:                  "source",
+			EventInvolvedKind:            "involvedObject.kind",
+			EventInvolvedNamespace:       "involvedObject.namespace",
+			EventInvolvedName:            "involvedObject.name",
+			EventInvolvedUID:             "involvedObject.uid",
+			EventInvolvedAPIVersion:      "involvedObject.apiVersion",
+			EventInvolvedResourceVersion: "involvedObject.resourceVersion",
+			EventInvolvedFieldPath:       "involvedObject.fieldPath",
+		},
+	},
+}
+
+// FieldsSelectorParam adds the given selector as a query parameter with the name paramName.
+func (r *Request) FieldsSelectorParam(s fields.Selector) *Request {
+	if r.err != nil {
+		return r
+	}
+	if s == nil {
+		return r
+	}
+	if s.Empty() {
+		return r
+	}
+	s2, err := s.Transform(func(field, value string) (newField, newValue string, err error) {
+		return fieldMappings.filterField(r.apiVersion, r.resource, field, value)
+	})
+	if err != nil {
+		r.err = err
+		return r
+	}
+	return r.setParam(api.FieldSelectorQueryParam(r.apiVersion), s2.String())
+}
+
+// LabelsSelectorParam adds the given selector as a query parameter
+func (r *Request) LabelsSelectorParam(s labels.Selector) *Request {
+	if r.err != nil {
+		return r
+	}
+	if s == nil {
+		return r
+	}
+	if s.Empty() {
+		return r
+	}
+	return r.setParam(api.LabelSelectorQueryParam(r.apiVersion), s.String())
+}
+
+// UintParam creates a query parameter with the given value.
+func (r *Request) UintParam(paramName string, u uint64) *Request {
+	if r.err != nil {
+		return r
+	}
+	return r.setParam(paramName, strconv.FormatUint(u, 10))
+}
+
+// Param creates a query parameter with the given string value.
+func (r *Request) Param(paramName, s string) *Request {
+	if r.err != nil {
+		return r
+	}
+	return r.setParam(paramName, s)
+}
+
+func (r *Request) setParam(paramName, value string) *Request {
+	if specialParams.Has(paramName) {
+		r.err = fmt.Errorf("must set %v through the corresponding function, not directly.", paramName)
+		return r
+	}
+	if r.params == nil {
+		r.params = make(url.Values)
+	}
+	r.params[paramName] = append(r.params[paramName], value)
+	return r
+}
+
+func (r *Request) SetHeader(key, value string) *Request {
+	if r.headers == nil {
+		r.headers = http.Header{}
+	}
+	r.headers.Set(key, value)
+	return r
+}
+
+// Timeout makes the request use the given duration as a timeout. Sets the "timeout"
+// parameter.
+func (r *Request) Timeout(d time.Duration) *Request {
+	if r.err != nil {
+		return r
+	}
+	r.timeout = d
+	return r
+}
+
+// Body makes the request use obj as the body. Optional.
+// If obj is a string, try to read a file of that name.
+// If obj is a []byte, send it directly.
+// If obj is an io.Reader, use it directly.
+// If obj is a runtime.Object, marshal it correctly.
+// Otherwise, set an error.
+func (r *Request) Body(obj interface{}) *Request {
+	if r.err != nil {
+		return r
+	}
+	switch t := obj.(type) {
+	case string:
+		data, err := ioutil.ReadFile(t)
+		if err != nil {
+			r.err = err
+			return r
+		}
+		glog.V(8).Infof("Request Body: %s", string(data))
+		r.body = bytes.NewBuffer(data)
+	case []byte:
+		glog.V(8).Infof("Request Body: %s", string(t))
+		r.body = bytes.NewBuffer(t)
+	case io.Reader:
+		r.body = t
+	case runtime.Object:
+		data, err := r.codec.Encode(t)
+		if err != nil {
+			r.err = err
+			return r
+		}
+		glog.V(8).Infof("Request Body: %s", string(data))
+		r.body = bytes.NewBuffer(data)
+	default:
+		r.err = fmt.Errorf("unknown type used for body: %+v", obj)
+	}
+	return r
+}
+
+// URL returns the current working URL.
+func (r *Request) URL() *url.URL {
+	p := r.path
+	if r.namespaceSet && len(r.namespace) > 0 {
+		p = path.Join(p, "namespaces", r.namespace)
+	}
+	if len(r.resource) != 0 {
+		p = path.Join(p, strings.ToLower(r.resource))
+	}
+	// Join trims trailing slashes, so preserve r.path's trailing slash for backwards compat if nothing was changed
+	if len(r.resourceName) != 0 || len(r.subpath) != 0 || len(r.subresource) != 0 {
+		p = path.Join(p, r.resourceName, r.subresource, r.subpath)
+	}
+
+	finalURL := &url.URL{}
+	if r.baseURL != nil {
+		*finalURL = *r.baseURL
+	}
+	finalURL.Path = p
+
+	query := url.Values{}
+	for key, values := range r.params {
+		for _, value := range values {
+			query.Add(key, value)
+		}
+	}
+
+	// timeout is handled specially here.
+	if r.timeout != 0 {
+		query.Set("timeout", r.timeout.String())
+	}
+	finalURL.RawQuery = query.Encode()
+	return finalURL
+}
+
+// finalURLTemplate is similar to URL(), but will make all specific parameter values equal
+// - instead of name or namespace, "{name}" and "{namespace}" will be used, and all query
+// parameters will be reset. This creates a copy of the request so as not to change the
+// underyling object.  This means some useful request info (like the types of field
+// selectors in use) will be lost.
+// TODO: preserve field selector keys
+func (r Request) finalURLTemplate() string {
+	if len(r.resourceName) != 0 {
+		r.resourceName = "{name}"
+	}
+	if r.namespaceSet && len(r.namespace) != 0 {
+		r.namespace = "{namespace}"
+	}
+	newParams := url.Values{}
+	v := []string{"{value}"}
+	for k := range r.params {
+		newParams[k] = v
+	}
+	r.params = newParams
+	return r.URL().String()
+}
+
+// Watch attempts to begin watching the requested location.
+// Returns a watch.Interface, or an error.
+func (r *Request) Watch() (watch.Interface, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	url := r.URL().String()
+	req, err := http.NewRequest(r.verb, url, r.body)
+	if err != nil {
+		return nil, err
+	}
+	client := r.client
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		// The watch stream mechanism handles many common partial data errors, so closed
+		// connections can be retried in many cases.
+		if util.IsProbableEOF(err) {
+			return watch.NewEmptyWatch(), nil
+		}
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		if result := r.transformResponse(resp, req); result.err != nil {
+			return nil, result.err
+		}
+		return nil, fmt.Errorf("for request '%+v', got status: %v", url, resp.StatusCode)
+	}
+	return watch.NewStreamWatcher(watchjson.NewDecoder(resp.Body, r.codec)), nil
+}
+
+// Stream formats and executes the request, and offers streaming of the response.
+// Returns io.ReadCloser which could be used for streaming of the response, or an error
+// Any non-2xx http status code causes an error.  If we get a non-2xx code, we try to convert the body into an APIStatus object.
+// If we can, we return that as an error.  Otherwise, we create an error that lists the http status and the content of the response.
+func (r *Request) Stream() (io.ReadCloser, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	url := r.URL().String()
+	req, err := http.NewRequest(r.verb, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	client := r.client
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	switch {
+	case (resp.StatusCode >= 200) && (resp.StatusCode < 300):
+		return resp.Body, nil
+
+	default:
+		// ensure we close the body before returning the error
+		defer resp.Body.Close()
+
+		// we have a decent shot at taking the object returned, parsing it as a status object and returning a more normal error
+		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("%v while accessing %v", resp.Status, url)
+		}
+
+		if runtimeObject, err := r.codec.Decode(bodyBytes); err == nil {
+			statusError := errors.FromObject(runtimeObject)
+
+			if _, ok := statusError.(APIStatus); ok {
+				return nil, statusError
+			}
+		}
+
+		bodyText := string(bodyBytes)
+		return nil, fmt.Errorf("%s while accessing %v: %s", resp.Status, url, bodyText)
+	}
+}
+
+// Upgrade upgrades the request so that it supports multiplexed bidirectional
+// streams. The current implementation uses SPDY, but this could be replaced
+// with HTTP/2 once it's available, or something else.
+func (r *Request) Upgrade(config *Config, newRoundTripperFunc func(*tls.Config) httpstream.UpgradeRoundTripper) (httpstream.Connection, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+
+	tlsConfig, err := TLSConfigFor(config)
+	if err != nil {
+		return nil, err
+	}
+
+	upgradeRoundTripper := newRoundTripperFunc(tlsConfig)
+	wrapper, err := HTTPWrappersForConfig(config, upgradeRoundTripper)
+	if err != nil {
+		return nil, err
+	}
+
+	r.client = &http.Client{Transport: wrapper}
+
+	req, err := http.NewRequest(r.verb, r.URL().String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating request: %s", err)
+	}
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("Error sending request: %s", err)
+	}
+	defer resp.Body.Close()
+
+	return upgradeRoundTripper.NewConnection(resp)
+}
+
+// request connects to the server and invokes the provided function when a server response is
+// received. It handles retry behavior and up front validation of requests. It wil invoke
+// fn at most once. It will return an error if a problem occurred prior to connecting to the
+// server - the provided function is responsible for handling server errors.
+func (r *Request) request(fn func(*http.Request, *http.Response)) error {
+	if r.err != nil {
+		return r.err
+	}
+
+	// TODO: added to catch programmer errors (invoking operations with an object with an empty namespace)
+	if (r.verb == "GET" || r.verb == "PUT" || r.verb == "DELETE") && r.namespaceSet && len(r.resourceName) > 0 && len(r.namespace) == 0 {
+		return fmt.Errorf("an empty namespace may not be set when a resource name is provided")
+	}
+	if (r.verb == "POST") && r.namespaceSet && len(r.namespace) == 0 {
+		return fmt.Errorf("an empty namespace may not be set during creation")
+	}
+
+	client := r.client
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	// Right now we make about ten retry attempts if we get a Retry-After response.
+	// TODO: Change to a timeout based approach.
+	maxRetries := 10
+	retries := 0
+	for {
+		url := r.URL().String()
+		req, err := http.NewRequest(r.verb, url, r.body)
+		if err != nil {
+			return err
+		}
+		req.Header = r.headers
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+
+		done := func() bool {
+			// ensure the response body is closed before we reconnect, so that we reuse the same
+			// TCP connection
+			defer resp.Body.Close()
+
+			retries++
+			if seconds, wait := checkWait(resp); wait && retries < maxRetries {
+				glog.V(4).Infof("Got a Retry-After %s response for attempt %d to %v", seconds, retries, url)
+				time.Sleep(time.Duration(seconds) * time.Second)
+				return false
+			}
+			fn(req, resp)
+			return true
+		}()
+		if done {
+			return nil
+		}
+	}
+}
+
+// Do formats and executes the request. Returns a Result object for easy response
+// processing.
+//
+// Error type:
+//  * If the request can't be constructed, or an error happened earlier while building its
+//    arguments: *RequestConstructionError
+//  * If the server responds with a status: *errors.StatusError or *errors.UnexpectedObjectError
+//  * http.Client.Do errors are returned directly.
+func (r *Request) Do() Result {
+	start := time.Now()
+	defer func() {
+		metrics.RequestLatency.WithLabelValues(r.verb, r.finalURLTemplate()).Observe(metrics.SinceInMicroseconds(start))
+	}()
+	var result Result
+	err := r.request(func(req *http.Request, resp *http.Response) {
+		result = r.transformResponse(resp, req)
+	})
+	if err != nil {
+		return Result{err: err}
+	}
+	return result
+}
+
+// DoRaw executes the request but does not process the response body.
+func (r *Request) DoRaw() ([]byte, error) {
+	start := time.Now()
+	defer func() {
+		metrics.RequestLatency.WithLabelValues(r.verb, r.finalURLTemplate()).Observe(metrics.SinceInMicroseconds(start))
+	}()
+	var result Result
+	err := r.request(func(req *http.Request, resp *http.Response) {
+		result.body, result.err = ioutil.ReadAll(resp.Body)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.body, result.err
+}
+
+// transformResponse converts an API response into a structured API object
+func (r *Request) transformResponse(resp *http.Response, req *http.Request) Result {
+	var body []byte
+	if resp.Body != nil {
+		if data, err := ioutil.ReadAll(resp.Body); err == nil {
+			body = data
+		}
+	}
+	glog.V(8).Infof("Response Body: %s", string(body))
+
+	// Did the server give us a status response?
+	isStatusResponse := false
+	var status unversioned.Status
+	if err := r.codec.DecodeInto(body, &status); err == nil && status.Status != "" {
+		isStatusResponse = true
+	}
+
+	switch {
+	case resp.StatusCode == http.StatusSwitchingProtocols:
+		// no-op, we've been upgraded
+	case resp.StatusCode < http.StatusOK || resp.StatusCode > http.StatusPartialContent:
+		if !isStatusResponse {
+			return Result{err: r.transformUnstructuredResponseError(resp, req, body)}
+		}
+		return Result{err: errors.FromObject(&status)}
+	}
+
+	// If the server gave us a status back, look at what it was.
+	success := resp.StatusCode >= http.StatusOK && resp.StatusCode <= http.StatusPartialContent
+	if isStatusResponse && (status.Status != unversioned.StatusSuccess && !success) {
+		// "Failed" requests are clearly just an error and it makes sense to return them as such.
+		return Result{err: errors.FromObject(&status)}
+	}
+
+	return Result{
+		body:       body,
+		statusCode: resp.StatusCode,
+		codec:      r.codec,
+	}
+}
+
+// transformUnstructuredResponseError handles an error from the server that is not in a structured form.
+// It is expected to transform any response that is not recognizable as a clear server sent error from the
+// K8S API using the information provided with the request. In practice, HTTP proxies and client libraries
+// introduce a level of uncertainty to the responses returned by servers that in common use result in
+// unexpected responses. The rough structure is:
+//
+// 1. Assume the server sends you something sane - JSON + well defined error objects + proper codes
+//    - this is the happy path
+//    - when you get this output, trust what the server sends
+// 2. Guard against empty fields / bodies in received JSON and attempt to cull sufficient info from them to
+//    generate a reasonable facsimile of the original failure.
+//    - Be sure to use a distinct error type or flag that allows a client to distinguish between this and error 1 above
+// 3. Handle true disconnect failures / completely malformed data by moving up to a more generic client error
+// 4. Distinguish between various connection failures like SSL certificates, timeouts, proxy errors, unexpected
+//    initial contact, the presence of mismatched body contents from posted content types
+//    - Give these a separate distinct error type and capture as much as possible of the original message
+//
+// TODO: introduce transformation of generic http.Client.Do() errors that separates 4.
+func (r *Request) transformUnstructuredResponseError(resp *http.Response, req *http.Request, body []byte) error {
+	if body == nil && resp.Body != nil {
+		if data, err := ioutil.ReadAll(resp.Body); err == nil {
+			body = data
+		}
+	}
+	glog.V(8).Infof("Response Body: %s", string(body))
+
+	message := "unknown"
+	if isTextResponse(resp) {
+		message = strings.TrimSpace(string(body))
+	}
+	retryAfter, _ := retryAfterSeconds(resp)
+	return errors.NewGenericServerResponse(resp.StatusCode, req.Method, r.resource, r.resourceName, message, retryAfter, true)
+}
+
+// isTextResponse returns true if the response appears to be a textual media type.
+func isTextResponse(resp *http.Response) bool {
+	contentType := resp.Header.Get("Content-Type")
+	if len(contentType) == 0 {
+		return true
+	}
+	media, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return false
+	}
+	return strings.HasPrefix(media, "text/")
+}
+
+// checkWait returns true along with a number of seconds if the server instructed us to wait
+// before retrying.
+func checkWait(resp *http.Response) (int, bool) {
+	if resp.StatusCode != errors.StatusTooManyRequests {
+		return 0, false
+	}
+	i, ok := retryAfterSeconds(resp)
+	return i, ok
+}
+
+// retryAfterSeconds returns the value of the Retry-After header and true, or 0 and false if
+// the header was missing or not a valid number.
+func retryAfterSeconds(resp *http.Response) (int, bool) {
+	if h := resp.Header.Get("Retry-After"); len(h) > 0 {
+		if i, err := strconv.Atoi(h); err == nil {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+// Result contains the result of calling Request.Do().
+type Result struct {
+	body       []byte
+	err        error
+	statusCode int
+
+	codec runtime.Codec
+}
+
+// Raw returns the raw result.
+func (r Result) Raw() ([]byte, error) {
+	return r.body, r.err
+}
+
+// Get returns the result as an object.
+func (r Result) Get() (runtime.Object, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.codec.Decode(r.body)
+}
+
+// StatusCode returns the HTTP status code of the request. (Only valid if no
+// error was returned.)
+func (r Result) StatusCode(statusCode *int) Result {
+	*statusCode = r.statusCode
+	return r
+}
+
+// Into stores the result into obj, if possible.
+func (r Result) Into(obj runtime.Object) error {
+	if r.err != nil {
+		return r.err
+	}
+	return r.codec.DecodeInto(r.body, obj)
+}
+
+// WasCreated updates the provided bool pointer to whether the server returned
+// 201 created or a different response.
+func (r Result) WasCreated(wasCreated *bool) Result {
+	*wasCreated = r.statusCode == http.StatusCreated
+	return r
+}
+
+// Error returns the error executing the request, nil if no error occurred.
+// See the Request.Do() comment for what errors you might get.
+func (r Result) Error() error {
+	return r.err
+}

--- a/pkg/client/v1/request_test.go
+++ b/pkg/client/v1/request_test.go
@@ -1,0 +1,1268 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/base64"
+	"errors"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/kubernetes/pkg/api"
+	apierrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/httpstream"
+	"k8s.io/kubernetes/pkg/watch"
+	watchjson "k8s.io/kubernetes/pkg/watch/json"
+)
+
+func TestRequestWithErrorWontChange(t *testing.T) {
+	original := Request{
+		err:        errors.New("test"),
+		apiVersion: testapi.Default.Version(),
+	}
+	r := original
+	changed := r.Param("foo", "bar").
+		LabelsSelectorParam(labels.Set{"a": "b"}.AsSelector()).
+		UintParam("uint", 1).
+		AbsPath("/abs").
+		Prefix("test").
+		Suffix("testing").
+		Namespace("new").
+		Resource("foos").
+		Name("bars").
+		Body("foo").
+		Timeout(time.Millisecond)
+	if changed != &r {
+		t.Errorf("returned request should point to the same object")
+	}
+	if !reflect.DeepEqual(changed, &original) {
+		t.Errorf("expected %#v, got %#v", &original, changed)
+	}
+}
+
+func TestRequestPreservesBaseTrailingSlash(t *testing.T) {
+	r := &Request{baseURL: &url.URL{}, path: "/path/"}
+	if s := r.URL().String(); s != "/path/" {
+		t.Errorf("trailing slash should be preserved: %s", s)
+	}
+}
+
+func TestRequestAbsPathPreservesTrailingSlash(t *testing.T) {
+	r := (&Request{baseURL: &url.URL{}}).AbsPath("/foo/")
+	if s := r.URL().String(); s != "/foo/" {
+		t.Errorf("trailing slash should be preserved: %s", s)
+	}
+
+	r = (&Request{baseURL: &url.URL{}}).AbsPath("/foo/")
+	if s := r.URL().String(); s != "/foo/" {
+		t.Errorf("trailing slash should be preserved: %s", s)
+	}
+}
+
+func TestRequestAbsPathJoins(t *testing.T) {
+	r := (&Request{baseURL: &url.URL{}}).AbsPath("foo/bar", "baz")
+	if s := r.URL().String(); s != "foo/bar/baz" {
+		t.Errorf("trailing slash should be preserved: %s", s)
+	}
+}
+
+func TestRequestSetsNamespace(t *testing.T) {
+	r := (&Request{
+		baseURL: &url.URL{
+			Path: "/",
+		},
+	}).Namespace("foo")
+	if r.namespace == "" {
+		t.Errorf("namespace should be set: %#v", r)
+	}
+
+	if s := r.URL().String(); s != "namespaces/foo" {
+		t.Errorf("namespace should be in path: %s", s)
+	}
+}
+
+func TestRequestOrdersNamespaceInPath(t *testing.T) {
+	r := (&Request{
+		baseURL: &url.URL{},
+		path:    "/test/",
+	}).Name("bar").Resource("baz").Namespace("foo")
+	if s := r.URL().String(); s != "/test/namespaces/foo/baz/bar" {
+		t.Errorf("namespace should be in order in path: %s", s)
+	}
+}
+
+func TestRequestOrdersSubResource(t *testing.T) {
+	r := (&Request{
+		baseURL: &url.URL{},
+		path:    "/test/",
+	}).Name("bar").Resource("baz").Namespace("foo").Suffix("test").SubResource("a", "b")
+	if s := r.URL().String(); s != "/test/namespaces/foo/baz/bar/a/b/test" {
+		t.Errorf("namespace should be in order in path: %s", s)
+	}
+}
+
+func TestRequestSetTwiceError(t *testing.T) {
+	if (&Request{}).Name("bar").Name("baz").err == nil {
+		t.Errorf("setting name twice should result in error")
+	}
+	if (&Request{}).Namespace("bar").Namespace("baz").err == nil {
+		t.Errorf("setting namespace twice should result in error")
+	}
+	if (&Request{}).Resource("bar").Resource("baz").err == nil {
+		t.Errorf("setting resource twice should result in error")
+	}
+	if (&Request{}).SubResource("bar").SubResource("baz").err == nil {
+		t.Errorf("setting subresource twice should result in error")
+	}
+}
+
+func TestRequestParam(t *testing.T) {
+	r := (&Request{}).Param("foo", "a")
+	if !api.Semantic.DeepDerivative(r.params, url.Values{"foo": []string{"a"}}) {
+		t.Errorf("should have set a param: %#v", r)
+	}
+
+	r.Param("bar", "1")
+	r.Param("bar", "2")
+	if !api.Semantic.DeepDerivative(r.params, url.Values{"foo": []string{"a"}, "bar": []string{"1", "2"}}) {
+		t.Errorf("should have set a param: %#v", r)
+	}
+}
+
+func TestRequestURI(t *testing.T) {
+	r := (&Request{}).Param("foo", "a")
+	r.Prefix("other")
+	r.RequestURI("/test?foo=b&a=b&c=1&c=2")
+	if r.path != "/test" {
+		t.Errorf("path is wrong: %#v", r)
+	}
+	if !api.Semantic.DeepDerivative(r.params, url.Values{"a": []string{"b"}, "foo": []string{"b"}, "c": []string{"1", "2"}}) {
+		t.Errorf("should have set a param: %#v", r)
+	}
+}
+
+type NotAnAPIObject struct{}
+
+func (NotAnAPIObject) IsAnAPIObject() {}
+
+func TestRequestBody(t *testing.T) {
+	// test unknown type
+	r := (&Request{}).Body([]string{"test"})
+	if r.err == nil || r.body != nil {
+		t.Errorf("should have set err and left body nil: %#v", r)
+	}
+
+	// test error set when failing to read file
+	f, err := ioutil.TempFile("", "test")
+	if err != nil {
+		t.Fatalf("unable to create temp file")
+	}
+	os.Remove(f.Name())
+	r = (&Request{}).Body(f.Name())
+	if r.err == nil || r.body != nil {
+		t.Errorf("should have set err and left body nil: %#v", r)
+	}
+
+	// test unencodable api object
+	r = (&Request{codec: testapi.Default.Codec()}).Body(&NotAnAPIObject{})
+	if r.err == nil || r.body != nil {
+		t.Errorf("should have set err and left body nil: %#v", r)
+	}
+}
+
+func TestResultIntoWithErrReturnsErr(t *testing.T) {
+	res := Result{err: errors.New("test")}
+	if err := res.Into(&api.Pod{}); err != res.err {
+		t.Errorf("should have returned exact error from result")
+	}
+}
+
+func TestURLTemplate(t *testing.T) {
+	uri, _ := url.Parse("http://localhost")
+	r := NewRequest(nil, "POST", uri, "test", nil)
+	r.Prefix("pre1").Resource("r1").Namespace("ns").Name("nm").Param("p0", "v0")
+	full := r.URL()
+	if full.String() != "http://localhost/pre1/namespaces/ns/r1/nm?p0=v0" {
+		t.Errorf("unexpected initial URL: %s", full)
+	}
+	actual := r.finalURLTemplate()
+	expected := "http://localhost/pre1/namespaces/%7Bnamespace%7D/r1/%7Bname%7D?p0=%7Bvalue%7D"
+	if actual != expected {
+		t.Errorf("unexpected URL template: %s %s", actual, expected)
+	}
+	if r.URL().String() != full.String() {
+		t.Errorf("creating URL template changed request: %s -> %s", full.String(), r.URL().String())
+	}
+}
+
+func TestTransformResponse(t *testing.T) {
+	invalid := []byte("aaaaa")
+	uri, _ := url.Parse("http://localhost")
+	testCases := []struct {
+		Response *http.Response
+		Data     []byte
+		Created  bool
+		Error    bool
+		ErrFn    func(err error) bool
+	}{
+		{Response: &http.Response{StatusCode: 200}, Data: []byte{}},
+		{Response: &http.Response{StatusCode: 201}, Data: []byte{}, Created: true},
+		{Response: &http.Response{StatusCode: 199}, Error: true},
+		{Response: &http.Response{StatusCode: 500}, Error: true},
+		{Response: &http.Response{StatusCode: 422}, Error: true},
+		{Response: &http.Response{StatusCode: 409}, Error: true},
+		{Response: &http.Response{StatusCode: 404}, Error: true},
+		{Response: &http.Response{StatusCode: 401}, Error: true},
+		{
+			Response: &http.Response{
+				StatusCode: 401,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       ioutil.NopCloser(bytes.NewReader(invalid)),
+			},
+			Error: true,
+			ErrFn: func(err error) bool {
+				return err.Error() != "aaaaa" && apierrors.IsUnauthorized(err)
+			},
+		},
+		{
+			Response: &http.Response{
+				StatusCode: 401,
+				Header:     http.Header{"Content-Type": []string{"text/any"}},
+				Body:       ioutil.NopCloser(bytes.NewReader(invalid)),
+			},
+			Error: true,
+			ErrFn: func(err error) bool {
+				return strings.Contains(err.Error(), "server has asked for the client to provide") && apierrors.IsUnauthorized(err)
+			},
+		},
+		{Response: &http.Response{StatusCode: 403}, Error: true},
+		{Response: &http.Response{StatusCode: 200, Body: ioutil.NopCloser(bytes.NewReader(invalid))}, Data: invalid},
+		{Response: &http.Response{StatusCode: 200, Body: ioutil.NopCloser(bytes.NewReader(invalid))}, Data: invalid},
+	}
+	for i, test := range testCases {
+		r := NewRequest(nil, "", uri, testapi.Default.Version(), testapi.Default.Codec())
+		if test.Response.Body == nil {
+			test.Response.Body = ioutil.NopCloser(bytes.NewReader([]byte{}))
+		}
+		result := r.transformResponse(test.Response, &http.Request{})
+		response, created, err := result.body, result.statusCode == http.StatusCreated, result.err
+		hasErr := err != nil
+		if hasErr != test.Error {
+			t.Errorf("%d: unexpected error: %t %v", i, test.Error, err)
+		} else if hasErr && test.Response.StatusCode > 399 {
+			status, ok := err.(APIStatus)
+			if !ok {
+				t.Errorf("%d: response should have been transformable into APIStatus: %v", i, err)
+				continue
+			}
+			if status.Status().Code != test.Response.StatusCode {
+				t.Errorf("%d: status code did not match response: %#v", i, status.Status())
+			}
+		}
+		if test.ErrFn != nil && !test.ErrFn(err) {
+			t.Errorf("%d: error function did not match: %v", i, err)
+		}
+		if !(test.Data == nil && response == nil) && !api.Semantic.DeepDerivative(test.Data, response) {
+			t.Errorf("%d: unexpected response: %#v %#v", i, test.Data, response)
+		}
+		if test.Created != created {
+			t.Errorf("%d: expected created %t, got %t", i, test.Created, created)
+		}
+	}
+}
+
+func TestTransformUnstructuredError(t *testing.T) {
+	testCases := []struct {
+		Req *http.Request
+		Res *http.Response
+
+		Resource string
+		Name     string
+
+		ErrFn func(error) bool
+	}{
+		{
+			Resource: "foo",
+			Name:     "bar",
+			Req: &http.Request{
+				Method: "POST",
+			},
+			Res: &http.Response{
+				StatusCode: http.StatusConflict,
+				Body:       ioutil.NopCloser(bytes.NewReader(nil)),
+			},
+			ErrFn: apierrors.IsAlreadyExists,
+		},
+		{
+			Resource: "foo",
+			Name:     "bar",
+			Req: &http.Request{
+				Method: "PUT",
+			},
+			Res: &http.Response{
+				StatusCode: http.StatusConflict,
+				Body:       ioutil.NopCloser(bytes.NewReader(nil)),
+			},
+			ErrFn: apierrors.IsConflict,
+		},
+		{
+			Resource: "foo",
+			Name:     "bar",
+			Req:      &http.Request{},
+			Res: &http.Response{
+				StatusCode: http.StatusNotFound,
+				Body:       ioutil.NopCloser(bytes.NewReader(nil)),
+			},
+			ErrFn: apierrors.IsNotFound,
+		},
+		{
+			Req: &http.Request{},
+			Res: &http.Response{
+				StatusCode: http.StatusBadRequest,
+				Body:       ioutil.NopCloser(bytes.NewReader(nil)),
+			},
+			ErrFn: apierrors.IsBadRequest,
+		},
+	}
+
+	for _, testCase := range testCases {
+		r := &Request{
+			codec:        testapi.Default.Codec(),
+			resourceName: testCase.Name,
+			resource:     testCase.Resource,
+		}
+		result := r.transformResponse(testCase.Res, testCase.Req)
+		err := result.err
+		if !testCase.ErrFn(err) {
+			t.Errorf("unexpected error: %v", err)
+			continue
+		}
+		if len(testCase.Name) != 0 && !strings.Contains(err.Error(), testCase.Name) {
+			t.Errorf("unexpected error string: %s", err)
+		}
+		if len(testCase.Resource) != 0 && !strings.Contains(err.Error(), testCase.Resource) {
+			t.Errorf("unexpected error string: %s", err)
+		}
+	}
+}
+
+type clientFunc func(req *http.Request) (*http.Response, error)
+
+func (f clientFunc) Do(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestRequestWatch(t *testing.T) {
+	testCases := []struct {
+		Request *Request
+		Err     bool
+		ErrFn   func(error) bool
+		Empty   bool
+	}{
+		{
+			Request: &Request{err: errors.New("bail")},
+			Err:     true,
+		},
+		{
+			Request: &Request{baseURL: &url.URL{}, path: "%"},
+			Err:     true,
+		},
+		{
+			Request: &Request{
+				client: clientFunc(func(req *http.Request) (*http.Response, error) {
+					return nil, errors.New("err")
+				}),
+				baseURL: &url.URL{},
+			},
+			Err: true,
+		},
+		{
+			Request: &Request{
+				codec: testapi.Default.Codec(),
+				client: clientFunc(func(req *http.Request) (*http.Response, error) {
+					return &http.Response{StatusCode: http.StatusForbidden}, nil
+				}),
+				baseURL: &url.URL{},
+			},
+			Err: true,
+			ErrFn: func(err error) bool {
+				return apierrors.IsForbidden(err)
+			},
+		},
+		{
+			Request: &Request{
+				codec: testapi.Default.Codec(),
+				client: clientFunc(func(req *http.Request) (*http.Response, error) {
+					return &http.Response{StatusCode: http.StatusUnauthorized}, nil
+				}),
+				baseURL: &url.URL{},
+			},
+			Err: true,
+			ErrFn: func(err error) bool {
+				return apierrors.IsUnauthorized(err)
+			},
+		},
+		{
+			Request: &Request{
+				codec: testapi.Default.Codec(),
+				client: clientFunc(func(req *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: http.StatusUnauthorized,
+						Body: ioutil.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(testapi.Default.Codec(), &unversioned.Status{
+							Status: unversioned.StatusFailure,
+							Reason: unversioned.StatusReasonUnauthorized,
+						})))),
+					}, nil
+				}),
+				baseURL: &url.URL{},
+			},
+			Err: true,
+			ErrFn: func(err error) bool {
+				return apierrors.IsUnauthorized(err)
+			},
+		},
+		{
+			Request: &Request{
+				client: clientFunc(func(req *http.Request) (*http.Response, error) {
+					return nil, io.EOF
+				}),
+				baseURL: &url.URL{},
+			},
+			Empty: true,
+		},
+		{
+			Request: &Request{
+				client: clientFunc(func(req *http.Request) (*http.Response, error) {
+					return nil, &url.Error{Err: io.EOF}
+				}),
+				baseURL: &url.URL{},
+			},
+			Empty: true,
+		},
+		{
+			Request: &Request{
+				client: clientFunc(func(req *http.Request) (*http.Response, error) {
+					return nil, errors.New("http: can't write HTTP request on broken connection")
+				}),
+				baseURL: &url.URL{},
+			},
+			Empty: true,
+		},
+		{
+			Request: &Request{
+				client: clientFunc(func(req *http.Request) (*http.Response, error) {
+					return nil, errors.New("foo: connection reset by peer")
+				}),
+				baseURL: &url.URL{},
+			},
+			Empty: true,
+		},
+	}
+	for i, testCase := range testCases {
+		watch, err := testCase.Request.Watch()
+		hasErr := err != nil
+		if hasErr != testCase.Err {
+			t.Errorf("%d: expected %t, got %t: %v", i, testCase.Err, hasErr, err)
+			continue
+		}
+		if testCase.ErrFn != nil && !testCase.ErrFn(err) {
+			t.Errorf("%d: error not valid: %v", i, err)
+		}
+		if hasErr && watch != nil {
+			t.Errorf("%d: watch should be nil when error is returned", i)
+			continue
+		}
+		if testCase.Empty {
+			_, ok := <-watch.ResultChan()
+			if ok {
+				t.Errorf("%d: expected the watch to be empty: %#v", i, watch)
+			}
+		}
+	}
+}
+
+func TestRequestStream(t *testing.T) {
+	testCases := []struct {
+		Request *Request
+		Err     bool
+	}{
+		{
+			Request: &Request{err: errors.New("bail")},
+			Err:     true,
+		},
+		{
+			Request: &Request{baseURL: &url.URL{}, path: "%"},
+			Err:     true,
+		},
+		{
+			Request: &Request{
+				client: clientFunc(func(req *http.Request) (*http.Response, error) {
+					return nil, errors.New("err")
+				}),
+				baseURL: &url.URL{},
+			},
+			Err: true,
+		},
+		{
+			Request: &Request{
+				client: clientFunc(func(req *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: http.StatusUnauthorized,
+						Body: ioutil.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(testapi.Default.Codec(), &unversioned.Status{
+							Status: unversioned.StatusFailure,
+							Reason: unversioned.StatusReasonUnauthorized,
+						})))),
+					}, nil
+				}),
+				codec:   testapi.Default.Codec(),
+				baseURL: &url.URL{},
+			},
+			Err: true,
+		},
+	}
+	for i, testCase := range testCases {
+		body, err := testCase.Request.Stream()
+		hasErr := err != nil
+		if hasErr != testCase.Err {
+			t.Errorf("%d: expected %t, got %t: %v", i, testCase.Err, hasErr, err)
+		}
+		if hasErr && body != nil {
+			t.Errorf("%d: body should be nil when error is returned", i)
+		}
+	}
+}
+
+type fakeUpgradeConnection struct{}
+
+func (c *fakeUpgradeConnection) CreateStream(headers http.Header) (httpstream.Stream, error) {
+	return nil, nil
+}
+func (c *fakeUpgradeConnection) Close() error {
+	return nil
+}
+func (c *fakeUpgradeConnection) CloseChan() <-chan bool {
+	return make(chan bool)
+}
+func (c *fakeUpgradeConnection) SetIdleTimeout(timeout time.Duration) {
+}
+
+type fakeUpgradeRoundTripper struct {
+	req  *http.Request
+	conn httpstream.Connection
+}
+
+func (f *fakeUpgradeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	f.req = req
+	b := []byte{}
+	body := ioutil.NopCloser(bytes.NewReader(b))
+	resp := &http.Response{
+		StatusCode: 101,
+		Body:       body,
+	}
+	return resp, nil
+}
+
+func (f *fakeUpgradeRoundTripper) NewConnection(resp *http.Response) (httpstream.Connection, error) {
+	return f.conn, nil
+}
+
+func TestRequestUpgrade(t *testing.T) {
+	uri, _ := url.Parse("http://localhost/")
+	testCases := []struct {
+		Request          *Request
+		Config           *Config
+		RoundTripper     *fakeUpgradeRoundTripper
+		Err              bool
+		AuthBasicHeader  bool
+		AuthBearerHeader bool
+	}{
+		{
+			Request: &Request{err: errors.New("bail")},
+			Err:     true,
+		},
+		{
+			Request: &Request{},
+			Config: &Config{
+				TLSClientConfig: TLSClientConfig{
+					CAFile: "foo",
+				},
+				Insecure: true,
+			},
+			Err: true,
+		},
+		{
+			Request: &Request{},
+			Config: &Config{
+				Username:    "u",
+				Password:    "p",
+				BearerToken: "b",
+			},
+			Err: true,
+		},
+		{
+			Request: NewRequest(nil, "", uri, testapi.Default.Version(), testapi.Default.Codec()),
+			Config: &Config{
+				Username: "u",
+				Password: "p",
+			},
+			AuthBasicHeader: true,
+			Err:             false,
+		},
+		{
+			Request: NewRequest(nil, "", uri, testapi.Default.Version(), testapi.Default.Codec()),
+			Config: &Config{
+				BearerToken: "b",
+			},
+			AuthBearerHeader: true,
+			Err:              false,
+		},
+	}
+	for i, testCase := range testCases {
+		r := testCase.Request
+		rt := &fakeUpgradeRoundTripper{}
+		expectedConn := &fakeUpgradeConnection{}
+		conn, err := r.Upgrade(testCase.Config, func(config *tls.Config) httpstream.UpgradeRoundTripper {
+			rt.conn = expectedConn
+			return rt
+		})
+		_ = conn
+		hasErr := err != nil
+		if hasErr != testCase.Err {
+			t.Errorf("%d: expected %t, got %t: %v", i, testCase.Err, hasErr, r.err)
+		}
+		if testCase.Err {
+			continue
+		}
+
+		if testCase.AuthBasicHeader && !strings.Contains(rt.req.Header.Get("Authorization"), "Basic") {
+			t.Errorf("%d: expected basic auth header, got: %s", i, rt.req.Header.Get("Authorization"))
+		}
+
+		if testCase.AuthBearerHeader && !strings.Contains(rt.req.Header.Get("Authorization"), "Bearer") {
+			t.Errorf("%d: expected bearer auth header, got: %s", i, rt.req.Header.Get("Authorization"))
+		}
+
+		if e, a := expectedConn, conn; e != a {
+			t.Errorf("%d: conn: expected %#v, got %#v", i, e, a)
+		}
+	}
+}
+
+func TestRequestDo(t *testing.T) {
+	testCases := []struct {
+		Request *Request
+		Err     bool
+	}{
+		{
+			Request: &Request{err: errors.New("bail")},
+			Err:     true,
+		},
+		{
+			Request: &Request{baseURL: &url.URL{}, path: "%"},
+			Err:     true,
+		},
+		{
+			Request: &Request{
+				client: clientFunc(func(req *http.Request) (*http.Response, error) {
+					return nil, errors.New("err")
+				}),
+				baseURL: &url.URL{},
+			},
+			Err: true,
+		},
+	}
+	for i, testCase := range testCases {
+		body, err := testCase.Request.Do().Raw()
+		hasErr := err != nil
+		if hasErr != testCase.Err {
+			t.Errorf("%d: expected %t, got %t: %v", i, testCase.Err, hasErr, err)
+		}
+		if hasErr && body != nil {
+			t.Errorf("%d: body should be nil when error is returned", i)
+		}
+	}
+}
+
+func TestDoRequestNewWay(t *testing.T) {
+	reqBody := "request body"
+	expectedObj := &api.Service{Spec: api.ServiceSpec{Ports: []api.ServicePort{{
+		Protocol:   "TCP",
+		Port:       12345,
+		TargetPort: util.NewIntOrStringFromInt(12345),
+	}}}}
+	expectedBody, _ := testapi.Default.Codec().Encode(expectedObj)
+	fakeHandler := util.FakeHandler{
+		StatusCode:   200,
+		ResponseBody: string(expectedBody),
+		T:            t,
+	}
+	testServer := httptest.NewServer(&fakeHandler)
+	defer testServer.Close()
+	c := NewOrDie(&Config{Host: testServer.URL, Version: testapi.Default.Version(), Username: "user", Password: "pass"})
+	obj, err := c.Verb("POST").
+		Prefix("foo", "bar").
+		Suffix("baz").
+		Timeout(time.Second).
+		Body([]byte(reqBody)).
+		Do().Get()
+	if err != nil {
+		t.Errorf("Unexpected error: %v %#v", err, err)
+		return
+	}
+	if obj == nil {
+		t.Error("nil obj")
+	} else if !api.Semantic.DeepDerivative(expectedObj, obj) {
+		t.Errorf("Expected: %#v, got %#v", expectedObj, obj)
+	}
+	requestURL := testapi.Default.ResourcePathWithPrefix("foo/bar", "", "", "baz")
+	requestURL += "?timeout=1s"
+	fakeHandler.ValidateRequest(t, requestURL, "POST", &reqBody)
+	if fakeHandler.RequestReceived.Header["Authorization"] == nil {
+		t.Errorf("Request is missing authorization header: %#v", *fakeHandler.RequestReceived)
+	}
+}
+
+func TestCheckRetryClosesBody(t *testing.T) {
+	count := 0
+	ch := make(chan struct{})
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		count++
+		t.Logf("attempt %d", count)
+		if count >= 5 {
+			w.WriteHeader(http.StatusOK)
+			close(ch)
+			return
+		}
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(apierrors.StatusTooManyRequests)
+	}))
+	defer testServer.Close()
+
+	c := NewOrDie(&Config{Host: testServer.URL, Version: testapi.Default.Version(), Username: "user", Password: "pass"})
+	_, err := c.Verb("POST").
+		Prefix("foo", "bar").
+		Suffix("baz").
+		Timeout(time.Second).
+		Body([]byte(strings.Repeat("abcd", 1000))).
+		DoRaw()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v %#v", err, err)
+	}
+	<-ch
+	if count != 5 {
+		t.Errorf("unexpected retries: %d", count)
+	}
+}
+
+func BenchmarkCheckRetryClosesBody(t *testing.B) {
+	count := 0
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		count++
+		if count%3 == 0 {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(apierrors.StatusTooManyRequests)
+	}))
+	defer testServer.Close()
+
+	c := NewOrDie(&Config{Host: testServer.URL, Version: testapi.Default.Version(), Username: "user", Password: "pass"})
+	r := c.Verb("POST").
+		Prefix("foo", "bar").
+		Suffix("baz").
+		Timeout(time.Second).
+		Body([]byte(strings.Repeat("abcd", 1000)))
+
+	for i := 0; i < t.N; i++ {
+		if _, err := r.DoRaw(); err != nil {
+			t.Fatalf("Unexpected error: %v %#v", err, err)
+		}
+	}
+}
+func TestDoRequestNewWayReader(t *testing.T) {
+	reqObj := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}}
+	reqBodyExpected, _ := testapi.Default.Codec().Encode(reqObj)
+	expectedObj := &api.Service{Spec: api.ServiceSpec{Ports: []api.ServicePort{{
+		Protocol:   "TCP",
+		Port:       12345,
+		TargetPort: util.NewIntOrStringFromInt(12345),
+	}}}}
+	expectedBody, _ := testapi.Default.Codec().Encode(expectedObj)
+	fakeHandler := util.FakeHandler{
+		StatusCode:   200,
+		ResponseBody: string(expectedBody),
+		T:            t,
+	}
+	testServer := httptest.NewServer(&fakeHandler)
+	c := NewOrDie(&Config{Host: testServer.URL, Version: testapi.Default.Version(), Username: "user", Password: "pass"})
+	obj, err := c.Verb("POST").
+		Resource("bar").
+		Name("baz").
+		Prefix("foo").
+		LabelsSelectorParam(labels.Set{"name": "foo"}.AsSelector()).
+		Timeout(time.Second).
+		Body(bytes.NewBuffer(reqBodyExpected)).
+		Do().Get()
+	if err != nil {
+		t.Errorf("Unexpected error: %v %#v", err, err)
+		return
+	}
+	if obj == nil {
+		t.Error("nil obj")
+	} else if !api.Semantic.DeepDerivative(expectedObj, obj) {
+		t.Errorf("Expected: %#v, got %#v", expectedObj, obj)
+	}
+	tmpStr := string(reqBodyExpected)
+	requestURL := testapi.Default.ResourcePathWithPrefix("foo", "bar", "", "baz")
+	requestURL += "?" + api.LabelSelectorQueryParam(testapi.Default.Version()) + "=name%3Dfoo&timeout=1s"
+	fakeHandler.ValidateRequest(t, requestURL, "POST", &tmpStr)
+	if fakeHandler.RequestReceived.Header["Authorization"] == nil {
+		t.Errorf("Request is missing authorization header: %#v", *fakeHandler.RequestReceived)
+	}
+}
+
+func TestDoRequestNewWayObj(t *testing.T) {
+	reqObj := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}}
+	reqBodyExpected, _ := testapi.Default.Codec().Encode(reqObj)
+	expectedObj := &api.Service{Spec: api.ServiceSpec{Ports: []api.ServicePort{{
+		Protocol:   "TCP",
+		Port:       12345,
+		TargetPort: util.NewIntOrStringFromInt(12345),
+	}}}}
+	expectedBody, _ := testapi.Default.Codec().Encode(expectedObj)
+	fakeHandler := util.FakeHandler{
+		StatusCode:   200,
+		ResponseBody: string(expectedBody),
+		T:            t,
+	}
+	testServer := httptest.NewServer(&fakeHandler)
+	c := NewOrDie(&Config{Host: testServer.URL, Version: testapi.Default.Version(), Username: "user", Password: "pass"})
+	obj, err := c.Verb("POST").
+		Suffix("baz").
+		Name("bar").
+		Resource("foo").
+		LabelsSelectorParam(labels.Set{"name": "foo"}.AsSelector()).
+		Timeout(time.Second).
+		Body(reqObj).
+		Do().Get()
+	if err != nil {
+		t.Errorf("Unexpected error: %v %#v", err, err)
+		return
+	}
+	if obj == nil {
+		t.Error("nil obj")
+	} else if !api.Semantic.DeepDerivative(expectedObj, obj) {
+		t.Errorf("Expected: %#v, got %#v", expectedObj, obj)
+	}
+	tmpStr := string(reqBodyExpected)
+	requestURL := testapi.Default.ResourcePath("foo", "", "bar/baz")
+	requestURL += "?" + api.LabelSelectorQueryParam(testapi.Default.Version()) + "=name%3Dfoo&timeout=1s"
+	fakeHandler.ValidateRequest(t, requestURL, "POST", &tmpStr)
+	if fakeHandler.RequestReceived.Header["Authorization"] == nil {
+		t.Errorf("Request is missing authorization header: %#v", *fakeHandler.RequestReceived)
+	}
+}
+
+func TestDoRequestNewWayFile(t *testing.T) {
+	reqObj := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}}
+	reqBodyExpected, err := testapi.Default.Codec().Encode(reqObj)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	file, err := ioutil.TempFile("", "foo")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	_, err = file.Write(reqBodyExpected)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	expectedObj := &api.Service{Spec: api.ServiceSpec{Ports: []api.ServicePort{{
+		Protocol:   "TCP",
+		Port:       12345,
+		TargetPort: util.NewIntOrStringFromInt(12345),
+	}}}}
+	expectedBody, _ := testapi.Default.Codec().Encode(expectedObj)
+	fakeHandler := util.FakeHandler{
+		StatusCode:   200,
+		ResponseBody: string(expectedBody),
+		T:            t,
+	}
+	testServer := httptest.NewServer(&fakeHandler)
+	c := NewOrDie(&Config{Host: testServer.URL, Version: testapi.Default.Version(), Username: "user", Password: "pass"})
+	wasCreated := true
+	obj, err := c.Verb("POST").
+		Prefix("foo/bar", "baz").
+		Timeout(time.Second).
+		Body(file.Name()).
+		Do().WasCreated(&wasCreated).Get()
+	if err != nil {
+		t.Errorf("Unexpected error: %v %#v", err, err)
+		return
+	}
+	if obj == nil {
+		t.Error("nil obj")
+	} else if !api.Semantic.DeepDerivative(expectedObj, obj) {
+		t.Errorf("Expected: %#v, got %#v", expectedObj, obj)
+	}
+	if wasCreated {
+		t.Errorf("expected object was not created")
+	}
+	tmpStr := string(reqBodyExpected)
+	requestURL := testapi.Default.ResourcePathWithPrefix("foo/bar/baz", "", "", "")
+	requestURL += "?timeout=1s"
+	fakeHandler.ValidateRequest(t, requestURL, "POST", &tmpStr)
+	if fakeHandler.RequestReceived.Header["Authorization"] == nil {
+		t.Errorf("Request is missing authorization header: %#v", *fakeHandler.RequestReceived)
+	}
+}
+
+func TestWasCreated(t *testing.T) {
+	reqObj := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}}
+	reqBodyExpected, err := testapi.Default.Codec().Encode(reqObj)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	expectedObj := &api.Service{Spec: api.ServiceSpec{Ports: []api.ServicePort{{
+		Protocol:   "TCP",
+		Port:       12345,
+		TargetPort: util.NewIntOrStringFromInt(12345),
+	}}}}
+	expectedBody, _ := testapi.Default.Codec().Encode(expectedObj)
+	fakeHandler := util.FakeHandler{
+		StatusCode:   201,
+		ResponseBody: string(expectedBody),
+		T:            t,
+	}
+	testServer := httptest.NewServer(&fakeHandler)
+	c := NewOrDie(&Config{Host: testServer.URL, Version: testapi.Default.Version(), Username: "user", Password: "pass"})
+	wasCreated := false
+	obj, err := c.Verb("PUT").
+		Prefix("foo/bar", "baz").
+		Timeout(time.Second).
+		Body(reqBodyExpected).
+		Do().WasCreated(&wasCreated).Get()
+	if err != nil {
+		t.Errorf("Unexpected error: %v %#v", err, err)
+		return
+	}
+	if obj == nil {
+		t.Error("nil obj")
+	} else if !api.Semantic.DeepDerivative(expectedObj, obj) {
+		t.Errorf("Expected: %#v, got %#v", expectedObj, obj)
+	}
+	if !wasCreated {
+		t.Errorf("Expected object was created")
+	}
+
+	tmpStr := string(reqBodyExpected)
+	requestURL := testapi.Default.ResourcePathWithPrefix("foo/bar/baz", "", "", "")
+	requestURL += "?timeout=1s"
+	fakeHandler.ValidateRequest(t, requestURL, "PUT", &tmpStr)
+	if fakeHandler.RequestReceived.Header["Authorization"] == nil {
+		t.Errorf("Request is missing authorization header: %#v", *fakeHandler.RequestReceived)
+	}
+}
+
+func TestVerbs(t *testing.T) {
+	c := NewOrDie(&Config{})
+	if r := c.Post(); r.verb != "POST" {
+		t.Errorf("Post verb is wrong")
+	}
+	if r := c.Put(); r.verb != "PUT" {
+		t.Errorf("Put verb is wrong")
+	}
+	if r := c.Get(); r.verb != "GET" {
+		t.Errorf("Get verb is wrong")
+	}
+	if r := c.Delete(); r.verb != "DELETE" {
+		t.Errorf("Delete verb is wrong")
+	}
+}
+
+func TestUnversionedPath(t *testing.T) {
+	tt := []struct {
+		host         string
+		prefix       string
+		unversioned  string
+		expectedPath string
+	}{
+		{"", "", "", "/api"},
+		{"", "", "versions", "/api/versions"},
+		{"", "/", "", "/"},
+		{"", "/versions", "", "/versions"},
+		{"", "/api", "", "/api"},
+		{"", "/api/vfake", "", "/api/vfake"},
+		{"", "/api/vfake", "v1beta100", "/api/vfake/v1beta100"},
+		{"", "/api", "/versions", "/api/versions"},
+		{"", "/api", "versions", "/api/versions"},
+		{"", "/a/api", "", "/a/api"},
+		{"", "/a/api", "/versions", "/a/api/versions"},
+		{"", "/a/api", "/versions/d/e", "/a/api/versions/d/e"},
+		{"", "/a/api/vfake", "/versions/d/e", "/a/api/vfake/versions/d/e"},
+	}
+	for i, tc := range tt {
+		c := NewOrDie(&Config{Host: tc.host, Prefix: tc.prefix})
+		r := c.Post().Prefix("/alpha").UnversionedPath(tc.unversioned)
+		if r.path != tc.expectedPath {
+			t.Errorf("test case %d failed: unexpected path: %s, expected %s", i+1, r.path, tc.expectedPath)
+		}
+	}
+	for i, tc := range tt {
+		c := NewOrDie(&Config{Host: tc.host, Prefix: tc.prefix, Version: "v1"})
+		r := c.Post().Prefix("/alpha").UnversionedPath(tc.unversioned)
+		if r.path != tc.expectedPath {
+			t.Errorf("test case %d failed: unexpected path: %s, expected %s", i+1, r.path, tc.expectedPath)
+		}
+	}
+}
+
+func TestAbsPath(t *testing.T) {
+	expectedPath := "/bar/foo"
+	c := NewOrDie(&Config{})
+	r := c.Post().Prefix("/foo").AbsPath(expectedPath)
+	if r.path != expectedPath {
+		t.Errorf("unexpected path: %s, expected %s", r.path, expectedPath)
+	}
+}
+
+func TestUintParam(t *testing.T) {
+	table := []struct {
+		name      string
+		testVal   uint64
+		expectStr string
+	}{
+		{"foo", 31415, "http://localhost?foo=31415"},
+		{"bar", 42, "http://localhost?bar=42"},
+		{"baz", 0, "http://localhost?baz=0"},
+	}
+
+	for _, item := range table {
+		c := NewOrDie(&Config{})
+		r := c.Get().AbsPath("").UintParam(item.name, item.testVal)
+		if e, a := item.expectStr, r.URL().String(); e != a {
+			t.Errorf("expected %v, got %v", e, a)
+		}
+	}
+}
+
+func TestUnacceptableParamNames(t *testing.T) {
+	table := []struct {
+		name          string
+		testVal       string
+		expectSuccess bool
+	}{
+		{"timeout", "42", false},
+	}
+
+	for _, item := range table {
+		c := NewOrDie(&Config{})
+		r := c.Get().setParam(item.name, item.testVal)
+		if e, a := item.expectSuccess, r.err == nil; e != a {
+			t.Errorf("expected %v, got %v (%v)", e, a, r.err)
+		}
+	}
+}
+
+func TestBody(t *testing.T) {
+	const data = "test payload"
+
+	f, err := ioutil.TempFile("", "test_body")
+	if err != nil {
+		t.Fatalf("TempFile error: %v", err)
+	}
+	if _, err := f.WriteString(data); err != nil {
+		t.Fatalf("TempFile.WriteString error: %v", err)
+	}
+	f.Close()
+
+	c := NewOrDie(&Config{})
+	tests := []interface{}{[]byte(data), f.Name(), strings.NewReader(data)}
+	for i, tt := range tests {
+		r := c.Post().Body(tt)
+		if r.err != nil {
+			t.Errorf("%d: r.Body(%#v) error: %v", i, tt, r.err)
+			continue
+		}
+		buf := make([]byte, len(data))
+		if _, err := r.body.Read(buf); err != nil {
+			t.Errorf("%d: r.body.Read error: %v", i, err)
+			continue
+		}
+		body := string(buf)
+		if body != data {
+			t.Errorf("%d: r.body = %q; want %q", i, body, data)
+		}
+	}
+}
+
+func authFromReq(r *http.Request) (*Config, bool) {
+	auth, ok := r.Header["Authorization"]
+	if !ok {
+		return nil, false
+	}
+
+	encoded := strings.Split(auth[0], " ")
+	if len(encoded) != 2 || encoded[0] != "Basic" {
+		return nil, false
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(encoded[1])
+	if err != nil {
+		return nil, false
+	}
+	parts := strings.Split(string(decoded), ":")
+	if len(parts) != 2 {
+		return nil, false
+	}
+	return &Config{Username: parts[0], Password: parts[1]}, true
+}
+
+// checkAuth sets errors if the auth found in r doesn't match the expectation.
+// TODO: Move to util, test in more places.
+func checkAuth(t *testing.T, expect *Config, r *http.Request) {
+	foundAuth, found := authFromReq(r)
+	if !found {
+		t.Errorf("no auth found")
+	} else if e, a := expect, foundAuth; !api.Semantic.DeepDerivative(e, a) {
+		t.Fatalf("Wrong basic auth: wanted %#v, got %#v", e, a)
+	}
+}
+
+func TestWatch(t *testing.T) {
+	var table = []struct {
+		t   watch.EventType
+		obj runtime.Object
+	}{
+		{watch.Added, &api.Pod{ObjectMeta: api.ObjectMeta{Name: "first"}}},
+		{watch.Modified, &api.Pod{ObjectMeta: api.ObjectMeta{Name: "second"}}},
+		{watch.Deleted, &api.Pod{ObjectMeta: api.ObjectMeta{Name: "last"}}},
+	}
+
+	auth := &Config{Username: "user", Password: "pass"}
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		checkAuth(t, auth, r)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			panic("need flusher!")
+		}
+
+		w.Header().Set("Transfer-Encoding", "chunked")
+		w.WriteHeader(http.StatusOK)
+		flusher.Flush()
+
+		encoder := watchjson.NewEncoder(w, testapi.Default.Codec())
+		for _, item := range table {
+			if err := encoder.Encode(&watch.Event{Type: item.t, Object: item.obj}); err != nil {
+				panic(err)
+			}
+			flusher.Flush()
+		}
+	}))
+
+	s, err := New(&Config{
+		Host:     testServer.URL,
+		Version:  testapi.Default.Version(),
+		Username: "user",
+		Password: "pass",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	watching, err := s.Get().Prefix("path/to/watch/thing").Watch()
+	if err != nil {
+		t.Fatalf("Unexpected error")
+	}
+
+	for _, item := range table {
+		got, ok := <-watching.ResultChan()
+		if !ok {
+			t.Fatalf("Unexpected early close")
+		}
+		if e, a := item.t, got.Type; e != a {
+			t.Errorf("Expected %v, got %v", e, a)
+		}
+		if e, a := item.obj, got.Object; !api.Semantic.DeepDerivative(e, a) {
+			t.Errorf("Expected %v, got %v", e, a)
+		}
+	}
+
+	_, ok := <-watching.ResultChan()
+	if ok {
+		t.Fatal("Unexpected non-close")
+	}
+}
+
+func TestStream(t *testing.T) {
+	auth := &Config{Username: "user", Password: "pass"}
+	expectedBody := "expected body"
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		checkAuth(t, auth, r)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			panic("need flusher!")
+		}
+		w.Header().Set("Transfer-Encoding", "chunked")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(expectedBody))
+		flusher.Flush()
+	}))
+
+	s, err := New(&Config{
+		Host:     testServer.URL,
+		Version:  testapi.Default.Version(),
+		Username: "user",
+		Password: "pass",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	readCloser, err := s.Get().Prefix("path/to/stream/thing").Stream()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer readCloser.Close()
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(readCloser)
+	resultBody := buf.String()
+
+	if expectedBody != resultBody {
+		t.Errorf("Expected %s, got %s", expectedBody, resultBody)
+	}
+}

--- a/pkg/client/v1/request_test.go
+++ b/pkg/client/v1/request_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"bytes"
@@ -36,6 +36,7 @@ import (
 	apierrors "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
@@ -201,7 +202,7 @@ func TestRequestBody(t *testing.T) {
 
 func TestResultIntoWithErrReturnsErr(t *testing.T) {
 	res := Result{err: errors.New("test")}
-	if err := res.Into(&api.Pod{}); err != res.err {
+	if err := res.Into(&v1.Pod{}); err != res.err {
 		t.Errorf("should have returned exact error from result")
 	}
 }
@@ -714,7 +715,7 @@ func TestRequestDo(t *testing.T) {
 
 func TestDoRequestNewWay(t *testing.T) {
 	reqBody := "request body"
-	expectedObj := &api.Service{Spec: api.ServiceSpec{Ports: []api.ServicePort{{
+	expectedObj := &v1.Service{Spec: v1.ServiceSpec{Ports: []v1.ServicePort{{
 		Protocol:   "TCP",
 		Port:       12345,
 		TargetPort: util.NewIntOrStringFromInt(12345),
@@ -810,9 +811,9 @@ func BenchmarkCheckRetryClosesBody(t *testing.B) {
 	}
 }
 func TestDoRequestNewWayReader(t *testing.T) {
-	reqObj := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}}
+	reqObj := &v1.Pod{ObjectMeta: v1.ObjectMeta{Name: "foo"}}
 	reqBodyExpected, _ := testapi.Default.Codec().Encode(reqObj)
-	expectedObj := &api.Service{Spec: api.ServiceSpec{Ports: []api.ServicePort{{
+	expectedObj := &v1.Service{Spec: v1.ServiceSpec{Ports: []v1.ServicePort{{
 		Protocol:   "TCP",
 		Port:       12345,
 		TargetPort: util.NewIntOrStringFromInt(12345),
@@ -852,9 +853,9 @@ func TestDoRequestNewWayReader(t *testing.T) {
 }
 
 func TestDoRequestNewWayObj(t *testing.T) {
-	reqObj := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}}
+	reqObj := &v1.Pod{ObjectMeta: v1.ObjectMeta{Name: "foo"}}
 	reqBodyExpected, _ := testapi.Default.Codec().Encode(reqObj)
-	expectedObj := &api.Service{Spec: api.ServiceSpec{Ports: []api.ServicePort{{
+	expectedObj := &v1.Service{Spec: v1.ServiceSpec{Ports: []v1.ServicePort{{
 		Protocol:   "TCP",
 		Port:       12345,
 		TargetPort: util.NewIntOrStringFromInt(12345),
@@ -894,7 +895,7 @@ func TestDoRequestNewWayObj(t *testing.T) {
 }
 
 func TestDoRequestNewWayFile(t *testing.T) {
-	reqObj := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}}
+	reqObj := &v1.Pod{ObjectMeta: v1.ObjectMeta{Name: "foo"}}
 	reqBodyExpected, err := testapi.Default.Codec().Encode(reqObj)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -910,7 +911,7 @@ func TestDoRequestNewWayFile(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	expectedObj := &api.Service{Spec: api.ServiceSpec{Ports: []api.ServicePort{{
+	expectedObj := &v1.Service{Spec: v1.ServiceSpec{Ports: []v1.ServicePort{{
 		Protocol:   "TCP",
 		Port:       12345,
 		TargetPort: util.NewIntOrStringFromInt(12345),
@@ -951,13 +952,13 @@ func TestDoRequestNewWayFile(t *testing.T) {
 }
 
 func TestWasCreated(t *testing.T) {
-	reqObj := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}}
+	reqObj := &v1.Pod{ObjectMeta: v1.ObjectMeta{Name: "foo"}}
 	reqBodyExpected, err := testapi.Default.Codec().Encode(reqObj)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	expectedObj := &api.Service{Spec: api.ServiceSpec{Ports: []api.ServicePort{{
+	expectedObj := &v1.Service{Spec: v1.ServiceSpec{Ports: []v1.ServicePort{{
 		Protocol:   "TCP",
 		Port:       12345,
 		TargetPort: util.NewIntOrStringFromInt(12345),
@@ -1168,9 +1169,9 @@ func TestWatch(t *testing.T) {
 		t   watch.EventType
 		obj runtime.Object
 	}{
-		{watch.Added, &api.Pod{ObjectMeta: api.ObjectMeta{Name: "first"}}},
-		{watch.Modified, &api.Pod{ObjectMeta: api.ObjectMeta{Name: "second"}}},
-		{watch.Deleted, &api.Pod{ObjectMeta: api.ObjectMeta{Name: "last"}}},
+		{watch.Added, &v1.Pod{ObjectMeta: v1.ObjectMeta{Name: "first"}}},
+		{watch.Modified, &v1.Pod{ObjectMeta: v1.ObjectMeta{Name: "second"}}},
+		{watch.Deleted, &v1.Pod{ObjectMeta: v1.ObjectMeta{Name: "last"}}},
 	}
 
 	auth := &Config{Username: "user", Password: "pass"}

--- a/pkg/client/v1/resource_quotas.go
+++ b/pkg/client/v1/resource_quotas.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// ResourceQuotasNamespacer has methods to work with ResourceQuota resources in a namespace
+type ResourceQuotasNamespacer interface {
+	ResourceQuotas(namespace string) ResourceQuotaInterface
+}
+
+// ResourceQuotaInterface has methods to work with ResourceQuota resources.
+type ResourceQuotaInterface interface {
+	List(selector labels.Selector) (*api.ResourceQuotaList, error)
+	Get(name string) (*api.ResourceQuota, error)
+	Delete(name string) error
+	Create(resourceQuota *api.ResourceQuota) (*api.ResourceQuota, error)
+	Update(resourceQuota *api.ResourceQuota) (*api.ResourceQuota, error)
+	UpdateStatus(resourceQuota *api.ResourceQuota) (*api.ResourceQuota, error)
+	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
+}
+
+// resourceQuotas implements ResourceQuotasNamespacer interface
+type resourceQuotas struct {
+	r  *Client
+	ns string
+}
+
+// newResourceQuotas returns a resourceQuotas
+func newResourceQuotas(c *Client, namespace string) *resourceQuotas {
+	return &resourceQuotas{
+		r:  c,
+		ns: namespace,
+	}
+}
+
+// List takes a selector, and returns the list of resourceQuotas that match that selector.
+func (c *resourceQuotas) List(selector labels.Selector) (result *api.ResourceQuotaList, err error) {
+	result = &api.ResourceQuotaList{}
+	err = c.r.Get().Namespace(c.ns).Resource("resourceQuotas").LabelsSelectorParam(selector).Do().Into(result)
+	return
+}
+
+// Get takes the name of the resourceQuota, and returns the corresponding ResourceQuota object, and an error if it occurs
+func (c *resourceQuotas) Get(name string) (result *api.ResourceQuota, err error) {
+	result = &api.ResourceQuota{}
+	err = c.r.Get().Namespace(c.ns).Resource("resourceQuotas").Name(name).Do().Into(result)
+	return
+}
+
+// Delete takes the name of the resourceQuota, and returns an error if one occurs
+func (c *resourceQuotas) Delete(name string) error {
+	return c.r.Delete().Namespace(c.ns).Resource("resourceQuotas").Name(name).Do().Error()
+}
+
+// Create takes the representation of a resourceQuota.  Returns the server's representation of the resourceQuota, and an error, if it occurs.
+func (c *resourceQuotas) Create(resourceQuota *api.ResourceQuota) (result *api.ResourceQuota, err error) {
+	result = &api.ResourceQuota{}
+	err = c.r.Post().Namespace(c.ns).Resource("resourceQuotas").Body(resourceQuota).Do().Into(result)
+	return
+}
+
+// Update takes the representation of a resourceQuota to update spec.  Returns the server's representation of the resourceQuota, and an error, if it occurs.
+func (c *resourceQuotas) Update(resourceQuota *api.ResourceQuota) (result *api.ResourceQuota, err error) {
+	result = &api.ResourceQuota{}
+	err = c.r.Put().Namespace(c.ns).Resource("resourceQuotas").Name(resourceQuota.Name).Body(resourceQuota).Do().Into(result)
+	return
+}
+
+// Status takes the representation of a resourceQuota to update status.  Returns the server's representation of the resourceQuota, and an error, if it occurs.
+func (c *resourceQuotas) UpdateStatus(resourceQuota *api.ResourceQuota) (result *api.ResourceQuota, err error) {
+	result = &api.ResourceQuota{}
+	err = c.r.Put().Namespace(c.ns).Resource("resourceQuotas").Name(resourceQuota.Name).SubResource("status").Body(resourceQuota).Do().Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested resource
+func (c *resourceQuotas) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.r.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("resourceQuotas").
+		Param("resourceVersion", resourceVersion).
+		LabelsSelectorParam(label).
+		FieldsSelectorParam(field).
+		Watch()
+}

--- a/pkg/client/v1/resource_quotas.go
+++ b/pkg/client/v1/resource_quotas.go
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
-	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/watch"
@@ -30,12 +30,12 @@ type ResourceQuotasNamespacer interface {
 
 // ResourceQuotaInterface has methods to work with ResourceQuota resources.
 type ResourceQuotaInterface interface {
-	List(selector labels.Selector) (*api.ResourceQuotaList, error)
-	Get(name string) (*api.ResourceQuota, error)
+	List(selector labels.Selector) (*v1.ResourceQuotaList, error)
+	Get(name string) (*v1.ResourceQuota, error)
 	Delete(name string) error
-	Create(resourceQuota *api.ResourceQuota) (*api.ResourceQuota, error)
-	Update(resourceQuota *api.ResourceQuota) (*api.ResourceQuota, error)
-	UpdateStatus(resourceQuota *api.ResourceQuota) (*api.ResourceQuota, error)
+	Create(resourceQuota *v1.ResourceQuota) (*v1.ResourceQuota, error)
+	Update(resourceQuota *v1.ResourceQuota) (*v1.ResourceQuota, error)
+	UpdateStatus(resourceQuota *v1.ResourceQuota) (*v1.ResourceQuota, error)
 	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
 }
 
@@ -54,15 +54,15 @@ func newResourceQuotas(c *Client, namespace string) *resourceQuotas {
 }
 
 // List takes a selector, and returns the list of resourceQuotas that match that selector.
-func (c *resourceQuotas) List(selector labels.Selector) (result *api.ResourceQuotaList, err error) {
-	result = &api.ResourceQuotaList{}
+func (c *resourceQuotas) List(selector labels.Selector) (result *v1.ResourceQuotaList, err error) {
+	result = &v1.ResourceQuotaList{}
 	err = c.r.Get().Namespace(c.ns).Resource("resourceQuotas").LabelsSelectorParam(selector).Do().Into(result)
 	return
 }
 
 // Get takes the name of the resourceQuota, and returns the corresponding ResourceQuota object, and an error if it occurs
-func (c *resourceQuotas) Get(name string) (result *api.ResourceQuota, err error) {
-	result = &api.ResourceQuota{}
+func (c *resourceQuotas) Get(name string) (result *v1.ResourceQuota, err error) {
+	result = &v1.ResourceQuota{}
 	err = c.r.Get().Namespace(c.ns).Resource("resourceQuotas").Name(name).Do().Into(result)
 	return
 }
@@ -73,22 +73,22 @@ func (c *resourceQuotas) Delete(name string) error {
 }
 
 // Create takes the representation of a resourceQuota.  Returns the server's representation of the resourceQuota, and an error, if it occurs.
-func (c *resourceQuotas) Create(resourceQuota *api.ResourceQuota) (result *api.ResourceQuota, err error) {
-	result = &api.ResourceQuota{}
+func (c *resourceQuotas) Create(resourceQuota *v1.ResourceQuota) (result *v1.ResourceQuota, err error) {
+	result = &v1.ResourceQuota{}
 	err = c.r.Post().Namespace(c.ns).Resource("resourceQuotas").Body(resourceQuota).Do().Into(result)
 	return
 }
 
 // Update takes the representation of a resourceQuota to update spec.  Returns the server's representation of the resourceQuota, and an error, if it occurs.
-func (c *resourceQuotas) Update(resourceQuota *api.ResourceQuota) (result *api.ResourceQuota, err error) {
-	result = &api.ResourceQuota{}
+func (c *resourceQuotas) Update(resourceQuota *v1.ResourceQuota) (result *v1.ResourceQuota, err error) {
+	result = &v1.ResourceQuota{}
 	err = c.r.Put().Namespace(c.ns).Resource("resourceQuotas").Name(resourceQuota.Name).Body(resourceQuota).Do().Into(result)
 	return
 }
 
 // Status takes the representation of a resourceQuota to update status.  Returns the server's representation of the resourceQuota, and an error, if it occurs.
-func (c *resourceQuotas) UpdateStatus(resourceQuota *api.ResourceQuota) (result *api.ResourceQuota, err error) {
-	result = &api.ResourceQuota{}
+func (c *resourceQuotas) UpdateStatus(resourceQuota *v1.ResourceQuota) (result *v1.ResourceQuota, err error) {
+	result = &v1.ResourceQuota{}
 	err = c.r.Put().Namespace(c.ns).Resource("resourceQuotas").Name(resourceQuota.Name).SubResource("status").Body(resourceQuota).Do().Into(result)
 	return
 }

--- a/pkg/client/v1/resource_quotas_test.go
+++ b/pkg/client/v1/resource_quotas_test.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"net/url"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func getResourceQuotasResoureName() string {
+	return "resourcequotas"
+}
+
+func TestResourceQuotaCreate(t *testing.T) {
+	ns := api.NamespaceDefault
+	resourceQuota := &api.ResourceQuota{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "abc",
+			Namespace: "foo",
+		},
+		Spec: api.ResourceQuotaSpec{
+			Hard: api.ResourceList{
+				api.ResourceCPU:                    resource.MustParse("100"),
+				api.ResourceMemory:                 resource.MustParse("10000"),
+				api.ResourcePods:                   resource.MustParse("10"),
+				api.ResourceServices:               resource.MustParse("10"),
+				api.ResourceReplicationControllers: resource.MustParse("10"),
+				api.ResourceQuotas:                 resource.MustParse("10"),
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "POST",
+			Path:   testapi.Default.ResourcePath(getResourceQuotasResoureName(), ns, ""),
+			Query:  buildQueryValues(nil),
+			Body:   resourceQuota,
+		},
+		Response: Response{StatusCode: 200, Body: resourceQuota},
+	}
+
+	response, err := c.Setup(t).ResourceQuotas(ns).Create(resourceQuota)
+	c.Validate(t, response, err)
+}
+
+func TestResourceQuotaGet(t *testing.T) {
+	ns := api.NamespaceDefault
+	resourceQuota := &api.ResourceQuota{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "abc",
+			Namespace: "foo",
+		},
+		Spec: api.ResourceQuotaSpec{
+			Hard: api.ResourceList{
+				api.ResourceCPU:                    resource.MustParse("100"),
+				api.ResourceMemory:                 resource.MustParse("10000"),
+				api.ResourcePods:                   resource.MustParse("10"),
+				api.ResourceServices:               resource.MustParse("10"),
+				api.ResourceReplicationControllers: resource.MustParse("10"),
+				api.ResourceQuotas:                 resource.MustParse("10"),
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath(getResourceQuotasResoureName(), ns, "abc"),
+			Query:  buildQueryValues(nil),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: resourceQuota},
+	}
+
+	response, err := c.Setup(t).ResourceQuotas(ns).Get("abc")
+	c.Validate(t, response, err)
+}
+
+func TestResourceQuotaList(t *testing.T) {
+	ns := api.NamespaceDefault
+
+	resourceQuotaList := &api.ResourceQuotaList{
+		Items: []api.ResourceQuota{
+			{
+				ObjectMeta: api.ObjectMeta{Name: "foo"},
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath(getResourceQuotasResoureName(), ns, ""),
+			Query:  buildQueryValues(nil),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: resourceQuotaList},
+	}
+	response, err := c.Setup(t).ResourceQuotas(ns).List(labels.Everything())
+	c.Validate(t, response, err)
+}
+
+func TestResourceQuotaUpdate(t *testing.T) {
+	ns := api.NamespaceDefault
+	resourceQuota := &api.ResourceQuota{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "abc",
+			Namespace:       "foo",
+			ResourceVersion: "1",
+		},
+		Spec: api.ResourceQuotaSpec{
+			Hard: api.ResourceList{
+				api.ResourceCPU:                    resource.MustParse("100"),
+				api.ResourceMemory:                 resource.MustParse("10000"),
+				api.ResourcePods:                   resource.MustParse("10"),
+				api.ResourceServices:               resource.MustParse("10"),
+				api.ResourceReplicationControllers: resource.MustParse("10"),
+				api.ResourceQuotas:                 resource.MustParse("10"),
+			},
+		},
+	}
+	c := &testClient{
+		Request:  testRequest{Method: "PUT", Path: testapi.Default.ResourcePath(getResourceQuotasResoureName(), ns, "abc"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200, Body: resourceQuota},
+	}
+	response, err := c.Setup(t).ResourceQuotas(ns).Update(resourceQuota)
+	c.Validate(t, response, err)
+}
+
+func TestResourceQuotaStatusUpdate(t *testing.T) {
+	ns := api.NamespaceDefault
+	resourceQuota := &api.ResourceQuota{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "abc",
+			Namespace:       "foo",
+			ResourceVersion: "1",
+		},
+		Status: api.ResourceQuotaStatus{
+			Hard: api.ResourceList{
+				api.ResourceCPU:                    resource.MustParse("100"),
+				api.ResourceMemory:                 resource.MustParse("10000"),
+				api.ResourcePods:                   resource.MustParse("10"),
+				api.ResourceServices:               resource.MustParse("10"),
+				api.ResourceReplicationControllers: resource.MustParse("10"),
+				api.ResourceQuotas:                 resource.MustParse("10"),
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "PUT",
+			Path:   testapi.Default.ResourcePath(getResourceQuotasResoureName(), ns, "abc") + "/status",
+			Query:  buildQueryValues(nil)},
+		Response: Response{StatusCode: 200, Body: resourceQuota},
+	}
+	response, err := c.Setup(t).ResourceQuotas(ns).UpdateStatus(resourceQuota)
+	c.Validate(t, response, err)
+}
+
+func TestResourceQuotaDelete(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request:  testRequest{Method: "DELETE", Path: testapi.Default.ResourcePath(getResourceQuotasResoureName(), ns, "foo"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200},
+	}
+	err := c.Setup(t).ResourceQuotas(ns).Delete("foo")
+	c.Validate(t, nil, err)
+}
+
+func TestResourceQuotaWatch(t *testing.T) {
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePathWithPrefix("watch", getResourceQuotasResoureName(), "", ""),
+			Query:  url.Values{"resourceVersion": []string{}}},
+		Response: Response{StatusCode: 200},
+	}
+	_, err := c.Setup(t).ResourceQuotas(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), "")
+	c.Validate(t, nil, err)
+}

--- a/pkg/client/v1/resource_quotas_test.go
+++ b/pkg/client/v1/resource_quotas_test.go
@@ -14,15 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"net/url"
 	"testing"
 
-	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 )
@@ -32,20 +32,20 @@ func getResourceQuotasResoureName() string {
 }
 
 func TestResourceQuotaCreate(t *testing.T) {
-	ns := api.NamespaceDefault
-	resourceQuota := &api.ResourceQuota{
-		ObjectMeta: api.ObjectMeta{
+	ns := v1.NamespaceDefault
+	resourceQuota := &v1.ResourceQuota{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "abc",
 			Namespace: "foo",
 		},
-		Spec: api.ResourceQuotaSpec{
-			Hard: api.ResourceList{
-				api.ResourceCPU:                    resource.MustParse("100"),
-				api.ResourceMemory:                 resource.MustParse("10000"),
-				api.ResourcePods:                   resource.MustParse("10"),
-				api.ResourceServices:               resource.MustParse("10"),
-				api.ResourceReplicationControllers: resource.MustParse("10"),
-				api.ResourceQuotas:                 resource.MustParse("10"),
+		Spec: v1.ResourceQuotaSpec{
+			Hard: v1.ResourceList{
+				v1.ResourceCPU:                    resource.MustParse("100"),
+				v1.ResourceMemory:                 resource.MustParse("10000"),
+				v1.ResourcePods:                   resource.MustParse("10"),
+				v1.ResourceServices:               resource.MustParse("10"),
+				v1.ResourceReplicationControllers: resource.MustParse("10"),
+				v1.ResourceQuotas:                 resource.MustParse("10"),
 			},
 		},
 	}
@@ -64,20 +64,20 @@ func TestResourceQuotaCreate(t *testing.T) {
 }
 
 func TestResourceQuotaGet(t *testing.T) {
-	ns := api.NamespaceDefault
-	resourceQuota := &api.ResourceQuota{
-		ObjectMeta: api.ObjectMeta{
+	ns := v1.NamespaceDefault
+	resourceQuota := &v1.ResourceQuota{
+		ObjectMeta: v1.ObjectMeta{
 			Name:      "abc",
 			Namespace: "foo",
 		},
-		Spec: api.ResourceQuotaSpec{
-			Hard: api.ResourceList{
-				api.ResourceCPU:                    resource.MustParse("100"),
-				api.ResourceMemory:                 resource.MustParse("10000"),
-				api.ResourcePods:                   resource.MustParse("10"),
-				api.ResourceServices:               resource.MustParse("10"),
-				api.ResourceReplicationControllers: resource.MustParse("10"),
-				api.ResourceQuotas:                 resource.MustParse("10"),
+		Spec: v1.ResourceQuotaSpec{
+			Hard: v1.ResourceList{
+				v1.ResourceCPU:                    resource.MustParse("100"),
+				v1.ResourceMemory:                 resource.MustParse("10000"),
+				v1.ResourcePods:                   resource.MustParse("10"),
+				v1.ResourceServices:               resource.MustParse("10"),
+				v1.ResourceReplicationControllers: resource.MustParse("10"),
+				v1.ResourceQuotas:                 resource.MustParse("10"),
 			},
 		},
 	}
@@ -96,12 +96,12 @@ func TestResourceQuotaGet(t *testing.T) {
 }
 
 func TestResourceQuotaList(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 
-	resourceQuotaList := &api.ResourceQuotaList{
-		Items: []api.ResourceQuota{
+	resourceQuotaList := &v1.ResourceQuotaList{
+		Items: []v1.ResourceQuota{
 			{
-				ObjectMeta: api.ObjectMeta{Name: "foo"},
+				ObjectMeta: v1.ObjectMeta{Name: "foo"},
 			},
 		},
 	}
@@ -119,21 +119,21 @@ func TestResourceQuotaList(t *testing.T) {
 }
 
 func TestResourceQuotaUpdate(t *testing.T) {
-	ns := api.NamespaceDefault
-	resourceQuota := &api.ResourceQuota{
-		ObjectMeta: api.ObjectMeta{
+	ns := v1.NamespaceDefault
+	resourceQuota := &v1.ResourceQuota{
+		ObjectMeta: v1.ObjectMeta{
 			Name:            "abc",
 			Namespace:       "foo",
 			ResourceVersion: "1",
 		},
-		Spec: api.ResourceQuotaSpec{
-			Hard: api.ResourceList{
-				api.ResourceCPU:                    resource.MustParse("100"),
-				api.ResourceMemory:                 resource.MustParse("10000"),
-				api.ResourcePods:                   resource.MustParse("10"),
-				api.ResourceServices:               resource.MustParse("10"),
-				api.ResourceReplicationControllers: resource.MustParse("10"),
-				api.ResourceQuotas:                 resource.MustParse("10"),
+		Spec: v1.ResourceQuotaSpec{
+			Hard: v1.ResourceList{
+				v1.ResourceCPU:                    resource.MustParse("100"),
+				v1.ResourceMemory:                 resource.MustParse("10000"),
+				v1.ResourcePods:                   resource.MustParse("10"),
+				v1.ResourceServices:               resource.MustParse("10"),
+				v1.ResourceReplicationControllers: resource.MustParse("10"),
+				v1.ResourceQuotas:                 resource.MustParse("10"),
 			},
 		},
 	}
@@ -146,21 +146,21 @@ func TestResourceQuotaUpdate(t *testing.T) {
 }
 
 func TestResourceQuotaStatusUpdate(t *testing.T) {
-	ns := api.NamespaceDefault
-	resourceQuota := &api.ResourceQuota{
-		ObjectMeta: api.ObjectMeta{
+	ns := v1.NamespaceDefault
+	resourceQuota := &v1.ResourceQuota{
+		ObjectMeta: v1.ObjectMeta{
 			Name:            "abc",
 			Namespace:       "foo",
 			ResourceVersion: "1",
 		},
-		Status: api.ResourceQuotaStatus{
-			Hard: api.ResourceList{
-				api.ResourceCPU:                    resource.MustParse("100"),
-				api.ResourceMemory:                 resource.MustParse("10000"),
-				api.ResourcePods:                   resource.MustParse("10"),
-				api.ResourceServices:               resource.MustParse("10"),
-				api.ResourceReplicationControllers: resource.MustParse("10"),
-				api.ResourceQuotas:                 resource.MustParse("10"),
+		Status: v1.ResourceQuotaStatus{
+			Hard: v1.ResourceList{
+				v1.ResourceCPU:                    resource.MustParse("100"),
+				v1.ResourceMemory:                 resource.MustParse("10000"),
+				v1.ResourcePods:                   resource.MustParse("10"),
+				v1.ResourceServices:               resource.MustParse("10"),
+				v1.ResourceReplicationControllers: resource.MustParse("10"),
+				v1.ResourceQuotas:                 resource.MustParse("10"),
 			},
 		},
 	}
@@ -176,7 +176,7 @@ func TestResourceQuotaStatusUpdate(t *testing.T) {
 }
 
 func TestResourceQuotaDelete(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	c := &testClient{
 		Request:  testRequest{Method: "DELETE", Path: testapi.Default.ResourcePath(getResourceQuotasResoureName(), ns, "foo"), Query: buildQueryValues(nil)},
 		Response: Response{StatusCode: 200},
@@ -193,6 +193,6 @@ func TestResourceQuotaWatch(t *testing.T) {
 			Query:  url.Values{"resourceVersion": []string{}}},
 		Response: Response{StatusCode: 200},
 	}
-	_, err := c.Setup(t).ResourceQuotas(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), "")
+	_, err := c.Setup(t).ResourceQuotas(v1.NamespaceAll).Watch(labels.Everything(), fields.Everything(), "")
 	c.Validate(t, nil, err)
 }

--- a/pkg/client/v1/restclient.go
+++ b/pkg/client/v1/restclient.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"net/url"
+	"strings"
+	"time"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util"
+)
+
+// RESTClient imposes common Kubernetes API conventions on a set of resource paths.
+// The baseURL is expected to point to an HTTP or HTTPS path that is the parent
+// of one or more resources.  The server should return a decodable API resource
+// object, or an api.Status object which contains information about the reason for
+// any failure.
+//
+// Most consumers should use client.New() to get a Kubernetes API client.
+type RESTClient struct {
+	baseURL *url.URL
+	// A string identifying the version of the API this client is expected to use.
+	apiVersion string
+
+	// Codec is the encoding and decoding scheme that applies to a particular set of
+	// REST resources.
+	Codec runtime.Codec
+
+	// Set specific behavior of the client.  If not set http.DefaultClient will be
+	// used.
+	Client HTTPClient
+
+	Timeout time.Duration
+
+	// TODO extract this into a wrapper interface via the RESTClient interface in kubectl.
+	Throttle util.RateLimiter
+}
+
+// NewRESTClient creates a new RESTClient. This client performs generic REST functions
+// such as Get, Put, Post, and Delete on specified paths.  Codec controls encoding and
+// decoding of responses from the server.
+func NewRESTClient(baseURL *url.URL, apiVersion string, c runtime.Codec, maxQPS float32, maxBurst int) *RESTClient {
+	base := *baseURL
+	if !strings.HasSuffix(base.Path, "/") {
+		base.Path += "/"
+	}
+	base.RawQuery = ""
+	base.Fragment = ""
+
+	var throttle util.RateLimiter
+	if maxQPS > 0 {
+		throttle = util.NewTokenBucketRateLimiter(maxQPS, maxBurst)
+	}
+	return &RESTClient{
+		baseURL:    &base,
+		apiVersion: apiVersion,
+		Codec:      c,
+		Throttle:   throttle,
+	}
+}
+
+// Verb begins a request with a verb (GET, POST, PUT, DELETE).
+//
+// Example usage of RESTClient's request building interface:
+// c := NewRESTClient(url, codec)
+// resp, err := c.Verb("GET").
+//  Path("pods").
+//  SelectorParam("labels", "area=staging").
+//  Timeout(10*time.Second).
+//  Do()
+// if err != nil { ... }
+// list, ok := resp.(*api.PodList)
+//
+func (c *RESTClient) Verb(verb string) *Request {
+	if c.Throttle != nil {
+		c.Throttle.Accept()
+	}
+	return NewRequest(c.Client, verb, c.baseURL, c.apiVersion, c.Codec).Timeout(c.Timeout)
+}
+
+// Post begins a POST request. Short for c.Verb("POST").
+func (c *RESTClient) Post() *Request {
+	return c.Verb("POST")
+}
+
+// Put begins a PUT request. Short for c.Verb("PUT").
+func (c *RESTClient) Put() *Request {
+	return c.Verb("PUT")
+}
+
+// Patch begins a PATCH request. Short for c.Verb("Patch").
+func (c *RESTClient) Patch(pt api.PatchType) *Request {
+	return c.Verb("PATCH").SetHeader("Content-Type", string(pt))
+}
+
+// Get begins a GET request. Short for c.Verb("GET").
+func (c *RESTClient) Get() *Request {
+	return c.Verb("GET")
+}
+
+// Delete begins a DELETE request. Short for c.Verb("DELETE").
+func (c *RESTClient) Delete() *Request {
+	return c.Verb("DELETE")
+}
+
+// APIVersion returns the APIVersion this RESTClient is expected to use.
+func (c *RESTClient) APIVersion() string {
+	return c.apiVersion
+}

--- a/pkg/client/v1/restclient.go
+++ b/pkg/client/v1/restclient.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"net/url"

--- a/pkg/client/v1/restclient_test.go
+++ b/pkg/client/v1/restclient_test.go
@@ -1,0 +1,288 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util"
+)
+
+func TestSetsCodec(t *testing.T) {
+	testCases := map[string]struct {
+		Err    bool
+		Prefix string
+		Codec  runtime.Codec
+	}{
+		testapi.Default.Version(): {false, "/api/" + testapi.Default.Version() + "/", testapi.Default.Codec()},
+		"invalidVersion":          {true, "", nil},
+	}
+	for version, expected := range testCases {
+		client, err := New(&Config{Host: "127.0.0.1", Version: version})
+		switch {
+		case err == nil && expected.Err:
+			t.Errorf("expected error but was nil")
+			continue
+		case err != nil && !expected.Err:
+			t.Errorf("unexpected error %v", err)
+			continue
+		case err != nil:
+			continue
+		}
+		if e, a := expected.Prefix, client.RESTClient.baseURL.Path; e != a {
+			t.Errorf("expected %#v, got %#v", e, a)
+		}
+		if e, a := expected.Codec, client.RESTClient.Codec; e != a {
+			t.Errorf("expected %#v, got %#v", e, a)
+		}
+	}
+}
+
+func TestRESTClientRequires(t *testing.T) {
+	if _, err := RESTClientFor(&Config{Host: "127.0.0.1", Version: "", Codec: testapi.Default.Codec()}); err == nil {
+		t.Errorf("unexpected non-error")
+	}
+	if _, err := RESTClientFor(&Config{Host: "127.0.0.1", Version: testapi.Default.Version()}); err == nil {
+		t.Errorf("unexpected non-error")
+	}
+	if _, err := RESTClientFor(&Config{Host: "127.0.0.1", Version: testapi.Default.Version(), Codec: testapi.Default.Codec()}); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestValidatesHostParameter(t *testing.T) {
+	testCases := []struct {
+		Host   string
+		Prefix string
+
+		URL string
+		Err bool
+	}{
+		{"127.0.0.1", "", "http://127.0.0.1/" + testapi.Default.Version() + "/", false},
+		{"127.0.0.1:8080", "", "http://127.0.0.1:8080/" + testapi.Default.Version() + "/", false},
+		{"foo.bar.com", "", "http://foo.bar.com/" + testapi.Default.Version() + "/", false},
+		{"http://host/prefix", "", "http://host/prefix/" + testapi.Default.Version() + "/", false},
+		{"http://host", "", "http://host/" + testapi.Default.Version() + "/", false},
+		{"http://host", "/", "http://host/" + testapi.Default.Version() + "/", false},
+		{"http://host", "/other", "http://host/other/" + testapi.Default.Version() + "/", false},
+		{"host/server", "", "", true},
+	}
+	for i, testCase := range testCases {
+		c, err := RESTClientFor(&Config{Host: testCase.Host, Prefix: testCase.Prefix, Version: testapi.Default.Version(), Codec: testapi.Default.Codec()})
+		switch {
+		case err == nil && testCase.Err:
+			t.Errorf("expected error but was nil")
+			continue
+		case err != nil && !testCase.Err:
+			t.Errorf("unexpected error %v", err)
+			continue
+		case err != nil:
+			continue
+		}
+		if e, a := testCase.URL, c.baseURL.String(); e != a {
+			t.Errorf("%d: expected host %s, got %s", i, e, a)
+			continue
+		}
+	}
+}
+
+func TestDoRequestBearer(t *testing.T) {
+	status := &unversioned.Status{Status: unversioned.StatusFailure}
+	expectedBody, _ := testapi.Default.Codec().Encode(status)
+	fakeHandler := util.FakeHandler{
+		StatusCode:   400,
+		ResponseBody: string(expectedBody),
+		T:            t,
+	}
+	testServer := httptest.NewServer(&fakeHandler)
+	defer testServer.Close()
+	request, _ := http.NewRequest("GET", testServer.URL, nil)
+	c, err := RESTClientFor(&Config{
+		Host:        testServer.URL,
+		Version:     testapi.Default.Version(),
+		Codec:       testapi.Default.Codec(),
+		BearerToken: "test",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	err = c.Get().Do().Error()
+	if err == nil {
+		t.Fatalf("unexpected non-error: %v", err)
+	}
+	if fakeHandler.RequestReceived.Header.Get("Authorization") != "Bearer test" {
+		t.Errorf("Request is missing authorization header: %#v", *request)
+	}
+}
+
+func TestDoRequestWithoutPassword(t *testing.T) {
+	status := &unversioned.Status{Status: unversioned.StatusFailure}
+	expectedBody, _ := testapi.Default.Codec().Encode(status)
+	fakeHandler := util.FakeHandler{
+		StatusCode:   400,
+		ResponseBody: string(expectedBody),
+		T:            t,
+	}
+	testServer := httptest.NewServer(&fakeHandler)
+	defer testServer.Close()
+	c, err := RESTClientFor(&Config{
+		Host:     testServer.URL,
+		Version:  testapi.Default.Version(),
+		Codec:    testapi.Default.Codec(),
+		Username: "test",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body, err := c.Get().Prefix("test").Do().Raw()
+	if err == nil {
+		t.Fatalf("Unexpected non-error")
+	}
+	if fakeHandler.RequestReceived.Header["Authorization"] == nil {
+		t.Errorf("Request is missing authorization header: %#v", fakeHandler.RequestReceived)
+	}
+	se, ok := err.(APIStatus)
+	if !ok {
+		t.Fatalf("Unexpected kind of error: %#v", err)
+	}
+	if !reflect.DeepEqual(se.Status(), *status) {
+		t.Errorf("Unexpected status: %#v %#v", se.Status(), status)
+	}
+	if body != nil {
+		t.Errorf("Expected nil body, but saw: '%s'", string(body))
+	}
+	fakeHandler.ValidateRequest(t, "/"+testapi.Default.Version()+"/test", "GET", nil)
+}
+
+func TestDoRequestSuccess(t *testing.T) {
+	status := &unversioned.Status{Status: unversioned.StatusSuccess}
+	expectedBody, _ := testapi.Default.Codec().Encode(status)
+	fakeHandler := util.FakeHandler{
+		StatusCode:   200,
+		ResponseBody: string(expectedBody),
+		T:            t,
+	}
+	testServer := httptest.NewServer(&fakeHandler)
+	defer testServer.Close()
+	c, err := RESTClientFor(&Config{
+		Host:     testServer.URL,
+		Version:  testapi.Default.Version(),
+		Codec:    testapi.Default.Codec(),
+		Username: "user",
+		Password: "pass",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body, err := c.Get().Prefix("test").Do().Raw()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fakeHandler.RequestReceived.Header["Authorization"] == nil {
+		t.Errorf("Request is missing authorization header: %#v", fakeHandler.RequestReceived)
+	}
+	statusOut, err := testapi.Default.Codec().Decode(body)
+	if err != nil {
+		t.Errorf("Unexpected error %#v", err)
+	}
+	if !reflect.DeepEqual(status, statusOut) {
+		t.Errorf("Unexpected mis-match. Expected %#v.  Saw %#v", status, statusOut)
+	}
+	fakeHandler.ValidateRequest(t, "/"+testapi.Default.Version()+"/test", "GET", nil)
+}
+
+func TestDoRequestFailed(t *testing.T) {
+	status := &unversioned.Status{
+		Code:    http.StatusNotFound,
+		Status:  unversioned.StatusFailure,
+		Reason:  unversioned.StatusReasonNotFound,
+		Message: " \"\" not found",
+		Details: &unversioned.StatusDetails{},
+	}
+	expectedBody, _ := testapi.Default.Codec().Encode(status)
+	fakeHandler := util.FakeHandler{
+		StatusCode:   404,
+		ResponseBody: string(expectedBody),
+		T:            t,
+	}
+	testServer := httptest.NewServer(&fakeHandler)
+	defer testServer.Close()
+	c, err := RESTClientFor(&Config{
+		Host:    testServer.URL,
+		Version: testapi.Default.Version(),
+		Codec:   testapi.Default.Codec(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body, err := c.Get().Do().Raw()
+	if err == nil || body != nil {
+		t.Errorf("unexpected non-error: %#v", body)
+	}
+	ss, ok := err.(APIStatus)
+	if !ok {
+		t.Errorf("unexpected error type %v", err)
+	}
+	actual := ss.Status()
+	if !reflect.DeepEqual(status, &actual) {
+		t.Errorf("Unexpected mis-match: %s", util.ObjectDiff(status, &actual))
+	}
+}
+
+func TestDoRequestCreated(t *testing.T) {
+	status := &unversioned.Status{Status: unversioned.StatusSuccess}
+	expectedBody, _ := testapi.Default.Codec().Encode(status)
+	fakeHandler := util.FakeHandler{
+		StatusCode:   201,
+		ResponseBody: string(expectedBody),
+		T:            t,
+	}
+	testServer := httptest.NewServer(&fakeHandler)
+	defer testServer.Close()
+	c, err := RESTClientFor(&Config{
+		Host:     testServer.URL,
+		Version:  testapi.Default.Version(),
+		Codec:    testapi.Default.Codec(),
+		Username: "user",
+		Password: "pass",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	created := false
+	body, err := c.Get().Prefix("test").Do().WasCreated(&created).Raw()
+	if err != nil {
+		t.Errorf("Unexpected error %#v", err)
+	}
+	if !created {
+		t.Errorf("Expected object to be created")
+	}
+	statusOut, err := testapi.Default.Codec().Decode(body)
+	if err != nil {
+		t.Errorf("Unexpected error %#v", err)
+	}
+	if !reflect.DeepEqual(status, statusOut) {
+		t.Errorf("Unexpected mis-match. Expected %#v.  Saw %#v", status, statusOut)
+	}
+	fakeHandler.ValidateRequest(t, "/"+testapi.Default.Version()+"/test", "GET", nil)
+}

--- a/pkg/client/v1/restclient_test.go
+++ b/pkg/client/v1/restclient_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"net/http"

--- a/pkg/client/v1/scale.go
+++ b/pkg/client/v1/scale.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/apis/experimental"
+)
+
+type ScaleNamespacer interface {
+	Scales(namespace string) ScaleInterface
+}
+
+// ScaleInterface has methods to work with Scale (sub)resources.
+type ScaleInterface interface {
+	Get(string, string) (*experimental.Scale, error)
+	Update(string, *experimental.Scale) (*experimental.Scale, error)
+}
+
+// horizontalPodAutoscalers implements HorizontalPodAutoscalersNamespacer interface
+type scales struct {
+	client *ExperimentalClient
+	ns     string
+}
+
+// newHorizontalPodAutoscalers returns a horizontalPodAutoscalers
+func newScales(c *ExperimentalClient, namespace string) *scales {
+	return &scales{
+		client: c,
+		ns:     namespace,
+	}
+}
+
+// Get takes the reference to scale subresource and returns the subresource or error, if one occurs.
+func (c *scales) Get(kind string, name string) (result *experimental.Scale, err error) {
+	result = &experimental.Scale{}
+	resource, _ := meta.KindToResource(kind, false)
+	err = c.client.Get().Namespace(c.ns).Resource(resource).Name(name).SubResource("scale").Do().Into(result)
+	return
+}
+
+func (c *scales) Update(kind string, scale *experimental.Scale) (result *experimental.Scale, err error) {
+	result = &experimental.Scale{}
+	resource, _ := meta.KindToResource(kind, false)
+	err = c.client.Put().
+		Namespace(scale.Namespace).
+		Resource(resource).
+		Name(scale.Name).
+		SubResource("scale").
+		Body(scale).
+		Do().
+		Into(result)
+	return
+}

--- a/pkg/client/v1/scale.go
+++ b/pkg/client/v1/scale.go
@@ -14,11 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"k8s.io/kubernetes/pkg/api/meta"
-	"k8s.io/kubernetes/pkg/apis/experimental"
+	experimental "k8s.io/kubernetes/pkg/apis/experimental/v1"
 )
 
 type ScaleNamespacer interface {

--- a/pkg/client/v1/secrets.go
+++ b/pkg/client/v1/secrets.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+type SecretsNamespacer interface {
+	Secrets(namespace string) SecretsInterface
+}
+
+type SecretsInterface interface {
+	Create(secret *api.Secret) (*api.Secret, error)
+	Update(secret *api.Secret) (*api.Secret, error)
+	Delete(name string) error
+	List(label labels.Selector, field fields.Selector) (*api.SecretList, error)
+	Get(name string) (*api.Secret, error)
+	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
+}
+
+// events implements Secrets interface
+type secrets struct {
+	client    *Client
+	namespace string
+}
+
+// newSecrets returns a new secrets object.
+func newSecrets(c *Client, ns string) *secrets {
+	return &secrets{
+		client:    c,
+		namespace: ns,
+	}
+}
+
+func (s *secrets) Create(secret *api.Secret) (*api.Secret, error) {
+	result := &api.Secret{}
+	err := s.client.Post().
+		Namespace(s.namespace).
+		Resource("secrets").
+		Body(secret).
+		Do().
+		Into(result)
+
+	return result, err
+}
+
+// List returns a list of secrets matching the selectors.
+func (s *secrets) List(label labels.Selector, field fields.Selector) (*api.SecretList, error) {
+	result := &api.SecretList{}
+
+	err := s.client.Get().
+		Namespace(s.namespace).
+		Resource("secrets").
+		LabelsSelectorParam(label).
+		FieldsSelectorParam(field).
+		Do().
+		Into(result)
+
+	return result, err
+}
+
+// Get returns the given secret, or an error.
+func (s *secrets) Get(name string) (*api.Secret, error) {
+	result := &api.Secret{}
+	err := s.client.Get().
+		Namespace(s.namespace).
+		Resource("secrets").
+		Name(name).
+		Do().
+		Into(result)
+
+	return result, err
+}
+
+// Watch starts watching for secrets matching the given selectors.
+func (s *secrets) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return s.client.Get().
+		Prefix("watch").
+		Namespace(s.namespace).
+		Resource("secrets").
+		Param("resourceVersion", resourceVersion).
+		LabelsSelectorParam(label).
+		FieldsSelectorParam(field).
+		Watch()
+}
+
+func (s *secrets) Delete(name string) error {
+	return s.client.Delete().
+		Namespace(s.namespace).
+		Resource("secrets").
+		Name(name).
+		Do().
+		Error()
+}
+
+func (s *secrets) Update(secret *api.Secret) (result *api.Secret, err error) {
+	result = &api.Secret{}
+	err = s.client.Put().
+		Namespace(s.namespace).
+		Resource("secrets").
+		Name(secret.Name).
+		Body(secret).
+		Do().
+		Into(result)
+
+	return
+}

--- a/pkg/client/v1/secrets.go
+++ b/pkg/client/v1/secrets.go
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
-	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/watch"
@@ -28,11 +28,11 @@ type SecretsNamespacer interface {
 }
 
 type SecretsInterface interface {
-	Create(secret *api.Secret) (*api.Secret, error)
-	Update(secret *api.Secret) (*api.Secret, error)
+	Create(secret *v1.Secret) (*v1.Secret, error)
+	Update(secret *v1.Secret) (*v1.Secret, error)
 	Delete(name string) error
-	List(label labels.Selector, field fields.Selector) (*api.SecretList, error)
-	Get(name string) (*api.Secret, error)
+	List(label labels.Selector, field fields.Selector) (*v1.SecretList, error)
+	Get(name string) (*v1.Secret, error)
 	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
 }
 
@@ -50,8 +50,8 @@ func newSecrets(c *Client, ns string) *secrets {
 	}
 }
 
-func (s *secrets) Create(secret *api.Secret) (*api.Secret, error) {
-	result := &api.Secret{}
+func (s *secrets) Create(secret *v1.Secret) (*v1.Secret, error) {
+	result := &v1.Secret{}
 	err := s.client.Post().
 		Namespace(s.namespace).
 		Resource("secrets").
@@ -63,8 +63,8 @@ func (s *secrets) Create(secret *api.Secret) (*api.Secret, error) {
 }
 
 // List returns a list of secrets matching the selectors.
-func (s *secrets) List(label labels.Selector, field fields.Selector) (*api.SecretList, error) {
-	result := &api.SecretList{}
+func (s *secrets) List(label labels.Selector, field fields.Selector) (*v1.SecretList, error) {
+	result := &v1.SecretList{}
 
 	err := s.client.Get().
 		Namespace(s.namespace).
@@ -78,8 +78,8 @@ func (s *secrets) List(label labels.Selector, field fields.Selector) (*api.Secre
 }
 
 // Get returns the given secret, or an error.
-func (s *secrets) Get(name string) (*api.Secret, error) {
-	result := &api.Secret{}
+func (s *secrets) Get(name string) (*v1.Secret, error) {
+	result := &v1.Secret{}
 	err := s.client.Get().
 		Namespace(s.namespace).
 		Resource("secrets").
@@ -111,8 +111,8 @@ func (s *secrets) Delete(name string) error {
 		Error()
 }
 
-func (s *secrets) Update(secret *api.Secret) (result *api.Secret, err error) {
-	result = &api.Secret{}
+func (s *secrets) Update(secret *v1.Secret) (result *v1.Secret, err error) {
+	result = &v1.Secret{}
 	err = s.client.Put().
 		Namespace(s.namespace).
 		Resource("secrets").

--- a/pkg/client/v1/service_accounts.go
+++ b/pkg/client/v1/service_accounts.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+type ServiceAccountsNamespacer interface {
+	ServiceAccounts(namespace string) ServiceAccountsInterface
+}
+
+type ServiceAccountsInterface interface {
+	Create(serviceAccount *api.ServiceAccount) (*api.ServiceAccount, error)
+	Update(serviceAccount *api.ServiceAccount) (*api.ServiceAccount, error)
+	Delete(name string) error
+	List(label labels.Selector, field fields.Selector) (*api.ServiceAccountList, error)
+	Get(name string) (*api.ServiceAccount, error)
+	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
+}
+
+// serviceAccounts implements ServiceAccounts interface
+type serviceAccounts struct {
+	client    *Client
+	namespace string
+}
+
+// newServiceAccounts returns a new serviceAccounts object.
+func newServiceAccounts(c *Client, ns string) ServiceAccountsInterface {
+	return &serviceAccounts{
+		client:    c,
+		namespace: ns,
+	}
+}
+
+func (s *serviceAccounts) Create(serviceAccount *api.ServiceAccount) (*api.ServiceAccount, error) {
+	result := &api.ServiceAccount{}
+	err := s.client.Post().
+		Namespace(s.namespace).
+		Resource("serviceAccounts").
+		Body(serviceAccount).
+		Do().
+		Into(result)
+
+	return result, err
+}
+
+// List returns a list of serviceAccounts matching the selectors.
+func (s *serviceAccounts) List(label labels.Selector, field fields.Selector) (*api.ServiceAccountList, error) {
+	result := &api.ServiceAccountList{}
+
+	err := s.client.Get().
+		Namespace(s.namespace).
+		Resource("serviceAccounts").
+		LabelsSelectorParam(label).
+		FieldsSelectorParam(field).
+		Do().
+		Into(result)
+
+	return result, err
+}
+
+// Get returns the given serviceAccount, or an error.
+func (s *serviceAccounts) Get(name string) (*api.ServiceAccount, error) {
+	result := &api.ServiceAccount{}
+	err := s.client.Get().
+		Namespace(s.namespace).
+		Resource("serviceAccounts").
+		Name(name).
+		Do().
+		Into(result)
+
+	return result, err
+}
+
+// Watch starts watching for serviceAccounts matching the given selectors.
+func (s *serviceAccounts) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return s.client.Get().
+		Prefix("watch").
+		Namespace(s.namespace).
+		Resource("serviceAccounts").
+		Param("resourceVersion", resourceVersion).
+		LabelsSelectorParam(label).
+		FieldsSelectorParam(field).
+		Watch()
+}
+
+func (s *serviceAccounts) Delete(name string) error {
+	return s.client.Delete().
+		Namespace(s.namespace).
+		Resource("serviceAccounts").
+		Name(name).
+		Do().
+		Error()
+}
+
+func (s *serviceAccounts) Update(serviceAccount *api.ServiceAccount) (result *api.ServiceAccount, err error) {
+	result = &api.ServiceAccount{}
+	err = s.client.Put().
+		Namespace(s.namespace).
+		Resource("serviceAccounts").
+		Name(serviceAccount.Name).
+		Body(serviceAccount).
+		Do().
+		Into(result)
+
+	return
+}

--- a/pkg/client/v1/service_accounts.go
+++ b/pkg/client/v1/service_accounts.go
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
-	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/watch"
@@ -28,11 +28,11 @@ type ServiceAccountsNamespacer interface {
 }
 
 type ServiceAccountsInterface interface {
-	Create(serviceAccount *api.ServiceAccount) (*api.ServiceAccount, error)
-	Update(serviceAccount *api.ServiceAccount) (*api.ServiceAccount, error)
+	Create(serviceAccount *v1.ServiceAccount) (*v1.ServiceAccount, error)
+	Update(serviceAccount *v1.ServiceAccount) (*v1.ServiceAccount, error)
 	Delete(name string) error
-	List(label labels.Selector, field fields.Selector) (*api.ServiceAccountList, error)
-	Get(name string) (*api.ServiceAccount, error)
+	List(label labels.Selector, field fields.Selector) (*v1.ServiceAccountList, error)
+	Get(name string) (*v1.ServiceAccount, error)
 	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
 }
 
@@ -50,8 +50,8 @@ func newServiceAccounts(c *Client, ns string) ServiceAccountsInterface {
 	}
 }
 
-func (s *serviceAccounts) Create(serviceAccount *api.ServiceAccount) (*api.ServiceAccount, error) {
-	result := &api.ServiceAccount{}
+func (s *serviceAccounts) Create(serviceAccount *v1.ServiceAccount) (*v1.ServiceAccount, error) {
+	result := &v1.ServiceAccount{}
 	err := s.client.Post().
 		Namespace(s.namespace).
 		Resource("serviceAccounts").
@@ -63,8 +63,8 @@ func (s *serviceAccounts) Create(serviceAccount *api.ServiceAccount) (*api.Servi
 }
 
 // List returns a list of serviceAccounts matching the selectors.
-func (s *serviceAccounts) List(label labels.Selector, field fields.Selector) (*api.ServiceAccountList, error) {
-	result := &api.ServiceAccountList{}
+func (s *serviceAccounts) List(label labels.Selector, field fields.Selector) (*v1.ServiceAccountList, error) {
+	result := &v1.ServiceAccountList{}
 
 	err := s.client.Get().
 		Namespace(s.namespace).
@@ -78,8 +78,8 @@ func (s *serviceAccounts) List(label labels.Selector, field fields.Selector) (*a
 }
 
 // Get returns the given serviceAccount, or an error.
-func (s *serviceAccounts) Get(name string) (*api.ServiceAccount, error) {
-	result := &api.ServiceAccount{}
+func (s *serviceAccounts) Get(name string) (*v1.ServiceAccount, error) {
+	result := &v1.ServiceAccount{}
 	err := s.client.Get().
 		Namespace(s.namespace).
 		Resource("serviceAccounts").
@@ -111,8 +111,8 @@ func (s *serviceAccounts) Delete(name string) error {
 		Error()
 }
 
-func (s *serviceAccounts) Update(serviceAccount *api.ServiceAccount) (result *api.ServiceAccount, err error) {
-	result = &api.ServiceAccount{}
+func (s *serviceAccounts) Update(serviceAccount *v1.ServiceAccount) (result *v1.ServiceAccount, err error) {
+	result = &v1.ServiceAccount{}
 	err = s.client.Put().
 		Namespace(s.namespace).
 		Resource("serviceAccounts").

--- a/pkg/client/v1/services.go
+++ b/pkg/client/v1/services.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// ServicesNamespacer has methods to work with Service resources in a namespace
+type ServicesNamespacer interface {
+	Services(namespace string) ServiceInterface
+}
+
+// ServiceInterface has methods to work with Service resources.
+type ServiceInterface interface {
+	List(selector labels.Selector) (*api.ServiceList, error)
+	Get(name string) (*api.Service, error)
+	Create(srv *api.Service) (*api.Service, error)
+	Update(srv *api.Service) (*api.Service, error)
+	Delete(name string) error
+	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
+	ProxyGet(name, path string, params map[string]string) ResponseWrapper
+}
+
+// services implements ServicesNamespacer interface
+type services struct {
+	r  *Client
+	ns string
+}
+
+// newServices returns a services
+func newServices(c *Client, namespace string) *services {
+	return &services{c, namespace}
+}
+
+// List takes a selector, and returns the list of services that match that selector
+func (c *services) List(selector labels.Selector) (result *api.ServiceList, err error) {
+	result = &api.ServiceList{}
+	err = c.r.Get().
+		Namespace(c.ns).
+		Resource("services").
+		LabelsSelectorParam(selector).
+		Do().
+		Into(result)
+	return
+}
+
+// Get returns information about a particular service.
+func (c *services) Get(name string) (result *api.Service, err error) {
+	result = &api.Service{}
+	err = c.r.Get().Namespace(c.ns).Resource("services").Name(name).Do().Into(result)
+	return
+}
+
+// Create creates a new service.
+func (c *services) Create(svc *api.Service) (result *api.Service, err error) {
+	result = &api.Service{}
+	err = c.r.Post().Namespace(c.ns).Resource("services").Body(svc).Do().Into(result)
+	return
+}
+
+// Update updates an existing service.
+func (c *services) Update(svc *api.Service) (result *api.Service, err error) {
+	result = &api.Service{}
+	err = c.r.Put().Namespace(c.ns).Resource("services").Name(svc.Name).Body(svc).Do().Into(result)
+	return
+}
+
+// Delete deletes an existing service.
+func (c *services) Delete(name string) error {
+	return c.r.Delete().Namespace(c.ns).Resource("services").Name(name).Do().Error()
+}
+
+// Watch returns a watch.Interface that watches the requested services.
+func (c *services) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.r.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("services").
+		Param("resourceVersion", resourceVersion).
+		LabelsSelectorParam(label).
+		FieldsSelectorParam(field).
+		Watch()
+}
+
+// ProxyGet returns a response of the service by calling it through the proxy.
+func (c *services) ProxyGet(name, path string, params map[string]string) ResponseWrapper {
+	request := c.r.Get().
+		Prefix("proxy").
+		Namespace(c.ns).
+		Resource("services").
+		Name(name).
+		Suffix(path)
+	for k, v := range params {
+		request = request.Param(k, v)
+	}
+	return request
+}

--- a/pkg/client/v1/services.go
+++ b/pkg/client/v1/services.go
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
-	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/watch"
@@ -30,10 +30,10 @@ type ServicesNamespacer interface {
 
 // ServiceInterface has methods to work with Service resources.
 type ServiceInterface interface {
-	List(selector labels.Selector) (*api.ServiceList, error)
-	Get(name string) (*api.Service, error)
-	Create(srv *api.Service) (*api.Service, error)
-	Update(srv *api.Service) (*api.Service, error)
+	List(selector labels.Selector) (*v1.ServiceList, error)
+	Get(name string) (*v1.Service, error)
+	Create(srv *v1.Service) (*v1.Service, error)
+	Update(srv *v1.Service) (*v1.Service, error)
 	Delete(name string) error
 	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
 	ProxyGet(name, path string, params map[string]string) ResponseWrapper
@@ -51,8 +51,8 @@ func newServices(c *Client, namespace string) *services {
 }
 
 // List takes a selector, and returns the list of services that match that selector
-func (c *services) List(selector labels.Selector) (result *api.ServiceList, err error) {
-	result = &api.ServiceList{}
+func (c *services) List(selector labels.Selector) (result *v1.ServiceList, err error) {
+	result = &v1.ServiceList{}
 	err = c.r.Get().
 		Namespace(c.ns).
 		Resource("services").
@@ -63,22 +63,22 @@ func (c *services) List(selector labels.Selector) (result *api.ServiceList, err 
 }
 
 // Get returns information about a particular service.
-func (c *services) Get(name string) (result *api.Service, err error) {
-	result = &api.Service{}
+func (c *services) Get(name string) (result *v1.Service, err error) {
+	result = &v1.Service{}
 	err = c.r.Get().Namespace(c.ns).Resource("services").Name(name).Do().Into(result)
 	return
 }
 
 // Create creates a new service.
-func (c *services) Create(svc *api.Service) (result *api.Service, err error) {
-	result = &api.Service{}
+func (c *services) Create(svc *v1.Service) (result *v1.Service, err error) {
+	result = &v1.Service{}
 	err = c.r.Post().Namespace(c.ns).Resource("services").Body(svc).Do().Into(result)
 	return
 }
 
 // Update updates an existing service.
-func (c *services) Update(svc *api.Service) (result *api.Service, err error) {
-	result = &api.Service{}
+func (c *services) Update(svc *v1.Service) (result *v1.Service, err error) {
+	result = &v1.Service{}
 	err = c.r.Put().Namespace(c.ns).Resource("services").Name(svc.Name).Body(svc).Do().Into(result)
 	return
 }

--- a/pkg/client/v1/services_test.go
+++ b/pkg/client/v1/services_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"net/url"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func TestListServices(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath("services", ns, ""),
+			Query:  buildQueryValues(nil)},
+		Response: Response{StatusCode: 200,
+			Body: &api.ServiceList{
+				Items: []api.Service{
+					{
+						ObjectMeta: api.ObjectMeta{
+							Name: "name",
+							Labels: map[string]string{
+								"foo":  "bar",
+								"name": "baz",
+							},
+						},
+						Spec: api.ServiceSpec{
+							Selector: map[string]string{
+								"one": "two",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	receivedServiceList, err := c.Setup(t).Services(ns).List(labels.Everything())
+	t.Logf("received services: %v %#v", err, receivedServiceList)
+	c.Validate(t, receivedServiceList, err)
+}
+
+func TestListServicesLabels(t *testing.T) {
+	ns := api.NamespaceDefault
+	labelSelectorQueryParamName := api.LabelSelectorQueryParam(testapi.Default.Version())
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath("services", ns, ""),
+			Query:  buildQueryValues(url.Values{labelSelectorQueryParamName: []string{"foo=bar,name=baz"}})},
+		Response: Response{StatusCode: 200,
+			Body: &api.ServiceList{
+				Items: []api.Service{
+					{
+						ObjectMeta: api.ObjectMeta{
+							Name: "name",
+							Labels: map[string]string{
+								"foo":  "bar",
+								"name": "baz",
+							},
+						},
+						Spec: api.ServiceSpec{
+							Selector: map[string]string{
+								"one": "two",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	c.Setup(t)
+	c.QueryValidator[labelSelectorQueryParamName] = validateLabels
+	selector := labels.Set{"foo": "bar", "name": "baz"}.AsSelector()
+	receivedServiceList, err := c.Services(ns).List(selector)
+	c.Validate(t, receivedServiceList, err)
+}
+
+func TestGetService(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath("services", ns, "1"),
+			Query:  buildQueryValues(nil)},
+		Response: Response{StatusCode: 200, Body: &api.Service{ObjectMeta: api.ObjectMeta{Name: "service-1"}}},
+	}
+	response, err := c.Setup(t).Services(ns).Get("1")
+	c.Validate(t, response, err)
+}
+
+func TestGetServiceWithNoName(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{Error: true}
+	receivedPod, err := c.Setup(t).Services(ns).Get("")
+	if (err != nil) && (err.Error() != nameRequiredError) {
+		t.Errorf("Expected error: %v, but got %v", nameRequiredError, err)
+	}
+
+	c.Validate(t, receivedPod, err)
+}
+
+func TestCreateService(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request: testRequest{
+			Method: "POST",
+			Path:   testapi.Default.ResourcePath("services", ns, ""),
+			Body:   &api.Service{ObjectMeta: api.ObjectMeta{Name: "service-1"}},
+			Query:  buildQueryValues(nil)},
+		Response: Response{StatusCode: 200, Body: &api.Service{ObjectMeta: api.ObjectMeta{Name: "service-1"}}},
+	}
+	response, err := c.Setup(t).Services(ns).Create(&api.Service{ObjectMeta: api.ObjectMeta{Name: "service-1"}})
+	c.Validate(t, response, err)
+}
+
+func TestUpdateService(t *testing.T) {
+	ns := api.NamespaceDefault
+	svc := &api.Service{ObjectMeta: api.ObjectMeta{Name: "service-1", ResourceVersion: "1"}}
+	c := &testClient{
+		Request:  testRequest{Method: "PUT", Path: testapi.Default.ResourcePath("services", ns, "service-1"), Body: svc, Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200, Body: svc},
+	}
+	response, err := c.Setup(t).Services(ns).Update(svc)
+	c.Validate(t, response, err)
+}
+
+func TestDeleteService(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request:  testRequest{Method: "DELETE", Path: testapi.Default.ResourcePath("services", ns, "1"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200},
+	}
+	err := c.Setup(t).Services(ns).Delete("1")
+	c.Validate(t, nil, err)
+}
+
+func TestServiceProxyGet(t *testing.T) {
+	body := "OK"
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePathWithPrefix("proxy", "services", ns, "service-1") + "/foo",
+			Query:  buildQueryValues(url.Values{"param-name": []string{"param-value"}}),
+		},
+		Response: Response{StatusCode: 200, RawBody: &body},
+	}
+	response, err := c.Setup(t).Services(ns).ProxyGet("service-1", "foo", map[string]string{"param-name": "param-value"}).DoRaw()
+	c.ValidateRaw(t, response, err)
+}

--- a/pkg/client/v1/services_test.go
+++ b/pkg/client/v1/services_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"net/url"
@@ -22,28 +22,29 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/labels"
 )
 
 func TestListServices(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	c := &testClient{
 		Request: testRequest{
 			Method: "GET",
 			Path:   testapi.Default.ResourcePath("services", ns, ""),
 			Query:  buildQueryValues(nil)},
 		Response: Response{StatusCode: 200,
-			Body: &api.ServiceList{
-				Items: []api.Service{
+			Body: &v1.ServiceList{
+				Items: []v1.Service{
 					{
-						ObjectMeta: api.ObjectMeta{
+						ObjectMeta: v1.ObjectMeta{
 							Name: "name",
 							Labels: map[string]string{
 								"foo":  "bar",
 								"name": "baz",
 							},
 						},
-						Spec: api.ServiceSpec{
+						Spec: v1.ServiceSpec{
 							Selector: map[string]string{
 								"one": "two",
 							},
@@ -59,7 +60,7 @@ func TestListServices(t *testing.T) {
 }
 
 func TestListServicesLabels(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	labelSelectorQueryParamName := api.LabelSelectorQueryParam(testapi.Default.Version())
 	c := &testClient{
 		Request: testRequest{
@@ -67,17 +68,17 @@ func TestListServicesLabels(t *testing.T) {
 			Path:   testapi.Default.ResourcePath("services", ns, ""),
 			Query:  buildQueryValues(url.Values{labelSelectorQueryParamName: []string{"foo=bar,name=baz"}})},
 		Response: Response{StatusCode: 200,
-			Body: &api.ServiceList{
-				Items: []api.Service{
+			Body: &v1.ServiceList{
+				Items: []v1.Service{
 					{
-						ObjectMeta: api.ObjectMeta{
+						ObjectMeta: v1.ObjectMeta{
 							Name: "name",
 							Labels: map[string]string{
 								"foo":  "bar",
 								"name": "baz",
 							},
 						},
-						Spec: api.ServiceSpec{
+						Spec: v1.ServiceSpec{
 							Selector: map[string]string{
 								"one": "two",
 							},
@@ -95,20 +96,20 @@ func TestListServicesLabels(t *testing.T) {
 }
 
 func TestGetService(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	c := &testClient{
 		Request: testRequest{
 			Method: "GET",
 			Path:   testapi.Default.ResourcePath("services", ns, "1"),
 			Query:  buildQueryValues(nil)},
-		Response: Response{StatusCode: 200, Body: &api.Service{ObjectMeta: api.ObjectMeta{Name: "service-1"}}},
+		Response: Response{StatusCode: 200, Body: &v1.Service{ObjectMeta: v1.ObjectMeta{Name: "service-1"}}},
 	}
 	response, err := c.Setup(t).Services(ns).Get("1")
 	c.Validate(t, response, err)
 }
 
 func TestGetServiceWithNoName(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	c := &testClient{Error: true}
 	receivedPod, err := c.Setup(t).Services(ns).Get("")
 	if (err != nil) && (err.Error() != nameRequiredError) {
@@ -119,22 +120,22 @@ func TestGetServiceWithNoName(t *testing.T) {
 }
 
 func TestCreateService(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	c := &testClient{
 		Request: testRequest{
 			Method: "POST",
 			Path:   testapi.Default.ResourcePath("services", ns, ""),
-			Body:   &api.Service{ObjectMeta: api.ObjectMeta{Name: "service-1"}},
+			Body:   &v1.Service{ObjectMeta: v1.ObjectMeta{Name: "service-1"}},
 			Query:  buildQueryValues(nil)},
-		Response: Response{StatusCode: 200, Body: &api.Service{ObjectMeta: api.ObjectMeta{Name: "service-1"}}},
+		Response: Response{StatusCode: 200, Body: &v1.Service{ObjectMeta: v1.ObjectMeta{Name: "service-1"}}},
 	}
-	response, err := c.Setup(t).Services(ns).Create(&api.Service{ObjectMeta: api.ObjectMeta{Name: "service-1"}})
+	response, err := c.Setup(t).Services(ns).Create(&v1.Service{ObjectMeta: v1.ObjectMeta{Name: "service-1"}})
 	c.Validate(t, response, err)
 }
 
 func TestUpdateService(t *testing.T) {
-	ns := api.NamespaceDefault
-	svc := &api.Service{ObjectMeta: api.ObjectMeta{Name: "service-1", ResourceVersion: "1"}}
+	ns := v1.NamespaceDefault
+	svc := &v1.Service{ObjectMeta: v1.ObjectMeta{Name: "service-1", ResourceVersion: "1"}}
 	c := &testClient{
 		Request:  testRequest{Method: "PUT", Path: testapi.Default.ResourcePath("services", ns, "service-1"), Body: svc, Query: buildQueryValues(nil)},
 		Response: Response{StatusCode: 200, Body: svc},
@@ -144,7 +145,7 @@ func TestUpdateService(t *testing.T) {
 }
 
 func TestDeleteService(t *testing.T) {
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	c := &testClient{
 		Request:  testRequest{Method: "DELETE", Path: testapi.Default.ResourcePath("services", ns, "1"), Query: buildQueryValues(nil)},
 		Response: Response{StatusCode: 200},
@@ -155,7 +156,7 @@ func TestDeleteService(t *testing.T) {
 
 func TestServiceProxyGet(t *testing.T) {
 	body := "OK"
-	ns := api.NamespaceDefault
+	ns := v1.NamespaceDefault
 	c := &testClient{
 		Request: testRequest{
 			Method: "GET",

--- a/pkg/client/v1/testclient/actions.go
+++ b/pkg/client/v1/testclient/actions.go
@@ -1,0 +1,327 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"strings"
+
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+func NewRootGetAction(resource, name string) GetActionImpl {
+	action := GetActionImpl{}
+	action.Verb = "get"
+	action.Resource = resource
+	action.Name = name
+
+	return action
+}
+
+func NewGetAction(resource, namespace, name string) GetActionImpl {
+	action := GetActionImpl{}
+	action.Verb = "get"
+	action.Resource = resource
+	action.Namespace = namespace
+	action.Name = name
+
+	return action
+}
+
+func NewRootListAction(resource string, label labels.Selector, field fields.Selector) ListActionImpl {
+	action := ListActionImpl{}
+	action.Verb = "list"
+	action.Resource = resource
+	action.ListRestrictions = ListRestrictions{label, field}
+
+	return action
+}
+
+func NewListAction(resource, namespace string, label labels.Selector, field fields.Selector) ListActionImpl {
+	action := ListActionImpl{}
+	action.Verb = "list"
+	action.Resource = resource
+	action.Namespace = namespace
+	action.ListRestrictions = ListRestrictions{label, field}
+
+	return action
+}
+
+func NewRootCreateAction(resource string, object runtime.Object) CreateActionImpl {
+	action := CreateActionImpl{}
+	action.Verb = "create"
+	action.Resource = resource
+	action.Object = object
+
+	return action
+}
+
+func NewCreateAction(resource, namespace string, object runtime.Object) CreateActionImpl {
+	action := CreateActionImpl{}
+	action.Verb = "create"
+	action.Resource = resource
+	action.Namespace = namespace
+	action.Object = object
+
+	return action
+}
+
+func NewRootUpdateAction(resource string, object runtime.Object) UpdateActionImpl {
+	action := UpdateActionImpl{}
+	action.Verb = "update"
+	action.Resource = resource
+	action.Object = object
+
+	return action
+}
+
+func NewUpdateAction(resource, namespace string, object runtime.Object) UpdateActionImpl {
+	action := UpdateActionImpl{}
+	action.Verb = "update"
+	action.Resource = resource
+	action.Namespace = namespace
+	action.Object = object
+
+	return action
+}
+
+func NewUpdateSubresourceAction(resource, subresource, namespace string, object runtime.Object) UpdateActionImpl {
+	action := UpdateActionImpl{}
+	action.Verb = "update"
+	action.Resource = resource
+	action.Subresource = subresource
+	action.Namespace = namespace
+	action.Object = object
+
+	return action
+}
+
+func NewRootDeleteAction(resource, name string) DeleteActionImpl {
+	action := DeleteActionImpl{}
+	action.Verb = "delete"
+	action.Resource = resource
+	action.Name = name
+
+	return action
+}
+
+func NewDeleteAction(resource, namespace, name string) DeleteActionImpl {
+	action := DeleteActionImpl{}
+	action.Verb = "delete"
+	action.Resource = resource
+	action.Namespace = namespace
+	action.Name = name
+
+	return action
+}
+
+func NewRootWatchAction(resource string, label labels.Selector, field fields.Selector, resourceVersion string) WatchActionImpl {
+	action := WatchActionImpl{}
+	action.Verb = "watch"
+	action.Resource = resource
+	action.WatchRestrictions = WatchRestrictions{label, field, resourceVersion}
+
+	return action
+}
+
+func NewWatchAction(resource, namespace string, label labels.Selector, field fields.Selector, resourceVersion string) WatchActionImpl {
+	action := WatchActionImpl{}
+	action.Verb = "watch"
+	action.Resource = resource
+	action.Namespace = namespace
+	action.WatchRestrictions = WatchRestrictions{label, field, resourceVersion}
+
+	return action
+}
+
+func NewProxyGetAction(resource, namespace, name, path string, params map[string]string) ProxyGetActionImpl {
+	action := ProxyGetActionImpl{}
+	action.Verb = "get"
+	action.Resource = resource
+	action.Namespace = namespace
+	action.Name = name
+	action.Path = path
+	action.Params = params
+	return action
+}
+
+type ListRestrictions struct {
+	Labels labels.Selector
+	Fields fields.Selector
+}
+type WatchRestrictions struct {
+	Labels          labels.Selector
+	Fields          fields.Selector
+	ResourceVersion string
+}
+
+type Action interface {
+	GetNamespace() string
+	GetVerb() string
+	GetResource() string
+	GetSubresource() string
+	Matches(verb, resource string) bool
+}
+
+type GenericAction interface {
+	Action
+	GetValue() interface{}
+}
+
+type GetAction interface {
+	Action
+	GetName() string
+}
+
+type ListAction interface {
+	Action
+	GetListRestrictions() ListRestrictions
+}
+
+type CreateAction interface {
+	Action
+	GetObject() runtime.Object
+}
+
+type UpdateAction interface {
+	Action
+	GetObject() runtime.Object
+}
+
+type DeleteAction interface {
+	Action
+	GetName() string
+}
+
+type WatchAction interface {
+	Action
+	GetWatchRestrictions() WatchRestrictions
+}
+
+type ProxyGetAction interface {
+	Action
+	GetName() string
+	GetPath() string
+	GetParams() map[string]string
+}
+
+type ActionImpl struct {
+	Namespace   string
+	Verb        string
+	Resource    string
+	Subresource string
+}
+
+func (a ActionImpl) GetNamespace() string {
+	return a.Namespace
+}
+func (a ActionImpl) GetVerb() string {
+	return a.Verb
+}
+func (a ActionImpl) GetResource() string {
+	return a.Resource
+}
+func (a ActionImpl) GetSubresource() string {
+	return a.Subresource
+}
+func (a ActionImpl) Matches(verb, resource string) bool {
+	return strings.ToLower(verb) == strings.ToLower(a.Verb) &&
+		strings.ToLower(resource) == strings.ToLower(a.Resource)
+}
+
+type GenericActionImpl struct {
+	ActionImpl
+	Value interface{}
+}
+
+func (a GenericActionImpl) GetValue() interface{} {
+	return a.Value
+}
+
+type GetActionImpl struct {
+	ActionImpl
+	Name string
+}
+
+func (a GetActionImpl) GetName() string {
+	return a.Name
+}
+
+type ListActionImpl struct {
+	ActionImpl
+	ListRestrictions ListRestrictions
+}
+
+func (a ListActionImpl) GetListRestrictions() ListRestrictions {
+	return a.ListRestrictions
+}
+
+type CreateActionImpl struct {
+	ActionImpl
+	Object runtime.Object
+}
+
+func (a CreateActionImpl) GetObject() runtime.Object {
+	return a.Object
+}
+
+type UpdateActionImpl struct {
+	ActionImpl
+	Object runtime.Object
+}
+
+func (a UpdateActionImpl) GetObject() runtime.Object {
+	return a.Object
+}
+
+type DeleteActionImpl struct {
+	ActionImpl
+	Name string
+}
+
+func (a DeleteActionImpl) GetName() string {
+	return a.Name
+}
+
+type WatchActionImpl struct {
+	ActionImpl
+	WatchRestrictions WatchRestrictions
+}
+
+func (a WatchActionImpl) GetWatchRestrictions() WatchRestrictions {
+	return a.WatchRestrictions
+}
+
+type ProxyGetActionImpl struct {
+	ActionImpl
+	Name   string
+	Path   string
+	Params map[string]string
+}
+
+func (a ProxyGetActionImpl) GetName() string {
+	return a.Name
+}
+
+func (a ProxyGetActionImpl) GetPath() string {
+	return a.Path
+}
+
+func (a ProxyGetActionImpl) GetParams() map[string]string {
+	return a.Params
+}

--- a/pkg/client/v1/testclient/fake_componentstatuses.go
+++ b/pkg/client/v1/testclient/fake_componentstatuses.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+// Fake implements ComponentStatusInterface.
+type FakeComponentStatuses struct {
+	Fake *Fake
+}
+
+func (c *FakeComponentStatuses) Get(name string) (*api.ComponentStatus, error) {
+	obj, err := c.Fake.Invokes(NewRootGetAction("componentstatuses", name), &api.ComponentStatus{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.ComponentStatus), err
+}
+
+func (c *FakeComponentStatuses) List(label labels.Selector, field fields.Selector) (result *api.ComponentStatusList, err error) {
+	obj, err := c.Fake.Invokes(NewRootListAction("componentstatuses", label, field), &api.ComponentStatusList{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.ComponentStatusList), err
+}

--- a/pkg/client/v1/testclient/fake_componentstatuses.go
+++ b/pkg/client/v1/testclient/fake_componentstatuses.go
@@ -17,7 +17,7 @@ limitations under the License.
 package testclient
 
 import (
-	"k8s.io/kubernetes/pkg/api"
+	api "k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 )

--- a/pkg/client/v1/testclient/fake_daemon_sets.go
+++ b/pkg/client/v1/testclient/fake_daemon_sets.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"k8s.io/kubernetes/pkg/apis/experimental"
+	kClientLib "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeDaemonSet implements DaemonInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the method you want to test easier.
+type FakeDaemonSets struct {
+	Fake      *FakeExperimental
+	Namespace string
+}
+
+// Ensure statically that FakeDaemonSets implements DaemonInterface.
+var _ kClientLib.DaemonSetInterface = &FakeDaemonSets{}
+
+func (c *FakeDaemonSets) Get(name string) (*experimental.DaemonSet, error) {
+	obj, err := c.Fake.Invokes(NewGetAction("daemonsets", c.Namespace, name), &experimental.DaemonSet{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*experimental.DaemonSet), err
+}
+
+func (c *FakeDaemonSets) List(label labels.Selector) (*experimental.DaemonSetList, error) {
+	obj, err := c.Fake.Invokes(NewListAction("daemonsets", c.Namespace, label, nil), &experimental.DaemonSetList{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*experimental.DaemonSetList), err
+}
+
+func (c *FakeDaemonSets) Create(daemon *experimental.DaemonSet) (*experimental.DaemonSet, error) {
+	obj, err := c.Fake.Invokes(NewCreateAction("daemonsets", c.Namespace, daemon), &experimental.DaemonSet{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*experimental.DaemonSet), err
+}
+
+func (c *FakeDaemonSets) Update(daemon *experimental.DaemonSet) (*experimental.DaemonSet, error) {
+	obj, err := c.Fake.Invokes(NewUpdateAction("daemonsets", c.Namespace, daemon), &experimental.DaemonSet{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*experimental.DaemonSet), err
+}
+
+func (c *FakeDaemonSets) Delete(name string) error {
+	_, err := c.Fake.Invokes(NewDeleteAction("daemonsets", c.Namespace, name), &experimental.DaemonSet{})
+	return err
+}
+
+func (c *FakeDaemonSets) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.Fake.InvokesWatch(NewWatchAction("daemonsets", c.Namespace, label, field, resourceVersion))
+}

--- a/pkg/client/v1/testclient/fake_daemon_sets.go
+++ b/pkg/client/v1/testclient/fake_daemon_sets.go
@@ -17,8 +17,8 @@ limitations under the License.
 package testclient
 
 import (
-	"k8s.io/kubernetes/pkg/apis/experimental"
-	kClientLib "k8s.io/kubernetes/pkg/client/unversioned"
+	experimental "k8s.io/kubernetes/pkg/apis/experimental/v1"
+	kClientLib "k8s.io/kubernetes/pkg/client/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/watch"

--- a/pkg/client/v1/testclient/fake_deployments.go
+++ b/pkg/client/v1/testclient/fake_deployments.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/experimental"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeDeployments implements DeploymentsInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the methods you want to test easier.
+type FakeDeployments struct {
+	Fake      *FakeExperimental
+	Namespace string
+}
+
+func (c *FakeDeployments) Get(name string) (*experimental.Deployment, error) {
+	obj, err := c.Fake.Invokes(NewGetAction("deployments", c.Namespace, name), &experimental.Deployment{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*experimental.Deployment), err
+}
+
+func (c *FakeDeployments) List(label labels.Selector, field fields.Selector) (*experimental.DeploymentList, error) {
+	obj, err := c.Fake.Invokes(NewListAction("deployments", c.Namespace, label, field), &experimental.DeploymentList{})
+	if obj == nil {
+		return nil, err
+	}
+	list := &experimental.DeploymentList{}
+	for _, deployment := range obj.(*experimental.DeploymentList).Items {
+		if label.Matches(labels.Set(deployment.Labels)) {
+			list.Items = append(list.Items, deployment)
+		}
+	}
+	return list, err
+}
+
+func (c *FakeDeployments) Create(deployment *experimental.Deployment) (*experimental.Deployment, error) {
+	obj, err := c.Fake.Invokes(NewCreateAction("deployments", c.Namespace, deployment), deployment)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*experimental.Deployment), err
+}
+
+func (c *FakeDeployments) Update(deployment *experimental.Deployment) (*experimental.Deployment, error) {
+	obj, err := c.Fake.Invokes(NewUpdateAction("deployments", c.Namespace, deployment), deployment)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*experimental.Deployment), err
+}
+
+func (c *FakeDeployments) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.Invokes(NewDeleteAction("deployments", c.Namespace, name), &experimental.Deployment{})
+	return err
+}
+
+func (c *FakeDeployments) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.Fake.InvokesWatch(NewWatchAction("deployments", c.Namespace, label, field, resourceVersion))
+}

--- a/pkg/client/v1/testclient/fake_deployments.go
+++ b/pkg/client/v1/testclient/fake_deployments.go
@@ -17,8 +17,8 @@ limitations under the License.
 package testclient
 
 import (
-	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/apis/experimental"
+	api "k8s.io/kubernetes/pkg/api/v1"
+	experimental "k8s.io/kubernetes/pkg/apis/experimental/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/watch"

--- a/pkg/client/v1/testclient/fake_endpoints.go
+++ b/pkg/client/v1/testclient/fake_endpoints.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeEndpoints implements EndpointInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the method you want to test easier.
+type FakeEndpoints struct {
+	Fake      *Fake
+	Namespace string
+}
+
+func (c *FakeEndpoints) Get(name string) (*api.Endpoints, error) {
+	obj, err := c.Fake.Invokes(NewGetAction("endpoints", c.Namespace, name), &api.Endpoints{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.Endpoints), err
+}
+
+func (c *FakeEndpoints) List(label labels.Selector) (*api.EndpointsList, error) {
+	obj, err := c.Fake.Invokes(NewListAction("endpoints", c.Namespace, label, nil), &api.EndpointsList{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.EndpointsList), err
+}
+
+func (c *FakeEndpoints) Create(endpoints *api.Endpoints) (*api.Endpoints, error) {
+	obj, err := c.Fake.Invokes(NewCreateAction("endpoints", c.Namespace, endpoints), endpoints)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.Endpoints), err
+}
+
+func (c *FakeEndpoints) Update(endpoints *api.Endpoints) (*api.Endpoints, error) {
+	obj, err := c.Fake.Invokes(NewUpdateAction("endpoints", c.Namespace, endpoints), endpoints)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.Endpoints), err
+}
+
+func (c *FakeEndpoints) Delete(name string) error {
+	_, err := c.Fake.Invokes(NewDeleteAction("endpoints", c.Namespace, name), &api.Endpoints{})
+	return err
+}
+
+func (c *FakeEndpoints) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.Fake.InvokesWatch(NewWatchAction("endpoints", c.Namespace, label, field, resourceVersion))
+}

--- a/pkg/client/v1/testclient/fake_endpoints.go
+++ b/pkg/client/v1/testclient/fake_endpoints.go
@@ -17,7 +17,7 @@ limitations under the License.
 package testclient
 
 import (
-	"k8s.io/kubernetes/pkg/api"
+	api "k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/watch"

--- a/pkg/client/v1/testclient/fake_events.go
+++ b/pkg/client/v1/testclient/fake_events.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeEvents implements EventInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the method you want to test easier.
+type FakeEvents struct {
+	Fake      *Fake
+	Namespace string
+}
+
+// Get returns the given event, or an error.
+func (c *FakeEvents) Get(name string) (*api.Event, error) {
+	action := NewRootGetAction("events", name)
+	if c.Namespace != "" {
+		action = NewGetAction("events", c.Namespace, name)
+	}
+	obj, err := c.Fake.Invokes(action, &api.Event{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.Event), err
+}
+
+// List returns a list of events matching the selectors.
+func (c *FakeEvents) List(label labels.Selector, field fields.Selector) (*api.EventList, error) {
+	action := NewRootListAction("events", label, field)
+	if c.Namespace != "" {
+		action = NewListAction("events", c.Namespace, label, field)
+	}
+	obj, err := c.Fake.Invokes(action, &api.EventList{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.EventList), err
+}
+
+// Create makes a new event. Returns the copy of the event the server returns, or an error.
+func (c *FakeEvents) Create(event *api.Event) (*api.Event, error) {
+	action := NewRootCreateAction("events", event)
+	if c.Namespace != "" {
+		action = NewCreateAction("events", c.Namespace, event)
+	}
+	obj, err := c.Fake.Invokes(action, event)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.Event), err
+}
+
+// Update replaces an existing event. Returns the copy of the event the server returns, or an error.
+func (c *FakeEvents) Update(event *api.Event) (*api.Event, error) {
+	action := NewRootUpdateAction("events", event)
+	if c.Namespace != "" {
+		action = NewUpdateAction("events", c.Namespace, event)
+	}
+	obj, err := c.Fake.Invokes(action, event)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.Event), err
+}
+
+func (c *FakeEvents) Delete(name string) error {
+	action := NewRootDeleteAction("events", name)
+	if c.Namespace != "" {
+		action = NewDeleteAction("events", c.Namespace, name)
+	}
+	_, err := c.Fake.Invokes(action, &api.Event{})
+	return err
+}
+
+// Watch starts watching for events matching the given selectors.
+func (c *FakeEvents) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	action := NewRootWatchAction("events", label, field, resourceVersion)
+	if c.Namespace != "" {
+		action = NewWatchAction("events", c.Namespace, label, field, resourceVersion)
+	}
+	return c.Fake.InvokesWatch(action)
+}
+
+// Search returns a list of events matching the specified object.
+func (c *FakeEvents) Search(objOrRef runtime.Object) (*api.EventList, error) {
+	action := NewRootListAction("events", nil, nil)
+	if c.Namespace != "" {
+		action = NewListAction("events", c.Namespace, nil, nil)
+	}
+	obj, err := c.Fake.Invokes(action, &api.EventList{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.EventList), err
+}
+
+func (c *FakeEvents) GetFieldSelector(involvedObjectName, involvedObjectNamespace, involvedObjectKind, involvedObjectUID *string) fields.Selector {
+	action := GenericActionImpl{}
+	action.Verb = "get-field-selector"
+	action.Resource = "events"
+
+	c.Fake.Invokes(action, nil)
+	return fields.Everything()
+}

--- a/pkg/client/v1/testclient/fake_events.go
+++ b/pkg/client/v1/testclient/fake_events.go
@@ -17,7 +17,7 @@ limitations under the License.
 package testclient
 
 import (
-	"k8s.io/kubernetes/pkg/api"
+	api "k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"

--- a/pkg/client/v1/testclient/fake_horizontal_pod_autoscalers.go
+++ b/pkg/client/v1/testclient/fake_horizontal_pod_autoscalers.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/experimental"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeHorizontalPodAutoscalers implements HorizontalPodAutoscalerInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the methods you want to test easier.
+type FakeHorizontalPodAutoscalers struct {
+	Fake      *FakeExperimental
+	Namespace string
+}
+
+func (c *FakeHorizontalPodAutoscalers) Get(name string) (*experimental.HorizontalPodAutoscaler, error) {
+	obj, err := c.Fake.Invokes(NewGetAction("horizontalpodautoscalers", c.Namespace, name), &experimental.HorizontalPodAutoscaler{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*experimental.HorizontalPodAutoscaler), err
+}
+
+func (c *FakeHorizontalPodAutoscalers) List(label labels.Selector, field fields.Selector) (*experimental.HorizontalPodAutoscalerList, error) {
+	obj, err := c.Fake.Invokes(NewListAction("horizontalpodautoscalers", c.Namespace, label, field), &experimental.HorizontalPodAutoscalerList{})
+	if obj == nil {
+		return nil, err
+	}
+	list := &experimental.HorizontalPodAutoscalerList{}
+	for _, a := range obj.(*experimental.HorizontalPodAutoscalerList).Items {
+		if label.Matches(labels.Set(a.Labels)) {
+			list.Items = append(list.Items, a)
+		}
+	}
+	return list, err
+}
+
+func (c *FakeHorizontalPodAutoscalers) Create(a *experimental.HorizontalPodAutoscaler) (*experimental.HorizontalPodAutoscaler, error) {
+	obj, err := c.Fake.Invokes(NewCreateAction("horizontalpodautoscalers", c.Namespace, a), a)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*experimental.HorizontalPodAutoscaler), err
+}
+
+func (c *FakeHorizontalPodAutoscalers) Update(a *experimental.HorizontalPodAutoscaler) (*experimental.HorizontalPodAutoscaler, error) {
+	obj, err := c.Fake.Invokes(NewUpdateAction("horizontalpodautoscalers", c.Namespace, a), a)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*experimental.HorizontalPodAutoscaler), err
+}
+
+func (c *FakeHorizontalPodAutoscalers) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.Invokes(NewDeleteAction("horizontalpodautoscalers", c.Namespace, name), &experimental.HorizontalPodAutoscaler{})
+	return err
+}
+
+func (c *FakeHorizontalPodAutoscalers) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.Fake.InvokesWatch(NewWatchAction("horizontalpodautoscalers", c.Namespace, label, field, resourceVersion))
+}

--- a/pkg/client/v1/testclient/fake_horizontal_pod_autoscalers.go
+++ b/pkg/client/v1/testclient/fake_horizontal_pod_autoscalers.go
@@ -17,8 +17,8 @@ limitations under the License.
 package testclient
 
 import (
-	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/apis/experimental"
+	api "k8s.io/kubernetes/pkg/api/v1"
+	experimental "k8s.io/kubernetes/pkg/apis/experimental/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/watch"

--- a/pkg/client/v1/testclient/fake_jobs.go
+++ b/pkg/client/v1/testclient/fake_jobs.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/experimental"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeJobs implements JobInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the method you want to test easier.
+type FakeJobs struct {
+	Fake      *FakeExperimental
+	Namespace string
+}
+
+func (c *FakeJobs) Get(name string) (*experimental.Job, error) {
+	obj, err := c.Fake.Invokes(NewGetAction("jobs", c.Namespace, name), &experimental.Job{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*experimental.Job), err
+}
+
+func (c *FakeJobs) List(label labels.Selector, fields fields.Selector) (*experimental.JobList, error) {
+	obj, err := c.Fake.Invokes(NewListAction("jobs", c.Namespace, label, nil), &experimental.JobList{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*experimental.JobList), err
+}
+
+func (c *FakeJobs) Create(job *experimental.Job) (*experimental.Job, error) {
+	obj, err := c.Fake.Invokes(NewCreateAction("jobs", c.Namespace, job), job)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*experimental.Job), err
+}
+
+func (c *FakeJobs) Update(job *experimental.Job) (*experimental.Job, error) {
+	obj, err := c.Fake.Invokes(NewUpdateAction("jobs", c.Namespace, job), job)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*experimental.Job), err
+}
+
+func (c *FakeJobs) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.Invokes(NewDeleteAction("jobs", c.Namespace, name), &experimental.Job{})
+	return err
+}
+
+func (c *FakeJobs) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.Fake.InvokesWatch(NewWatchAction("jobs", c.Namespace, label, field, resourceVersion))
+}
+
+func (c *FakeJobs) UpdateStatus(job *experimental.Job) (result *experimental.Job, err error) {
+	obj, err := c.Fake.Invokes(NewUpdateSubresourceAction("jobs", "status", c.Namespace, job), job)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*experimental.Job), err
+}

--- a/pkg/client/v1/testclient/fake_jobs.go
+++ b/pkg/client/v1/testclient/fake_jobs.go
@@ -17,8 +17,8 @@ limitations under the License.
 package testclient
 
 import (
-	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/apis/experimental"
+	"k8s.io/kubernetes/pkg/api/v1"
+	experimental "k8s.io/kubernetes/pkg/apis/experimental/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/watch"
@@ -67,7 +67,7 @@ func (c *FakeJobs) Update(job *experimental.Job) (*experimental.Job, error) {
 	return obj.(*experimental.Job), err
 }
 
-func (c *FakeJobs) Delete(name string, options *api.DeleteOptions) error {
+func (c *FakeJobs) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.Invokes(NewDeleteAction("jobs", c.Namespace, name), &experimental.Job{})
 	return err
 }

--- a/pkg/client/v1/testclient/fake_limit_ranges.go
+++ b/pkg/client/v1/testclient/fake_limit_ranges.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeLimitRanges implements PodsInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the methods you want to test easier.
+type FakeLimitRanges struct {
+	Fake      *Fake
+	Namespace string
+}
+
+func (c *FakeLimitRanges) Get(name string) (*api.LimitRange, error) {
+	obj, err := c.Fake.Invokes(NewGetAction("limitranges", c.Namespace, name), &api.LimitRange{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.LimitRange), err
+}
+
+func (c *FakeLimitRanges) List(label labels.Selector) (*api.LimitRangeList, error) {
+	obj, err := c.Fake.Invokes(NewListAction("limitranges", c.Namespace, label, nil), &api.LimitRangeList{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.LimitRangeList), err
+}
+
+func (c *FakeLimitRanges) Create(limitRange *api.LimitRange) (*api.LimitRange, error) {
+	obj, err := c.Fake.Invokes(NewCreateAction("limitranges", c.Namespace, limitRange), limitRange)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.LimitRange), err
+}
+
+func (c *FakeLimitRanges) Update(limitRange *api.LimitRange) (*api.LimitRange, error) {
+	obj, err := c.Fake.Invokes(NewUpdateAction("limitranges", c.Namespace, limitRange), limitRange)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.LimitRange), err
+}
+
+func (c *FakeLimitRanges) Delete(name string) error {
+	_, err := c.Fake.Invokes(NewDeleteAction("limitranges", c.Namespace, name), &api.LimitRange{})
+	return err
+}
+
+func (c *FakeLimitRanges) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.Fake.InvokesWatch(NewWatchAction("limitranges", c.Namespace, label, field, resourceVersion))
+}

--- a/pkg/client/v1/testclient/fake_limit_ranges.go
+++ b/pkg/client/v1/testclient/fake_limit_ranges.go
@@ -17,7 +17,7 @@ limitations under the License.
 package testclient
 
 import (
-	"k8s.io/kubernetes/pkg/api"
+	api "k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/watch"

--- a/pkg/client/v1/testclient/fake_namespaces.go
+++ b/pkg/client/v1/testclient/fake_namespaces.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeNamespaces implements NamespacesInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the methods you want to test easier.
+type FakeNamespaces struct {
+	Fake *Fake
+}
+
+func (c *FakeNamespaces) Get(name string) (*api.Namespace, error) {
+	obj, err := c.Fake.Invokes(NewRootGetAction("namespaces", name), &api.Namespace{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.Namespace), err
+}
+
+func (c *FakeNamespaces) List(label labels.Selector, field fields.Selector) (*api.NamespaceList, error) {
+	obj, err := c.Fake.Invokes(NewRootListAction("namespaces", label, field), &api.NamespaceList{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.NamespaceList), err
+}
+
+func (c *FakeNamespaces) Create(namespace *api.Namespace) (*api.Namespace, error) {
+	obj, err := c.Fake.Invokes(NewRootCreateAction("namespaces", namespace), namespace)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.Namespace), err
+}
+
+func (c *FakeNamespaces) Update(namespace *api.Namespace) (*api.Namespace, error) {
+	obj, err := c.Fake.Invokes(NewRootUpdateAction("namespaces", namespace), namespace)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.Namespace), err
+}
+
+func (c *FakeNamespaces) Delete(name string) error {
+	_, err := c.Fake.Invokes(NewRootDeleteAction("namespaces", name), &api.Namespace{})
+	return err
+}
+
+func (c *FakeNamespaces) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.Fake.InvokesWatch(NewRootWatchAction("namespaces", label, field, resourceVersion))
+}
+
+func (c *FakeNamespaces) Finalize(namespace *api.Namespace) (*api.Namespace, error) {
+	action := CreateActionImpl{}
+	action.Verb = "create"
+	action.Resource = "namespaces"
+	action.Subresource = "finalize"
+	action.Object = namespace
+
+	obj, err := c.Fake.Invokes(action, namespace)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.Namespace), err
+}
+
+func (c *FakeNamespaces) Status(namespace *api.Namespace) (*api.Namespace, error) {
+	action := CreateActionImpl{}
+	action.Verb = "create"
+	action.Resource = "namespaces"
+	action.Subresource = "status"
+	action.Object = namespace
+
+	obj, err := c.Fake.Invokes(action, namespace)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.Namespace), err
+}

--- a/pkg/client/v1/testclient/fake_namespaces.go
+++ b/pkg/client/v1/testclient/fake_namespaces.go
@@ -17,7 +17,7 @@ limitations under the License.
 package testclient
 
 import (
-	"k8s.io/kubernetes/pkg/api"
+	api "k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/watch"

--- a/pkg/client/v1/testclient/fake_nodes.go
+++ b/pkg/client/v1/testclient/fake_nodes.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeNodes implements NodeInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the method you want to test easier.
+type FakeNodes struct {
+	Fake *Fake
+}
+
+func (c *FakeNodes) Get(name string) (*api.Node, error) {
+	obj, err := c.Fake.Invokes(NewRootGetAction("nodes", name), &api.Node{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.Node), err
+}
+
+func (c *FakeNodes) List(label labels.Selector, field fields.Selector) (*api.NodeList, error) {
+	obj, err := c.Fake.Invokes(NewRootListAction("nodes", label, field), &api.NodeList{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.NodeList), err
+}
+
+func (c *FakeNodes) Create(node *api.Node) (*api.Node, error) {
+	obj, err := c.Fake.Invokes(NewRootCreateAction("nodes", node), node)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.Node), err
+}
+
+func (c *FakeNodes) Update(node *api.Node) (*api.Node, error) {
+	obj, err := c.Fake.Invokes(NewRootUpdateAction("nodes", node), node)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.Node), err
+}
+
+func (c *FakeNodes) Delete(name string) error {
+	_, err := c.Fake.Invokes(NewRootDeleteAction("nodes", name), &api.Node{})
+	return err
+}
+
+func (c *FakeNodes) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.Fake.InvokesWatch(NewRootWatchAction("nodes", label, field, resourceVersion))
+}
+
+func (c *FakeNodes) UpdateStatus(node *api.Node) (*api.Node, error) {
+	action := CreateActionImpl{}
+	action.Verb = "update"
+	action.Resource = "nodes"
+	action.Subresource = "status"
+	action.Object = node
+
+	obj, err := c.Fake.Invokes(action, node)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.Node), err
+}

--- a/pkg/client/v1/testclient/fake_nodes.go
+++ b/pkg/client/v1/testclient/fake_nodes.go
@@ -17,7 +17,7 @@ limitations under the License.
 package testclient
 
 import (
-	"k8s.io/kubernetes/pkg/api"
+	api "k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/watch"

--- a/pkg/client/v1/testclient/fake_persistent_volume_claims.go
+++ b/pkg/client/v1/testclient/fake_persistent_volume_claims.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+type FakePersistentVolumeClaims struct {
+	Fake      *Fake
+	Namespace string
+}
+
+func (c *FakePersistentVolumeClaims) Get(name string) (*api.PersistentVolumeClaim, error) {
+	obj, err := c.Fake.Invokes(NewGetAction("persistentvolumeclaims", c.Namespace, name), &api.PersistentVolumeClaim{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.PersistentVolumeClaim), err
+}
+
+func (c *FakePersistentVolumeClaims) List(label labels.Selector, field fields.Selector) (*api.PersistentVolumeClaimList, error) {
+	obj, err := c.Fake.Invokes(NewListAction("persistentvolumeclaims", c.Namespace, label, field), &api.PersistentVolumeClaimList{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.PersistentVolumeClaimList), err
+}
+
+func (c *FakePersistentVolumeClaims) Create(claim *api.PersistentVolumeClaim) (*api.PersistentVolumeClaim, error) {
+	obj, err := c.Fake.Invokes(NewCreateAction("persistentvolumeclaims", c.Namespace, claim), claim)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.PersistentVolumeClaim), err
+}
+
+func (c *FakePersistentVolumeClaims) Update(claim *api.PersistentVolumeClaim) (*api.PersistentVolumeClaim, error) {
+	obj, err := c.Fake.Invokes(NewUpdateAction("persistentvolumeclaims", c.Namespace, claim), claim)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.PersistentVolumeClaim), err
+}
+
+func (c *FakePersistentVolumeClaims) Delete(name string) error {
+	_, err := c.Fake.Invokes(NewDeleteAction("persistentvolumeclaims", c.Namespace, name), &api.PersistentVolumeClaim{})
+	return err
+}
+
+func (c *FakePersistentVolumeClaims) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.Fake.InvokesWatch(NewWatchAction("persistentvolumeclaims", c.Namespace, label, field, resourceVersion))
+}
+
+func (c *FakePersistentVolumeClaims) UpdateStatus(claim *api.PersistentVolumeClaim) (*api.PersistentVolumeClaim, error) {
+	obj, err := c.Fake.Invokes(NewUpdateSubresourceAction("persistentvolumeclaims", "status", c.Namespace, claim), claim)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.PersistentVolumeClaim), err
+}

--- a/pkg/client/v1/testclient/fake_persistent_volume_claims.go
+++ b/pkg/client/v1/testclient/fake_persistent_volume_claims.go
@@ -17,7 +17,7 @@ limitations under the License.
 package testclient
 
 import (
-	"k8s.io/kubernetes/pkg/api"
+	api "k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/watch"

--- a/pkg/client/v1/testclient/fake_persistent_volumes.go
+++ b/pkg/client/v1/testclient/fake_persistent_volumes.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+type FakePersistentVolumes struct {
+	Fake *Fake
+}
+
+func (c *FakePersistentVolumes) Get(name string) (*api.PersistentVolume, error) {
+	obj, err := c.Fake.Invokes(NewRootGetAction("persistentvolumes", name), &api.PersistentVolume{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.PersistentVolume), err
+}
+
+func (c *FakePersistentVolumes) List(label labels.Selector, field fields.Selector) (*api.PersistentVolumeList, error) {
+	obj, err := c.Fake.Invokes(NewRootListAction("persistentvolumes", label, field), &api.PersistentVolumeList{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.PersistentVolumeList), err
+}
+
+func (c *FakePersistentVolumes) Create(pv *api.PersistentVolume) (*api.PersistentVolume, error) {
+	obj, err := c.Fake.Invokes(NewRootCreateAction("persistentvolumes", pv), pv)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.PersistentVolume), err
+}
+
+func (c *FakePersistentVolumes) Update(pv *api.PersistentVolume) (*api.PersistentVolume, error) {
+	obj, err := c.Fake.Invokes(NewRootUpdateAction("persistentvolumes", pv), pv)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.PersistentVolume), err
+}
+
+func (c *FakePersistentVolumes) Delete(name string) error {
+	_, err := c.Fake.Invokes(NewRootDeleteAction("persistentvolumes", name), &api.PersistentVolume{})
+	return err
+}
+
+func (c *FakePersistentVolumes) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.Fake.InvokesWatch(NewRootWatchAction("persistentvolumes", label, field, resourceVersion))
+}
+
+func (c *FakePersistentVolumes) UpdateStatus(pv *api.PersistentVolume) (*api.PersistentVolume, error) {
+	action := UpdateActionImpl{}
+	action.Verb = "update"
+	action.Resource = "persistentvolumes"
+	action.Subresource = "status"
+	action.Object = pv
+
+	obj, err := c.Fake.Invokes(action, pv)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.PersistentVolume), err
+}

--- a/pkg/client/v1/testclient/fake_persistent_volumes.go
+++ b/pkg/client/v1/testclient/fake_persistent_volumes.go
@@ -17,7 +17,7 @@ limitations under the License.
 package testclient
 
 import (
-	"k8s.io/kubernetes/pkg/api"
+	api "k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/watch"

--- a/pkg/client/v1/testclient/fake_pod_templates.go
+++ b/pkg/client/v1/testclient/fake_pod_templates.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// FakePodTemplates implements PodTemplatesInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the methods you want to test easier.
+type FakePodTemplates struct {
+	Fake      *Fake
+	Namespace string
+}
+
+func (c *FakePodTemplates) Get(name string) (*api.PodTemplate, error) {
+	obj, err := c.Fake.Invokes(NewGetAction("podtemplates", c.Namespace, name), &api.PodTemplate{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.PodTemplate), err
+}
+
+func (c *FakePodTemplates) List(label labels.Selector, field fields.Selector) (*api.PodTemplateList, error) {
+	obj, err := c.Fake.Invokes(NewListAction("podtemplates", c.Namespace, label, field), &api.PodTemplateList{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.PodTemplateList), err
+}
+
+func (c *FakePodTemplates) Create(pod *api.PodTemplate) (*api.PodTemplate, error) {
+	obj, err := c.Fake.Invokes(NewCreateAction("podtemplates", c.Namespace, pod), pod)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.PodTemplate), err
+}
+
+func (c *FakePodTemplates) Update(pod *api.PodTemplate) (*api.PodTemplate, error) {
+	obj, err := c.Fake.Invokes(NewUpdateAction("podtemplates", c.Namespace, pod), pod)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.PodTemplate), err
+}
+
+func (c *FakePodTemplates) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.Invokes(NewDeleteAction("podtemplates", c.Namespace, name), &api.PodTemplate{})
+	return err
+}
+
+func (c *FakePodTemplates) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.Fake.InvokesWatch(NewWatchAction("podtemplates", c.Namespace, label, field, resourceVersion))
+}

--- a/pkg/client/v1/testclient/fake_pod_templates.go
+++ b/pkg/client/v1/testclient/fake_pod_templates.go
@@ -17,7 +17,7 @@ limitations under the License.
 package testclient
 
 import (
-	"k8s.io/kubernetes/pkg/api"
+	api "k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/watch"

--- a/pkg/client/v1/testclient/fake_pods.go
+++ b/pkg/client/v1/testclient/fake_pods.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// FakePods implements PodsInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the methods you want to test easier.
+type FakePods struct {
+	Fake      *Fake
+	Namespace string
+}
+
+func (c *FakePods) Get(name string) (*api.Pod, error) {
+	obj, err := c.Fake.Invokes(NewGetAction("pods", c.Namespace, name), &api.Pod{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.Pod), err
+}
+
+func (c *FakePods) List(label labels.Selector, field fields.Selector) (*api.PodList, error) {
+	obj, err := c.Fake.Invokes(NewListAction("pods", c.Namespace, label, field), &api.PodList{})
+	if obj == nil {
+		return nil, err
+	}
+	list := &api.PodList{}
+	for _, pod := range obj.(*api.PodList).Items {
+		if label.Matches(labels.Set(pod.Labels)) {
+			list.Items = append(list.Items, pod)
+		}
+	}
+	return list, err
+}
+
+func (c *FakePods) Create(pod *api.Pod) (*api.Pod, error) {
+	obj, err := c.Fake.Invokes(NewCreateAction("pods", c.Namespace, pod), pod)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.Pod), err
+}
+
+func (c *FakePods) Update(pod *api.Pod) (*api.Pod, error) {
+	obj, err := c.Fake.Invokes(NewUpdateAction("pods", c.Namespace, pod), pod)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.Pod), err
+}
+
+func (c *FakePods) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.Invokes(NewDeleteAction("pods", c.Namespace, name), &api.Pod{})
+	return err
+}
+
+func (c *FakePods) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.Fake.InvokesWatch(NewWatchAction("pods", c.Namespace, label, field, resourceVersion))
+}
+
+func (c *FakePods) Bind(binding *api.Binding) error {
+	action := CreateActionImpl{}
+	action.Verb = "create"
+	action.Resource = "pods"
+	action.Subresource = "bindings"
+	action.Object = binding
+
+	_, err := c.Fake.Invokes(action, binding)
+	return err
+}
+
+func (c *FakePods) UpdateStatus(pod *api.Pod) (*api.Pod, error) {
+	obj, err := c.Fake.Invokes(NewUpdateSubresourceAction("pods", "status", c.Namespace, pod), pod)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.Pod), err
+}

--- a/pkg/client/v1/testclient/fake_pods.go
+++ b/pkg/client/v1/testclient/fake_pods.go
@@ -17,7 +17,7 @@ limitations under the License.
 package testclient
 
 import (
-	"k8s.io/kubernetes/pkg/api"
+	api "k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/watch"

--- a/pkg/client/v1/testclient/fake_replication_controllers.go
+++ b/pkg/client/v1/testclient/fake_replication_controllers.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeReplicationControllers implements ReplicationControllerInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the method you want to test easier.
+type FakeReplicationControllers struct {
+	Fake      *Fake
+	Namespace string
+}
+
+func (c *FakeReplicationControllers) Get(name string) (*api.ReplicationController, error) {
+	obj, err := c.Fake.Invokes(NewGetAction("replicationcontrollers", c.Namespace, name), &api.ReplicationController{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.ReplicationController), err
+}
+
+func (c *FakeReplicationControllers) List(label labels.Selector) (*api.ReplicationControllerList, error) {
+	obj, err := c.Fake.Invokes(NewListAction("replicationcontrollers", c.Namespace, label, nil), &api.ReplicationControllerList{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.ReplicationControllerList), err
+}
+
+func (c *FakeReplicationControllers) Create(controller *api.ReplicationController) (*api.ReplicationController, error) {
+	obj, err := c.Fake.Invokes(NewCreateAction("replicationcontrollers", c.Namespace, controller), controller)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.ReplicationController), err
+}
+
+func (c *FakeReplicationControllers) Update(controller *api.ReplicationController) (*api.ReplicationController, error) {
+	obj, err := c.Fake.Invokes(NewUpdateAction("replicationcontrollers", c.Namespace, controller), controller)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.ReplicationController), err
+}
+
+func (c *FakeReplicationControllers) Delete(name string) error {
+	_, err := c.Fake.Invokes(NewDeleteAction("replicationcontrollers", c.Namespace, name), &api.ReplicationController{})
+	return err
+}
+
+func (c *FakeReplicationControllers) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.Fake.InvokesWatch(NewWatchAction("replicationcontrollers", c.Namespace, label, field, resourceVersion))
+}

--- a/pkg/client/v1/testclient/fake_replication_controllers.go
+++ b/pkg/client/v1/testclient/fake_replication_controllers.go
@@ -17,7 +17,7 @@ limitations under the License.
 package testclient
 
 import (
-	"k8s.io/kubernetes/pkg/api"
+	api "k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/watch"

--- a/pkg/client/v1/testclient/fake_resource_quotas.go
+++ b/pkg/client/v1/testclient/fake_resource_quotas.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeResourceQuotas implements ResourceQuotaInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the methods you want to test easier.
+type FakeResourceQuotas struct {
+	Fake      *Fake
+	Namespace string
+}
+
+func (c *FakeResourceQuotas) Get(name string) (*api.ResourceQuota, error) {
+	obj, err := c.Fake.Invokes(NewGetAction("resourcequotas", c.Namespace, name), &api.ResourceQuota{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.ResourceQuota), err
+}
+
+func (c *FakeResourceQuotas) List(label labels.Selector) (*api.ResourceQuotaList, error) {
+	obj, err := c.Fake.Invokes(NewListAction("resourcequotas", c.Namespace, label, nil), &api.ResourceQuotaList{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.ResourceQuotaList), err
+}
+
+func (c *FakeResourceQuotas) Create(resourceQuota *api.ResourceQuota) (*api.ResourceQuota, error) {
+	obj, err := c.Fake.Invokes(NewCreateAction("resourcequotas", c.Namespace, resourceQuota), resourceQuota)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.ResourceQuota), err
+}
+
+func (c *FakeResourceQuotas) Update(resourceQuota *api.ResourceQuota) (*api.ResourceQuota, error) {
+	obj, err := c.Fake.Invokes(NewUpdateAction("resourcequotas", c.Namespace, resourceQuota), resourceQuota)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.ResourceQuota), err
+}
+
+func (c *FakeResourceQuotas) Delete(name string) error {
+	_, err := c.Fake.Invokes(NewDeleteAction("resourcequotas", c.Namespace, name), &api.ResourceQuota{})
+	return err
+}
+
+func (c *FakeResourceQuotas) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.Fake.InvokesWatch(NewWatchAction("resourcequotas", c.Namespace, label, field, resourceVersion))
+}
+
+func (c *FakeResourceQuotas) UpdateStatus(resourceQuota *api.ResourceQuota) (*api.ResourceQuota, error) {
+	obj, err := c.Fake.Invokes(NewUpdateSubresourceAction("resourcequotas", "status", c.Namespace, resourceQuota), resourceQuota)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.ResourceQuota), err
+}

--- a/pkg/client/v1/testclient/fake_resource_quotas.go
+++ b/pkg/client/v1/testclient/fake_resource_quotas.go
@@ -17,7 +17,7 @@ limitations under the License.
 package testclient
 
 import (
-	"k8s.io/kubernetes/pkg/api"
+	api "k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/watch"

--- a/pkg/client/v1/testclient/fake_scales.go
+++ b/pkg/client/v1/testclient/fake_scales.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"k8s.io/kubernetes/pkg/apis/experimental"
+)
+
+// FakeScales implements ScaleInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the methods you want to test easier.
+type FakeScales struct {
+	Fake      *FakeExperimental
+	Namespace string
+}
+
+func (c *FakeScales) Get(kind string, name string) (result *experimental.Scale, err error) {
+	action := GetActionImpl{}
+	action.Verb = "get"
+	action.Namespace = c.Namespace
+	action.Resource = kind
+	action.Subresource = "scale"
+	action.Name = name
+	obj, err := c.Fake.Invokes(action, &experimental.Scale{})
+	result = obj.(*experimental.Scale)
+	return
+}
+
+func (c *FakeScales) Update(kind string, scale *experimental.Scale) (result *experimental.Scale, err error) {
+	action := UpdateActionImpl{}
+	action.Verb = "update"
+	action.Namespace = c.Namespace
+	action.Resource = kind
+	action.Subresource = "scale"
+	action.Object = scale
+	obj, err := c.Fake.Invokes(action, scale)
+	result = obj.(*experimental.Scale)
+	return
+}

--- a/pkg/client/v1/testclient/fake_scales.go
+++ b/pkg/client/v1/testclient/fake_scales.go
@@ -17,7 +17,7 @@ limitations under the License.
 package testclient
 
 import (
-	"k8s.io/kubernetes/pkg/apis/experimental"
+	experimental "k8s.io/kubernetes/pkg/apis/experimental/v1"
 )
 
 // FakeScales implements ScaleInterface. Meant to be embedded into a struct to get a default

--- a/pkg/client/v1/testclient/fake_secrets.go
+++ b/pkg/client/v1/testclient/fake_secrets.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// Fake implements SecretInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the method you want to test easier.
+type FakeSecrets struct {
+	Fake      *Fake
+	Namespace string
+}
+
+func (c *FakeSecrets) Get(name string) (*api.Secret, error) {
+	obj, err := c.Fake.Invokes(NewGetAction("secrets", c.Namespace, name), &api.Secret{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.Secret), err
+}
+
+func (c *FakeSecrets) List(label labels.Selector, field fields.Selector) (*api.SecretList, error) {
+	obj, err := c.Fake.Invokes(NewListAction("secrets", c.Namespace, label, field), &api.SecretList{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.SecretList), err
+}
+
+func (c *FakeSecrets) Create(secret *api.Secret) (*api.Secret, error) {
+	obj, err := c.Fake.Invokes(NewCreateAction("secrets", c.Namespace, secret), secret)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.Secret), err
+}
+
+func (c *FakeSecrets) Update(secret *api.Secret) (*api.Secret, error) {
+	obj, err := c.Fake.Invokes(NewUpdateAction("secrets", c.Namespace, secret), secret)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.Secret), err
+}
+
+func (c *FakeSecrets) Delete(name string) error {
+	_, err := c.Fake.Invokes(NewDeleteAction("secrets", c.Namespace, name), &api.Secret{})
+	return err
+}
+
+func (c *FakeSecrets) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.Fake.InvokesWatch(NewWatchAction("secrets", c.Namespace, label, field, resourceVersion))
+}

--- a/pkg/client/v1/testclient/fake_secrets.go
+++ b/pkg/client/v1/testclient/fake_secrets.go
@@ -17,7 +17,7 @@ limitations under the License.
 package testclient
 
 import (
-	"k8s.io/kubernetes/pkg/api"
+	api "k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/watch"

--- a/pkg/client/v1/testclient/fake_service_accounts.go
+++ b/pkg/client/v1/testclient/fake_service_accounts.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeServiceAccounts implements ServiceAccountsInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the method you want to test easier.
+type FakeServiceAccounts struct {
+	Fake      *Fake
+	Namespace string
+}
+
+func (c *FakeServiceAccounts) Get(name string) (*api.ServiceAccount, error) {
+	obj, err := c.Fake.Invokes(NewGetAction("serviceaccounts", c.Namespace, name), &api.ServiceAccount{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.ServiceAccount), err
+}
+
+func (c *FakeServiceAccounts) List(label labels.Selector, field fields.Selector) (*api.ServiceAccountList, error) {
+	obj, err := c.Fake.Invokes(NewListAction("serviceaccounts", c.Namespace, label, field), &api.ServiceAccountList{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.ServiceAccountList), err
+}
+
+func (c *FakeServiceAccounts) Create(serviceAccount *api.ServiceAccount) (*api.ServiceAccount, error) {
+	obj, err := c.Fake.Invokes(NewCreateAction("serviceaccounts", c.Namespace, serviceAccount), serviceAccount)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.ServiceAccount), err
+}
+
+func (c *FakeServiceAccounts) Update(serviceAccount *api.ServiceAccount) (*api.ServiceAccount, error) {
+	obj, err := c.Fake.Invokes(NewUpdateAction("serviceaccounts", c.Namespace, serviceAccount), serviceAccount)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.ServiceAccount), err
+}
+
+func (c *FakeServiceAccounts) Delete(name string) error {
+	_, err := c.Fake.Invokes(NewDeleteAction("serviceaccounts", c.Namespace, name), &api.ServiceAccount{})
+	return err
+}
+
+func (c *FakeServiceAccounts) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.Fake.InvokesWatch(NewWatchAction("serviceaccounts", c.Namespace, label, field, resourceVersion))
+}

--- a/pkg/client/v1/testclient/fake_service_accounts.go
+++ b/pkg/client/v1/testclient/fake_service_accounts.go
@@ -17,7 +17,7 @@ limitations under the License.
 package testclient
 
 import (
-	"k8s.io/kubernetes/pkg/api"
+	api "k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/watch"

--- a/pkg/client/v1/testclient/fake_services.go
+++ b/pkg/client/v1/testclient/fake_services.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// Fake implements ServiceInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the method you want to test easier.
+type FakeServices struct {
+	Fake      *Fake
+	Namespace string
+}
+
+func (c *FakeServices) Get(name string) (*api.Service, error) {
+	obj, err := c.Fake.Invokes(NewGetAction("services", c.Namespace, name), &api.Service{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.Service), err
+}
+
+func (c *FakeServices) List(label labels.Selector) (*api.ServiceList, error) {
+	obj, err := c.Fake.Invokes(NewListAction("services", c.Namespace, label, nil), &api.ServiceList{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.ServiceList), err
+}
+
+func (c *FakeServices) Create(service *api.Service) (*api.Service, error) {
+	obj, err := c.Fake.Invokes(NewCreateAction("services", c.Namespace, service), service)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.Service), err
+}
+
+func (c *FakeServices) Update(service *api.Service) (*api.Service, error) {
+	obj, err := c.Fake.Invokes(NewUpdateAction("services", c.Namespace, service), service)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.Service), err
+}
+
+func (c *FakeServices) Delete(name string) error {
+	_, err := c.Fake.Invokes(NewDeleteAction("services", c.Namespace, name), &api.Service{})
+	return err
+}
+
+func (c *FakeServices) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.Fake.InvokesWatch(NewWatchAction("services", c.Namespace, label, field, resourceVersion))
+}
+
+func (c *FakeServices) ProxyGet(name, path string, params map[string]string) unversioned.ResponseWrapper {
+	return c.Fake.InvokesProxy(NewProxyGetAction("services", c.Namespace, name, path, params))
+}

--- a/pkg/client/v1/testclient/fake_services.go
+++ b/pkg/client/v1/testclient/fake_services.go
@@ -17,8 +17,8 @@ limitations under the License.
 package testclient
 
 import (
-	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/client/unversioned"
+	api "k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/client/v1"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/watch"
@@ -76,6 +76,6 @@ func (c *FakeServices) Watch(label labels.Selector, field fields.Selector, resou
 	return c.Fake.InvokesWatch(NewWatchAction("services", c.Namespace, label, field, resourceVersion))
 }
 
-func (c *FakeServices) ProxyGet(name, path string, params map[string]string) unversioned.ResponseWrapper {
+func (c *FakeServices) ProxyGet(name, path string, params map[string]string) v1.ResponseWrapper {
 	return c.Fake.InvokesProxy(NewProxyGetAction("services", c.Namespace, name, path, params))
 }

--- a/pkg/client/v1/testclient/fake_test.go
+++ b/pkg/client/v1/testclient/fake_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"testing"
+
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+)
+
+// This test file just ensures that Fake and structs it is embedded in
+// implement Interface.
+
+func TestFakeImplementsInterface(t *testing.T) {
+	_ = client.Interface(&Fake{})
+}
+
+type MyFake struct {
+	*Fake
+}
+
+func TestEmbeddedFakeImplementsInterface(t *testing.T) {
+	_ = client.Interface(MyFake{&Fake{}})
+	_ = client.Interface(&MyFake{&Fake{}})
+}

--- a/pkg/client/v1/testclient/fake_test.go
+++ b/pkg/client/v1/testclient/fake_test.go
@@ -19,7 +19,7 @@ package testclient
 import (
 	"testing"
 
-	client "k8s.io/kubernetes/pkg/client/unversioned"
+	client "k8s.io/kubernetes/pkg/client/v1"
 )
 
 // This test file just ensures that Fake and structs it is embedded in

--- a/pkg/client/v1/testclient/fixture.go
+++ b/pkg/client/v1/testclient/fixture.go
@@ -1,0 +1,305 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"fmt"
+	"io/ioutil"
+	"reflect"
+	"strings"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/yaml"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// ObjectRetriever abstracts the implementation for retrieving or setting generic
+// objects. It is intended to be used to fake calls to a server by returning
+// objects based on their kind and name.
+type ObjectRetriever interface {
+	// Kind should return a resource or a list of resources (depending on the provided kind and
+	// name). It should return an error if the caller should communicate an error to the server.
+	Kind(kind, name string) (runtime.Object, error)
+	// Add adds a runtime object for test purposes into this object.
+	Add(runtime.Object) error
+}
+
+// ObjectReaction returns a ReactionFunc that takes a generic action string of the form
+// <verb>-<resource> or <verb>-<subresource>-<resource> and attempts to return a runtime
+// Object or error that matches the requested action. For instance, list-replicationControllers
+// should attempt to return a list of replication controllers. This method delegates to the
+// ObjectRetriever interface to satisfy retrieval of lists or retrieval of single items.
+// TODO: add support for sub resources
+func ObjectReaction(o ObjectRetriever, mapper meta.RESTMapper) ReactionFunc {
+
+	return func(action Action) (bool, runtime.Object, error) {
+		_, kind, err := mapper.VersionAndKindForResource(action.GetResource())
+		if err != nil {
+			return false, nil, fmt.Errorf("unrecognized action %s: %v", action.GetResource(), err)
+		}
+
+		// TODO: have mapper return a Kind for a subresource?
+		switch castAction := action.(type) {
+		case ListAction:
+			resource, err := o.Kind(kind+"List", "")
+			return true, resource, err
+
+		case GetAction:
+			resource, err := o.Kind(kind, castAction.GetName())
+			return true, resource, err
+
+		case DeleteAction:
+			resource, err := o.Kind(kind, castAction.GetName())
+			return true, resource, err
+
+		case CreateAction:
+			meta, err := api.ObjectMetaFor(castAction.GetObject())
+			if err != nil {
+				return true, nil, err
+			}
+			resource, err := o.Kind(kind, meta.Name)
+			return true, resource, err
+
+		case UpdateAction:
+			meta, err := api.ObjectMetaFor(castAction.GetObject())
+			if err != nil {
+				return true, nil, err
+			}
+			resource, err := o.Kind(kind, meta.Name)
+			return true, resource, err
+
+		default:
+			return false, nil, fmt.Errorf("no reaction implemented for %s", action)
+		}
+
+		return true, nil, nil
+	}
+}
+
+// AddObjectsFromPath loads the JSON or YAML file containing Kubernetes API resources
+// and adds them to the provided ObjectRetriever.
+func AddObjectsFromPath(path string, o ObjectRetriever, decoder runtime.Decoder) error {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	data, err = yaml.ToJSON(data)
+	if err != nil {
+		return err
+	}
+	obj, err := decoder.Decode(data)
+	if err != nil {
+		return err
+	}
+	if err := o.Add(obj); err != nil {
+		return err
+	}
+	return nil
+}
+
+type objects struct {
+	types   map[string][]runtime.Object
+	last    map[string]int
+	scheme  runtime.ObjectScheme
+	decoder runtime.ObjectDecoder
+}
+
+var _ ObjectRetriever = &objects{}
+
+// NewObjects implements the ObjectRetriever interface by introspecting the
+// objects provided to Add() and returning them when the Kind method is invoked.
+// If an api.List object is provided to Add(), each child item is added. If an
+// object is added that is itself a list (PodList, ServiceList) then that is added
+// to the "PodList" kind. If no PodList is added, the retriever will take any loaded
+// Pods and return them in a list. If an api.Status is added, and the Details.Kind field
+// is set, that status will be returned instead (as an error if Status != Success, or
+// as a runtime.Object if Status == Success).  If multiple PodLists are provided, they
+// will be returned in order by the Kind call, and the last PodList will be reused for
+// subsequent calls.
+func NewObjects(scheme runtime.ObjectScheme, decoder runtime.ObjectDecoder) ObjectRetriever {
+	return objects{
+		types:   make(map[string][]runtime.Object),
+		last:    make(map[string]int),
+		scheme:  scheme,
+		decoder: decoder,
+	}
+}
+
+func (o objects) Kind(kind, name string) (runtime.Object, error) {
+	empty, _ := o.scheme.New("", kind)
+	nilValue := reflect.Zero(reflect.TypeOf(empty)).Interface().(runtime.Object)
+
+	arr, ok := o.types[kind]
+	if !ok {
+		if strings.HasSuffix(kind, "List") {
+			itemKind := kind[:len(kind)-4]
+			arr, ok := o.types[itemKind]
+			if !ok {
+				return empty, nil
+			}
+			out, err := o.scheme.New("", kind)
+			if err != nil {
+				return nilValue, err
+			}
+			if err := runtime.SetList(out, arr); err != nil {
+				return nilValue, err
+			}
+			if out, err = o.scheme.Copy(out); err != nil {
+				return nilValue, err
+			}
+			return out, nil
+		}
+		return nilValue, errors.NewNotFound(kind, name)
+	}
+
+	index := o.last[kind]
+	if index >= len(arr) {
+		index = len(arr) - 1
+	}
+	if index < 0 {
+		return nilValue, errors.NewNotFound(kind, name)
+	}
+	out, err := o.scheme.Copy(arr[index])
+	if err != nil {
+		return nilValue, err
+	}
+	o.last[kind] = index + 1
+
+	if status, ok := out.(*unversioned.Status); ok {
+		if status.Details != nil {
+			status.Details.Kind = kind
+		}
+		if status.Status != unversioned.StatusSuccess {
+			return nilValue, &errors.StatusError{ErrStatus: *status}
+		}
+	}
+
+	return out, nil
+}
+
+func (o objects) Add(obj runtime.Object) error {
+	_, kind, err := o.scheme.ObjectVersionAndKind(obj)
+	if err != nil {
+		return err
+	}
+
+	switch {
+	case runtime.IsListType(obj):
+		if kind != "List" {
+			o.types[kind] = append(o.types[kind], obj)
+		}
+
+		list, err := runtime.ExtractList(obj)
+		if err != nil {
+			return err
+		}
+		if errs := runtime.DecodeList(list, o.decoder); len(errs) > 0 {
+			return errs[0]
+		}
+		for _, obj := range list {
+			if err := o.Add(obj); err != nil {
+				return err
+			}
+		}
+	default:
+		if status, ok := obj.(*unversioned.Status); ok && status.Details != nil {
+			kind = status.Details.Kind
+		}
+		o.types[kind] = append(o.types[kind], obj)
+	}
+
+	return nil
+}
+
+func DefaultWatchReactor(watchInterface watch.Interface, err error) WatchReactionFunc {
+	return func(action Action) (bool, watch.Interface, error) {
+		return true, watchInterface, err
+	}
+}
+
+// SimpleReactor is a Reactor.  Each reaction function is attached to a given verb,resource tuple.  "*" in either field matches everything for that value.
+// For instance, *,pods matches all verbs on pods.  This allows for easier composition of reaction functions
+type SimpleReactor struct {
+	Verb     string
+	Resource string
+
+	Reaction ReactionFunc
+}
+
+func (r *SimpleReactor) Handles(action Action) bool {
+	verbCovers := r.Verb == "*" || r.Verb == action.GetVerb()
+	if !verbCovers {
+		return false
+	}
+	resourceCovers := r.Resource == "*" || r.Resource == action.GetResource()
+	if !resourceCovers {
+		return false
+	}
+
+	return true
+}
+
+func (r *SimpleReactor) React(action Action) (bool, runtime.Object, error) {
+	return r.Reaction(action)
+}
+
+// SimpleWatchReactor is a WatchReactor.  Each reaction function is attached to a given resource.  "*" matches everything for that value.
+// For instance, *,pods matches all verbs on pods.  This allows for easier composition of reaction functions
+type SimpleWatchReactor struct {
+	Resource string
+
+	Reaction WatchReactionFunc
+}
+
+func (r *SimpleWatchReactor) Handles(action Action) bool {
+	resourceCovers := r.Resource == "*" || r.Resource == action.GetResource()
+	if !resourceCovers {
+		return false
+	}
+
+	return true
+}
+
+func (r *SimpleWatchReactor) React(action Action) (bool, watch.Interface, error) {
+	return r.Reaction(action)
+}
+
+// SimpleProxyReactor is a ProxyReactor.  Each reaction function is attached to a given resource.  "*" matches everything for that value.
+// For instance, *,pods matches all verbs on pods.  This allows for easier composition of reaction functions.
+type SimpleProxyReactor struct {
+	Resource string
+
+	Reaction ProxyReactionFunc
+}
+
+func (r *SimpleProxyReactor) Handles(action Action) bool {
+	resourceCovers := r.Resource == "*" || r.Resource == action.GetResource()
+	if !resourceCovers {
+		return false
+	}
+
+	return true
+}
+
+func (r *SimpleProxyReactor) React(action Action) (bool, client.ResponseWrapper, error) {
+	return r.Reaction(action)
+}

--- a/pkg/client/v1/testclient/testclient.go
+++ b/pkg/client/v1/testclient/testclient.go
@@ -1,0 +1,308 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"fmt"
+	"sync"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/latest"
+	"k8s.io/kubernetes/pkg/api/registered"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/version"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// NewSimpleFake returns a client that will respond with the provided objects
+func NewSimpleFake(objects ...runtime.Object) *Fake {
+	o := NewObjects(api.Scheme, api.Scheme)
+	for _, obj := range objects {
+		if err := o.Add(obj); err != nil {
+			panic(err)
+		}
+	}
+
+	fakeClient := &Fake{}
+	fakeClient.AddReactor("*", "*", ObjectReaction(o, latest.GroupOrDie("").RESTMapper))
+
+	return fakeClient
+}
+
+// Fake implements client.Interface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the method you want to test easier.
+type Fake struct {
+	sync.RWMutex
+	actions []Action // these may be castable to other types, but "Action" is the minimum
+
+	// ReactionChain is the list of reactors that will be attempted for every request in the order they are tried
+	ReactionChain []Reactor
+	// WatchReactionChain is the list of watch reactors that will be attempted for every request in the order they are tried
+	WatchReactionChain []WatchReactor
+	// ProxyReactionChain is the list of proxy reactors that will be attempted for every request in the order they are tried
+	ProxyReactionChain []ProxyReactor
+}
+
+// Reactor is an interface to allow the composition of reaction functions.
+type Reactor interface {
+	// Handles indicates whether or not this Reactor deals with a given action
+	Handles(action Action) bool
+	// React handles the action and returns results.  It may choose to delegate by indicated handled=false
+	React(action Action) (handled bool, ret runtime.Object, err error)
+}
+
+// WatchReactor is an interface to allow the composition of watch functions.
+type WatchReactor interface {
+	// Handles indicates whether or not this Reactor deals with a given action
+	Handles(action Action) bool
+	// React handles a watch action and returns results.  It may choose to delegate by indicated handled=false
+	React(action Action) (handled bool, ret watch.Interface, err error)
+}
+
+// ProxyReactor is an interface to allow the composition of proxy get functions.
+type ProxyReactor interface {
+	// Handles indicates whether or not this Reactor deals with a given action
+	Handles(action Action) bool
+	// React handles a watch action and returns results.  It may choose to delegate by indicated handled=false
+	React(action Action) (handled bool, ret client.ResponseWrapper, err error)
+}
+
+// ReactionFunc is a function that returns an object or error for a given Action.  If "handled" is false,
+// then the test client will continue ignore the results and continue to the next ReactionFunc
+type ReactionFunc func(action Action) (handled bool, ret runtime.Object, err error)
+
+// WatchReactionFunc is a function that returns a watch interface.  If "handled" is false,
+// then the test client will continue ignore the results and continue to the next ReactionFunc
+type WatchReactionFunc func(action Action) (handled bool, ret watch.Interface, err error)
+
+// ProxyReactionFunc is a function that returns a ResponseWrapper interface for a given Action.  If "handled" is false,
+// then the test client will continue ignore the results and continue to the next ProxyReactionFunc
+type ProxyReactionFunc func(action Action) (handled bool, ret client.ResponseWrapper, err error)
+
+// AddReactor appends a reactor to the end of the chain
+func (c *Fake) AddReactor(verb, resource string, reaction ReactionFunc) {
+	c.ReactionChain = append(c.ReactionChain, &SimpleReactor{verb, resource, reaction})
+}
+
+// PrependReactor adds a reactor to the beginning of the chain
+func (c *Fake) PrependReactor(verb, resource string, reaction ReactionFunc) {
+	newChain := make([]Reactor, 0, len(c.ReactionChain)+1)
+	newChain[0] = &SimpleReactor{verb, resource, reaction}
+	newChain = append(newChain, c.ReactionChain...)
+}
+
+// AddWatchReactor appends a reactor to the end of the chain
+func (c *Fake) AddWatchReactor(resource string, reaction WatchReactionFunc) {
+	c.WatchReactionChain = append(c.WatchReactionChain, &SimpleWatchReactor{resource, reaction})
+}
+
+// AddProxyReactor appends a reactor to the end of the chain
+func (c *Fake) AddProxyReactor(resource string, reaction ProxyReactionFunc) {
+	c.ProxyReactionChain = append(c.ProxyReactionChain, &SimpleProxyReactor{resource, reaction})
+}
+
+// Invokes records the provided Action and then invokes the ReactFn (if provided).
+// defaultReturnObj is expected to be of the same type a normal call would return.
+func (c *Fake) Invokes(action Action, defaultReturnObj runtime.Object) (runtime.Object, error) {
+	c.Lock()
+	defer c.Unlock()
+
+	c.actions = append(c.actions, action)
+	for _, reactor := range c.ReactionChain {
+		if !reactor.Handles(action) {
+			continue
+		}
+
+		handled, ret, err := reactor.React(action)
+		if !handled {
+			continue
+		}
+
+		return ret, err
+	}
+
+	return defaultReturnObj, nil
+}
+
+// InvokesWatch records the provided Action and then invokes the ReactFn (if provided).
+func (c *Fake) InvokesWatch(action Action) (watch.Interface, error) {
+	c.Lock()
+	defer c.Unlock()
+
+	c.actions = append(c.actions, action)
+	for _, reactor := range c.WatchReactionChain {
+		if !reactor.Handles(action) {
+			continue
+		}
+
+		handled, ret, err := reactor.React(action)
+		if !handled {
+			continue
+		}
+
+		return ret, err
+	}
+
+	return nil, fmt.Errorf("unhandled watch: %#v", action)
+}
+
+// InvokesProxy records the provided Action and then invokes the ReactFn (if provided).
+func (c *Fake) InvokesProxy(action Action) client.ResponseWrapper {
+	c.Lock()
+	defer c.Unlock()
+
+	c.actions = append(c.actions, action)
+	for _, reactor := range c.ProxyReactionChain {
+		if !reactor.Handles(action) {
+			continue
+		}
+
+		handled, ret, err := reactor.React(action)
+		if !handled || err != nil {
+			continue
+		}
+
+		return ret
+	}
+
+	return nil
+}
+
+// ClearActions clears the history of actions called on the fake client
+func (c *Fake) ClearActions() {
+	c.Lock()
+	c.Unlock()
+
+	c.actions = make([]Action, 0)
+}
+
+// Actions returns a chronologically ordered slice fake actions called on the fake client
+func (c *Fake) Actions() []Action {
+	c.RLock()
+	defer c.RUnlock()
+	fa := make([]Action, len(c.actions))
+	copy(fa, c.actions)
+	return fa
+}
+
+func (c *Fake) LimitRanges(namespace string) client.LimitRangeInterface {
+	return &FakeLimitRanges{Fake: c, Namespace: namespace}
+}
+
+func (c *Fake) ResourceQuotas(namespace string) client.ResourceQuotaInterface {
+	return &FakeResourceQuotas{Fake: c, Namespace: namespace}
+}
+
+func (c *Fake) ReplicationControllers(namespace string) client.ReplicationControllerInterface {
+	return &FakeReplicationControllers{Fake: c, Namespace: namespace}
+}
+
+func (c *Fake) Nodes() client.NodeInterface {
+	return &FakeNodes{Fake: c}
+}
+
+func (c *Fake) Events(namespace string) client.EventInterface {
+	return &FakeEvents{Fake: c, Namespace: namespace}
+}
+
+func (c *Fake) Endpoints(namespace string) client.EndpointsInterface {
+	return &FakeEndpoints{Fake: c, Namespace: namespace}
+}
+
+func (c *Fake) PersistentVolumes() client.PersistentVolumeInterface {
+	return &FakePersistentVolumes{Fake: c}
+}
+
+func (c *Fake) PersistentVolumeClaims(namespace string) client.PersistentVolumeClaimInterface {
+	return &FakePersistentVolumeClaims{Fake: c, Namespace: namespace}
+}
+
+func (c *Fake) Pods(namespace string) client.PodInterface {
+	return &FakePods{Fake: c, Namespace: namespace}
+}
+
+func (c *Fake) PodTemplates(namespace string) client.PodTemplateInterface {
+	return &FakePodTemplates{Fake: c, Namespace: namespace}
+}
+
+func (c *Fake) Services(namespace string) client.ServiceInterface {
+	return &FakeServices{Fake: c, Namespace: namespace}
+}
+
+func (c *Fake) ServiceAccounts(namespace string) client.ServiceAccountsInterface {
+	return &FakeServiceAccounts{Fake: c, Namespace: namespace}
+}
+
+func (c *Fake) Secrets(namespace string) client.SecretsInterface {
+	return &FakeSecrets{Fake: c, Namespace: namespace}
+}
+
+func (c *Fake) Namespaces() client.NamespaceInterface {
+	return &FakeNamespaces{Fake: c}
+}
+
+func (c *Fake) Experimental() client.ExperimentalInterface {
+	return &FakeExperimental{c}
+}
+
+func (c *Fake) ServerVersion() (*version.Info, error) {
+	action := ActionImpl{}
+	action.Verb = "get"
+	action.Resource = "version"
+
+	c.Invokes(action, nil)
+	versionInfo := version.Get()
+	return &versionInfo, nil
+}
+
+func (c *Fake) ServerAPIVersions() (*api.APIVersions, error) {
+	action := ActionImpl{}
+	action.Verb = "get"
+	action.Resource = "apiversions"
+
+	c.Invokes(action, nil)
+	return &api.APIVersions{Versions: registered.RegisteredVersions}, nil
+}
+
+func (c *Fake) ComponentStatuses() client.ComponentStatusInterface {
+	return &FakeComponentStatuses{Fake: c}
+}
+
+type FakeExperimental struct {
+	*Fake
+}
+
+func (c *FakeExperimental) DaemonSets(namespace string) client.DaemonSetInterface {
+	return &FakeDaemonSets{Fake: c, Namespace: namespace}
+}
+
+func (c *FakeExperimental) HorizontalPodAutoscalers(namespace string) client.HorizontalPodAutoscalerInterface {
+	return &FakeHorizontalPodAutoscalers{Fake: c, Namespace: namespace}
+}
+
+func (c *FakeExperimental) Deployments(namespace string) client.DeploymentInterface {
+	return &FakeDeployments{Fake: c, Namespace: namespace}
+}
+
+func (c *FakeExperimental) Scales(namespace string) client.ScaleInterface {
+	return &FakeScales{Fake: c, Namespace: namespace}
+}
+
+func (c *FakeExperimental) Jobs(namespace string) client.JobInterface {
+	return &FakeJobs{Fake: c, Namespace: namespace}
+}

--- a/pkg/client/v1/testclient/testclient.go
+++ b/pkg/client/v1/testclient/testclient.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/api/registered"
-	client "k8s.io/kubernetes/pkg/client/unversioned"
+	client "k8s.io/kubernetes/pkg/client/v1"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/version"
 	"k8s.io/kubernetes/pkg/watch"

--- a/pkg/client/v1/testclient/testclient_test.go
+++ b/pkg/client/v1/testclient/testclient_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+func TestNewClient(t *testing.T) {
+	o := NewObjects(api.Scheme, api.Scheme)
+	if err := AddObjectsFromPath("../../../../examples/guestbook/frontend-service.yaml", o, api.Scheme); err != nil {
+		t.Fatal(err)
+	}
+	client := &Fake{}
+	client.AddReactor("*", "*", ObjectReaction(o, testapi.Default.RESTMapper()))
+	list, err := client.Services("test").List(labels.Everything())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list.Items) != 1 {
+		t.Fatalf("unexpected list %#v", list)
+	}
+
+	// When list is invoked a second time, the same results are returned.
+	list, err = client.Services("test").List(labels.Everything())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list.Items) != 1 {
+		t.Fatalf("unexpected list %#v", list)
+	}
+	t.Logf("list: %#v", list)
+}
+
+func TestErrors(t *testing.T) {
+	o := NewObjects(api.Scheme, api.Scheme)
+	o.Add(&api.List{
+		Items: []runtime.Object{
+			// This first call to List will return this error
+			&(errors.NewNotFound("ServiceList", "").(*errors.StatusError).ErrStatus),
+			// The second call to List will return this error
+			&(errors.NewForbidden("ServiceList", "", nil).(*errors.StatusError).ErrStatus),
+		},
+	})
+	client := &Fake{}
+	client.AddReactor("*", "*", ObjectReaction(o, testapi.Default.RESTMapper()))
+	_, err := client.Services("test").List(labels.Everything())
+	if !errors.IsNotFound(err) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	t.Logf("error: %#v", err.(*errors.StatusError).Status())
+	_, err = client.Services("test").List(labels.Everything())
+	if !errors.IsForbidden(err) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/pkg/client/v1/transport.go
+++ b/pkg/client/v1/transport.go
@@ -1,0 +1,227 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+type userAgentRoundTripper struct {
+	agent string
+	rt    http.RoundTripper
+}
+
+func NewUserAgentRoundTripper(agent string, rt http.RoundTripper) http.RoundTripper {
+	return &userAgentRoundTripper{agent, rt}
+}
+
+func (rt *userAgentRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if len(req.Header.Get("User-Agent")) != 0 {
+		return rt.rt.RoundTrip(req)
+	}
+	req = cloneRequest(req)
+	req.Header.Set("User-Agent", rt.agent)
+	return rt.rt.RoundTrip(req)
+}
+
+type basicAuthRoundTripper struct {
+	username string
+	password string
+	rt       http.RoundTripper
+}
+
+// NewBasicAuthRoundTripper will apply a BASIC auth authorization header to a request unless it has
+// already been set.
+func NewBasicAuthRoundTripper(username, password string, rt http.RoundTripper) http.RoundTripper {
+	return &basicAuthRoundTripper{username, password, rt}
+}
+
+func (rt *basicAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if len(req.Header.Get("Authorization")) != 0 {
+		return rt.rt.RoundTrip(req)
+	}
+	req = cloneRequest(req)
+	req.SetBasicAuth(rt.username, rt.password)
+	return rt.rt.RoundTrip(req)
+}
+
+type bearerAuthRoundTripper struct {
+	bearer string
+	rt     http.RoundTripper
+}
+
+// NewBearerAuthRoundTripper adds the provided bearer token to a request unless the authorization
+// header has already been set.
+func NewBearerAuthRoundTripper(bearer string, rt http.RoundTripper) http.RoundTripper {
+	return &bearerAuthRoundTripper{bearer, rt}
+}
+
+func (rt *bearerAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if len(req.Header.Get("Authorization")) != 0 {
+		return rt.rt.RoundTrip(req)
+	}
+
+	req = cloneRequest(req)
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", rt.bearer))
+	return rt.rt.RoundTrip(req)
+}
+
+// TLSConfigFor returns a tls.Config that will provide the transport level security defined
+// by the provided Config. Will return nil if no transport level security is requested.
+func TLSConfigFor(config *Config) (*tls.Config, error) {
+	hasCA := len(config.CAFile) > 0 || len(config.CAData) > 0
+	hasCert := len(config.CertFile) > 0 || len(config.CertData) > 0
+
+	if hasCA && config.Insecure {
+		return nil, fmt.Errorf("specifying a root certificates file with the insecure flag is not allowed")
+	}
+	if err := LoadTLSFiles(config); err != nil {
+		return nil, err
+	}
+	var tlsConfig *tls.Config
+	switch {
+	case hasCert:
+		cfg, err := NewClientCertTLSConfig(config.CertData, config.KeyData, config.CAData)
+		if err != nil {
+			return nil, err
+		}
+		tlsConfig = cfg
+	case hasCA:
+		cfg, err := NewTLSConfig(config.CAData)
+		if err != nil {
+			return nil, err
+		}
+		tlsConfig = cfg
+	case config.Insecure:
+		tlsConfig = NewUnsafeTLSConfig()
+	}
+
+	return tlsConfig, nil
+}
+
+// tlsConfigKey returns a unique key for tls.Config objects returned from TLSConfigFor
+func tlsConfigKey(config *Config) (string, error) {
+	// Make sure ca/key/cert content is loaded
+	if err := LoadTLSFiles(config); err != nil {
+		return "", err
+	}
+	// Only include the things that actually affect the tls.Config
+	return fmt.Sprintf("%v/%x/%x/%x", config.Insecure, config.CAData, config.CertData, config.KeyData), nil
+}
+
+// LoadTLSFiles copies the data from the CertFile, KeyFile, and CAFile fields into the CertData,
+// KeyData, and CAFile fields, or returns an error. If no error is returned, all three fields are
+// either populated or were empty to start.
+func LoadTLSFiles(config *Config) error {
+	certData, err := dataFromSliceOrFile(config.CertData, config.CertFile)
+	if err != nil {
+		return err
+	}
+	config.CertData = certData
+	keyData, err := dataFromSliceOrFile(config.KeyData, config.KeyFile)
+	if err != nil {
+		return err
+	}
+	config.KeyData = keyData
+	caData, err := dataFromSliceOrFile(config.CAData, config.CAFile)
+	if err != nil {
+		return err
+	}
+	config.CAData = caData
+
+	return nil
+}
+
+// dataFromSliceOrFile returns data from the slice (if non-empty), or from the file,
+// or an error if an error occurred reading the file
+func dataFromSliceOrFile(data []byte, file string) ([]byte, error) {
+	if len(data) > 0 {
+		return data, nil
+	}
+	if len(file) > 0 {
+		fileData, err := ioutil.ReadFile(file)
+		if err != nil {
+			return []byte{}, err
+		}
+		return fileData, nil
+	}
+	return nil, nil
+}
+
+func NewClientCertTLSConfig(certData, keyData, caData []byte) (*tls.Config, error) {
+	cert, err := tls.X509KeyPair(certData, keyData)
+	if err != nil {
+		return nil, err
+	}
+
+	return &tls.Config{
+		// Change default from SSLv3 to TLSv1.0 (because of POODLE vulnerability)
+		MinVersion: tls.VersionTLS10,
+		Certificates: []tls.Certificate{
+			cert,
+		},
+		RootCAs: rootCertPool(caData),
+	}, nil
+}
+
+func NewTLSConfig(caData []byte) (*tls.Config, error) {
+	return &tls.Config{
+		// Change default from SSLv3 to TLSv1.0 (because of POODLE vulnerability)
+		MinVersion: tls.VersionTLS10,
+		RootCAs:    rootCertPool(caData),
+	}, nil
+}
+
+// rootCertPool returns nil if caData is empty.  When passed along, this will mean "use system CAs".
+// When caData is not empty, it will be the ONLY information used in the CertPool.
+func rootCertPool(caData []byte) *x509.CertPool {
+	// What we really want is a copy of x509.systemRootsPool, but that isn't exposed.  It's difficult to build (see the go
+	// code for a look at the platform specific insanity), so we'll use the fact that RootCAs == nil gives us the system values
+	// It doesn't allow trusting either/or, but hopefully that won't be an issue
+	if len(caData) == 0 {
+		return nil
+	}
+
+	// if we have caData, use it
+	certPool := x509.NewCertPool()
+	certPool.AppendCertsFromPEM(caData)
+	return certPool
+}
+
+func NewUnsafeTLSConfig() *tls.Config {
+	return &tls.Config{
+		InsecureSkipVerify: true,
+	}
+}
+
+// cloneRequest returns a clone of the provided *http.Request.
+// The clone is a shallow copy of the struct and its Header map.
+func cloneRequest(r *http.Request) *http.Request {
+	// shallow copy of the struct
+	r2 := new(http.Request)
+	*r2 = *r
+	// deep copy of the Header
+	r2.Header = make(http.Header)
+	for k, s := range r.Header {
+		r2.Header[k] = s
+	}
+	return r2
+}

--- a/pkg/client/v1/transport.go
+++ b/pkg/client/v1/transport.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"crypto/tls"

--- a/pkg/client/v1/transport_test.go
+++ b/pkg/client/v1/transport_test.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"encoding/base64"
+	"net/http"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api/testapi"
+)
+
+func TestUnsecuredTLSTransport(t *testing.T) {
+	cfg := NewUnsafeTLSConfig()
+	if !cfg.InsecureSkipVerify {
+		t.Errorf("expected config to be insecure")
+	}
+}
+
+type testRoundTripper struct {
+	Request  *http.Request
+	Response *http.Response
+	Err      error
+}
+
+func (rt *testRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.Request = req
+	return rt.Response, rt.Err
+}
+
+func TestBearerAuthRoundTripper(t *testing.T) {
+	rt := &testRoundTripper{}
+	req := &http.Request{}
+	NewBearerAuthRoundTripper("test", rt).RoundTrip(req)
+	if rt.Request == nil {
+		t.Fatalf("unexpected nil request: %v", rt)
+	}
+	if rt.Request == req {
+		t.Fatalf("round tripper should have copied request object: %#v", rt.Request)
+	}
+	if rt.Request.Header.Get("Authorization") != "Bearer test" {
+		t.Errorf("unexpected authorization header: %#v", rt.Request)
+	}
+}
+
+func TestBasicAuthRoundTripper(t *testing.T) {
+	rt := &testRoundTripper{}
+	req := &http.Request{}
+	NewBasicAuthRoundTripper("user", "pass", rt).RoundTrip(req)
+	if rt.Request == nil {
+		t.Fatalf("unexpected nil request: %v", rt)
+	}
+	if rt.Request == req {
+		t.Fatalf("round tripper should have copied request object: %#v", rt.Request)
+	}
+	if rt.Request.Header.Get("Authorization") != "Basic "+base64.StdEncoding.EncodeToString([]byte("user:pass")) {
+		t.Errorf("unexpected authorization header: %#v", rt.Request)
+	}
+}
+
+func TestUserAgentRoundTripper(t *testing.T) {
+	rt := &testRoundTripper{}
+	req := &http.Request{
+		Header: make(http.Header),
+	}
+	req.Header.Set("User-Agent", "other")
+	NewUserAgentRoundTripper("test", rt).RoundTrip(req)
+	if rt.Request == nil {
+		t.Fatalf("unexpected nil request: %v", rt)
+	}
+	if rt.Request != req {
+		t.Fatalf("round tripper should not have copied request object: %#v", rt.Request)
+	}
+	if rt.Request.Header.Get("User-Agent") != "other" {
+		t.Errorf("unexpected user agent header: %#v", rt.Request)
+	}
+
+	req = &http.Request{}
+	NewUserAgentRoundTripper("test", rt).RoundTrip(req)
+	if rt.Request == nil {
+		t.Fatalf("unexpected nil request: %v", rt)
+	}
+	if rt.Request == req {
+		t.Fatalf("round tripper should have copied request object: %#v", rt.Request)
+	}
+	if rt.Request.Header.Get("User-Agent") != "test" {
+		t.Errorf("unexpected user agent header: %#v", rt.Request)
+	}
+}
+
+func TestTLSConfigKey(t *testing.T) {
+	// Make sure config fields that don't affect the tls config don't affect the cache key
+	identicalConfigurations := map[string]*Config{
+		"empty":          {},
+		"host":           {Host: "foo"},
+		"prefix":         {Prefix: "foo"},
+		"version":        {Version: "foo"},
+		"codec":          {Codec: testapi.Default.Codec()},
+		"basic":          {Username: "bob", Password: "password"},
+		"bearer":         {BearerToken: "token"},
+		"user agent":     {UserAgent: "useragent"},
+		"transport":      {Transport: http.DefaultTransport},
+		"wrap transport": {WrapTransport: func(http.RoundTripper) http.RoundTripper { return nil }},
+		"qps/burst":      {QPS: 1.0, Burst: 10},
+	}
+	for nameA, valueA := range identicalConfigurations {
+		for nameB, valueB := range identicalConfigurations {
+			keyA, err := tlsConfigKey(valueA)
+			if err != nil {
+				t.Errorf("Unexpected error for %q: %v", nameA, err)
+				continue
+			}
+			keyB, err := tlsConfigKey(valueB)
+			if err != nil {
+				t.Errorf("Unexpected error for %q: %v", nameB, err)
+				continue
+			}
+			if keyA != keyB {
+				t.Errorf("Expected identical cache keys for %q and %q, got:\n\t%s\n\t%s", nameA, nameB, keyA, keyB)
+				continue
+			}
+		}
+	}
+
+	// Make sure config fields that affect the tls config affect the cache key
+	uniqueConfigurations := map[string]*Config{
+		"no tls":                  {},
+		"insecure":                {Insecure: true},
+		"cadata 1":                {TLSClientConfig: TLSClientConfig{CAData: []byte{1}}},
+		"cadata 2":                {TLSClientConfig: TLSClientConfig{CAData: []byte{2}}},
+		"cert 1, key 1":           {TLSClientConfig: TLSClientConfig{CertData: []byte{1}, KeyData: []byte{1}}},
+		"cert 1, key 2":           {TLSClientConfig: TLSClientConfig{CertData: []byte{1}, KeyData: []byte{2}}},
+		"cert 2, key 1":           {TLSClientConfig: TLSClientConfig{CertData: []byte{2}, KeyData: []byte{1}}},
+		"cert 2, key 2":           {TLSClientConfig: TLSClientConfig{CertData: []byte{2}, KeyData: []byte{2}}},
+		"cadata 1, cert 1, key 1": {TLSClientConfig: TLSClientConfig{CAData: []byte{1}, CertData: []byte{1}, KeyData: []byte{1}}},
+	}
+	for nameA, valueA := range uniqueConfigurations {
+		for nameB, valueB := range uniqueConfigurations {
+			// Don't compare to ourselves
+			if nameA == nameB {
+				continue
+			}
+
+			keyA, err := tlsConfigKey(valueA)
+			if err != nil {
+				t.Errorf("Unexpected error for %q: %v", nameA, err)
+				continue
+			}
+			keyB, err := tlsConfigKey(valueB)
+			if err != nil {
+				t.Errorf("Unexpected error for %q: %v", nameB, err)
+				continue
+			}
+			if keyA == keyB {
+				t.Errorf("Expected unique cache keys for %q and %q, got:\n\t%s\n\t%s", nameA, nameB, keyA, keyB)
+				continue
+			}
+		}
+	}
+}

--- a/pkg/client/v1/transport_test.go
+++ b/pkg/client/v1/transport_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package unversioned
+package v1
 
 import (
 	"encoding/base64"


### PR DESCRIPTION
cc @lavalamp 

Sorry this hasn't been finished yet. I hit some issues and decided that I was probably trying to go about this the wrong way. The approach that is in progress is to just accept that some things belong in the unversioned API like Status and the errors package that deals with it. So I have some changes in progress where `api` gets renamed to `unversionedAPI` just to mark where we're still using it.

Some other changes I made that have been merged: #12414 #12604 and #12679
