### PR TITLE
Actually make the pushed version directory match binary versions

### DIFF
--- a/build/push-ci-build.sh
+++ b/build/push-ci-build.sh
@@ -20,7 +20,22 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-LATEST=$(git describe)
+# TODO(zmerlynn): Blech, this belongs in build/common.sh, probably,
+# but common.sh sets up its readonly variables when its sourced, so
+# there's a chicken/egg issue getting it there and using it for
+# KUBE_GCE_RELEASE_PREFIX.
+function kube::release::semantic_version() {
+  # This takes:
+  # Client Version: version.Info{Major:"1", Minor:"1+", GitVersion:"v1.1.0-alpha.0.2328+3c0a05de4a38e3", GitCommit:"3c0a05de4a38e355d147dbfb4d85bad6d2d73bb9", GitTreeState:"clean"}
+  # and spits back the GitVersion piece in a way that is somewhat
+  # resilient to the other fields changing (we hope)
+  ${KUBE_ROOT}/cluster/kubectl.sh version -c | sed "s/, */\\
+/g" | egrep "^GitVersion:" | cut -f2 -d: | cut -f2 -d\"
+}
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+LATEST=$(kube::release::semantic_version)
+
 KUBE_GCS_NO_CACHING=n
 KUBE_GCS_MAKE_PUBLIC=y
 KUBE_GCS_UPLOAD_RELEASE=y
@@ -30,7 +45,6 @@ KUBE_GCS_RELEASE_PREFIX="ci/${LATEST}"
 KUBE_GCS_LATEST_FILE="ci/latest.txt"
 KUBE_GCS_LATEST_CONTENTS=${LATEST}
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "$KUBE_ROOT/build/common.sh"
 
 MAX_ATTEMPTS=3


### PR DESCRIPTION
A small bug from #11941: When we push to GCS, we were pushing bucket
names that matched the old pattern `git describe`, e.g.:

gs://kubernetes-release/ci/v1.1.0-alpha.0-2413-g986d37d/

But after #11941, the binaries inside these actually have versions that look like:

v1.1.0-alpha.0.2413+g986d37d

to more closely match up with semver.

This pull makes the GCS directory match the binaries it's already serving.
