### PR TITLE
Aggregate errors when validate kubectl required parameters and labels

### DIFF
--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/errors"
 )
 
 const (
@@ -78,12 +79,13 @@ func NewCmdLabel(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 }
 
 func validateNoOverwrites(meta *api.ObjectMeta, labels map[string]string) error {
+	allErrs := []error{}
 	for key := range labels {
 		if value, found := meta.Labels[key]; found {
-			return fmt.Errorf("'%s' already has a value (%s), and --overwrite is false", key, value)
+			allErrs = append(allErrs, fmt.Errorf("'%s' already has a value (%s), and --overwrite is false", key, value))
 		}
 	}
-	return nil
+	return errors.NewAggregate(allErrs)
 }
 
 func parseLabels(spec []string) (map[string]string, []string, error) {

--- a/pkg/kubectl/generate.go
+++ b/pkg/kubectl/generate.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/errors"
 )
 
 // GeneratorParam is a parameter for a generator
@@ -50,15 +51,16 @@ func IsZero(i interface{}) bool {
 
 // ValidateParams ensures that all required params are present in the params map
 func ValidateParams(paramSpec []GeneratorParam, params map[string]interface{}) error {
+	allErrs := []error{}
 	for ix := range paramSpec {
 		if paramSpec[ix].Required {
 			value, found := params[paramSpec[ix].Name]
 			if !found || IsZero(value) {
-				return fmt.Errorf("Parameter: %s is required", paramSpec[ix].Name)
+				allErrs = append(allErrs, fmt.Errorf("Parameter: %s is required", paramSpec[ix].Name))
 			}
 		}
 	}
-	return nil
+	return errors.NewAggregate(allErrs)
 }
 
 // MakeParams is a utility that creates generator parameters from a command line


### PR DESCRIPTION
We should aggregate errors when validate  kubectl command's required parameters, then show a user friendly aggregated errors . Also aggregate errors when validate labels.
