### PR TITLE
Save unit test results as JUnit XML for Shippable

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -39,6 +39,7 @@ install:
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/mattn/goveralls
   - go get github.com/tools/godep
+  - go get github.com/jstemmer/go-junit-report
   - ./hack/build-go.sh
   - godep go install ./...
   - ./hack/travis/install-etcd.sh
@@ -56,7 +57,7 @@ install:
 
 script:
   # Disable coverage collection on pull requests
-  - KUBE_RACE="-race" KUBE_COVER=$([[ "$PULL_REQUEST" =~ ^[0-9]+$ ]] && echo "n" || echo "y") KUBE_GOVERALLS_BIN="$GOPATH/bin/goveralls" KUBE_TIMEOUT='-timeout 300s' KUBE_COVERPROCS=8 KUBE_TEST_ETCD_PREFIXES="${KUBE_TEST_ETCD_PREFIXES}" KUBE_TEST_API_VERSIONS="${KUBE_TEST_API_VERSIONS}" ./hack/test-go.sh -- -p=2
+  - KUBE_RACE="-race" KUBE_COVER=$([[ "$PULL_REQUEST" =~ ^[0-9]+$ ]] && echo "n" || echo "y") KUBE_GOVERALLS_BIN="$GOPATH/bin/goveralls" KUBE_TIMEOUT='-timeout 300s' KUBE_COVERPROCS=8 KUBE_TEST_ETCD_PREFIXES="${KUBE_TEST_ETCD_PREFIXES}" KUBE_TEST_API_VERSIONS="${KUBE_TEST_API_VERSIONS}" KUBE_JUNIT_REPORT_DIR="$(pwd)/shippable/testresults" ./hack/test-go.sh -- -p=2
   - ./hack/test-cmd.sh
   - KUBE_TEST_API_VERSIONS="${KUBE_TEST_API_VERSIONS}" KUBE_INTEGRATION_TEST_MAX_CONCURRENCY=4 LOG_LEVEL=4 ./hack/test-integration.sh
   - ./hack/test-update-storage-objects.sh


### PR DESCRIPTION
Shippable will parse JUnit-style XML test results if they exist (http://docs.shippable.com/yml_reference/#test-results).

A little bit of hackery is needed to get our unit tests infrastructure to produce a JUnit-style test report, but this seems to work now.

This may help #10300. It will also be useful should we end up running unit tests on Jenkins.
