### PR TITLE
WIP: prototype using methods for defaults

### DIFF
--- a/pkg/api/util/defaults.go
+++ b/pkg/api/util/defaults.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/golang/glog"
+
+	v1gen "k8s.io/kubernetes/pkg/api/v1/generated"
+)
+
+// This is a map from Type to a function which will apply defaults to an
+// instance of that type.
+var defaultableTypes = map[reflect.Type]func(obj interface{}){}
+
+func init() {
+	v1gen.InitDefaultableTypes(registerDefaultableType)
+}
+
+func registerDefaultableType(t reflect.Type, fn func(obj interface{})) {
+	//FIXME: demand pointer
+	glog.Infof("registered defaultable type %s.%s", t.Elem().PkgPath(), t.Elem().Name())
+	if _, found := defaultableTypes[t]; found {
+		panic(fmt.Sprintf("repeated call to RegisterDefaultableType(%s.%s)", t.PkgPath(), t.Name()))
+	}
+	defaultableTypes[t] = fn
+}
+
+// Apply defaults to the passed object.  This is done with a (code-generated)
+// recursive walk of the type, looking for fields with an ApplyDefaults()
+// method.
+func ApplyDefaults(obj interface{}) {
+	//FIXME: demand pointer
+	if fn := defaultableTypes[reflect.TypeOf(obj)]; fn != nil {
+		fn(obj)
+	}
+}

