### PR TITLE
Implementation of HorizontalPodAutoscaler

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -620,6 +620,11 @@
 			"Rev": "d466437aa4adc35830964cffc5b5f262c63ddcb4"
 		},
 		{
+			"ImportPath": "k8s.io/heapster/api/v1/types",
+			"Comment": "v0.17.0-75-g0e1b652",
+			"Rev": "0e1b652781812dee2c51c75180fc590223e0b9c6"
+		},
+		{
 			"ImportPath": "speter.net/go/exp/math/dec/inf",
 			"Rev": "42ca6cd68aa922bc3f32f1e056e61b65945d9ad7"
 		}

--- a/Godeps/_workspace/src/k8s.io/heapster/api/v1/types/model_types.go
+++ b/Godeps/_workspace/src/k8s.io/heapster/api/v1/types/model_types.go
@@ -1,0 +1,33 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"time"
+)
+
+type MetricPoint struct {
+	Timestamp time.Time `json:"timestamp"`
+	Value     uint64    `json:"value"`
+}
+
+type MetricResult struct {
+	Metrics         []MetricPoint `json:"metrics"`
+	LatestTimestamp time.Time     `json:"latestTimestamp"`
+}
+
+type MetricResultList struct {
+	Items []MetricResult `json:"items"`
+}

--- a/Godeps/_workspace/src/k8s.io/heapster/api/v1/types/types.go
+++ b/Godeps/_workspace/src/k8s.io/heapster/api/v1/types/types.go
@@ -1,0 +1,81 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"time"
+)
+
+// Timeseries represents a set of metrics for the same target object
+// (typically a container).
+type Timeseries struct {
+	// Map of metric names to their values.
+	Metrics map[string][]Point `json:"metrics"`
+
+	// Common labels for all metrics.
+	Labels map[string]string `json:"labels,omitempty"`
+}
+
+// Point represent a metric value.
+type Point struct {
+	// The start and end time for which this data is representative.
+	Start time.Time `json:"start"`
+	End   time.Time `json:"end"`
+
+	// Labels specific to this data point.
+	Labels map[string]string `json:"labels,omitempty"`
+
+	// The value of the metric.
+	Value interface{} `json:"value"`
+}
+
+// TimeseriesSchema represents all the metrics and labels.
+type TimeseriesSchema struct {
+	// All the metrics handled by heapster.
+	Metrics []MetricDescriptor `json:"metrics,omitempty"`
+	// Labels that are common to all metrics.
+	CommonLabels []LabelDescriptor `json:"common_labels,omitempty"`
+	// Labels that are present only for containers in pods.
+	// A container metric belongs to a pod is "pod_name" label is set.
+	PodLabels []LabelDescriptor `json:"pod_labels,omitempty"`
+}
+
+type MetricDescriptor struct {
+	// The unique name of the metric.
+	Name string `json:"name,omitempty"`
+
+	// Description of the metric.
+	Description string `json:"description,omitempty"`
+
+	// Descriptor of the labels specific to this metric.
+	Labels []LabelDescriptor `json:"labels,omitempty"`
+
+	// Type and value of metric data.
+	Type string `json:"type,omitempty"`
+
+	// The type of value returned as part of this metric.
+	ValueType string `json:"value_type,omitempty"`
+
+	// The units of the value returned as part of this metric.
+	Units string `json:"units,omitempty"`
+}
+
+type LabelDescriptor struct {
+	// Key to use for the label.
+	Key string `json:"key,omitempty"`
+
+	// Description of the label.
+	Description string `json:"description,omitempty"`
+}

