### PR TITLE
Fix inconsistency path in GOPATH doc

### DIFF
--- a/docs/devel/development.md
+++ b/docs/devel/development.md
@@ -168,7 +168,7 @@ export GOPATH=$KPATH
 3) Populate your new GOPATH.
 
 ```sh
-cd $KPATH/src/github.com/kubernetes/kubernetes
+cd $KPATH/src/k8s.io/kubernetes
 godep restore
 ```
 


### PR DESCRIPTION
we set up $KPATH/src/k8s.io/kubernetes directory, but ask user to `cd` into $KPATH/src/github.com/kubernetes

Close this if I misunderstood.
