### PR TITLE
e2e: disable the restart count test

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -100,6 +100,7 @@ GCE_DEFAULT_SKIP_TESTS=(
 GCE_FLAKY_TESTS=(
     "DaemonRestart"
     "ResourceUsage"
+    "monotonically\sincreasing\srestart\scount"
     )
 
 # Tests which are not able to be run in parallel.


### PR DESCRIPTION
It  is unstable at this moment. Disable it for now.