--- a/pkg/client/unversioned/scale.go
+++ b/pkg/client/unversioned/scale.go
@@ -30,6 +30,7 @@ type ScaleNamespacer interface {
 // ScaleInterface has methods to work with Scale (sub)resources.
 type ScaleInterface interface {
 	Get(string, string) (*expapi.Scale, error)
+	Update(string, *expapi.Scale) (*expapi.Scale, error)
 }
 
 // horizontalPodAutoscalers implements HorizontalPodAutoscalersNamespacer interface
@@ -52,6 +53,25 @@ func (c *scales) Get(kind string, name string) (result *expapi.Scale, err error)
 	if strings.ToLower(kind) == "replicationcontroller" {
 		kind = "replicationControllers"
 		err = c.client.Get().Namespace(c.ns).Resource(kind).Name(name).SubResource("scale").Do().Into(result)
+		return
+	}
+	err = fmt.Errorf("Kind not supported: %s", kind)
+	return
+}
+
+func (c *scales) Update(kind string, scale *expapi.Scale) (result *expapi.Scale, err error) {
+	result = &expapi.Scale{}
+	if strings.ToLower(kind) == "replicationcontroller" {
+		kind = "replicationControllers"
+
+		err = c.client.Put().
+			Namespace(scale.Namespace).
+			Resource(kind).
+			Name(scale.Name).
+			SubResource("scale").
+			Body(scale).
+			Do().
+			Into(result)
 		return
 	}
 	err = fmt.Errorf("Kind not supported: %s", kind)

--- a/pkg/controller/autoscaler/horizontalpodautoscaler_controller.go
+++ b/pkg/controller/autoscaler/horizontalpodautoscaler_controller.go
@@ -17,16 +17,21 @@ limitations under the License.
 package autoscalercontroller
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/expapi"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/util"
+
+	heapster "k8s.io/heapster/api/v1/types"
 )
 
 const (
@@ -34,15 +39,37 @@ const (
 	heapsterService   = "monitoring-heapster"
 )
 
-var resourceToMetric = map[api.ResourceName]string{
-	api.ResourceCPU: "cpu-usage",
-}
-var heapsterQueryStart, _ = time.ParseDuration("-20m")
-
 type HorizontalPodAutoscalerController struct {
 	client    *client.Client
 	expClient client.ExperimentalInterface
 }
+
+// Aggregates results into ResourceConsumption. Also returns number of
+// pods included in the aggregation.
+type metricAggregator func(heapster.MetricResultList) (expapi.ResourceConsumption, int)
+
+type metricDefinition struct {
+	name       string
+	aggregator metricAggregator
+}
+
+var resourceDefinitions = map[api.ResourceName]metricDefinition{
+	//TODO: add memory
+	api.ResourceCPU: {"cpu-usage",
+		func(metrics heapster.MetricResultList) (expapi.ResourceConsumption, int) {
+			sum, count := calculateSumFromLatestSample(metrics)
+			value := "0"
+			if count > 0 {
+				// assumes that cpu usage is in millis
+				value = fmt.Sprintf("%dm", sum/uint64(count))
+			}
+			return expapi.ResourceConsumption{Resource: api.ResourceCPU, Quantity: resource.MustParse(value)}, count
+		}},
+}
+
+var heapsterQueryStart, _ = time.ParseDuration("-5m")
+var downscaleForbiddenWindow, _ = time.ParseDuration("20m")
+var upscaleForbiddenWindow, _ = time.ParseDuration("3m")
 
 func New(client *client.Client, expClient client.ExperimentalInterface) *HorizontalPodAutoscalerController {
 	//TODO: switch to client.Interface
@@ -86,16 +113,18 @@ func (a *HorizontalPodAutoscalerController) reconcileAutoscalers() error {
 			podNames = append(podNames, pod.Name)
 		}
 
-		metric, metricDefined := resourceToMetric[hpa.Spec.Target.Resource]
+		metricSpec, metricDefined := resourceDefinitions[hpa.Spec.Target.Resource]
 		if !metricDefined {
 			glog.Warningf("Heapster metric not defined for %s %v", reference, hpa.Spec.Target.Resource)
 			continue
 		}
-		startTime := time.Now().Add(heapsterQueryStart)
+		now := time.Now()
+
+		startTime := now.Add(heapsterQueryStart)
 		metricPath := fmt.Sprintf("/api/v1/model/namespaces/%s/pod-list/%s/metrics/%s",
 			hpa.Spec.ScaleRef.Namespace,
 			strings.Join(podNames, ","),
-			metric)
+			metricSpec.name)
 
 		resultRaw, err := a.client.
 			Get().
@@ -113,7 +142,90 @@ func (a *HorizontalPodAutoscalerController) reconcileAutoscalers() error {
 			continue
 		}
 
+		var metrics heapster.MetricResultList
+		err = json.Unmarshal(resultRaw, &metrics)
+		if err != nil {
+			glog.Warningf("Failed to unmarshall heapster response: %v", err)
+			continue
+		}
+
 		glog.Infof("Metrics available for %s: %s", reference, string(resultRaw))
+
+		currentConsumption, count := metricSpec.aggregator(metrics)
+		if count != len(podList.Items) {
+			glog.Warningf("Metrics obtained for %d/%d of pods", count, len(podList.Items))
+			continue
+		}
+
+		// if the ratio is 1.2 we want to have 2 replicas
+		desiredReplicas := 1 + int((currentConsumption.Quantity.MilliValue()*int64(count))/hpa.Spec.Target.Quantity.MilliValue())
+
+		if desiredReplicas < hpa.Spec.MinCount {
+			desiredReplicas = hpa.Spec.MinCount
+		}
+		if desiredReplicas > hpa.Spec.MaxCount {
+			desiredReplicas = hpa.Spec.MaxCount
+		}
+
+		rescale := false
+
+		if desiredReplicas != count {
+			// Going down
+			if desiredReplicas < count && (hpa.Status.LastScaleTimestamp == nil ||
+				hpa.Status.LastScaleTimestamp.Add(downscaleForbiddenWindow).Before(now)) {
+				rescale = true
+			}
+
+			// Going up
+			if desiredReplicas > count && (hpa.Status.LastScaleTimestamp == nil ||
+				hpa.Status.LastScaleTimestamp.Add(upscaleForbiddenWindow).Before(now)) {
+				rescale = true
+			}
+
+			if rescale {
+				scale.Spec.Replicas = desiredReplicas
+				_, err = a.expClient.Scales(hpa.Namespace).Update(hpa.Spec.ScaleRef.Kind, scale)
+				if err != nil {
+					glog.Warningf("Failed to rescale %s: %v", reference, err)
+					continue
+				}
+			}
+		}
+
+		hpa.Status = expapi.HorizontalPodAutoscalerStatus{
+			CurrentReplicas:    count,
+			DesiredReplicas:    desiredReplicas,
+			CurrentConsumption: currentConsumption,
+		}
+		if rescale {
+			now := util.NewTime(now)
+			hpa.Status.LastScaleTimestamp = &now
+		}
+
+		_, err = a.expClient.HorizontalPodAutoscalers(hpa.Namespace).Update(&hpa)
+		if err != nil {
+			glog.Warningf("Failed to update HorizontalPodAutoscaler %s: %v", hpa.Name, err)
+			continue
+		}
 	}
 	return nil
+}
+
+func calculateSumFromLatestSample(metrics heapster.MetricResultList) (uint64, int) {
+	sum := uint64(0)
+	count := 0
+	for _, metrics := range metrics.Items {
+		var newest *heapster.MetricPoint
+		newest = nil
+		for _, metricPoint := range metrics.Metrics {
+			if newest == nil || newest.Timestamp.Before(metricPoint.Timestamp) {
+				newest = &metricPoint
+			}
+		}
+		if newest != nil {
+			sum += newest.Value
+			count++
+		}
+	}
+	return sum, count
 }


### PR DESCRIPTION
- Adds Heapster api types as a new dependency
- Adds update method to `scale` client (kind will added to `Scale` in the next PR)
- Parses responses from Heapster
- Calculates avg consumption, compares it to the target level and gets the desired number of pods 
- Rescales  and updates `Scale` and `HorizontalPodAutoscaler` resources
