### PR TITLE
Fixed bug in NFS exporter run_nfs script

### DIFF
--- a/test/images/volumes-tester/gluster/run_gluster.sh
+++ b/test/images/volumes-tester/gluster/run_gluster.sh
@@ -33,7 +33,5 @@ trap stop TERM
 
 start "$@"
 
-while true; do
- read
-done
-
+tail -f /dev/null &
+wait

--- a/test/images/volumes-tester/iscsi/run_iscsid.sh
+++ b/test/images/volumes-tester/iscsi/run_iscsid.sh
@@ -36,6 +36,5 @@ function stop()
 trap stop TERM
 start
 
-while true; do
-    sleep 5
-done
+tail -f /dev/null &
+wait

--- a/test/images/volumes-tester/nfs/run_nfs.sh
+++ b/test/images/volumes-tester/nfs/run_nfs.sh
@@ -56,7 +56,5 @@ trap stop TERM
 
 start "$@"
 
-# Ugly hack to do nothing and wait for SIGTERM
-while true; do
-    read
-done
+tail -f /dev/null &
+wait

--- a/test/images/volumes-tester/rbd/bootstrap.sh
+++ b/test/images/volumes-tester/rbd/bootstrap.sh
@@ -41,7 +41,5 @@ rbd import block foo
 
 echo "Ceph is ready"
 
-# Wait forever
-while true; do
-    sleep 10
-done
+tail -f /dev/null &
+wait


### PR DESCRIPTION
I was noticing 100% CPU utilization when stdin was not attached. This
should fix that by blocking on a safer file descriptor.
