### PR TITLE
Plumb through configuration option to disable watch cache

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -107,6 +107,7 @@ type APIServer struct {
 	KubeletConfig              client.KubeletConfig
 	ClusterName                string
 	EnableProfiling            bool
+	EnableWatchCache           bool
 	MaxRequestsInFlight        int
 	MinRequestTimeout          int
 	LongRunningRequestRE       string
@@ -222,6 +223,8 @@ func (s *APIServer) AddFlags(fs *pflag.FlagSet) {
 	fs.Var(&s.RuntimeConfig, "runtime-config", "A set of key=value pairs that describe runtime configuration that may be passed to the apiserver. api/<version> key can be used to turn on/off specific api versions. api/all and api/legacy are special keys to control all and legacy api versions respectively.")
 	fs.StringVar(&s.ClusterName, "cluster-name", s.ClusterName, "The instance prefix for the cluster")
 	fs.BoolVar(&s.EnableProfiling, "profiling", true, "Enable profiling via web interface host:port/debug/pprof/")
+	// TODO: enable cache in integration tests.
+	fs.BoolVar(&s.EnableWatchCache, "watch-cache", true, "Enable watch caching in the apiserver")
 	fs.StringVar(&s.ExternalHost, "external-hostname", "", "The hostname to use when generating externalized URLs for this master (e.g. Swagger API Docs.)")
 	fs.IntVar(&s.MaxRequestsInFlight, "max-requests-inflight", 400, "The maximum number of requests in flight at a given time.  When the server exceeds this, it rejects requests.  Zero for no limit.")
 	fs.IntVar(&s.MinRequestTimeout, "min-request-timeout", 1800, "An optional field indicating the minimum number of seconds a handler must keep a request open before timing it out. Currently only honored by the watch request handler, which picks a randomized value above this number as the connection timeout, to spread out load.")
@@ -429,6 +432,7 @@ func (s *APIServer) Run(_ []string) error {
 		EnableUISupport:        true,
 		EnableSwaggerSupport:   true,
 		EnableProfiling:        s.EnableProfiling,
+		EnableWatchCache:       s.EnableWatchCache,
 		EnableIndex:            true,
 		APIPrefix:              s.APIPrefix,
 		ExpAPIPrefix:           s.ExpAPIPrefix,

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -248,6 +248,7 @@ update-period
 upgrade-target
 use-kubernetes-cluster-service
 user-whitelist
+watch-cache
 watch-only
 whitelist-override-label
 www-prefix

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -112,6 +112,7 @@ type Config struct {
 	// allow downstream consumers to disable the index route
 	EnableIndex           bool
 	EnableProfiling       bool
+	EnableWatchCache      bool
 	APIPrefix             string
 	ExpAPIPrefix          string
 	CorsAllowedOriginList []string
@@ -189,6 +190,7 @@ type Master struct {
 	enableUISupport       bool
 	enableSwaggerSupport  bool
 	enableProfiling       bool
+	enableWatchCache      bool
 	apiPrefix             string
 	expAPIPrefix          string
 	corsAllowedOriginList []string
@@ -344,6 +346,7 @@ func New(c *Config) *Master {
 		enableUISupport:       c.EnableUISupport,
 		enableSwaggerSupport:  c.EnableSwaggerSupport,
 		enableProfiling:       c.EnableProfiling,
+		enableWatchCache:      c.EnableWatchCache,
 		apiPrefix:             c.APIPrefix,
 		expAPIPrefix:          c.ExpAPIPrefix,
 		corsAllowedOriginList: c.CorsAllowedOriginList,
@@ -430,10 +433,9 @@ func logStackOnRecover(panicReason interface{}, httpWriter http.ResponseWriter) 
 
 // init initializes master.
 func (m *Master) init(c *Config) {
-	enableCacher := true
 	healthzChecks := []healthz.HealthzChecker{}
 	m.clock = util.RealClock{}
-	podStorage := podetcd.NewStorage(c.DatabaseStorage, enableCacher, c.KubeletClient)
+	podStorage := podetcd.NewStorage(c.DatabaseStorage, c.EnableWatchCache, c.KubeletClient)
 
 	podTemplateStorage := podtemplateetcd.NewREST(c.DatabaseStorage)
 
@@ -449,10 +451,10 @@ func (m *Master) init(c *Config) {
 	namespaceStorage, namespaceStatusStorage, namespaceFinalizeStorage := namespaceetcd.NewREST(c.DatabaseStorage)
 	m.namespaceRegistry = namespace.NewRegistry(namespaceStorage)
 
-	endpointsStorage := endpointsetcd.NewREST(c.DatabaseStorage, enableCacher)
+	endpointsStorage := endpointsetcd.NewREST(c.DatabaseStorage, c.EnableWatchCache)
 	m.endpointRegistry = endpoint.NewRegistry(endpointsStorage)
 
-	nodeStorage, nodeStatusStorage := nodeetcd.NewREST(c.DatabaseStorage, enableCacher, c.KubeletClient)
+	nodeStorage, nodeStatusStorage := nodeetcd.NewREST(c.DatabaseStorage, c.EnableWatchCache, c.KubeletClient)
 	m.nodeRegistry = minion.NewRegistry(nodeStorage)
 
 	serviceStorage := serviceetcd.NewREST(c.DatabaseStorage)


### PR DESCRIPTION
We are seeing anomolies on our load-balanced HA cluster relating to this change, so we would like to plumb through the option to disable.  

In general, I feel we should be doing this more often with new feature additions. 

/cc @wojtek-t 
