### PR TITLE
Added make verify to simplify running presubmit checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,23 @@ all:
 	hack/build-go.sh $(WHAT)
 .PHONY: all
 
+# Runs all the presubmission verifications.
+#
+# Example:
+#   make verify
+verify:
+	hack/verify-gofmt.sh
+	hack/verify-boilerplate.sh
+	hack/verify-description.sh
+	hack/verify-generated-conversions.sh
+	hack/verify-generated-deep-copies.sh
+	hack/verify-generated-docs.sh
+	hack/verify-swagger-spec.sh
+	hack/verify-linkcheck.sh
+	hack/verify-flags-underscore.py
+	hack/verify-godeps.sh
+.PHONY: verify
+
 # Build and run tests.
 #
 # Args:


### PR DESCRIPTION
@smarterclayton I've had enough of running those manually, I think it makes sense to have it as a target inside Makefile. Looking more I think it would be also beneficial to reuse that inside `.travis.yml` and `shippable.yml`, similarly to what we do in origin, but I might need some guidance on that if it's requested. 
