### PR TITLE
Be more lenient when deriving the node tag from a node name on GCE

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -442,10 +442,15 @@ func (gce *GCECloud) EnsureTCPLoadBalancer(name, region string, externalIP net.I
 }
 
 // This is kind of hacky, but the managed instance group adds 4 random chars and a hyphen
-// to the base name.
+// to the base name. Older naming schemes put a hyphen and an incrementing index after
+// the base name. Thus we pull off the characters after the final dash to support both.
 func (gce *GCECloud) computeHostTag(host string) string {
 	host = strings.SplitN(host, ".", 2)[0]
-	return host[:len(host)-5]
+	lastHyphen := strings.LastIndex(host, "-")
+	if lastHyphen == -1 {
+		return host
+	}
+	return host[:lastHyphen]
 }
 
 // UpdateTCPLoadBalancer is an implementation of TCPLoadBalancer.UpdateTCPLoadBalancer.


### PR DESCRIPTION
Helps with one of the issues in #13073.

@cjcullen 
