### PR TITLE
#11471 Readiness probe for kube-dns RC (HA)

### DIFF
--- a/cluster/addons/dns/skydns-rc.yaml.in
+++ b/cluster/addons/dns/skydns-rc.yaml.in
@@ -1,22 +1,22 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: kube-dns-v8
+  name: kube-dns-v9
   namespace: kube-system
   labels:
     k8s-app: kube-dns
-    version: v8
+    version: v9
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: {{ pillar['dns_replicas'] }}
   selector:
     k8s-app: kube-dns
-    version: v8
+    version: v9
   template:
     metadata:
       labels:
         k8s-app: kube-dns
-        version: v8
+        version: v9
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
@@ -72,6 +72,13 @@ spec:
             port: 8080
             scheme: HTTP
           initialDelaySeconds: 30
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 1
           timeoutSeconds: 5
       - name: healthz
         image: gcr.io/google_containers/exechealthz:1.0


### PR DESCRIPTION
- Added a readiness probe to the SkyDNS container
- This will be useful when the number of replicas is more than one ensuring that requests aren't forwarded to bad pods
- The same test as the one used for the livenessProbe is applicable to readiness as well since it simply does an nslookup. A successful nslookup would indicate readiness as well.
- Initial delay has been reduced to 10 seconds (as compared to 30 in the livenessProbe) so that pods that are ready are added sooner.
- Thus, kube-dns can be HA and the check will prevent failed instances from joining the set.
