### PR TITLE
MESOS: Add --contain-pod-resources flag to determine how k8s-mesos will contain pod resources

### DIFF
--- a/contrib/mesos/pkg/scheduler/mock_test.go
+++ b/contrib/mesos/pkg/scheduler/mock_test.go
@@ -42,11 +42,11 @@ func (m *MockScheduler) slaveFor(id string) (slave *Slave, ok bool) {
 	ok = args.Bool(1)
 	return
 }
-func (m *MockScheduler) algorithm() (f PodScheduleFunc) {
+func (m *MockScheduler) algorithm() (f PodScheduler) {
 	args := m.Called()
 	x := args.Get(0)
 	if x != nil {
-		f = x.(PodScheduleFunc)
+		f = x.(PodScheduler)
 	}
 	return
 }

--- a/contrib/mesos/pkg/scheduler/plugin.go
+++ b/contrib/mesos/pkg/scheduler/plugin.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/kubernetes/contrib/mesos/pkg/runtime"
 	annotation "k8s.io/kubernetes/contrib/mesos/pkg/scheduler/meta"
 	"k8s.io/kubernetes/contrib/mesos/pkg/scheduler/podtask"
-	mresource "k8s.io/kubernetes/contrib/mesos/pkg/scheduler/resource"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
@@ -56,8 +55,9 @@ const (
 // scheduler abstraction to allow for easier unit testing
 type schedulerInterface interface {
 	sync.Locker // synchronize scheduler plugin operations
+
 	SlaveIndex
-	algorithm() PodScheduleFunc // see types.go
+	algorithm() PodScheduler
 	offers() offers.Registry
 	tasks() podtask.Registry
 
@@ -76,8 +76,8 @@ type k8smScheduler struct {
 	internal *KubernetesScheduler
 }
 
-func (k *k8smScheduler) algorithm() PodScheduleFunc {
-	return k.internal.scheduleFunc
+func (k *k8smScheduler) algorithm() PodScheduler {
+	return k.internal
 }
 
 func (k *k8smScheduler) offers() offers.Registry {
@@ -231,10 +231,8 @@ func (b *binder) prepareTaskForLaunch(ctx api.Context, machine string, task *pod
 }
 
 type kubeScheduler struct {
-	api                      schedulerInterface
-	podUpdates               queue.FIFO
-	defaultContainerCPULimit mresource.CPUShares
-	defaultContainerMemLimit mresource.MegaBytes
+	api        schedulerInterface
+	podUpdates queue.FIFO
 }
 
 // recoverAssignedSlave recovers the assigned Mesos slave from a pod by searching
@@ -318,7 +316,7 @@ func (k *kubeScheduler) doSchedule(task *podtask.T, err error) (string, error) {
 		}
 	}
 	if err == nil && offer == nil {
-		offer, err = k.api.algorithm()(k.api.offers(), k.api, task)
+		offer, err = k.api.algorithm().SchedulePod(k.api.offers(), k.api, task)
 	}
 	if err != nil {
 		return "", err
@@ -338,18 +336,8 @@ func (k *kubeScheduler) doSchedule(task *podtask.T, err error) (string, error) {
 			return "", fmt.Errorf("task.offer assignment must be idempotent, task %+v: offer %+v", task, offer)
 		}
 
-		// write resource limits into the pod spec which is transferred to the executor. From here
-		// on we can expect that the pod spec of a task has proper limits for CPU and memory.
-		// TODO(sttts): For a later separation of the kubelet and the executor also patch the pod on the apiserver
-		if unlimitedCPU := mresource.LimitPodCPU(&task.Pod, k.defaultContainerCPULimit); unlimitedCPU {
-			log.Warningf("Pod %s/%s without cpu limits is admitted %.2f cpu shares", task.Pod.Namespace, task.Pod.Name, mresource.PodCPULimit(&task.Pod))
-		}
-		if unlimitedMem := mresource.LimitPodMem(&task.Pod, k.defaultContainerMemLimit); unlimitedMem {
-			log.Warningf("Pod %s/%s without memory limits is admitted %.2f MB", task.Pod.Namespace, task.Pod.Name, mresource.PodMemLimit(&task.Pod))
-		}
-
 		task.Offer = offer
-		task.FillFromDetails(details)
+		k.api.algorithm().Procurement()(task, details) // TODO(jdef) why is nothing checking the error returned here?
 
 		if err := k.api.tasks().Update(task); err != nil {
 			offer.Release()
@@ -556,7 +544,7 @@ func (k *errorHandler) handleSchedulingError(pod *api.Pod, schedulingErr error) 
 				defer k.api.Unlock()
 				switch task, state := k.api.tasks().Get(task.ID); state {
 				case podtask.StatePending:
-					return !task.Has(podtask.Launched) && task.AcceptOffer(offer)
+					return !task.Has(podtask.Launched) && k.api.algorithm().FitPredicate()(task, offer)
 				default:
 					// no point in continuing to check for matching offers
 					return true
@@ -698,10 +686,8 @@ func (k *KubernetesScheduler) NewPluginConfig(terminate <-chan struct{}, mux *ht
 		Config: &plugin.Config{
 			MinionLister: nil,
 			Algorithm: &kubeScheduler{
-				api:                      kapi,
-				podUpdates:               podUpdates,
-				defaultContainerCPULimit: k.defaultContainerCPULimit,
-				defaultContainerMemLimit: k.defaultContainerMemLimit,
+				api:        kapi,
+				podUpdates: podUpdates,
 			},
 			Binder:   &binder{api: kapi},
 			NextPod:  q.yield,

--- a/contrib/mesos/pkg/scheduler/plugin_test.go
+++ b/contrib/mesos/pkg/scheduler/plugin_test.go
@@ -393,13 +393,14 @@ func TestPlugin_LifeCycle(t *testing.T) {
 	executor.Data = []byte{0, 1, 2}
 
 	// create scheduler
+	as := NewAllocationStrategy(
+		podtask.DefaultPredicate,
+		podtask.NewDefaultProcurement(mresource.DefaultDefaultContainerCPULimit, mresource.DefaultDefaultContainerMemLimit))
 	testScheduler := New(Config{
-		Executor:                 executor,
-		Client:                   client.NewOrDie(&client.Config{Host: testApiServer.server.URL, Version: testapi.Version()}),
-		ScheduleFunc:             FCFSScheduleFunc,
-		Schedcfg:                 *schedcfg.CreateDefaultConfig(),
-		DefaultContainerCPULimit: mresource.DefaultDefaultContainerCPULimit,
-		DefaultContainerMemLimit: mresource.DefaultDefaultContainerMemLimit,
+		Executor:  executor,
+		Client:    client.NewOrDie(&client.Config{Host: testApiServer.server.URL, Version: testapi.Version()}),
+		Scheduler: NewFCFSPodScheduler(as),
+		Schedcfg:  *schedcfg.CreateDefaultConfig(),
 	})
 
 	assert.NotNil(testScheduler.client, "client is nil")

--- a/contrib/mesos/pkg/scheduler/podtask/minimal.go
+++ b/contrib/mesos/pkg/scheduler/podtask/minimal.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podtask
+
+import (
+	log "github.com/golang/glog"
+	mesos "github.com/mesos/mesos-go/mesosproto"
+)
+
+// bogus numbers that we use to make sure that there's some set of minimal offered resources on the slave
+const (
+	minimalCpus = 0.01
+	minimalMem  = 0.25
+)
+
+var (
+	DefaultMinimalPredicate = RequireAllPredicate([]FitPredicate{
+		ValidationPredicate,
+		NodeSelectorPredicate,
+		MinimalPodResourcesPredicate,
+		PortsPredicate,
+	}).Fit
+
+	DefaultMinimalProcurement = AllOrNothingProcurement([]Procurement{
+		ValidateProcurement,
+		NodeProcurement,
+		MinimalPodResourcesProcurement,
+		PortsProcurement,
+	}).Procure
+)
+
+func MinimalPodResourcesPredicate(t *T, offer *mesos.Offer) bool {
+	var (
+		offeredCpus float64
+		offeredMem  float64
+	)
+	for _, resource := range offer.Resources {
+		if resource.GetName() == "cpus" {
+			offeredCpus = resource.GetScalar().GetValue()
+		}
+
+		if resource.GetName() == "mem" {
+			offeredMem = resource.GetScalar().GetValue()
+		}
+	}
+	log.V(4).Infof("trying to match offer with pod %v/%v: cpus: %.2f mem: %.2f MB", t.Pod.Namespace, t.Pod.Name, minimalCpus, minimalMem)
+	if (minimalCpus > offeredCpus) || (minimalMem > offeredMem) {
+		log.V(3).Infof("not enough resources for pod %v/%v: cpus: %.2f mem: %.2f MB", t.Pod.Namespace, t.Pod.Name, minimalCpus, minimalMem)
+		return false
+	}
+	return true
+}
+
+func MinimalPodResourcesProcurement(t *T, details *mesos.Offer) error {
+	log.V(3).Infof("Recording offer(s) %s/%s against pod %v: cpu: %.2f, mem: %.2f MB", details.Id, t.Pod.Namespace, t.Pod.Name, minimalCpus, minimalMem)
+	t.Spec.CPU = minimalCpus
+	t.Spec.Memory = minimalMem
+	return nil
+}

--- a/contrib/mesos/pkg/scheduler/podtask/pod_task_test.go
+++ b/contrib/mesos/pkg/scheduler/podtask/pod_task_test.go
@@ -146,10 +146,10 @@ func TestEmptyOffer(t *testing.T) {
 	mresource.LimitPodCPU(&task.Pod, mresource.DefaultDefaultContainerCPULimit)
 	mresource.LimitPodMem(&task.Pod, mresource.DefaultDefaultContainerMemLimit)
 
-	if ok := task.AcceptOffer(nil); ok {
+	if ok := DefaultPredicate(task, nil); ok {
 		t.Fatalf("accepted nil offer")
 	}
-	if ok := task.AcceptOffer(&mesos.Offer{}); ok {
+	if ok := DefaultPredicate(task, &mesos.Offer{}); ok {
 		t.Fatalf("accepted empty offer")
 	}
 }
@@ -176,7 +176,7 @@ func TestNoPortsInPodOrOffer(t *testing.T) {
 			mutil.NewScalarResource("mem", 0.001),
 		},
 	}
-	if ok := task.AcceptOffer(offer); ok {
+	if ok := DefaultPredicate(task, offer); ok {
 		t.Fatalf("accepted offer %v:", offer)
 	}
 
@@ -186,7 +186,7 @@ func TestNoPortsInPodOrOffer(t *testing.T) {
 			mutil.NewScalarResource("mem", t_min_mem),
 		},
 	}
-	if ok := task.AcceptOffer(offer); !ok {
+	if ok := DefaultPredicate(task, offer); !ok {
 		t.Fatalf("did not accepted offer %v:", offer)
 	}
 }
@@ -203,7 +203,7 @@ func TestAcceptOfferPorts(t *testing.T) {
 			rangeResource("ports", []uint64{1, 1}),
 		},
 	}
-	if ok := task.AcceptOffer(offer); !ok {
+	if ok := DefaultPredicate(task, offer); !ok {
 		t.Fatalf("did not accepted offer %v:", offer)
 	}
 
@@ -218,17 +218,17 @@ func TestAcceptOfferPorts(t *testing.T) {
 	mresource.LimitPodCPU(&task.Pod, mresource.DefaultDefaultContainerCPULimit)
 	mresource.LimitPodMem(&task.Pod, mresource.DefaultDefaultContainerMemLimit)
 
-	if ok := task.AcceptOffer(offer); ok {
+	if ok := DefaultPredicate(task, offer); ok {
 		t.Fatalf("accepted offer %v:", offer)
 	}
 
 	pod.Spec.Containers[0].Ports[0].HostPort = 1
-	if ok := task.AcceptOffer(offer); !ok {
+	if ok := DefaultPredicate(task, offer); !ok {
 		t.Fatalf("did not accepted offer %v:", offer)
 	}
 
 	pod.Spec.Containers[0].Ports[0].HostPort = 0
-	if ok := task.AcceptOffer(offer); !ok {
+	if ok := DefaultPredicate(task, offer); !ok {
 		t.Fatalf("did not accepted offer %v:", offer)
 	}
 
@@ -236,12 +236,12 @@ func TestAcceptOfferPorts(t *testing.T) {
 		mutil.NewScalarResource("cpus", t_min_cpu),
 		mutil.NewScalarResource("mem", t_min_mem),
 	}
-	if ok := task.AcceptOffer(offer); ok {
+	if ok := DefaultPredicate(task, offer); ok {
 		t.Fatalf("accepted offer %v:", offer)
 	}
 
 	pod.Spec.Containers[0].Ports[0].HostPort = 1
-	if ok := task.AcceptOffer(offer); ok {
+	if ok := DefaultPredicate(task, offer); ok {
 		t.Fatalf("accepted offer %v:", offer)
 	}
 }
@@ -297,7 +297,7 @@ func TestNodeSelector(t *testing.T) {
 			},
 			Attributes: ts.attrs,
 		}
-		if got, want := task.AcceptOffer(offer), ts.ok; got != want {
+		if got, want := DefaultPredicate(task, offer), ts.ok; got != want {
 			t.Fatalf("expected acceptance of offer %v for selector %v to be %v, got %v:", want, got, ts.attrs, ts.selector)
 		}
 	}

--- a/contrib/mesos/pkg/scheduler/podtask/predicate.go
+++ b/contrib/mesos/pkg/scheduler/podtask/predicate.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podtask
+
+import (
+	log "github.com/golang/glog"
+	mesos "github.com/mesos/mesos-go/mesosproto"
+	mresource "k8s.io/kubernetes/contrib/mesos/pkg/scheduler/resource"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+var DefaultPredicate = RequireAllPredicate([]FitPredicate{
+	ValidationPredicate,
+	NodeSelectorPredicate,
+	PodFitsResourcesPredicate,
+	PortsPredicate,
+}).Fit
+
+// FitPredicate implementations determine if the given task "fits" into offered Mesos resources.
+// Neither the task or offer should be modified.
+type FitPredicate func(*T, *mesos.Offer) bool
+
+type RequireAllPredicate []FitPredicate
+
+func (f RequireAllPredicate) Fit(t *T, offer *mesos.Offer) bool {
+	for _, p := range f {
+		if !p(t, offer) {
+			return false
+		}
+	}
+	return true
+}
+
+func ValidationPredicate(t *T, offer *mesos.Offer) bool {
+	return t != nil && offer != nil
+}
+
+func NodeSelectorPredicate(t *T, offer *mesos.Offer) bool {
+	// if the user has specified a target host, make sure this offer is for that host
+	if t.Pod.Spec.NodeName != "" && offer.GetHostname() != t.Pod.Spec.NodeName {
+		return false
+	}
+
+	// check the NodeSelector
+	if len(t.Pod.Spec.NodeSelector) > 0 {
+		slaveLabels := map[string]string{}
+		for _, a := range offer.Attributes {
+			if a.GetType() == mesos.Value_TEXT {
+				slaveLabels[a.GetName()] = a.GetText().GetValue()
+			}
+		}
+		selector := labels.SelectorFromSet(t.Pod.Spec.NodeSelector)
+		if !selector.Matches(labels.Set(slaveLabels)) {
+			return false
+		}
+	}
+	return true
+}
+
+func PortsPredicate(t *T, offer *mesos.Offer) bool {
+	// check ports
+	if _, err := t.mapper.Generate(t, offer); err != nil {
+		log.V(3).Info(err)
+		return false
+	}
+	return true
+}
+
+func PodFitsResourcesPredicate(t *T, offer *mesos.Offer) bool {
+	// find offered cpu and mem
+	var (
+		offeredCpus mresource.CPUShares
+		offeredMem  mresource.MegaBytes
+	)
+	for _, resource := range offer.Resources {
+		if resource.GetName() == "cpus" {
+			offeredCpus = mresource.CPUShares(*resource.GetScalar().Value)
+		}
+
+		if resource.GetName() == "mem" {
+			offeredMem = mresource.MegaBytes(*resource.GetScalar().Value)
+		}
+	}
+
+	// calculate cpu and mem sum over all containers of the pod
+	// TODO (@sttts): also support pod.spec.resources.limit.request
+	// TODO (@sttts): take into account the executor resources
+	cpu := mresource.PodCPULimit(&t.Pod)
+	mem := mresource.PodMemLimit(&t.Pod)
+	log.V(4).Infof("trying to match offer with pod %v/%v: cpus: %.2f mem: %.2f MB", t.Pod.Namespace, t.Pod.Name, cpu, mem)
+	if (cpu > offeredCpus) || (mem > offeredMem) {
+		log.V(3).Infof("not enough resources for pod %v/%v: cpus: %.2f mem: %.2f MB", t.Pod.Namespace, t.Pod.Name, cpu, mem)
+		return false
+	}
+	return true
+}

--- a/contrib/mesos/pkg/scheduler/podtask/procurement.go
+++ b/contrib/mesos/pkg/scheduler/podtask/procurement.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podtask
+
+import (
+	"strings"
+
+	log "github.com/golang/glog"
+	mesos "github.com/mesos/mesos-go/mesosproto"
+	mresource "k8s.io/kubernetes/contrib/mesos/pkg/scheduler/resource"
+)
+
+// NewDefaultProcurement returns the default procurement strategy that combines validation
+// and responsible Mesos resource procurement. c and m are resource quantities written into
+// k8s api.Pod.Spec's that don't declare resources (all containers in k8s-mesos require cpu
+// and memory limits).
+func NewDefaultProcurement(c mresource.CPUShares, m mresource.MegaBytes) Procurement {
+	requireSome := &RequireSomePodResources{
+		defaultContainerCPULimit: c,
+		defaultContainerMemLimit: m,
+	}
+	return AllOrNothingProcurement([]Procurement{
+		ValidateProcurement,
+		NodeProcurement,
+		requireSome.Procure,
+		PodResourcesProcurement,
+		PortsProcurement,
+	}).Procure
+}
+
+// Procurement funcs allocate resources for a task from an offer.
+// Both the task and/or offer may be modified.
+type Procurement func(*T, *mesos.Offer) error
+
+// AllOrNothingProcurement provides a convenient wrapper around multiple Procurement
+// objectives: the failure of any Procurement in the set results in Procure failing.
+// see AllOrNothingProcurement.Procure
+type AllOrNothingProcurement []Procurement
+
+// Procure runs each Procurement in the receiver list. The first Procurement func that
+// fails triggers T.Reset() and the error is returned, otherwise returns nil.
+func (a AllOrNothingProcurement) Procure(t *T, offer *mesos.Offer) error {
+	for _, p := range a {
+		if err := p(t, offer); err != nil {
+			t.Reset()
+			return err
+		}
+	}
+	return nil
+}
+
+// ValidateProcurement checks that the offered resources are kosher, and if not panics.
+// If things check out ok, t.Spec is cleared and nil is returned.
+func ValidateProcurement(t *T, offer *mesos.Offer) error {
+	if offer == nil {
+		//programming error
+		panic("offer details are nil")
+	}
+	t.Spec = Spec{}
+	return nil
+}
+
+// NodeProcurement updates t.Spec in preparation for the task to be launched on the
+// slave associated with the offer.
+func NodeProcurement(t *T, offer *mesos.Offer) error {
+	t.Spec.SlaveID = offer.GetSlaveId().GetValue()
+	t.Spec.AssignedSlave = offer.GetHostname()
+
+	// hostname needs of the executor needs to match that of the offer, otherwise
+	// the kubelet node status checker/updater is very unhappy
+	const HOSTNAME_OVERRIDE_FLAG = "--hostname-override="
+	hostname := offer.GetHostname() // required field, non-empty
+	hostnameOverride := HOSTNAME_OVERRIDE_FLAG + hostname
+
+	argv := t.executor.Command.Arguments
+	overwrite := false
+	for i, arg := range argv {
+		if strings.HasPrefix(arg, HOSTNAME_OVERRIDE_FLAG) {
+			overwrite = true
+			argv[i] = hostnameOverride
+			break
+		}
+	}
+	if !overwrite {
+		t.executor.Command.Arguments = append(argv, hostnameOverride)
+	}
+	return nil
+}
+
+type RequireSomePodResources struct {
+	defaultContainerCPULimit mresource.CPUShares
+	defaultContainerMemLimit mresource.MegaBytes
+}
+
+func (r *RequireSomePodResources) Procure(t *T, offer *mesos.Offer) error {
+	// write resource limits into the pod spec which is transferred to the executor. From here
+	// on we can expect that the pod spec of a task has proper limits for CPU and memory.
+	// TODO(sttts): For a later separation of the kubelet and the executor also patch the pod on the apiserver
+	// TODO(jdef): changing the state of t.Pod here feels dirty, especially since we don't use a kosher
+	// method to clone the api.Pod state in T.Clone(). This needs some love.
+	if unlimitedCPU := mresource.LimitPodCPU(&t.Pod, r.defaultContainerCPULimit); unlimitedCPU {
+		log.Warningf("Pod %s/%s without cpu limits is admitted %.2f cpu shares", t.Pod.Namespace, t.Pod.Name, mresource.PodCPULimit(&t.Pod))
+	}
+	if unlimitedMem := mresource.LimitPodMem(&t.Pod, r.defaultContainerMemLimit); unlimitedMem {
+		log.Warningf("Pod %s/%s without memory limits is admitted %.2f MB", t.Pod.Namespace, t.Pod.Name, mresource.PodMemLimit(&t.Pod))
+	}
+	return nil
+}
+
+// PodResourcesProcurement converts k8s pod cpu and memory resource requirements into
+// mesos resource allocations.
+func PodResourcesProcurement(t *T, offer *mesos.Offer) error {
+	// compute used resources
+	cpu := mresource.PodCPULimit(&t.Pod)
+	mem := mresource.PodMemLimit(&t.Pod)
+
+	log.V(3).Infof("Recording offer(s) %s/%s against pod %v: cpu: %.2f, mem: %.2f MB", offer.Id, t.Pod.Namespace, t.Pod.Name, cpu, mem)
+
+	t.Spec.CPU = cpu
+	t.Spec.Memory = mem
+	return nil
+}
+
+// PortsProcurement convert host port mappings into mesos port resource allocations.
+func PortsProcurement(t *T, offer *mesos.Offer) error {
+	// fill in port mapping
+	if mapping, err := t.mapper.Generate(t, offer); err != nil {
+		return err
+	} else {
+		ports := []uint64{}
+		for _, entry := range mapping {
+			ports = append(ports, entry.OfferPort)
+		}
+		t.Spec.PortMap = mapping
+		t.Spec.Ports = ports
+	}
+	return nil
+}

--- a/contrib/mesos/pkg/scheduler/types.go
+++ b/contrib/mesos/pkg/scheduler/types.go
@@ -23,17 +23,29 @@ import (
 	"k8s.io/kubernetes/contrib/mesos/pkg/scheduler/podtask"
 )
 
-// PodScheduleFunc implements how to schedule pods among slaves.
-// We can have different implementation for different scheduling policy.
-//
-// The Schedule function accepts a group of slaves (each contains offers from
-// that slave) and a single pod, which aligns well with the k8s scheduling
-// algorithm. It returns an offerId that is acceptable for the pod, otherwise
-// nil. The caller is responsible for filling in task state w/ relevant offer
-// details.
-//
-// See the FCFSScheduleFunc for example.
-type PodScheduleFunc func(r offers.Registry, slaves SlaveIndex, task *podtask.T) (offers.Perishable, error)
+type AllocationStrategy interface {
+	// FitPredicate returns the selector used to determine pod fitness w/ respect to a given offer
+	FitPredicate() podtask.FitPredicate
+
+	// Procurement returns a func that obtains resources for a task from resource offer
+	Procurement() podtask.Procurement
+}
+
+type PodScheduler interface {
+	AllocationStrategy
+
+	// SchedulePod implements how to schedule pods among slaves.
+	// We can have different implementation for different scheduling policy.
+	//
+	// The function accepts a group of slaves (each contains offers from
+	// that slave) and a single pod, which aligns well with the k8s scheduling
+	// algorithm. It returns an offerId that is acceptable for the pod, otherwise
+	// nil. The caller is responsible for filling in task state w/ relevant offer
+	// details.
+	//
+	// See the FCFSPodScheduler for example.
+	SchedulePod(r offers.Registry, slaves SlaveIndex, task *podtask.T) (offers.Perishable, error)
+}
 
 // A minimal placeholder
 type empty struct{}

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -1,5 +1,6 @@
 accept-hosts
 accept-paths
+account-for-pod-resources
 admission-control
 admission-control-config-file
 advertise-address
@@ -43,6 +44,7 @@ cluster-name
 cluster-tag
 concurrent-endpoint-syncs
 configure-cbr0
+contain-pod-resources
 container-port
 container-runtime
 cors-allowed-origins


### PR DESCRIPTION
This is a complete hack. Because docker+systemd+mesos do not play well together ATM. The default is to contain pod resources (defaults don't change behavior currently in master). If you're having problems with docker+systemd+mesos you can now set this flag to false and k8s-mesos will no longer attempt to re-parent docker containers into the mesos cgroup (and it will also not allocate pod resources from mesos resource offers).

xref https://github.com/mesosphere/kubernetes-mesos/issues/461

/cc @sttts @karlkfi 
