### PR TITLE
Clean up the fluentd images to make them more debuggable

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Dockerfile
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Dockerfile
@@ -40,4 +40,4 @@ RUN /usr/sbin/td-agent-gem install fluent-plugin-record-reformer
 COPY td-agent.conf /etc/td-agent/td-agent.conf
 
 # Run the Fluentd service.
-CMD /usr/sbin/td-agent "$FLUENTD_ARGS" > /var/log/td-agent/td-agent.log
+CMD /usr/sbin/td-agent "$FLUENTD_ARGS"

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Makefile
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Makefile
@@ -1,7 +1,7 @@
 .PHONY:	build push
 
 IMAGE = fluentd-elasticsearch
-TAG = 1.9
+TAG = 1.10
 
 build:	
 	docker build -t gcr.io/google_containers/$(IMAGE):$(TAG) .

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/Dockerfile
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/Dockerfile
@@ -17,11 +17,14 @@ RUN apt-get -q update && \
     apt-get clean && \
     curl -s https://storage.googleapis.com/signals-agents/logging/google-fluentd-install.sh | sudo bash
 
-# Copy the Fluentd configuration file for logging Docker container logs.
-COPY google-fluentd.conf /etc/google-fluentd/google-fluentd.conf
-
 # Install the record reformer plugin.
 RUN /usr/sbin/google-fluentd-gem install fluent-plugin-record-reformer
 
+# Remove the misleading log file that gets generated when the agent is installed
+RUN rm -rf /var/log/google-fluentd
+
+# Copy the Fluentd configuration file for logging Docker container logs.
+COPY google-fluentd.conf /etc/google-fluentd/google-fluentd.conf
+
 # Start Fluentd to pick up our config that watches Docker container logs.
-CMD /usr/sbin/google-fluentd "$FLUENTD_ARGS" > /var/log/google-fluentd.log
+CMD /usr/sbin/google-fluentd "$FLUENTD_ARGS"

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
@@ -14,7 +14,7 @@
 
 .PHONY:	kbuild kpush
 
-TAG = 1.11
+TAG = 1.12
 
 # Rules for building the test image for deployment to Dockerhub with user kubernetes.
 

--- a/cluster/saltbase/salt/fluentd-es/fluentd-es.yaml
+++ b/cluster/saltbase/salt/fluentd-es/fluentd-es.yaml
@@ -12,7 +12,7 @@ spec:
         cpu: 100m
     env:
     - name: "FLUENTD_ARGS"
-      value: "-qq"
+      value: "-q"
     volumeMounts:
     - name: varlog
       mountPath: /varlog

--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
@@ -6,14 +6,14 @@ metadata:
 spec:
   containers:
   - name: fluentd-cloud-logging
-    image: gcr.io/google_containers/fluentd-gcp:1.11
+    image: gcr.io/google_containers/fluentd-gcp:1.12
     resources:
       limits:
         cpu: 100m
         memory: 200Mi
     env:
     - name: FLUENTD_ARGS
-      value: -qq
+      value: -q
     volumeMounts:
     - name: varlog
       mountPath: /varlog

--- a/docs/getting-started-guides/logging.md
+++ b/docs/getting-started-guides/logging.md
@@ -169,14 +169,14 @@ metadata:
 spec:
   containers:
   - name: fluentd-cloud-logging
-    image: gcr.io/google_containers/fluentd-gcp:1.11
+    image: gcr.io/google_containers/fluentd-gcp:1.12
     resources:
       limits:
         cpu: 100m
         memory: 200Mi
     env:
     - name: FLUENTD_ARGS
-      value: -qq
+      value: -q
     volumeMounts:
     - name: varlog
       mountPath: /varlog


### PR DESCRIPTION
Get rid of the garbage log file that misleads practically everyone who finds it, switch from only logging errors (which effectively means logging nothing) to logging warnings, and let the logs go to stdout such that they get picked up by Docker.

Yes, the last point will mean that Fluentd collects its own logs, but given its internal buffering logic, even the case of downstream errors causing more logs to be generated shouldn't cause any special problems for it that it wouldn't already face from having to collect other containers' logs.

@satnam6502 @saad-ali
