### PR TITLE
Don't name 'eth0' in MASQUERADE rule

### DIFF
--- a/pkg/kubelet/container_bridge.go
+++ b/pkg/kubelet/container_bridge.go
@@ -121,13 +121,23 @@ func cbr0CidrCorrect(wantCIDR *net.IPNet) bool {
 // TODO(dawnchen): Using pkg/util/iptables
 func ensureIPTablesMasqRule() error {
 	// Check if the MASQUERADE rule exist or not
-	if err := exec.Command("iptables", "-t", "nat", "-C", "POSTROUTING", "-o", "eth0", "-j", "MASQUERADE", "!", "-d", "10.0.0.0/8").Run(); err == nil {
+	if err := exec.Command("iptables",
+		"-t", "nat",
+		"-C", "POSTROUTING",
+		"!", "-d", "10.0.0.0/8",
+		"-m", "addrtype", "!", "--dst-type", "LOCAL",
+		"-j", "MASQUERADE").Run(); err == nil {
 		// The MASQUERADE rule exists
 		return nil
 	}
 
 	glog.Infof("MASQUERADE rule doesn't exist, recreate it")
-	if err := exec.Command("iptables", "-t", "nat", "-A", "POSTROUTING", "-o", "eth0", "-j", "MASQUERADE", "!", "-d", "10.0.0.0/8").Run(); err != nil {
+	if err := exec.Command("iptables",
+		"-t", "nat",
+		"-A", "POSTROUTING",
+		"!", "-d", "10.0.0.0/8",
+		"-m", "addrtype", "!", "--dst-type", "LOCAL",
+		"-j", "MASQUERADE").Run(); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
This causes endless loops of adding duplicate rules on machines without "eth0".
