### PR TITLE
Adding error message for openstack initialization

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -104,6 +104,7 @@ func init() {
 	cloudprovider.RegisterCloudProvider(ProviderName, func(config io.Reader) (cloudprovider.Interface, error) {
 		cfg, err := readConfig(config)
 		if err != nil {
+			glog.Errorf("Failed to initialize openstack cloudprovider: %s", err)
 			return nil, err
 		}
 		return newOpenStack(cfg)


### PR DESCRIPTION
We do not show any error message and just through a panic when we have an error during openstack initialization in kubelet/kube-apiserver. 

http://stackoverflow.com/questions/32226108/kubernetes-openstack-integration

This message would help us better during debugging.
