### PR TITLE
Automated cherry pick of #12438 #13121 upstream release 1.0

### DIFF
--- a/pkg/cloudprovider/gce/gce.go
+++ b/pkg/cloudprovider/gce/gce.go
@@ -445,6 +445,7 @@ func (gce *GCECloud) CreateTCPLoadBalancer(name, region string, externalIP net.I
 // This is kind of hacky, but the managed instance group adds 4 random chars and a hyphen
 // to the base name.
 func (gce *GCECloud) computeHostTag(host string) string {
+	host = strings.SplitN(host, ".", 2)[0]
 	return host[:len(host)-5]
 }
 

--- a/pkg/cloudprovider/gce/gce.go
+++ b/pkg/cloudprovider/gce/gce.go
@@ -443,10 +443,15 @@ func (gce *GCECloud) CreateTCPLoadBalancer(name, region string, externalIP net.I
 }
 
 // This is kind of hacky, but the managed instance group adds 4 random chars and a hyphen
-// to the base name.
+// to the base name. Older naming schemes put a hyphen and an incrementing index after
+// the base name. Thus we pull off the characters after the final dash to support both.
 func (gce *GCECloud) computeHostTag(host string) string {
 	host = strings.SplitN(host, ".", 2)[0]
-	return host[:len(host)-5]
+	lastHyphen := strings.LastIndex(host, "-")
+	if lastHyphen == -1 {
+		return host
+	}
+	return host[:lastHyphen]
 }
 
 // UpdateTCPLoadBalancer is an implementation of TCPLoadBalancer.UpdateTCPLoadBalancer.

--- a/pkg/cloudprovider/gce/gce_test.go
+++ b/pkg/cloudprovider/gce/gce_test.go
@@ -50,6 +50,10 @@ func TestGetHostTag(t *testing.T) {
 			host:     "gke-test-ea6e8c80-node-8ytk",
 			expected: "gke-test-ea6e8c80-node",
 		},
+		{
+			host:     "kubernetes-minion-559o.c.PROJECT_NAME.internal",
+			expected: "kubernetes-minion",
+		},
 	}
 
 	gce := &GCECloud{}


### PR DESCRIPTION
Reference #12438 #13121

Help alleviate the pain in #13073.

@roberthbailey 
