### PR TITLE
Simplify default output of "expose" command

### DIFF
--- a/pkg/kubectl/cmd/expose.go
+++ b/pkg/kubectl/cmd/expose.go
@@ -191,21 +191,28 @@ func RunExpose(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []str
 		}
 	}
 
+	resourceMapper := &resource.Mapper{ObjectTyper: typer, RESTMapper: mapper, ClientMapper: f.ClientMapperForCommand()}
+	info, err = resourceMapper.InfoForObject(object)
+	if err != nil {
+		return err
+	}
 	// TODO: extract this flag to a central location, when such a location exists.
-	if !cmdutil.GetFlagBool(cmd, "dry-run") {
-		resourceMapper := &resource.Mapper{ObjectTyper: typer, RESTMapper: mapper, ClientMapper: f.ClientMapperForCommand()}
-		info, err := resourceMapper.InfoForObject(object)
-		if err != nil {
-			return err
-		}
+	if cmdutil.GetFlagBool(cmd, "dry-run") {
+		fmt.Fprintln(out, "running in dry-run mode...")
+	} else {
 		data, err := info.Mapping.Codec.Encode(object)
 		if err != nil {
 			return err
 		}
-		_, err = resource.NewHelper(info.Client, info.Mapping).Create(namespace, false, data)
+		object, err = resource.NewHelper(info.Client, info.Mapping).Create(namespace, false, data)
 		if err != nil {
 			return err
 		}
 	}
-	return f.PrintObject(cmd, object, out)
+	outputFormat := cmdutil.GetFlagString(cmd, "output")
+	if outputFormat != "" {
+		return f.PrintObject(cmd, object, out)
+	}
+	cmdutil.PrintSuccess(mapper, false, out, info.Mapping.Resource, info.Name, "exposed")
+	return nil
 }

--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -242,11 +242,10 @@ func RunLabel(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []stri
 			}
 		}
 		outputFormat := cmdutil.GetFlagString(cmd, "output")
-		if outputFormat == "" {
-			cmdutil.PrintSuccess(mapper, false, out, info.Mapping.Resource, info.Name, "labeled")
-		} else {
+		if outputFormat != "" {
 			return f.PrintObject(cmd, outputObj, out)
 		}
+		cmdutil.PrintSuccess(mapper, false, out, info.Mapping.Resource, info.Name, "labeled")
 		return nil
 	})
 }


### PR DESCRIPTION
Closes: #10836

Use simple output string such as "rc nginx exposed" to show the
result. Users can still use options like "-o yaml" to view detailed
result.

IP will be printed with detailed result now.

@kubernetes/kubectl @thockin 
