### PR TITLE
Edit the community, discussion, and support section of the Kubernetes README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <hr>
 
-Kubernetes is an open source system for managing [containerized applications](https://github.com/GoogleCloudPlatform/kubernetes/wiki/Why-Kubernetes%3F#why-containers) across multiple hosts,
+Kubernetes is an open source system for managing [containerized applications](https://github.com/kubernetes/kubernetes/wiki/Why-Kubernetes%3F#why-containers) across multiple hosts,
 providing basic mechanisms for deployment, maintenance, and scaling of applications.
 
 Kubernetes is:
@@ -26,7 +26,7 @@ Kubernetes builds upon a [decade and a half of experience at Google running prod
 However, initial development was done on GCE and so our instructions and scripts are built around that.  If you make it work on other infrastructure please let us know and contribute instructions/code.
 
 ### Kubernetes is ready for Production!
-With the [1.0.1 release](https://github.com/GoogleCloudPlatform/kubernetes/releases/tag/v1.0.1) Kubernetes is ready to serve your production workloads.
+With the [1.0.1 release](https://github.com/kubernetes/kubernetes/releases/tag/v1.0.1) Kubernetes is ready to serve your production workloads.
 
 
 ## Concepts
@@ -64,10 +64,11 @@ Kubernetes documentation is organized into several categories.
       - in [Getting Started from Scratch](docs/getting-started-guides/scratch.md)
   - **User documentation**
     - for people who want to run programs on an existing Kubernetes cluster
-    - in the [Kubernetes User Guide: Managing Applications](docs/user-guide/README.md)
+    - in the [Kubernetes User Guide: Managing Applications](docs/user-guide/README.md)  
+	*Tip: You can also view help documentation out on [http://kubernetes.io/docs/](http://kubernetes.io/docs/).*
     - the [Kubectl Command Line Interface](docs/user-guide/kubectl/kubectl.md) is a detailed reference on
       the `kubectl` CLI
-    - [User FAQ](https://github.com/GoogleCloudPlatform/kubernetes/wiki/User-FAQ)
+    - [User FAQ](https://github.com/kubernetes/kubernetes/wiki/User-FAQ)
   - **Cluster administrator documentation**
     - for people who want to create a Kubernetes cluster and administer it
     - in the [Kubernetes Cluster Admin Guide](docs/admin/README.md)
@@ -89,17 +90,43 @@ Kubernetes documentation is organized into several categories.
     - design docs in the [Kubernetes Design Overview](docs/design/README.md) and the [docs/design directory](docs/design/)
     - proposals in the [docs/proposals directory](docs/proposals/)
   - **Wiki/FAQ**
-    - in the [wiki](https://github.com/GoogleCloudPlatform/kubernetes/wiki)
+    - in the [wiki](https://github.com/kubernetes/kubernetes/wiki)
     - troubleshooting information in the [troubleshooting guide](docs/troubleshooting.md)
 
-## Community, discussion and support
+## Community, discussion, contribution, and support
 
-If you have questions or want to start contributing please reach out.  We don't bite!
+See which companies are committed to driving quality in Kubernetes on our [community page](http://kubernetes.io/community/).
 
-Please see the [troubleshooting guide](docs/troubleshooting.md), or how to [get more help.](docs/troubleshooting.md#getting-help)
+Do you want to help "shape the evolution of technologies that are container packaged, dynamically scheduled and microservices oriented?"
 
-If you are a company and are looking for a more formal engagement with Google around Kubernetes and containers at Google as a whole, please fill out [this form](https://docs.google.com/a/google.com/forms/d/1_RfwC8LZU4CKe4vKq32x5xpEJI5QZ-j0ShGmZVv9cm4/viewform) and we'll be in touch.
+You should consider joining the [Cloud Native Computing Foundation](https://cncf.io/about). For details about who's involved and how Kubernetes plays a role, read [their announcement](https://cncf.io/news/announcement/2015/07/new-cloud-native-computing-foundation-drive-alignment-among-container).
 
+#### Are you ready to add to the discussion?
+
+We have presence on:
+
+ * [Twitter](https://twitter.com/kubernetesio)
+ * [Google+](https://plus.google.com/u/0/b/116512812300813784482/116512812300813784482)
+ * [Blogger](http://blog.kubernetes.io/)
+ 
+You can also view recordings of past events and presentations on our [Media page](http://kubernetes.io/media/).
+
+For Q&A, our threads are at:
+
+ * [Stack Overflow](http://stackoverflow.com/questions/tagged/kubernetes)
+ * [BotBot.me (IRC)](https://botbot.me/freenode/google-containers/)
+
+#### Want to do more than just 'discuss' Kubernetes?
+
+If you're interested in being a contributor and want to get involved in developing Kubernetes, start in the [Kubernetes Developer Guide](docs/devel/README.md) and also review the [contributor guidelines](CONTRIBUTING.md).
+
+#### Support
+ 
+While there are many different channels that you can use to get ahold of us, you can help make sure that we are efficient in getting you the help that you need.
+
+If you need support, start with the [troubleshooting guide](docs/troubleshooting.md#getting-help) and work your way through the process that we've outlined.
+
+That said, if you have questions, reach out to us one way or another.  We don't bite!
 
 
 [![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/README.md?pixel)]()


### PR DESCRIPTION
- add link to community page and cloud native computing foundation (replaces content removed in #13393)
- replace urls to GoogleCloudPlatform with: kubernetes
