### PR TITLE
MESOS: configure kube-proxy to run in mesos container instead of /kube-proxy

### DIFF
--- a/contrib/mesos/pkg/executor/config/config.go
+++ b/contrib/mesos/pkg/executor/config/config.go
@@ -26,5 +26,4 @@ const (
 	DefaultInfoSource     = "kubernetes"
 	DefaultInfoName       = "Kubelet-Executor"
 	DefaultSuicideTimeout = 20 * time.Minute
-	DefaultCgroupPrefix   = "mesos"
 )

--- a/contrib/mesos/pkg/executor/service/service.go
+++ b/contrib/mesos/pkg/executor/service/service.go
@@ -17,13 +17,11 @@ limitations under the License.
 package service
 
 import (
-	"fmt"
 	"io"
 	"math/rand"
 	"net"
 	"net/http"
 	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -63,33 +61,12 @@ type KubeletExecutorServer struct {
 	SuicideTimeout time.Duration
 	ShutdownFD     int
 	ShutdownFIFO   string
-	cgroupRoot     string
-	cgroupPrefix   string
-}
-
-func findMesosCgroup(prefix string) string {
-	// derive our cgroup from MESOS_DIRECTORY environment
-	mesosDir := os.Getenv("MESOS_DIRECTORY")
-	if mesosDir == "" {
-		log.V(2).Infof("cannot derive executor's cgroup because MESOS_DIRECTORY is empty")
-		return ""
-	}
-
-	containerId := path.Base(mesosDir)
-	if containerId == "" {
-		log.V(2).Infof("cannot derive executor's cgroup from MESOS_DIRECTORY=%q", mesosDir)
-		return ""
-	}
-	trimmedPrefix := strings.Trim(prefix, "/")
-	cgroupRoot := fmt.Sprintf("/%s/%v", trimmedPrefix, containerId)
-	return cgroupRoot
 }
 
 func NewKubeletExecutorServer() *KubeletExecutorServer {
 	k := &KubeletExecutorServer{
 		KubeletServer:  app.NewKubeletServer(),
 		SuicideTimeout: config.DefaultSuicideTimeout,
-		cgroupPrefix:   config.DefaultCgroupPrefix,
 	}
 	if pwd, err := os.Getwd(); err != nil {
 		log.Warningf("failed to determine current directory: %v", err)
@@ -107,7 +84,6 @@ func (s *KubeletExecutorServer) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&s.SuicideTimeout, "suicide-timeout", s.SuicideTimeout, "Self-terminate after this period of inactivity. Zero disables suicide watch.")
 	fs.IntVar(&s.ShutdownFD, "shutdown-fd", s.ShutdownFD, "File descriptor used to signal shutdown to external watchers, requires shutdown-fifo flag")
 	fs.StringVar(&s.ShutdownFIFO, "shutdown-fifo", s.ShutdownFIFO, "FIFO used to signal shutdown to external watchers, requires shutdown-fd flag")
-	fs.StringVar(&s.cgroupPrefix, "cgroup-prefix", s.cgroupPrefix, "The cgroup prefix concatenated with MESOS_DIRECTORY must give the executor cgroup set by Mesos")
 }
 
 // returns a Closer that should be closed to signal impending shutdown, but only if ShutdownFD
@@ -131,20 +107,10 @@ func (s *KubeletExecutorServer) Run(hks hyperkube.Interface, _ []string) error {
 		log.Info(err)
 	}
 
-	// derive the executor cgroup and use it as docker container cgroup root
-	mesosCgroup := findMesosCgroup(s.cgroupPrefix)
-	s.cgroupRoot = mesosCgroup
-	log.V(2).Infof("passing cgroup %q to the kubelet as cgroup root", s.CgroupRoot)
-
 	// empty string for the docker and system containers (= cgroup paths). This
 	// stops the kubelet taking any control over other system processes.
 	s.SystemContainer = ""
 	s.DockerDaemonContainer = ""
-
-	// We set kubelet container to its own cgroup below the executor cgroup.
-	// In contrast to the docker and system container, this has no other
-	// undesired side-effects.
-	s.ResourceContainer = mesosCgroup + "/kubelet"
 
 	// create apiserver client
 	var apiclient *client.Client
@@ -253,7 +219,7 @@ func (s *KubeletExecutorServer) Run(hks hyperkube.Interface, _ []string) error {
 		Cloud:                          nil, // TODO(jdef) Cloud, specifying null here because we don't want all kubelets polling mesos-master; need to account for this in the cloudprovider impl
 		NodeStatusUpdateFrequency: s.NodeStatusUpdateFrequency,
 		ResourceContainer:         s.ResourceContainer,
-		CgroupRoot:                s.cgroupRoot,
+		CgroupRoot:                s.CgroupRoot,
 		ContainerRuntime:          s.ContainerRuntime,
 		Mounter:                   mounter,
 		DockerDaemonContainer:     s.DockerDaemonContainer,

--- a/contrib/mesos/pkg/minion/config/config.go
+++ b/contrib/mesos/pkg/minion/config/config.go
@@ -23,6 +23,8 @@ import (
 const (
 	DefaultLogMaxBackups   = 5 // how many backup to keep
 	DefaultLogMaxAgeInDays = 7 // after how many days to rotate at most
+
+	DefaultCgroupPrefix = "mesos"
 )
 
 // DefaultLogMaxSize returns the maximal log file size before rotation

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -28,7 +28,6 @@ bind-pods-qps
 cadvisor-port
 cert-dir
 certificate-authority
-cgroup-prefix
 cgroup-root
 chaos-chance
 cleanup-iptables
@@ -74,7 +73,6 @@ etcd-server
 etcd-servers
 event-ttl
 executor-bindall
-executor-cgroup-prefix
 executor-logv
 executor-path
 executor-suicide-timeout
@@ -152,6 +150,7 @@ max-requests-inflight
 mesos-authentication-principal
 mesos-authentication-provider
 mesos-authentication-secret-file
+mesos-cgroup-prefix
 mesos-master
 mesos-role
 mesos-user


### PR DESCRIPTION
- moved cgroup-root detection to minion service
- kube proxy now configured to run in mesos container

xref https://github.com/mesosphere/kubernetes-mesos/issues/462
