### PR TITLE
Quote malformed host values in unversioned client helper

### DIFF
--- a/pkg/client/unversioned/helper.go
+++ b/pkg/client/unversioned/helper.go
@@ -479,7 +479,7 @@ func DefaultServerURL(host, prefix, version string, defaultTLS bool) (*url.URL, 
 			return nil, err
 		}
 		if hostURL.Path != "" && hostURL.Path != "/" {
-			return nil, fmt.Errorf("host must be a URL or a host:port pair: %s", base)
+			return nil, fmt.Errorf("host must be a URL or a host:port pair: %q", base)
 		}
 	}
 


### PR DESCRIPTION
@kubernetes/goog-ux PTAL

Found this today when I had passed `" https://somehost"` to `--host`.
