### PR TITLE
Update CentOS getting started guide with needed KUBELET_API_SERVER

### DIFF
--- a/docs/getting-started-guides/centos/centos_manual_config.md
+++ b/docs/getting-started-guides/centos/centos_manual_config.md
@@ -173,6 +173,9 @@ KUBELET_PORT="--port=10250"
 # You may leave this blank to use the actual hostname
 KUBELET_HOSTNAME="--hostname-override=centos-minion"
 
+# Location of the api-server
+KUBELET_API_SERVER="--api-server=http://centos-master:8080"
+
 # Add your own!
 KUBELET_ARGS=""
 ```


### PR DESCRIPTION
When following this guide we were not able to get it working without having the KUBELET_API_SERVER config parameter point to the api server. 

When looking at f.ex. the fedora guides, we also see this parameter present, hence we think this should be added to the CentOS guide as well. 
