### PR TITLE
Fix typo that caused an error at end of vagrant up

### DIFF
--- a/cluster/vagrant/util.sh
+++ b/cluster/vagrant/util.sh
@@ -260,7 +260,7 @@ function verify-cluster {
     echo
     echo "  https://${MASTER_IP}"
     echo
-    echo "The user name and password to use is located in ${KUBECONIG}"
+    echo "The user name and password to use is located in ${KUBECONFIG}"
     echo
     )
 }


### PR DESCRIPTION
There was a regression made in a recent change that introduced this typo.
