### PR TITLE
Enable kubectl rolling-update rc name bash completion

### DIFF
--- a/contrib/completions/bash/kubectl
+++ b/contrib/completions/bash/kubectl
@@ -186,6 +186,11 @@ __kubectl_get_resource_pod()
     __kubectl_parse_get "pod"
 }
 
+__kubectl_get_resource_rc()
+{
+    __kubectl_parse_get "rc"
+}
+
 # $1 is the name of the pod we want to get the list of containers inside
 __kubectl_get_containers()
 {
@@ -227,6 +232,10 @@ __custom_func() {
             ;;
         kubectl_exec)
             __kubectl_get_resource_pod
+            return
+            ;;
+        kubectl_rolling-update)
+            __kubectl_get_resource_rc
             return
             ;;
         *)

--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -52,6 +52,11 @@ __kubectl_get_resource_pod()
     __kubectl_parse_get "pod"
 }
 
+__kubectl_get_resource_rc()
+{
+    __kubectl_parse_get "rc"
+}
+
 # $1 is the name of the pod we want to get the list of containers inside
 __kubectl_get_containers()
 {
@@ -93,6 +98,10 @@ __custom_func() {
             ;;
         kubectl_exec)
             __kubectl_get_resource_pod
+            return
+            ;;
+        kubectl_rolling-update)
+            __kubectl_get_resource_rc
             return
             ;;
         *)


### PR DESCRIPTION
Partially fixes - #11310 

List all rc names when you type:
`kubectl rolling-update (--image=NEW_CONTAINER_IMAGE | -f NEW_CONTROLLER_SPEC) [tab][tab]`

cc @eparis 