--- a/pkg/api/v1/generated/defaults.go
+++ b/pkg/api/v1/generated/defaults.go
@@ -1,0 +1,347 @@
+package generated
+
+import (
+	"fmt"
+	"reflect"
+
+	_k8s_io_kubernetes_pkg_api_v1 "k8s.io/kubernetes/pkg/api/v1"
+)
+
+func applyDefaults__k8s_io_kubernetes_pkg_api_v1_Pod(obj *_k8s_io_kubernetes_pkg_api_v1.Pod) {
+	// Spec v1.PodSpec
+	applyDefaults__k8s_io_kubernetes_pkg_api_v1_PodSpec((&(obj.Spec)))
+}
+func applyDefaults__k8s_io_kubernetes_pkg_api_v1_PodSpec(obj *_k8s_io_kubernetes_pkg_api_v1.PodSpec) {
+	// Volumes []v1.Volume
+	for i := range obj.Volumes {
+		p := &((obj.Volumes)[i])
+		applyDefaults__k8s_io_kubernetes_pkg_api_v1_Volume((p))
+	}
+	// Containers []v1.Container
+	for i := range obj.Containers {
+		p := &((obj.Containers)[i])
+		applyDefaults__k8s_io_kubernetes_pkg_api_v1_Container((p))
+	}
+	obj.ApplyDefaults()
+}
+func applyDefaults__k8s_io_kubernetes_pkg_api_v1_Volume(obj *_k8s_io_kubernetes_pkg_api_v1.Volume) {
+	// VolumeSource v1.VolumeSource
+	applyDefaults__k8s_io_kubernetes_pkg_api_v1_VolumeSource((&(obj.VolumeSource)))
+	obj.ApplyDefaults()
+}
+func applyDefaults__k8s_io_kubernetes_pkg_api_v1_VolumeSource(obj *_k8s_io_kubernetes_pkg_api_v1.VolumeSource) {
+	obj.ApplyDefaults()
+}
+func applyDefaults__k8s_io_kubernetes_pkg_api_v1_Container(obj *_k8s_io_kubernetes_pkg_api_v1.Container) {
+	// Ports []v1.ContainerPort
+	for i := range obj.Ports {
+		p := &((obj.Ports)[i])
+		applyDefaults__k8s_io_kubernetes_pkg_api_v1_ContainerPort((p))
+	}
+	obj.ApplyDefaults()
+}
+func applyDefaults__k8s_io_kubernetes_pkg_api_v1_ContainerPort(obj *_k8s_io_kubernetes_pkg_api_v1.ContainerPort) {
+	obj.ApplyDefaults()
+}
+func applyDefaults__k8s_io_kubernetes_pkg_api_v1_ReplicationController(obj *_k8s_io_kubernetes_pkg_api_v1.ReplicationController) {
+	// Spec v1.ReplicationControllerSpec
+	applyDefaults__k8s_io_kubernetes_pkg_api_v1_ReplicationControllerSpec((&(obj.Spec)))
+}
+func applyDefaults__k8s_io_kubernetes_pkg_api_v1_ReplicationControllerSpec(obj *_k8s_io_kubernetes_pkg_api_v1.ReplicationControllerSpec) {
+	// Template *v1.PodTemplateSpec
+	if (obj.Template) != nil {
+		applyDefaults__k8s_io_kubernetes_pkg_api_v1_PodTemplateSpec((obj.Template))
+	}
+}
+func applyDefaults__k8s_io_kubernetes_pkg_api_v1_PodTemplateSpec(obj *_k8s_io_kubernetes_pkg_api_v1.PodTemplateSpec) {
+	// Spec v1.PodSpec
+	applyDefaults__k8s_io_kubernetes_pkg_api_v1_PodSpec((&(obj.Spec)))
+}
+func applyDefaults__k8s_io_kubernetes_pkg_api_v1_PodTemplateList(obj *_k8s_io_kubernetes_pkg_api_v1.PodTemplateList) {
+	// Items []v1.PodTemplate
+	for i := range obj.Items {
+		p := &((obj.Items)[i])
+		applyDefaults__k8s_io_kubernetes_pkg_api_v1_PodTemplate((p))
+	}
+}
+func applyDefaults__k8s_io_kubernetes_pkg_api_v1_PodTemplate(obj *_k8s_io_kubernetes_pkg_api_v1.PodTemplate) {
+	// Template v1.PodTemplateSpec
+	applyDefaults__k8s_io_kubernetes_pkg_api_v1_PodTemplateSpec((&(obj.Template)))
+}
+func applyDefaults__k8s_io_kubernetes_pkg_api_v1_Endpoints(obj *_k8s_io_kubernetes_pkg_api_v1.Endpoints) {
+	// Subsets []v1.EndpointSubset
+	for i := range obj.Subsets {
+		p := &((obj.Subsets)[i])
+		applyDefaults__k8s_io_kubernetes_pkg_api_v1_EndpointSubset((p))
+	}
+}
+func applyDefaults__k8s_io_kubernetes_pkg_api_v1_EndpointSubset(obj *_k8s_io_kubernetes_pkg_api_v1.EndpointSubset) {
+	// Ports []v1.EndpointPort
+	for i := range obj.Ports {
+		p := &((obj.Ports)[i])
+		applyDefaults__k8s_io_kubernetes_pkg_api_v1_EndpointPort((p))
+	}
+}
+func applyDefaults__k8s_io_kubernetes_pkg_api_v1_EndpointPort(obj *_k8s_io_kubernetes_pkg_api_v1.EndpointPort) {
+	obj.ApplyDefaults()
+}
+func applyDefaults__k8s_io_kubernetes_pkg_api_v1_Daemon(obj *_k8s_io_kubernetes_pkg_api_v1.Daemon) {
+	// Spec v1.DaemonSpec
+	applyDefaults__k8s_io_kubernetes_pkg_api_v1_DaemonSpec((&(obj.Spec)))
+}
+func applyDefaults__k8s_io_kubernetes_pkg_api_v1_DaemonSpec(obj *_k8s_io_kubernetes_pkg_api_v1.DaemonSpec) {
+	// Template *v1.PodTemplateSpec
+	if (obj.Template) != nil {
+		applyDefaults__k8s_io_kubernetes_pkg_api_v1_PodTemplateSpec((obj.Template))
+	}
+}
+func applyDefaults__k8s_io_kubernetes_pkg_api_v1_DaemonList(obj *_k8s_io_kubernetes_pkg_api_v1.DaemonList) {
+	// Items []v1.Daemon
+	for i := range obj.Items {
+		p := &((obj.Items)[i])
+		applyDefaults__k8s_io_kubernetes_pkg_api_v1_Daemon((p))
+	}
+}
+func applyDefaults__k8s_io_kubernetes_pkg_api_v1_ReplicationControllerList(obj *_k8s_io_kubernetes_pkg_api_v1.ReplicationControllerList) {
+	// Items []v1.ReplicationController
+	for i := range obj.Items {
+		p := &((obj.Items)[i])
+		applyDefaults__k8s_io_kubernetes_pkg_api_v1_ReplicationController((p))
+	}
+}
+func applyDefaults__k8s_io_kubernetes_pkg_api_v1_PodList(obj *_k8s_io_kubernetes_pkg_api_v1.PodList) {
+	// Items []v1.Pod
+	for i := range obj.Items {
+		p := &((obj.Items)[i])
+		applyDefaults__k8s_io_kubernetes_pkg_api_v1_Pod((p))
+	}
+}
+func applyDefaults__k8s_io_kubernetes_pkg_api_v1_EndpointsList(obj *_k8s_io_kubernetes_pkg_api_v1.EndpointsList) {
+	// Items []v1.Endpoints
+	for i := range obj.Items {
+		p := &((obj.Items)[i])
+		applyDefaults__k8s_io_kubernetes_pkg_api_v1_Endpoints((p))
+	}
+}
+func applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_Pod(obj interface{}) {
+	concrete, ok := obj.(*_k8s_io_kubernetes_pkg_api_v1.Pod)
+	if !ok {
+		panic(fmt.Sprintf("applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_Pod called for type %T", obj))
+	}
+	applyDefaults__k8s_io_kubernetes_pkg_api_v1_Pod(concrete)
+}
+
+func applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_PodSpec(obj interface{}) {
+	concrete, ok := obj.(*_k8s_io_kubernetes_pkg_api_v1.PodSpec)
+	if !ok {
+		panic(fmt.Sprintf("applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_PodSpec called for type %T", obj))
+	}
+	applyDefaults__k8s_io_kubernetes_pkg_api_v1_PodSpec(concrete)
+}
+
+func applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_Volume(obj interface{}) {
+	concrete, ok := obj.(*_k8s_io_kubernetes_pkg_api_v1.Volume)
+	if !ok {
+		panic(fmt.Sprintf("applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_Volume called for type %T", obj))
+	}
+	applyDefaults__k8s_io_kubernetes_pkg_api_v1_Volume(concrete)
+}
+
+func applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_VolumeSource(obj interface{}) {
+	concrete, ok := obj.(*_k8s_io_kubernetes_pkg_api_v1.VolumeSource)
+	if !ok {
+		panic(fmt.Sprintf("applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_VolumeSource called for type %T", obj))
+	}
+	applyDefaults__k8s_io_kubernetes_pkg_api_v1_VolumeSource(concrete)
+}
+
+func applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_Container(obj interface{}) {
+	concrete, ok := obj.(*_k8s_io_kubernetes_pkg_api_v1.Container)
+	if !ok {
+		panic(fmt.Sprintf("applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_Container called for type %T", obj))
+	}
+	applyDefaults__k8s_io_kubernetes_pkg_api_v1_Container(concrete)
+}
+
+func applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_ContainerPort(obj interface{}) {
+	concrete, ok := obj.(*_k8s_io_kubernetes_pkg_api_v1.ContainerPort)
+	if !ok {
+		panic(fmt.Sprintf("applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_ContainerPort called for type %T", obj))
+	}
+	applyDefaults__k8s_io_kubernetes_pkg_api_v1_ContainerPort(concrete)
+}
+
+func applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_ReplicationController(obj interface{}) {
+	concrete, ok := obj.(*_k8s_io_kubernetes_pkg_api_v1.ReplicationController)
+	if !ok {
+		panic(fmt.Sprintf("applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_ReplicationController called for type %T", obj))
+	}
+	applyDefaults__k8s_io_kubernetes_pkg_api_v1_ReplicationController(concrete)
+}
+
+func applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_ReplicationControllerSpec(obj interface{}) {
+	concrete, ok := obj.(*_k8s_io_kubernetes_pkg_api_v1.ReplicationControllerSpec)
+	if !ok {
+		panic(fmt.Sprintf("applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_ReplicationControllerSpec called for type %T", obj))
+	}
+	applyDefaults__k8s_io_kubernetes_pkg_api_v1_ReplicationControllerSpec(concrete)
+}
+
+func applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_PodTemplateSpec(obj interface{}) {
+	concrete, ok := obj.(*_k8s_io_kubernetes_pkg_api_v1.PodTemplateSpec)
+	if !ok {
+		panic(fmt.Sprintf("applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_PodTemplateSpec called for type %T", obj))
+	}
+	applyDefaults__k8s_io_kubernetes_pkg_api_v1_PodTemplateSpec(concrete)
+}
+
+func applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_PodTemplateList(obj interface{}) {
+	concrete, ok := obj.(*_k8s_io_kubernetes_pkg_api_v1.PodTemplateList)
+	if !ok {
+		panic(fmt.Sprintf("applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_PodTemplateList called for type %T", obj))
+	}
+	applyDefaults__k8s_io_kubernetes_pkg_api_v1_PodTemplateList(concrete)
+}
+
+func applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_PodTemplate(obj interface{}) {
+	concrete, ok := obj.(*_k8s_io_kubernetes_pkg_api_v1.PodTemplate)
+	if !ok {
+		panic(fmt.Sprintf("applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_PodTemplate called for type %T", obj))
+	}
+	applyDefaults__k8s_io_kubernetes_pkg_api_v1_PodTemplate(concrete)
+}
+
+func applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_Endpoints(obj interface{}) {
+	concrete, ok := obj.(*_k8s_io_kubernetes_pkg_api_v1.Endpoints)
+	if !ok {
+		panic(fmt.Sprintf("applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_Endpoints called for type %T", obj))
+	}
+	applyDefaults__k8s_io_kubernetes_pkg_api_v1_Endpoints(concrete)
+}
+
+func applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_EndpointSubset(obj interface{}) {
+	concrete, ok := obj.(*_k8s_io_kubernetes_pkg_api_v1.EndpointSubset)
+	if !ok {
+		panic(fmt.Sprintf("applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_EndpointSubset called for type %T", obj))
+	}
+	applyDefaults__k8s_io_kubernetes_pkg_api_v1_EndpointSubset(concrete)
+}
+
+func applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_EndpointPort(obj interface{}) {
+	concrete, ok := obj.(*_k8s_io_kubernetes_pkg_api_v1.EndpointPort)
+	if !ok {
+		panic(fmt.Sprintf("applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_EndpointPort called for type %T", obj))
+	}
+	applyDefaults__k8s_io_kubernetes_pkg_api_v1_EndpointPort(concrete)
+}
+
+func applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_Daemon(obj interface{}) {
+	concrete, ok := obj.(*_k8s_io_kubernetes_pkg_api_v1.Daemon)
+	if !ok {
+		panic(fmt.Sprintf("applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_Daemon called for type %T", obj))
+	}
+	applyDefaults__k8s_io_kubernetes_pkg_api_v1_Daemon(concrete)
+}
+
+func applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_DaemonSpec(obj interface{}) {
+	concrete, ok := obj.(*_k8s_io_kubernetes_pkg_api_v1.DaemonSpec)
+	if !ok {
+		panic(fmt.Sprintf("applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_DaemonSpec called for type %T", obj))
+	}
+	applyDefaults__k8s_io_kubernetes_pkg_api_v1_DaemonSpec(concrete)
+}
+
+func applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_DaemonList(obj interface{}) {
+	concrete, ok := obj.(*_k8s_io_kubernetes_pkg_api_v1.DaemonList)
+	if !ok {
+		panic(fmt.Sprintf("applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_DaemonList called for type %T", obj))
+	}
+	applyDefaults__k8s_io_kubernetes_pkg_api_v1_DaemonList(concrete)
+}
+
+func applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_ReplicationControllerList(obj interface{}) {
+	concrete, ok := obj.(*_k8s_io_kubernetes_pkg_api_v1.ReplicationControllerList)
+	if !ok {
+		panic(fmt.Sprintf("applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_ReplicationControllerList called for type %T", obj))
+	}
+	applyDefaults__k8s_io_kubernetes_pkg_api_v1_ReplicationControllerList(concrete)
+}
+
+func applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_PodList(obj interface{}) {
+	concrete, ok := obj.(*_k8s_io_kubernetes_pkg_api_v1.PodList)
+	if !ok {
+		panic(fmt.Sprintf("applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_PodList called for type %T", obj))
+	}
+	applyDefaults__k8s_io_kubernetes_pkg_api_v1_PodList(concrete)
+}
+
+func applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_EndpointsList(obj interface{}) {
+	concrete, ok := obj.(*_k8s_io_kubernetes_pkg_api_v1.EndpointsList)
+	if !ok {
+		panic(fmt.Sprintf("applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_EndpointsList called for type %T", obj))
+	}
+	applyDefaults__k8s_io_kubernetes_pkg_api_v1_EndpointsList(concrete)
+}
+
+func InitDefaultableTypes(register func(reflect.Type, func(obj interface{}))) {
+	register(
+		reflect.TypeOf(new(_k8s_io_kubernetes_pkg_api_v1.Pod)),
+		applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_Pod)
+	register(
+		reflect.TypeOf(new(_k8s_io_kubernetes_pkg_api_v1.PodSpec)),
+		applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_PodSpec)
+	register(
+		reflect.TypeOf(new(_k8s_io_kubernetes_pkg_api_v1.Volume)),
+		applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_Volume)
+	register(
+		reflect.TypeOf(new(_k8s_io_kubernetes_pkg_api_v1.VolumeSource)),
+		applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_VolumeSource)
+	register(
+		reflect.TypeOf(new(_k8s_io_kubernetes_pkg_api_v1.Container)),
+		applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_Container)
+	register(
+		reflect.TypeOf(new(_k8s_io_kubernetes_pkg_api_v1.ContainerPort)),
+		applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_ContainerPort)
+	register(
+		reflect.TypeOf(new(_k8s_io_kubernetes_pkg_api_v1.ReplicationController)),
+		applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_ReplicationController)
+	register(
+		reflect.TypeOf(new(_k8s_io_kubernetes_pkg_api_v1.ReplicationControllerSpec)),
+		applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_ReplicationControllerSpec)
+	register(
+		reflect.TypeOf(new(_k8s_io_kubernetes_pkg_api_v1.PodTemplateSpec)),
+		applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_PodTemplateSpec)
+	register(
+		reflect.TypeOf(new(_k8s_io_kubernetes_pkg_api_v1.PodTemplateList)),
+		applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_PodTemplateList)
+	register(
+		reflect.TypeOf(new(_k8s_io_kubernetes_pkg_api_v1.PodTemplate)),
+		applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_PodTemplate)
+	register(
+		reflect.TypeOf(new(_k8s_io_kubernetes_pkg_api_v1.Endpoints)),
+		applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_Endpoints)
+	register(
+		reflect.TypeOf(new(_k8s_io_kubernetes_pkg_api_v1.EndpointSubset)),
+		applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_EndpointSubset)
+	register(
+		reflect.TypeOf(new(_k8s_io_kubernetes_pkg_api_v1.EndpointPort)),
+		applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_EndpointPort)
+	register(
+		reflect.TypeOf(new(_k8s_io_kubernetes_pkg_api_v1.Daemon)),
+		applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_Daemon)
+	register(
+		reflect.TypeOf(new(_k8s_io_kubernetes_pkg_api_v1.DaemonSpec)),
+		applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_DaemonSpec)
+	register(
+		reflect.TypeOf(new(_k8s_io_kubernetes_pkg_api_v1.DaemonList)),
+		applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_DaemonList)
+	register(
+		reflect.TypeOf(new(_k8s_io_kubernetes_pkg_api_v1.ReplicationControllerList)),
+		applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_ReplicationControllerList)
+	register(
+		reflect.TypeOf(new(_k8s_io_kubernetes_pkg_api_v1.PodList)),
+		applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_PodList)
+	register(
+		reflect.TypeOf(new(_k8s_io_kubernetes_pkg_api_v1.EndpointsList)),
+		applyDefaults_entry__k8s_io_kubernetes_pkg_api_v1_EndpointsList)
+}

