### PR TITLE
use privileged source object

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -294,7 +294,9 @@ func (s *APIServer) Run(_ []string) error {
 	capabilities.Initialize(capabilities.Capabilities{
 		AllowPrivileged: s.AllowPrivileged,
 		// TODO(vmarmol): Implement support for HostNetworkSources.
-		HostNetworkSources:                     []string{},
+		PrivilegedSources: capabilities.PrivilegedSources{
+			HostNetworkSources: []string{},
+		},
 		PerConnectionBandwidthLimitBytesPerSec: s.MaxConnectionBytesPerSec,
 	})
 

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -642,7 +642,11 @@ func RunKubelet(kcfg *KubeletConfig, builder KubeletBuilder) error {
 	} else {
 		glog.Warning("No api server defined - no events will be sent to API server.")
 	}
-	capabilities.Setup(kcfg.AllowPrivileged, kcfg.HostNetworkSources, 0)
+
+	privilegedSources := capabilities.PrivilegedSources{
+		HostNetworkSources: kcfg.HostNetworkSources,
+	}
+	capabilities.Setup(kcfg.AllowPrivileged, privilegedSources, 0)
 
 	credentialprovider.SetPreferredDockercfgPath(kcfg.RootDirectory)
 

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -2828,7 +2828,9 @@ func TestHostNetworkAllowed(t *testing.T) {
 	kubelet := testKubelet.kubelet
 
 	capabilities.SetForTests(capabilities.Capabilities{
-		HostNetworkSources: []string{ApiserverSource, FileSource},
+		PrivilegedSources: capabilities.PrivilegedSources{
+			HostNetworkSources: []string{ApiserverSource, FileSource},
+		},
 	})
 	pod := &api.Pod{
 		ObjectMeta: api.ObjectMeta{
@@ -2858,7 +2860,9 @@ func TestHostNetworkDisallowed(t *testing.T) {
 	kubelet := testKubelet.kubelet
 
 	capabilities.SetForTests(capabilities.Capabilities{
-		HostNetworkSources: []string{},
+		PrivilegedSources: capabilities.PrivilegedSources{
+			HostNetworkSources: []string{},
+		},
 	})
 	pod := &api.Pod{
 		ObjectMeta: api.ObjectMeta{

--- a/pkg/kubelet/util.go
+++ b/pkg/kubelet/util.go
@@ -66,7 +66,7 @@ func allowHostNetwork(pod *api.Pod) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	for _, source := range capabilities.Get().HostNetworkSources {
+	for _, source := range capabilities.Get().PrivilegedSources.HostNetworkSources {
 		if source == podSource {
 			return true, nil
 		}


### PR DESCRIPTION
There are currently two features that define source lists for privileged requests: host networking and host IPC mode (in flight PR https://github.com/kubernetes/kubernetes/pull/12470).  I anticipate having a third for using the host PID namespace.

Suggested refactor: use an object to pass in all the privileged sources for these items until they are governed by policy as described in https://github.com/kubernetes/kubernetes/pull/7893.

@liggitt  @smarterclayton @bgrant0607 @eparis @simon3z
