### PR TITLE
Updates fedora ansible guide

### DIFF
--- a/docs/getting-started-guides/fedora/fedora_ansible_config.md
+++ b/docs/getting-started-guides/fedora/fedora_ansible_config.md
@@ -45,7 +45,7 @@ Configuring Kubernetes on Fedora via Ansible offers a simple way to quickly crea
 
 ## Prerequisites
 
-1. Host able to run ansible and able to clone the following repo: [kubernetes](https://github.com/GoogleCloudPlatform/kubernetes.git)
+1. Host able to run ansible and able to clone the following repo: [kubernetes](https://github.com/kubernetes/kubernetes.git)
 2. A Fedora 21+ host to act as cluster master
 3. As many Fedora 21+ hosts as you would like, that act as cluster nodes
 
@@ -76,13 +76,13 @@ yum install -y ansible git python-netaddr
 **Now clone down the Kubernetes repository**
 
 ```sh
-git clone https://github.com/GoogleCloudPlatform/kubernetes.git
-cd kubernetes/contrib/ansible
+git clone https://github.com/kubernetes/contrib.git
+cd contrib/ansible
 ```
 
 **Tell ansible about each machine and its role in your cluster**
 
-Get the IP addresses from the master and nodes.  Add those to the `~/kubernetes/contrib/ansible/inventory` file on the host running Ansible.
+Get the IP addresses from the master and nodes.  Add those to the `~/contrib/ansible/inventory` file on the host running Ansible.
 
 ```console
 [masters]
@@ -98,11 +98,11 @@ kube-node-02.example.com
 
 ## Setting up ansible access to your nodes
 
-If you already are running on a machine which has passwordless ssh access to the kube-master and kube-node-{01,02} nodes, and 'sudo' privileges, simply set the value of `ansible_ssh_user` in `~/kubernetes/contrib/ansible/group_vars/all.yaml` to the username which you use to ssh to the nodes (i.e. `fedora`), and proceed to the next step...
+If you already are running on a machine which has passwordless ssh access to the kube-master and kube-node-{01,02} nodes, and 'sudo' privileges, simply set the value of `ansible_ssh_user` in `~/contrib/ansible/group_vars/all.yaml` to the username which you use to ssh to the nodes (i.e. `fedora`), and proceed to the next step...
 
 *Otherwise* setup ssh on the machines like so (you will need to know the root password to all machines in the cluster).
 
-edit: ~/kubernetes/contrib/ansible/group_vars/all.yml
+edit: ~/contrib/ansible/group_vars/all.yml
 
 ```yaml
 ansible_ssh_user: root
@@ -128,9 +128,9 @@ done
 
 ## Setting up the cluster
 
-Although the default value of variables in `~/kubernetes/contrib/ansible/group_vars/all.yml` should be good enough, if not, change them as needed.
+Although the default value of variables in `~/contrib/ansible/group_vars/all.yml` should be good enough, if not, change them as needed.
 
-edit: ~/kubernetes/contrib/ansible/group_vars/all.yml
+edit: ~/contrib/ansible/group_vars/all.yml
 
 **Configure access to kubernetes packages**
 
@@ -178,7 +178,7 @@ dns_setup: true
 This will finally setup your whole Kubernetes cluster for you.
 
 ```sh
-cd ~/kubernetes/contrib/ansible/
+cd ~/contrib/ansible/
 
 ./setup.sh
 ```


### PR DESCRIPTION
Updates fedora ansible guide to reflect the move of the contrib dir to
https://github.com/kubernetes/contrib.git .
