### PR TITLE
Recover panics in finishRequest, write correct API response

### DIFF
--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -17,7 +17,6 @@ limitations under the License.
 package master
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -26,7 +25,6 @@ import (
 	"net/http/pprof"
 	"net/url"
 	"os"
-	rt "runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -410,22 +408,8 @@ func (m *Master) HandleFuncWithAuth(pattern string, handler func(http.ResponseWr
 func NewHandlerContainer(mux *http.ServeMux) *restful.Container {
 	container := restful.NewContainer()
 	container.ServeMux = mux
-	container.RecoverHandler(logStackOnRecover)
+	apiserver.InstallRecoverHandler(container)
 	return container
-}
-
-//TODO: Unify with RecoverPanics?
-func logStackOnRecover(panicReason interface{}, httpWriter http.ResponseWriter) {
-	var buffer bytes.Buffer
-	buffer.WriteString(fmt.Sprintf("recover from panic situation: - %v\r\n", panicReason))
-	for i := 2; ; i += 1 {
-		_, file, line, ok := rt.Caller(i)
-		if !ok {
-			break
-		}
-		buffer.WriteString(fmt.Sprintf("    %s:%d\r\n", file, line))
-	}
-	glog.Errorln(buffer.String())
 }
 
 // init initializes master.

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -44,12 +44,16 @@ var ReallyCrash bool
 var PanicHandlers = []func(interface{}){logPanic}
 
 // HandleCrash simply catches a crash and logs an error. Meant to be called via defer.
-func HandleCrash() {
+// Additional context-specific handlers can be provided, and will be called in case of panic
+func HandleCrash(additionalHandlers ...func(interface{})) {
 	if ReallyCrash {
 		return
 	}
 	if r := recover(); r != nil {
 		for _, fn := range PanicHandlers {
+			fn(r)
+		}
+		for _, fn := range additionalHandlers {
 			fn(r)
 		}
 	}


### PR DESCRIPTION
Fixes #13319

Panics are not propagated between goroutines, so if a panic occurs inside finishRequest, the API server exits. To illustrate this, add a `panic("here")` call to a validate function, like `ValidatePod`, start the api server, and attempt to create any pod. The API server exits

This PR:
- Recovers panics inside finishRequest, handles them, and propagates the panic to the finishRequest caller
- Moves `logStackOnRecover` into the apiserver package where it can use the API error writing code
- Handles panics at the API-level by writing an internal server API response (instead of an empty response)
