### PR TITLE
Bug fix for Elasticsearch Example

### DIFF
--- a/examples/elasticsearch/Makefile
+++ b/examples/elasticsearch/Makefile
@@ -1,6 +1,6 @@
 .PHONY: elasticsearch_discovery build push all
 
-TAG = 1.1
+TAG = 1.2
 
 build:	elasticsearch_discovery
 	docker build -t kubernetes/elasticsearch:$(TAG) .

--- a/examples/elasticsearch/README.md
+++ b/examples/elasticsearch/README.md
@@ -67,7 +67,7 @@ spec:
     spec:
       containers:
       - name: es
-        image: kubernetes/elasticsearch:1.1
+        image: kubernetes/elasticsearch:1.2
         env:
           - name: "CLUSTER_NAME"
             value: "mytunes-db"
@@ -126,7 +126,7 @@ Let's check to see if the replication controller and pods are running:
 ```console
 $ kubectl get rc,pods --namespace=mytunes
 CONTROLLER   CONTAINER(S)   IMAGE(S)                       SELECTOR        REPLICAS
-music-db     es             kubernetes/elasticsearch:1.1   name=music-db   4
+music-db     es             kubernetes/elasticsearch:1.2   name=music-db   4
 NAME             READY     STATUS    RESTARTS   AGE
 music-db-5p46b   1/1       Running   0          34s
 music-db-8re0f   1/1       Running   0          34s
@@ -199,7 +199,7 @@ music-db-8re0f   1/1       Running   0          7m
 music-db-eq8j0   1/1       Running   0          7m
 music-db-uq5px   1/1       Running   0          7m
 CONTROLLER   CONTAINER(S)   IMAGE(S)                       SELECTOR        REPLICAS
-music-db     es             kubernetes/elasticsearch:1.1   name=music-db   4
+music-db     es             kubernetes/elasticsearch:1.2   name=music-db   4
 NAME           LABELS          SELECTOR        IP(S)             PORT(S)
 music-server   name=music-db   name=music-db   10.0.185.179      9200/TCP
                                                104.197.114.130   

--- a/examples/elasticsearch/music-rc.yaml
+++ b/examples/elasticsearch/music-rc.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: es
-        image: kubernetes/elasticsearch:1.1
+        image: kubernetes/elasticsearch:1.2
         env:
           - name: "CLUSTER_NAME"
             value: "mytunes-db"

--- a/examples/elasticsearch/run.sh
+++ b/examples/elasticsearch/run.sh
@@ -18,8 +18,7 @@ export CLUSTER_NAME=${CLUSTER_NAME:-elasticsearch-default}
 export NODE_MASTER=${NODE_MASTER:-true}
 export NODE_DATA=${NODE_DATA:-true}
 export MULTICAST=${MULTICAST:-false}
-readonly TOKEN=$(cat /etc/apiserver-secret/token)
-/elasticsearch_discovery --namespace="${NAMESPACE}" --token="${TOKEN}" --selector="${SELECTOR}" >> /elasticsearch-1.5.2/config/elasticsearch.yml
+/elasticsearch_discovery --namespace="${NAMESPACE}" --selector="${SELECTOR}" >> /elasticsearch-1.5.2/config/elasticsearch.yml
 export HTTP_PORT=${HTTP_PORT:-9200}
 export TRANSPORT_PORT=${TRANSPORT_PORT:-9300}
 /elasticsearch-1.5.2/bin/elasticsearch


### PR DESCRIPTION
The `token` used previous to @satnam6502's kubernetes/kubernetes#12621 being merged is still used in `run.sh`. This causes `elasticsearch_discovery` to fail:

```
flag provided but not defined: -token
Usage of /elasticsearch_discovery:
  -alsologtostderr=false: log to standard error as well as files
  -log_backtrace_at=:0: when logging hits line file:N, emit a stack trace
  -log_dir="": If non-empty, write log files in this directory
  -logtostderr=false: log to standard error instead of files
  -namespace="default": The namespace containing Elasticsearch pods
  -selector="": Selector (label query) for selecting Elasticsearch pods
  -stderrthreshold=0: logs at or above this threshold go to stderr
  -v=0: log level for V logs
  -vmodule=: comma-separated list of pattern=N settings for file-filtered logging
```

The error leaves the unicast hosts in `/elasticsearch-1.5.2/config/elasticsearch.yml` empty which stops the Elasticsearch nodes from forming a cluster.

I've removed the token reference from `run.sh`, bumped the Dockerfile tag to `1.2`, and updated the config and readme to use the new version.