--- a/walk/test.go
+++ b/walk/test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"github.com/davecgh/go-spew/spew"
+	apiutil "k8s.io/kubernetes/pkg/api/util"
+	"k8s.io/kubernetes/pkg/api/v1"
+)
+
+func main() {
+	ep1 := v1.EndpointPort{}
+	ep2 := ep1
+	apiutil.ApplyDefaults(&ep2)
+	spew.Dump(ep1)
+	spew.Dump(ep2)
+
+	p1 := v1.Pod{}
+	p2 := p1
+	apiutil.ApplyDefaults(&p2)
+	spew.Dump(p1)
+	spew.Dump(p2)
+}

--- a/walk/walk.go
+++ b/walk/walk.go
@@ -1,0 +1,404 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"strings"
+	"unicode"
+
+	"k8s.io/kubernetes/pkg/api"
+	_ "k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/util"
+)
+
+/////////// This stuff would go in pkg/codegen/deep_visit.go
+
+// The map argument tracks types that have already been seen.
+func deepVisitType(t reflect.Type, parentType reflect.Type, fieldName string, visitor Visitor, visited map[reflect.Type]bool) {
+	//defer makeUsefulPanic(v1)
+
+	isNamedType := (t.PkgPath() != "")
+
+	if isNamedType {
+		if visited[t] {
+			return
+		}
+		visited[t] = true
+		visitor.OpenType(t)
+	}
+
+	switch t.Kind() {
+	case reflect.Map:
+		deepVisitType(t.Key(), nil, "", visitor, visited)
+		fallthrough
+	case reflect.Array, reflect.Slice, reflect.Ptr:
+		deepVisitType(t.Elem(), nil, "", visitor, visited)
+	case reflect.Struct:
+		pfx := ""
+		par := t
+		if !isNamedType {
+			// For anonymous structs we keep the parentType and expand the name
+			// expression.  An alternative to this would be to make up an
+			// anonymous type name, ensure it is unique, and pretend it was a
+			// named type.
+			pfx = fieldName + "."
+			par = parentType
+		}
+		for i, n := 0, t.NumField(); i < n; i++ {
+			if t.Field(i).PkgPath == "" {
+				// Deal with exported fields only.
+				fld := pfx + t.Field(i).Name
+				deepVisitType(t.Field(i).Type, par, fld, visitor, visited)
+				visitor.VisitField(t.Field(i), par, fld)
+			}
+		}
+	}
+
+	if isNamedType {
+		visitor.CloseType(t)
+	}
+}
+
+// Visitor is the interface that callers must implement to deep-visit a type.
+type Visitor interface {
+	OpenType(t reflect.Type)
+	// FIXME: document when fieldName differs from f.Name
+	VisitField(f reflect.StructField, parentType reflect.Type, fieldNameInParent string)
+	CloseType(t reflect.Type)
+}
+
+// DeepVisitType visits all fields of a type, recursively.
+func DeepVisitType(t reflect.Type, visitor Visitor) {
+	if t == nil {
+		return
+	}
+	DeepVisitTypeAccumulate(t, visitor, make(map[reflect.Type]bool))
+}
+
+// DeepVisitTypeAccumulate visits all fields of a type, recursively,
+// accumulating a set of previously visited types.  This is usefule to visit a
+// group of types without repeating work.
+func DeepVisitTypeAccumulate(t reflect.Type, visitor Visitor, accumulator map[reflect.Type]bool) {
+	if t == nil {
+		return
+	}
+	deepVisitType(t, nil, "", visitor, accumulator)
+}
+
+/////////// This stuff would go in pkg/codegen/line_buffer.go
+
+type LineBuffer []string
+
+func (lb *LineBuffer) Append(str string) {
+	*lb = append(*lb, str)
+}
+
+func (lb *LineBuffer) Appendf(format string, args ...interface{}) {
+	*lb = append(*lb, fmt.Sprintf(format, args...))
+}
+
+func (lb *LineBuffer) Prepend(str string) {
+	*lb = append([]string{str}, *lb...)
+}
+
+func (lb *LineBuffer) Prependf(format string, args ...interface{}) {
+	*lb = append([]string{fmt.Sprintf(format, args...)}, *lb...)
+}
+
+func (lb *LineBuffer) Join(other LineBuffer) {
+	*lb = append(*lb, other...)
+}
+
+func (lb LineBuffer) String() string {
+	return strings.Join(lb, "\n") + "\n"
+}
+
+/////////// This stuff would go in pkg/codegen/expr.go
+
+// A helper type for tracking whether an expression is a value or pointer.
+type Expr struct {
+	base   string
+	derefs int // > 0 means to dereference, < 0 means to take the address.
+}
+
+func (e Expr) Deref() Expr {
+	e.derefs++
+	return e
+}
+
+func (e Expr) Addr() Expr {
+	e.derefs--
+	return e
+}
+
+func (e Expr) String() string {
+	for ; e.derefs > 0; e.derefs-- {
+		e.base = fmt.Sprintf("(*%s)", e.base)
+	}
+	for ; e.derefs < 0; e.derefs++ {
+		e.base = fmt.Sprintf("(&%s)", e.base)
+	}
+	return e.base
+}
+
+func ptrExpr(base string) Expr {
+	return Expr{base: fmt.Sprintf("(%s)", base), derefs: 1}
+}
+
+func valExpr(base string) Expr {
+	return Expr{base: fmt.Sprintf("(%s)", base), derefs: 0}
+}
+
+/////////// This stuff would go in cmd/gendefaults/gendefaults.go
+
+type typeRecord struct {
+	buffer   LineBuffer
+	pkgAlias string
+	mustEmit bool
+}
+
+type myVisitor struct {
+	index  []reflect.Type
+	types  map[reflect.Type]*typeRecord
+	outPkg string
+}
+
+func NewVisitor(outPkg string) *myVisitor {
+	return &myVisitor{
+		index:  []reflect.Type{},
+		types:  map[reflect.Type]*typeRecord{},
+		outPkg: outPkg,
+	}
+}
+
+func implementsDefaulter(t reflect.Type) bool {
+	x := reflect.New(t).Interface()
+	_, ok := x.(defaulter)
+	return ok
+}
+
+func (v *myVisitor) OpenType(t reflect.Type) {
+	//fmt.Printf("// DBG: OpenType %q  %s\n", t.PkgPath(), t)
+	v.types[t] = &typeRecord{
+		buffer:   nil,
+		pkgAlias: v.pkgSymbol(t),
+	}
+	if implementsDefaulter(t) {
+		//fmt.Printf("// DBG: %v implements ApplyDefaults()\n", t)
+		v.types[t].mustEmit = true
+	}
+	v.index = append(v.index, t)
+}
+
+func (v *myVisitor) CloseType(t reflect.Type) {
+	//fmt.Printf("// DBG: CloseType %q  %s\n", t.PkgPath(), t)
+	if implementsDefaulter(t) {
+		v.types[t].buffer.Appendf("obj.ApplyDefaults()")
+	}
+}
+
+// FIXME: would be nice to expose this somewhere, but circular deps hurt.
+// Maybe pkg/api
+type defaulter interface {
+	ApplyDefaults()
+}
+
+func (v *myVisitor) VisitField(f reflect.StructField, parentType reflect.Type, fieldName string) {
+	//fmt.Printf("// DBG: VisitField %v.%s type %v\n", parentType, fieldName, f.Type)
+	buf := v.visitExpr(f.Type, parentType, valExpr(fmt.Sprintf("obj.%s", fieldName)))
+	if buf != nil {
+		buf.Prependf("// %s %v", fieldName, f.Type)
+		v.types[parentType].buffer.Join(buf)
+		v.types[parentType].mustEmit = true
+	}
+}
+
+// Returns true if the value might have changed.
+func (v *myVisitor) visitExpr(t reflect.Type, parentType reflect.Type, expr Expr) LineBuffer {
+	if t.PkgPath() == "" {
+		// Unpack unnamed aggregate types.
+		switch t.Kind() {
+		case reflect.Array, reflect.Slice:
+			return v.visitArray(t, parentType, expr)
+		case reflect.Ptr:
+			return v.visitPtr(t, parentType, expr)
+		case reflect.Map:
+			return v.visitMap(t, parentType, expr)
+		default:
+			// Struct is handed by the visitor machinery.
+			return nil
+		}
+	}
+
+	if v.types[t].mustEmit {
+		ret := LineBuffer{}
+		ret.Appendf("applyDefaults_%s(%s)", v.pkgTypeSymbol(t), expr.Addr())
+		return ret
+	}
+	return nil
+}
+
+func (v *myVisitor) visitArray(t reflect.Type, parentType reflect.Type, expr Expr) LineBuffer {
+	buf := LineBuffer{}
+
+	buf.Appendf("for i := range %s {", expr)
+	buf.Appendf("  p := &(%s[i])", expr)
+	childBuf := v.visitExpr(t.Elem(), parentType, ptrExpr("p"))
+	if childBuf == nil {
+		return nil
+	}
+	buf.Join(childBuf)
+	buf.Appendf("}")
+
+	return buf
+}
+
+func (v *myVisitor) visitPtr(t reflect.Type, parentType reflect.Type, expr Expr) LineBuffer {
+	buf := LineBuffer{}
+
+	buf.Appendf("if (%s) != nil {", expr)
+	childBuf := v.visitExpr(t.Elem(), parentType, expr.Deref())
+	if childBuf == nil {
+		return nil
+	}
+	buf.Join(childBuf)
+	buf.Appendf("}")
+
+	return buf
+}
+
+func (v *myVisitor) visitMap(t reflect.Type, parentType reflect.Type, expr Expr) LineBuffer {
+	buf := LineBuffer{}
+
+	buf.Appendf("for k, v := range %s {", expr)
+	childBuf := v.visitExpr(t.Elem(), parentType, valExpr("v"))
+	if childBuf == nil {
+		return nil
+	}
+	buf.Join(childBuf)
+	buf.Appendf("    %s[k] = v", expr)
+	buf.Appendf("}")
+
+	return buf
+}
+
+func pathToSymbol(path string) string {
+	// At the cost of some ugly, the leading '_' ensures that any string we get
+	// (even if it starts with a digit) becomes a valid symbol.
+	out := bytes.NewBuffer([]byte("_"))
+	for _, r := range path {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			out.WriteRune(r)
+		} else {
+			out.WriteRune('_')
+		}
+	}
+	return out.String()
+}
+
+func (v *myVisitor) pkgSymbol(t reflect.Type) string {
+	return pathToSymbol(t.PkgPath())
+}
+
+func (v *myVisitor) pkgTypeSymbol(t reflect.Type) string {
+	return fmt.Sprintf("%s_%s", v.pkgSymbol(t), t.Name())
+}
+
+func (v *myVisitor) typeString(t reflect.Type) string {
+	pkg := v.types[t].pkgAlias
+	tn := t.Name()
+	if pkg != "" {
+		return pkg + "." + tn
+	}
+	return t.Name()
+}
+
+func (v *myVisitor) Dump() {
+	buf := LineBuffer{}
+
+	// Emit package line.
+	buf.Appendf("package %s", v.outPkg)
+
+	// Emit import lines.
+	imports := util.NewStringSet()
+	for _, t := range v.index {
+		if v.types[t].buffer == nil {
+			continue
+		}
+		imports.Insert(fmt.Sprintf("%s %q\n", v.types[t].pkgAlias, t.PkgPath()))
+	}
+	for i := range imports {
+		buf.Appendf("import %s", i)
+	}
+
+	// Emit per-type functions.
+	for _, t := range v.index {
+		if v.types[t].buffer == nil {
+			continue
+		}
+		ts := v.typeString(t)
+		ss := v.pkgTypeSymbol(t)
+		buf.Appendf("func applyDefaults_%s(obj *%s) {", ss, ts)
+		buf.Join(v.types[t].buffer)
+		buf.Append("}")
+	}
+
+	// Emit top-level entrypoints.
+	//FIXME: only register for registered API Objects or for all?
+	for _, t := range v.index {
+		if v.types[t].buffer == nil {
+			continue
+		}
+		ts := v.typeString(t)
+		ss := v.pkgTypeSymbol(t)
+		buf.Appendf("func applyDefaults_entry_%s(obj interface{}) {", ss)
+		buf.Appendf("    concrete, ok := obj.(*%s)", ts)
+		//FIXME: maybe don't bother to panic, just let the assertion do it
+		buf.Appendf("    if !ok { panic(fmt.Sprintf(\"applyDefaults_entry_%s called for type %%T\", obj)) }", ss)
+		buf.Appendf("    applyDefaults_%s(concrete)", ss)
+		buf.Append("}\n")
+	}
+
+	// Register entrypoints.
+	buf.Append("func InitDefaultableTypes(register func(reflect.Type, func(obj interface{}))) {")
+	for _, t := range v.index {
+		if v.types[t].buffer == nil {
+			continue
+		}
+		ts := v.typeString(t)
+		buf.Append("register(")
+		buf.Appendf("    reflect.TypeOf(new(%s)),", ts)
+		buf.Appendf("    applyDefaults_entry_%s)", v.pkgTypeSymbol(t))
+	}
+	buf.Append("}")
+
+	fmt.Print(buf)
+}
+
+func main() {
+	// The assumption is that you generate into a new pkg.
+	visitor := NewVisitor("generated")
+	acc := map[reflect.Type]bool{}
+	//FIXME: need to sort input types for stable output
+	for _, knownType := range api.Scheme.KnownTypes("v1") {
+		DeepVisitTypeAccumulate(knownType, visitor, acc)
+	}
+	visitor.Dump()
+}


### PR DESCRIPTION
This is a prototype of a sketch of some of my ideas in #8190 - specifically, moving things like defaulting into methods.

I whipped up a code-generator (because F**K reflection) which emits functions that (statically) call SetDefaults() on any given value (if it is known).  I moved a handful of default blocks into methods in v1.  As discussed, the methods could be implemented on "subtypes" (in as much as Go has them with embedded types) so the structs are clean - no business logic - though I am not convinced that is worthwhile.

This is far from done, but I think it captures the net complexity.  A similar code-generator for validation would be pretty easy, and this codegen infra could probably be merged back to the deep-copy and conversion logic (on which it was based).

To regenerate code for v1: `godep go run walk/walk.go 2>&1 | goimports | gofmt -s > pkg/api/v1/generated/defaults.go`.  Note that the output is not stable-sorted, so it will be different every time.  Sorry - it's a prototype :)

To run the test: `godep go run walk/test.go`

Thoughts?  I'm happy to pursue this in free time - validation and constructors next, in that order.

@bgrant0607 @lavalamp @smarterclayton 
