### PR TITLE
Add Travis notifications to Slack channel.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,4 @@ script:
 
 notifications:
   irc: "chat.freenode.net#kubernetes-dev"
+  slack: kubernetes:PHPPkljtEsHXED6xl9IfOvKe


### PR DESCRIPTION
Should enable Travis to stream notifications about kubernetes project to Slack.
