### PR TITLE
WIP [Do not merge] Save Cobertura-style coverage reports on Shippable

### DIFF
--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -220,4 +220,17 @@ kube::util::analytics-link() {
   echo "[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/${path}?pixel)]()"
 }
 
+# Checks that the specified Go tool (full package path $1) is installed in
+# $PATH.
+kube::util::check-tool-installed() {
+  local -r package="$1"
+  local binary_name
+  binary_name=$(basename "${package}")
+  if ! command -v "${binary_name}" >/dev/null 2>&1; then
+    kube::log::error "${binary_name} not found; please install with " \
+      "go get -u ${package}"
+    return 1
+  fi
+}
+
 # ex: ts=2 sw=2 et filetype=sh

--- a/shippable.yml
+++ b/shippable.yml
@@ -39,6 +39,7 @@ install:
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/mattn/goveralls
   - go get github.com/tools/godep
+  - go get github.com/jstemmer/go-junit-report
   - ./hack/build-go.sh
   - godep go install ./...
   - ./hack/travis/install-etcd.sh
@@ -56,7 +57,7 @@ install:
 
 script:
   # Disable coverage collection on pull requests
-  - KUBE_RACE="-race" KUBE_COVER=$([[ "$PULL_REQUEST" =~ ^[0-9]+$ ]] && echo "n" || echo "y") KUBE_GOVERALLS_BIN="$GOPATH/bin/goveralls" KUBE_TIMEOUT='-timeout 300s' KUBE_COVERPROCS=8 KUBE_TEST_ETCD_PREFIXES="${KUBE_TEST_ETCD_PREFIXES}" KUBE_TEST_API_VERSIONS="${KUBE_TEST_API_VERSIONS}" ./hack/test-go.sh -- -p=2
+  - KUBE_RACE="-race" KUBE_COVER=$([[ "$PULL_REQUEST" =~ ^[0-9]+$ ]] && echo "n" || echo "y") KUBE_GOVERALLS_BIN="$GOPATH/bin/goveralls" KUBE_TIMEOUT='-timeout 300s' KUBE_COVERPROCS=8 KUBE_TEST_ETCD_PREFIXES="${KUBE_TEST_ETCD_PREFIXES}" KUBE_TEST_API_VERSIONS="${KUBE_TEST_API_VERSIONS}" KUBE_JUNIT_REPORT_DIR="$(pwd)/shippable/testresults" ./hack/test-go.sh -- -p=2
   - ./hack/test-cmd.sh
   - KUBE_TEST_API_VERSIONS="${KUBE_TEST_API_VERSIONS}" KUBE_INTEGRATION_TEST_MAX_CONCURRENCY=4 LOG_LEVEL=4 ./hack/test-integration.sh
   - ./hack/test-update-storage-objects.sh

--- a/shippable.yml
+++ b/shippable.yml
@@ -59,7 +59,7 @@ install:
 
 script:
   # Disable coverage collection on pull requests
-  - KUBE_RACE="-race" KUBE_COVER=$([[ "$PULL_REQUEST" =~ ^[0-9]+$ ]] && echo "n" || echo "y") KUBE_GOVERALLS_BIN="$GOPATH/bin/goveralls" KUBE_TIMEOUT='-timeout 300s' KUBE_COVERPROCS=8 KUBE_TEST_ETCD_PREFIXES="${KUBE_TEST_ETCD_PREFIXES}" KUBE_TEST_API_VERSIONS="${KUBE_TEST_API_VERSIONS}" KUBE_JUNIT_REPORT_DIR="$(pwd)/shippable/testresults" KUBE_COVERAGE_XML_DIR="$(pwd)/shippable/codecoverage" ./hack/test-go.sh -- -p=2
+  - KUBE_RACE="-race" KUBE_COVER="y" KUBE_GOVERALLS_BIN="$GOPATH/bin/goveralls" KUBE_TIMEOUT='-timeout 300s' KUBE_COVERPROCS=8 KUBE_TEST_ETCD_PREFIXES="${KUBE_TEST_ETCD_PREFIXES}" KUBE_TEST_API_VERSIONS="${KUBE_TEST_API_VERSIONS}" KUBE_JUNIT_REPORT_DIR="$(pwd)/shippable/testresults" KUBE_COVERAGE_XML_DIR="$(pwd)/shippable/codecoverage" ./hack/test-go.sh -- -p=2
   - ./hack/test-cmd.sh
   - KUBE_TEST_API_VERSIONS="${KUBE_TEST_API_VERSIONS}" KUBE_INTEGRATION_TEST_MAX_CONCURRENCY=4 LOG_LEVEL=4 ./hack/test-integration.sh
   - ./hack/test-update-storage-objects.sh

--- a/shippable.yml
+++ b/shippable.yml
@@ -36,10 +36,12 @@ before_install:
   - export PATH=$GOPATH/bin:./third_party/etcd:$PATH
 
 install:
-  - go get golang.org/x/tools/cmd/cover
-  - go get github.com/mattn/goveralls
   - go get github.com/tools/godep
   - go get github.com/jstemmer/go-junit-report
+  - go get golang.org/x/tools/cmd/cover
+  - go get github.com/mattn/goveralls
+  - go get github.com/axw/gocov/gocov
+  - go get github.com/t-yuki/gocov-xml
   - ./hack/build-go.sh
   - godep go install ./...
   - ./hack/travis/install-etcd.sh
@@ -57,7 +59,7 @@ install:
 
 script:
   # Disable coverage collection on pull requests
-  - KUBE_RACE="-race" KUBE_COVER=$([[ "$PULL_REQUEST" =~ ^[0-9]+$ ]] && echo "n" || echo "y") KUBE_GOVERALLS_BIN="$GOPATH/bin/goveralls" KUBE_TIMEOUT='-timeout 300s' KUBE_COVERPROCS=8 KUBE_TEST_ETCD_PREFIXES="${KUBE_TEST_ETCD_PREFIXES}" KUBE_TEST_API_VERSIONS="${KUBE_TEST_API_VERSIONS}" KUBE_JUNIT_REPORT_DIR="$(pwd)/shippable/testresults" ./hack/test-go.sh -- -p=2
+  - KUBE_RACE="-race" KUBE_COVER=$([[ "$PULL_REQUEST" =~ ^[0-9]+$ ]] && echo "n" || echo "y") KUBE_GOVERALLS_BIN="$GOPATH/bin/goveralls" KUBE_TIMEOUT='-timeout 300s' KUBE_COVERPROCS=8 KUBE_TEST_ETCD_PREFIXES="${KUBE_TEST_ETCD_PREFIXES}" KUBE_TEST_API_VERSIONS="${KUBE_TEST_API_VERSIONS}" KUBE_JUNIT_REPORT_DIR="$(pwd)/shippable/testresults" KUBE_COVERAGE_XML_DIR="$(pwd)/shippable/codecoverage" ./hack/test-go.sh -- -p=2
   - ./hack/test-cmd.sh
   - KUBE_TEST_API_VERSIONS="${KUBE_TEST_API_VERSIONS}" KUBE_INTEGRATION_TEST_MAX_CONCURRENCY=4 LOG_LEVEL=4 ./hack/test-integration.sh
   - ./hack/test-update-storage-objects.sh


### PR DESCRIPTION
Use gocov and gocov-xml to produce a Cobertura-style code coverage report, parseable by Shippable.
