### PR TITLE
Updates fedora flannel guide to remove setting caps on ping explicitly.

### DIFF
--- a/docs/getting-started-guides/fedora/flannel_multi_node_cluster.md
+++ b/docs/getting-started-guides/fedora/flannel_multi_node_cluster.md
@@ -181,11 +181,10 @@ FLANNEL_IPMASQ=false
 bash-4.3# 
 ```
 
-* This will place you inside the container. Install iproute and iputils packages to install ip and ping utilities. Due to a [bug](https://bugzilla.redhat.com/show_bug.cgi?id=1142311), it is required to modify capabilities of ping binary to work around "Operation not permitted" error.
+* This will place you inside the container. Install iproute and iputils packages to install ip and ping utilities.
 
 ```console
 bash-4.3# yum -y install iproute iputils
-bash-4.3# setcap cap_net_raw-ep /usr/bin/ping
 ```
 
 * Now note the IP address on the first node:


### PR DESCRIPTION
Updates fedora flannel guide to remove setting caps on ping explicitly as was required due to the bug (rhbz 1142311). But the bug has been fixed and that is not needed any more.
