### PR TITLE
add a fuzz function for expapi.APIVersion

### DIFF
--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -32,9 +32,8 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
 
-	// TODO: enable when exapi problems are fixed #13083
-	//_ "k8s.io/kubernetes/pkg/expapi"
-	//_ "k8s.io/kubernetes/pkg/expapi/v1"
+	_ "k8s.io/kubernetes/pkg/expapi"
+	_ "k8s.io/kubernetes/pkg/expapi/v1"
 
 	flag "github.com/spf13/pflag"
 )
@@ -125,7 +124,7 @@ func TestList(t *testing.T) {
 	roundTripSame(t, item)
 }
 
-var nonRoundTrippableTypes = util.NewStringSet("ThirdPartyResource")
+var nonRoundTrippableTypes = util.NewStringSet()
 var nonInternalRoundTrippableTypes = util.NewStringSet("List", "ListOptions", "PodExecOptions", "PodAttachOptions")
 var nonRoundTrippableTypesByVersion = map[string][]string{}
 

--- a/pkg/api/testing/fuzzer.go
+++ b/pkg/api/testing/fuzzer.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/registered"
 	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/expapi"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
@@ -300,6 +301,11 @@ func FuzzerFor(t *testing.T, version string, src rand.Source) *fuzz.Fuzzer {
 		func(n *api.Node, c fuzz.Continue) {
 			c.FuzzNoCustom(n)
 			n.Spec.ExternalID = "external"
+		},
+		func(s *expapi.APIVersion, c fuzz.Continue) {
+			// We can't use c.RandString() here because it may generate empty
+			// string, which will cause tests failure.
+			s.APIGroup = "something"
 		},
 	)
 	return f


### PR DESCRIPTION
fix #13083, revert #13084, add a fuzz function for expapi.APIVersion.

I removed ThirdPartyResource from nonRoundTrippableTypes because we have the fuzz function now and ThirdPartyResource will pass the TestRoundTripTypes.

@mwielgus @brendandburns 
