### PR TITLE
Validating deployment

### DIFF
--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -234,7 +234,6 @@ func TestValidateAnnotations(t *testing.T) {
 }
 
 func testVolume(name string, namespace string, spec api.PersistentVolumeSpec) *api.PersistentVolume {
-
 	objMeta := api.ObjectMeta{Name: name}
 	if namespace != "" {
 		objMeta.Namespace = namespace
@@ -247,7 +246,6 @@ func testVolume(name string, namespace string, spec api.PersistentVolumeSpec) *a
 }
 
 func TestValidatePersistentVolumes(t *testing.T) {
-
 	scenarios := map[string]struct {
 		isExpectedFailure bool
 		volume            *api.PersistentVolume
@@ -358,7 +356,6 @@ func testVolumeClaim(name string, namespace string, spec api.PersistentVolumeCla
 }
 
 func TestValidatePersistentVolumeClaim(t *testing.T) {
-
 	scenarios := map[string]struct {
 		isExpectedFailure bool
 		claim             *api.PersistentVolumeClaim
@@ -802,7 +799,6 @@ func TestValidatePullPolicy(t *testing.T) {
 			t.Errorf("case[%s] expected policy %v, got %v", k, v.ExpectedPolicy, ctr.ImagePullPolicy)
 		}
 	}
-
 }
 
 func getResourceLimits(cpu, memory string) api.ResourceList {
@@ -2144,7 +2140,6 @@ func TestValidateReplicationControllerUpdate(t *testing.T) {
 			t.Errorf("expected failure: %s", testName)
 		}
 	}
-
 }
 
 func TestValidateReplicationController(t *testing.T) {

--- a/pkg/expapi/deep_copy_generated.go
+++ b/pkg/expapi/deep_copy_generated.go
@@ -787,12 +787,7 @@ func deepCopy_expapi_DeploymentList(in DeploymentList, out *DeploymentList, c *c
 }
 
 func deepCopy_expapi_DeploymentSpec(in DeploymentSpec, out *DeploymentSpec, c *conversion.Cloner) error {
-	if in.Replicas != nil {
-		out.Replicas = new(int)
-		*out.Replicas = *in.Replicas
-	} else {
-		out.Replicas = nil
-	}
+	out.Replicas = in.Replicas
 	if in.Selector != nil {
 		out.Selector = make(map[string]string)
 		for key, val := range in.Selector {

--- a/pkg/expapi/types.go
+++ b/pkg/expapi/types.go
@@ -179,9 +179,8 @@ type Deployment struct {
 }
 
 type DeploymentSpec struct {
-	// Number of desired pods. This is a pointer to distinguish between explicit
-	// zero and not specified. Defaults to 1.
-	Replicas *int `json:"replicas,omitempty"`
+	// Number of desired pods.
+	Replicas int `json:"replicas,omitempty"`
 
 	// Label selector for pods. Existing ReplicationControllers whose pods are
 	// selected by this will be scaled down.

--- a/pkg/expapi/v1/conversion_generated.go
+++ b/pkg/expapi/v1/conversion_generated.go
@@ -1512,44 +1512,6 @@ func convert_expapi_DeploymentList_To_v1_DeploymentList(in *expapi.DeploymentLis
 	return nil
 }
 
-func convert_expapi_DeploymentSpec_To_v1_DeploymentSpec(in *expapi.DeploymentSpec, out *DeploymentSpec, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*expapi.DeploymentSpec))(in)
-	}
-	if in.Replicas != nil {
-		out.Replicas = new(int)
-		*out.Replicas = *in.Replicas
-	} else {
-		out.Replicas = nil
-	}
-	if in.Selector != nil {
-		out.Selector = make(map[string]string)
-		for key, val := range in.Selector {
-			out.Selector[key] = val
-		}
-	} else {
-		out.Selector = nil
-	}
-	if in.Template != nil {
-		out.Template = new(v1.PodTemplateSpec)
-		if err := convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(in.Template, out.Template, s); err != nil {
-			return err
-		}
-	} else {
-		out.Template = nil
-	}
-	if err := convert_expapi_DeploymentStrategy_To_v1_DeploymentStrategy(&in.Strategy, &out.Strategy, s); err != nil {
-		return err
-	}
-	if in.UniqueLabelKey != nil {
-		out.UniqueLabelKey = new(string)
-		*out.UniqueLabelKey = *in.UniqueLabelKey
-	} else {
-		out.UniqueLabelKey = nil
-	}
-	return nil
-}
-
 func convert_expapi_DeploymentStatus_To_v1_DeploymentStatus(in *expapi.DeploymentStatus, out *DeploymentStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*expapi.DeploymentStatus))(in)
@@ -1929,66 +1891,12 @@ func convert_v1_DeploymentList_To_expapi_DeploymentList(in *DeploymentList, out 
 	return nil
 }
 
-func convert_v1_DeploymentSpec_To_expapi_DeploymentSpec(in *DeploymentSpec, out *expapi.DeploymentSpec, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*DeploymentSpec))(in)
-	}
-	if in.Replicas != nil {
-		out.Replicas = new(int)
-		*out.Replicas = *in.Replicas
-	} else {
-		out.Replicas = nil
-	}
-	if in.Selector != nil {
-		out.Selector = make(map[string]string)
-		for key, val := range in.Selector {
-			out.Selector[key] = val
-		}
-	} else {
-		out.Selector = nil
-	}
-	if in.Template != nil {
-		out.Template = new(api.PodTemplateSpec)
-		if err := convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in.Template, out.Template, s); err != nil {
-			return err
-		}
-	} else {
-		out.Template = nil
-	}
-	if err := convert_v1_DeploymentStrategy_To_expapi_DeploymentStrategy(&in.Strategy, &out.Strategy, s); err != nil {
-		return err
-	}
-	if in.UniqueLabelKey != nil {
-		out.UniqueLabelKey = new(string)
-		*out.UniqueLabelKey = *in.UniqueLabelKey
-	} else {
-		out.UniqueLabelKey = nil
-	}
-	return nil
-}
-
 func convert_v1_DeploymentStatus_To_expapi_DeploymentStatus(in *DeploymentStatus, out *expapi.DeploymentStatus, s conversion.Scope) error {
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*DeploymentStatus))(in)
 	}
 	out.Replicas = in.Replicas
 	out.UpdatedReplicas = in.UpdatedReplicas
