### PR TITLE
Fix typo KUBECONIG=>KUBECONFIG in vagrant scripts.

### DIFF
--- a/cluster/vagrant/util.sh
+++ b/cluster/vagrant/util.sh
@@ -260,7 +260,7 @@ function verify-cluster {
     echo
     echo "  https://${MASTER_IP}"
     echo
-    echo "The user name and password to use is located in ${KUBECONIG}"
+    echo "The user name and password to use is located in ${KUBECONFIG}"
     echo
     )
 }


### PR DESCRIPTION
Fix a benign typo which was causing an error after vagrant
provisioning completed.

Fixes: #13164
