### PR TITLE
Update quota example in admission_control_resource_quota.md

### DIFF
--- a/docs/design/admission_control_resource_quota.md
+++ b/docs/design/admission_control_resource_quota.md
@@ -218,8 +218,6 @@ replicationcontrollers   0         20
 resourcequotas           1         1
 secrets                  1         10
 services                 0         5
-
-
 ```
 
 ## More information

--- a/docs/design/admission_control_resource_quota.md
+++ b/docs/design/admission_control_resource_quota.md
@@ -201,21 +201,25 @@ kubectl is modified to support the **ResourceQuota** resource.
 For example,
 
 ```console
-$ kubectl namespace myspace
-$ kubectl create -f docs/user-guide/resourcequota/quota.yaml
-$ kubectl get quota
-NAME
-quota
-$ kubectl describe quota quota
-Name:                   quota
-Resource                Used    Hard
---------                ----    ----
-cpu                     0m      20
-memory                  0       1Gi
-pods                    5       10
-replicationcontrollers  5       20
-resourcequotas          1       1
-services                3       5
+$ kubectl create -f docs/user-guide/resourcequota/namespace.yaml
+namespace "quota-example" created
+$ kubectl create -f docs/user-guide/resourcequota/quota.yaml --namespace=quota-example
+resourcequota "quota" created
+$ kubectl describe quota quota --namespace=quota-example
+Name:                    quota
+Namespace:               quota-example
+Resource                 Used      Hard
+--------                 ----      ----
+cpu                      0         20
+memory                   0         1Gi
+persistentvolumeclaims   0         10
+pods                     0         10
+replicationcontrollers   0         20
+resourcequotas           1         1
+secrets                  1         10
+services                 0         5
+
+
 ```
 
 ## More information


### PR DESCRIPTION
Two modifications:

1, The example used in this document is outdated so update it
2, Delete the old `kubectl namespace myspace` since it produces an error `error: namespace has been superceded by the context.namespace field of .kubeconfig files`
