### PR TITLE
Change "chmod +X" to "chmod +x" in prereqs.md

### DIFF
--- a/docs/user-guide/prereqs.md
+++ b/docs/user-guide/prereqs.md
@@ -55,7 +55,7 @@ $ sudo cp kubernetes/platforms/linux/amd64/kubectl /usr/local/bin/kubectl
 You also need to ensure it's executable:
 
 ```console
-$ sudo chmod +X /usr/local/bin/kubectl
+$ sudo chmod +x /usr/local/bin/kubectl
 ```
 
 If you prefer not to copy kubectl, you need to ensure the tool is in your path:


### PR DESCRIPTION
Change `chmod +X` to `chmod +x`, since `+X` does not take affect when there is no  execute permission bit already set (either user, group or other).

``` console
# ls -l /usr/bin/kubectl
-rw-r--r-- 1 root root 14190181 Aug 10 16:16 /usr/bin/kubectl
# chmod +X /usr/bin/kubectl
# ls -l /usr/bin/kubectl
-rw-r--r-- 1 root root 14190181 Aug 10 16:16 /usr/bin/kubectl
```

Please refer to [chmod](https://en.wikipedia.org/wiki/Chmod) for more details.

> which is not a permission in itself but rather can be used instead of x. It applies execute permissions to directories regardless of their current permissions and **applies execute permissions to a file which already has at least one execute permission bit already set (either user, group or other)**. It is only really useful when used with '+' and usually in combination with the -R option for giving group or other access to a big directory tree without setting execute permission on normal files (such as text files), which would normally happen if you just used "chmod -R a+rx .", whereas with 'X' you can do "chmod -R a+rX ." instead