-	return nil
-}
-
-func convert_v1_DeploymentStrategy_To_expapi_DeploymentStrategy(in *DeploymentStrategy, out *expapi.DeploymentStrategy, s conversion.Scope) error {
-	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
-		defaulting.(func(*DeploymentStrategy))(in)
-	}
-	out.Type = expapi.DeploymentType(in.Type)
-	if in.RollingUpdate != nil {
-		out.RollingUpdate = new(expapi.RollingUpdateDeployment)
-		if err := convert_v1_RollingUpdateDeployment_To_expapi_RollingUpdateDeployment(in.RollingUpdate, out.RollingUpdate, s); err != nil {
-			return err
-		}
-	} else {
-		out.RollingUpdate = nil
-	}
 	return nil
 }
 
@@ -2262,7 +2170,6 @@ func init() {
 		convert_expapi_DaemonStatus_To_v1_DaemonStatus,
 		convert_expapi_Daemon_To_v1_Daemon,
 		convert_expapi_DeploymentList_To_v1_DeploymentList,
-		convert_expapi_DeploymentSpec_To_v1_DeploymentSpec,
 		convert_expapi_DeploymentStatus_To_v1_DeploymentStatus,
 		convert_expapi_DeploymentStrategy_To_v1_DeploymentStrategy,
 		convert_expapi_Deployment_To_v1_Deployment,
@@ -2289,9 +2196,7 @@ func init() {
 		convert_v1_DaemonStatus_To_expapi_DaemonStatus,
 		convert_v1_Daemon_To_expapi_Daemon,
 		convert_v1_DeploymentList_To_expapi_DeploymentList,
-		convert_v1_DeploymentSpec_To_expapi_DeploymentSpec,
 		convert_v1_DeploymentStatus_To_expapi_DeploymentStatus,
-		convert_v1_DeploymentStrategy_To_expapi_DeploymentStrategy,
 		convert_v1_Deployment_To_expapi_Deployment,
 		convert_v1_EmptyDirVolumeSource_To_api_EmptyDirVolumeSource,
 		convert_v1_EnvVarSource_To_api_EnvVarSource,

--- a/pkg/expapi/validation/validation.go
+++ b/pkg/expapi/validation/validation.go
@@ -17,6 +17,8 @@ limitations under the License.
 package validation
 
 import (
+	"strconv"
+
 	"k8s.io/kubernetes/pkg/api"
 	apivalidation "k8s.io/kubernetes/pkg/api/validation"
 	"k8s.io/kubernetes/pkg/expapi"
@@ -155,4 +157,103 @@ func ValidateDaemonSpec(spec *expapi.DaemonSpec) errs.ValidationErrorList {
 // trailing dashes are allowed.
 func ValidateDaemonName(name string, prefix bool) (bool, string) {
 	return apivalidation.NameIsDNSSubdomain(name, prefix)
+}
+
+// Validates that the given name can be used as a deployment name.
+func ValidateDeploymentName(name string, prefix bool) (bool, string) {
+	return apivalidation.NameIsDNSSubdomain(name, prefix)
+}
+
+func ValidatePositiveIntOrPercent(intOrPercent util.IntOrString, fieldName string) errs.ValidationErrorList {
+	allErrs := errs.ValidationErrorList{}
+	if intOrPercent.Kind == util.IntstrString {
+		if !util.IsValidPercent(intOrPercent.StrVal) {
+			allErrs = append(allErrs, errs.NewFieldInvalid(fieldName, intOrPercent, "value should be int(5) or percentage(5%)"))
+		}
+
+	} else if intOrPercent.Kind == util.IntstrInt {
+		allErrs = append(allErrs, apivalidation.ValidatePositiveField(int64(intOrPercent.IntVal), fieldName)...)
+	}
+	return allErrs
+}
+
+func getPercentValue(intOrStringValue util.IntOrString) (int, bool) {
+	if intOrStringValue.Kind != util.IntstrString || !util.IsValidPercent(intOrStringValue.StrVal) {
+		return 0, false
+	}
+	value, _ := strconv.Atoi(intOrStringValue.StrVal[:len(intOrStringValue.StrVal)-1])
+	return value, true
+}
+
+func getIntOrPercentValue(intOrStringValue util.IntOrString) int {
+	value, isPercent := getPercentValue(intOrStringValue)
+	if isPercent {
+		return value
+	}
+	return intOrStringValue.IntVal
+}
+
+func IsNotMoreThan100Percent(intOrStringValue util.IntOrString, fieldName string) errs.ValidationErrorList {
+	allErrs := errs.ValidationErrorList{}
+	value, isPercent := getPercentValue(intOrStringValue)
+	if !isPercent || value <= 100 {
+		return nil
+	}
+	allErrs = append(allErrs, errs.NewFieldInvalid(fieldName, intOrStringValue, "should not be more than 100%"))
+	return allErrs
+}
+
+func ValidateRollingUpdateDeployment(rollingUpdate *expapi.RollingUpdateDeployment, fieldName string) errs.ValidationErrorList {
+	allErrs := errs.ValidationErrorList{}
+	allErrs = append(allErrs, ValidatePositiveIntOrPercent(rollingUpdate.MaxUnavailable, fieldName+"maxUnavailable")...)
+	allErrs = append(allErrs, ValidatePositiveIntOrPercent(rollingUpdate.MaxSurge, fieldName+".maxSurge")...)
+	if getIntOrPercentValue(rollingUpdate.MaxUnavailable) == 0 && getIntOrPercentValue(rollingUpdate.MaxSurge) == 0 {
+		// Both MaxSurge and MaxUnavailable cannot be zero.
+		allErrs = append(allErrs, errs.NewFieldInvalid(fieldName+".maxUnavailable", rollingUpdate.MaxUnavailable, "cannot be 0 when maxSurge is 0 as well"))
+	}
+	// Validate that MaxUnavailable is not more than 100%.
+	allErrs = append(allErrs, IsNotMoreThan100Percent(rollingUpdate.MaxUnavailable, fieldName+".maxUnavailable")...)
+	allErrs = append(allErrs, apivalidation.ValidatePositiveField(int64(rollingUpdate.MinReadySeconds), fieldName+".minReadySeconds")...)
+	return allErrs
+}
+
+func ValidateDeploymentStrategy(strategy *expapi.DeploymentStrategy, fieldName string) errs.ValidationErrorList {
+	allErrs := errs.ValidationErrorList{}
+	if strategy.RollingUpdate == nil {
+		return allErrs
+	}
+	switch strategy.Type {
+	case expapi.DeploymentRecreate:
+		allErrs = append(allErrs, errs.NewFieldForbidden("rollingUpdate", "rollingUpdate should be nil when strategy type is "+expapi.DeploymentRecreate))
+	case expapi.DeploymentRollingUpdate:
+		allErrs = append(allErrs, ValidateRollingUpdateDeployment(strategy.RollingUpdate, "rollingUpdate")...)
+	}
+	return allErrs
+}
+
+// Validates given deployment spec.
+func ValidateDeploymentSpec(spec *expapi.DeploymentSpec) errs.ValidationErrorList {
+	allErrs := errs.ValidationErrorList{}
+	allErrs = append(allErrs, apivalidation.ValidateNonEmptySelector(spec.Selector, "selector")...)
+	allErrs = append(allErrs, apivalidation.ValidatePositiveField(int64(spec.Replicas), "replicas")...)
+	allErrs = append(allErrs, apivalidation.ValidatePodTemplateSpecForRC(spec.Template, spec.Selector, spec.Replicas, "template")...)
+	allErrs = append(allErrs, ValidateDeploymentStrategy(&spec.Strategy, "strategy")...)
+	if spec.UniqueLabelKey != nil {
+		allErrs = append(allErrs, apivalidation.ValidateLabelName(*spec.UniqueLabelKey, "uniqueLabel")...)
+	}
+	return allErrs
+}
+
+func ValidateDeploymentUpdate(old, update *expapi.Deployment) errs.ValidationErrorList {
+	allErrs := errs.ValidationErrorList{}
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&update.ObjectMeta, &old.ObjectMeta).Prefix("metadata")...)
+	allErrs = append(allErrs, ValidateDeploymentSpec(&update.Spec).Prefix("spec")...)
+	return allErrs
+}
+
+func ValidateDeployment(obj *expapi.Deployment) errs.ValidationErrorList {
+	allErrs := errs.ValidationErrorList{}
+	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&obj.ObjectMeta, true, ValidateDeploymentName).Prefix("metadata")...)
+	allErrs = append(allErrs, ValidateDeploymentSpec(&obj.Spec).Prefix("spec")...)
+	return allErrs
 }

--- a/pkg/util/validation.go
+++ b/pkg/util/validation.go
@@ -139,3 +139,11 @@ func IsValidPortName(port string) bool {
 func IsValidIPv4(value string) bool {
 	return net.ParseIP(value) != nil && net.ParseIP(value).To4() != nil
 }
+
+const percentFmt string = "[0-9]+%"
+
+var percentRegexp = regexp.MustCompile("^" + percentFmt + "$")
+
+func IsValidPercent(percent string) bool {
+	return percentRegexp.MatchString(percent)
+}


### PR DESCRIPTION
Adding logic to validate deployments.
Also realized that Deployment.Spec.Replicas does not need to be a pointer in internal API. Changing that to int.

cc @bgrant0607 @ghodss @wojtek-t @lavalamp 

Ref: #1743
