### PR TITLE
httpGet livenessprobe fails for controller and scheduler when following steps in scratch.md (fixes #12740)

### DIFF
--- a/docs/getting-started-guides/scratch.md
+++ b/docs/getting-started-guides/scratch.md
@@ -710,6 +710,7 @@ Complete this template for the scheduler pod:
         ],
         "livenessProbe": {
           "httpGet": {
+            "host" : "127.0.0.1",
             "path": "/healthz",
             "port": 10251
           },
@@ -766,6 +767,7 @@ Template for controller manager pod:
         ],
         "livenessProbe": {
           "httpGet": {
+            "host": "127.0.0.1",
             "path": "/healthz",
             "port": 10252
           },

--- a/docs/user-guide/liveness/README.md
+++ b/docs/user-guide/liveness/README.md
@@ -69,7 +69,7 @@ The [http-liveness.yaml](http-liveness.yaml) demonstrates the HTTP check.
       timeoutSeconds: 1
 ```
 
-The Kubelet sends a HTTP request to the specified path and port to perform the health check. If you take a look at image/server.go, you will see the server starts to respond with an error code 500 after 10 seconds, so the check fails.
+The Kubelet sends an HTTP request to the specified path and port to perform the health check. If you take a look at image/server.go, you will see the server starts to respond with an error code 500 after 10 seconds, so the check fails. The Kubelet sends the probe to the container's ip address by default which could be specified with `host` as part of httpGet probe. If the container listens on `127.0.0.1`, `host` should be specified as `127.0.0.1`. In general, if the container listens on its ip address or on all interfaces (0.0.0.0), there is no need to specify the `host` as part of the httpGet probe.
 
 This [guide](../walkthrough/k8s201.md#health-checking) has more information on health checks.
 


### PR DESCRIPTION
This PR updates scratch.md so that httpGet livenessprobe is sent to "host" : "127.0.0.1" for controller-manager and scheduler containers as they listen on 127.0.0.1 by default. If the "host" : "127.0.0.1" is not specified as part of the probe, the probe fails and both containers are restarted continuously. Another way to solve this is to start both containers with --address=0.0.0.0. This PR also updates the liveness userguide README to describe the host part of the httpGet probe.

Fixes #12740
