### PR TITLE
plugin/oidc: add minor documentation details.

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -194,7 +194,7 @@ func (s *APIServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.BasicAuthFile, "basic-auth-file", s.BasicAuthFile, "If set, the file that will be used to admit requests to the secure port of the API server via http basic authentication.")
 	fs.StringVar(&s.ClientCAFile, "client-ca-file", s.ClientCAFile, "If set, any request presenting a client certificate signed by one of the authorities in the client-ca-file is authenticated with an identity corresponding to the CommonName of the client certificate.")
 	fs.StringVar(&s.TokenAuthFile, "token-auth-file", s.TokenAuthFile, "If set, the file that will be used to secure the secure port of the API server via token authentication.")
-	fs.StringVar(&s.OIDCIssuerURL, "oidc-issuer-url", s.OIDCIssuerURL, "The URL of the OpenID issuer. If set, it will be used to verify the OIDC JSON Web Token (JWT)")
+	fs.StringVar(&s.OIDCIssuerURL, "oidc-issuer-url", s.OIDCIssuerURL, "The URL of the OpenID issuer, only HTTPS scheme will be accepted. If set, it will be used to verify the OIDC JSON Web Token (JWT)")
 	fs.StringVar(&s.OIDCClientID, "oidc-client-id", s.OIDCClientID, "The client ID for the OpenID Connect client, must be set if oidc-issuer-url is set")
 	fs.StringVar(&s.OIDCCAFile, "oidc-ca-file", s.OIDCCAFile, "If set, the OpenID server's certificate will be verified by one of the authorities in the oidc-ca-file, otherwise the host's root CA set will be used")
 	fs.StringVar(&s.OIDCUsernameClaim, "oidc-username-claim", "sub", ""+

--- a/docs/admin/authentication.md
+++ b/docs/admin/authentication.md
@@ -52,7 +52,7 @@ When using token authentication from an http client the apiserver expects an `Au
 header with a value of `Bearer SOMETOKEN`.
 
 **OpenID Connect ID Token** is enabled by passing the following options to the apiserver:
-- `--oidc-issuer-url` (required) tells the apiserver where to connect to the OpenID provider.
+- `--oidc-issuer-url` (required) tells the apiserver where to connect to the OpenID provider. Only HTTPS scheme will be accepted.
 - `--oidc-client-id` (required) is used by apiserver to verify the audience of the token.
 A valid [ID token](http://openid.net/specs/openid-connect-core-1_0.html#IDToken) MUST have this
 client-id in its `aud` claims.


### PR DESCRIPTION
Add a sentence to tell the users that HTTPS is a required.
/cc @erictune @liggitt @jboeuf
