### PR TITLE
Use make verify in Travis and Shippable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,16 +13,7 @@ install:
   - export PATH=$GOPATH/bin:./third_party/etcd:$PATH
 
 script:
-  - ./hack/verify-gofmt.sh
-  - ./hack/verify-boilerplate.sh
-  - ./hack/verify-description.sh
-  - ./hack/verify-generated-conversions.sh
-  - ./hack/verify-generated-deep-copies.sh
-  - ./hack/verify-generated-docs.sh
-  - ./hack/verify-swagger-spec.sh
-  - ./hack/verify-linkcheck.sh
-  - ./hack/verify-flags-underscore.py
-  - ./hack/verify-godeps.sh $TRAVIS_BRANCH
+  - make verify BRANCH=$TRAVIS_BRANCH
 
 notifications:
   irc: "chat.freenode.net#kubernetes-dev"

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,12 @@ all:
 
 # Runs all the presubmission verifications.
 #
+# Args:
+#   BRANCH: Branch to be passed to hack/verify-godeps.sh script.
+#
 # Example:
 #   make verify
+#   make verify BRANCH=branch_x
 verify:
 	hack/verify-gofmt.sh
 	hack/verify-boilerplate.sh
@@ -46,7 +50,7 @@ verify:
 	hack/verify-swagger-spec.sh
 	hack/verify-linkcheck.sh
 	hack/verify-flags-underscore.py
-	hack/verify-godeps.sh
+	hack/verify-godeps.sh $(BRANCH)
 .PHONY: verify
 
 # Build and run tests.

--- a/shippable.yml
+++ b/shippable.yml
@@ -42,17 +42,8 @@ install:
   - ./hack/build-go.sh
   - godep go install ./...
   - ./hack/travis/install-etcd.sh
-  - ./hack/verify-gofmt.sh
-  - ./hack/verify-boilerplate.sh
-  - ./hack/verify-description.sh
-  - ./hack/verify-flags-underscore.py
-  - ./hack/verify-godeps.sh ${BASE_BRANCH}
   - ./hack/travis/install-std-race.sh
-  - ./hack/verify-generated-conversions.sh
-  - ./hack/verify-generated-deep-copies.sh
-  - ./hack/verify-generated-docs.sh
-  - ./hack/verify-swagger-spec.sh
-  - ./hack/verify-linkcheck.sh
+  - make verify BRANCH=${BASE_BRANCH}
 
 script:
   # Disable coverage collection on pull requests


### PR DESCRIPTION
This is a followup to #13204 to use `make verify` in travis and shippable. I've also removed go1.3 stress testing from shippable as I've noticed it was removed from travis over a month ago.
@smarterclayton ptal
