### PR TITLE
Update the browser tab title to reflect the current page's title

### DIFF
--- a/_layouts/docwithnav.html
+++ b/_layouts/docwithnav.html
@@ -93,6 +93,13 @@
 					if (clickedon.hasClass('gentoc')) {//generate the in-page TOC (load the full page load)
 						window.location = href;
 					}
+					$.get(href, function(html){//update the page's <title> tags with title from loaded page (so browser shows current title)
+					    var matches = html.match(/<title>([^<]*)/);
+					    if (matches.length>0) {
+					        var title = matches[1];
+					        document.title = title;
+					    }
+					});
 				}
 				if(clickedon.parents().hasClass('bodywrapper')){//animate navigation menu
 					animatenav(findcurnavitem());//is an in-page link


### PR DESCRIPTION
Ensures that the title displayed in the browser tab matches the title of the page that gets loaded (.load()).

Can test in my fork at: http://richieescarez.github.io/kubernetes/v1.0/

Result: As you click through and navigate to each topic in the Documentation section of the site, the browser's tab will also update and show the current page's title.
