### PR TITLE
Kubectl version should show client version at least

### DIFF
--- a/pkg/kubectl/cmd/version.go
+++ b/pkg/kubectl/cmd/version.go
@@ -39,8 +39,8 @@ func NewCmdVersion(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 }
 
 func RunVersion(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command) error {
+	kubectl.GetClientVersion(out)
 	if cmdutil.GetFlagBool(cmd, "client") {
-		kubectl.GetClientVersion(out)
 		return nil
 	}
 
@@ -49,6 +49,6 @@ func RunVersion(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command) error {
 		return err
 	}
 
-	kubectl.GetVersion(out, client)
+	kubectl.GetServerVersion(out, client)
 	return nil
 }

--- a/pkg/kubectl/version.go
+++ b/pkg/kubectl/version.go
@@ -25,12 +25,10 @@ import (
 	"k8s.io/kubernetes/pkg/version"
 )
 
-func GetVersion(w io.Writer, kubeClient client.Interface) {
-	GetClientVersion(w)
-
+func GetServerVersion(w io.Writer, kubeClient client.Interface) {
 	serverVersion, err := kubeClient.ServerVersion()
 	if err != nil {
-		fmt.Printf("Couldn't read version from server: %v\n", err)
+		fmt.Printf("Couldn't read server version from server: %v\n", err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Kubectl version should show client version at least when couldn't read server version.
