### PR TITLE
e2e: collect supervisord.log

### DIFF
--- a/test/e2e/core.go
+++ b/test/e2e/core.go
@@ -53,7 +53,7 @@ func CoreDump(dir string) {
 	cmds := []command{
 		{"cat /var/log/kubelet.log", "kubelet"},
 		{"cat /var/log/kube-proxy.log", "kube-proxy"},
-		{"cat /var/log/monit.log", "monit"},
+		{"cat /var/log/supervisor/supervisord.log", "supervisord"},
 	}
 	logCore(cmds, hosts, dir, provider)
 
@@ -69,7 +69,7 @@ func CoreDump(dir string) {
 		{"cat /var/log/kube-apiserver.log", "kube-apiserver"},
 		{"cat /var/log/kube-scheduler.log", "kube-scheduler"},
 		{"cat /var/log/kube-controller-manager.log", "kube-controller-manager"},
-		{"cat /var/log/monit.log", "monit"},
+		{"cat /var/log/supervisor/supervisord.log", "supervisord"},
 	}
 	logCore(cmds, []string{master}, dir, provider)
 }


### PR DESCRIPTION
monit has been replaced with supervisord. Collect its log instead.
