### PR TITLE
Automated cherry pick of #12514

### DIFF
--- a/cluster/vagrant/config-default.sh
+++ b/cluster/vagrant/config-default.sh
@@ -27,6 +27,9 @@ export KUBE_MASTER_IP="10.245.1.2"
 export INSTANCE_PREFIX="kubernetes"
 export MASTER_NAME="${INSTANCE_PREFIX}-master"
 
+# Should the master serve as a node
+REGISTER_MASTER_KUBELET=${REGISTER_MASTER:-false}
+
 # Map out the IPs, names and container subnets of each minion
 export MINION_IP_BASE="10.245.1."
 MINION_CONTAINER_SUBNET_BASE="10.246"

--- a/cluster/vagrant/config-test.sh
+++ b/cluster/vagrant/config-test.sh
@@ -20,3 +20,6 @@ NUM_MINIONS=2
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
 source "${KUBE_ROOT}/cluster/vagrant/config-default.sh"
+
+# Do not register the master kubelet during testing
+REGISTER_MASTER_KUBELET=${REGISTER_MASTER:-false}

--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -170,20 +170,20 @@ if [[ ! -f "${known_tokens_file}" ]]; then
   cat > "${kubelet_kubeconfig_file}" << EOF
 apiVersion: v1
 kind: Config
-users:
-- name: kubelet
-  user:
-    token: ${KUBELET_TOKEN}
 clusters:
-- name: local
-  cluster:
+- cluster:
     insecure-skip-tls-verify: true
+  name: local
 contexts:
-  - context:
+- context:
     cluster: local
     user: kubelet
   name: service-account-context
 current-context: service-account-context
+users:
+- name: kubelet
+  user:
+    token: ${KUBELET_TOKEN}
 EOF
 )
 
@@ -197,20 +197,20 @@ EOF
   cat > "${kube_proxy_kubeconfig_file}" << EOF
 apiVersion: v1
 kind: Config
-users:
-- name: kube-proxy
-  user:
-    token: ${KUBE_PROXY_TOKEN}
 clusters:
-- name: local
-  cluster:
-     insecure-skip-tls-verify: true
+- cluster:
+    insecure-skip-tls-verify: true
+  name: local
 contexts:
 - context:
     cluster: local
     user: kube-proxy
   name: service-account-context
 current-context: service-account-context
+users:
+- name: kube-proxy
+  user:
+    token: ${KUBE_PROXY_TOKEN}
 EOF
 )
 


### PR DESCRIPTION
This fixes registration of the nodes with the kube-apiserver.

There was an extra space character in the YAML file that made the context not understood and cert validation happen and fail.

Fixes https://github.com/kubernetes/kubernetes/issues/12854
Fixes https://github.com/kubernetes/kubernetes/issues/12892
Fixes https://github.com/kubernetes/kubernetes/issues/12773
Fixes https://github.com/kubernetes/kubernetes/issues/12614
Fixes https://github.com/kubernetes/kubernetes/issues/12184
