### PR TITLE
Fix docker-machine typo in daemon help

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -219,7 +219,7 @@ function kube::build::ensure_docker_daemon_connectivity {
       echo "Possible causes:"
       echo "  - On Mac OS X, DOCKER_HOST hasn't been set. You may need to: "
       echo "    - Create and start your VM using docker-machine or boot2docker: "
-      echo "      - docker-machine create -f <provider> kube-dev"
+      echo "      - docker-machine create -d <driver> kube-dev"
       echo "      - boot2docker init && boot2docker start"
       echo "    - Set your environment variables using: "
       echo "      - eval \$(docker-machine env kube-dev)"


### PR DESCRIPTION
I made a typo when updating the failure help for the build script. The docker-machine line should have '-d <driver>' instead of '-f <provider>'. This PR corrects that typo.

Shout out to @technosophos for bringing this typo to my attention.
