### PR TITLE
Fix remotecommand races

### DIFF
--- a/pkg/client/unversioned/remotecommand/remotecommand_test.go
+++ b/pkg/client/unversioned/remotecommand/remotecommand_test.go
@@ -63,6 +63,7 @@ func fakeExecServer(t *testing.T, i int, stdinData, stdoutData, stderrData, erro
 		for {
 			select {
 			case stream := <-streamCh:
+
 				streamType := stream.Headers().Get(api.StreamType)
 				switch streamType {
 				case api.StreamTypeError:
@@ -70,7 +71,6 @@ func fakeExecServer(t *testing.T, i int, stdinData, stdoutData, stderrData, erro
 					receivedStreams++
 				case api.StreamTypeStdin:
 					stdinStream = stream
-					stdinStream.Close()
 					receivedStreams++
 				case api.StreamTypeStdout:
 					stdoutStream = stream
@@ -83,6 +83,7 @@ func fakeExecServer(t *testing.T, i int, stdinData, stdoutData, stderrData, erro
 				}
 
 				defer stream.Reset()
+				defer stream.Close()
 
 				if receivedStreams == expectedStreams {
 					break WaitForStreams

--- a/pkg/client/unversioned/remotecommand/remotecommand_test.go
+++ b/pkg/client/unversioned/remotecommand/remotecommand_test.go
@@ -19,7 +19,7 @@ package remotecommand
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -92,19 +92,17 @@ func fakeExecServer(t *testing.T, i int, stdinData, stdoutData, stderrData, erro
 
 		if len(errorData) > 0 {
 			fmt.Fprint(errorStream, errorData)
-			errorStream.Close()
 		}
 
 		if len(stdoutData) > 0 {
 			fmt.Fprint(stdoutStream, stdoutData)
-			stdoutStream.Close()
 		}
 		if len(stderrData) > 0 {
 			fmt.Fprint(stderrStream, stderrData)
-			stderrStream.Close()
 		}
 		if len(stdinData) > 0 {
-			data, err := ioutil.ReadAll(stdinStream)
+			data := make([]byte, len(stdinData))
+			_, err := io.ReadFull(stdinStream, data)
 			if err != nil {
 				t.Errorf("%d: error reading stdin stream: %v", i, err)
 			}


### PR DESCRIPTION
There are two races that can occur in TestRequestExecuteRemoteCommand:
1. The stdout/stderr streams are written and closed, and Execute() returns a nil error before the error written to the errorStream is copied and detected as an error inside Execute(). Manifests as:
   
   ```
   --- FAIL: TestRequestExecuteRemoteCommand-2 (0.08s)
       remotecommand_test.go:161: 0: expected an error
   ```
   
   The fix is to wait for the errorStream to close (with or without an error) before returning nil
2. The stdout/stderr streams are written and closed, and Execute() tears down all streams (including stdin) before the test driver can fully read the input. Manifests as:
   
   ```
   --- FAIL: TestRequestExecuteRemoteCommand-2 (0.11s)
     remotecommand_test.go:112: 1: stdin: expected "a", got ""
   ```
   
   The fix is to update the test driver to defer closing the stdout/stderr streams. This means switching the stdin read to use io.ReadFull with the expected length, rather than io.ReadAll, since stdin doesn't close/EOF until the other streams are torn down.
