### PR TITLE
Change default output of `run` command

### DIFF
--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -220,7 +220,13 @@ func Run(f *cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer, cmd *cob
 			return fmt.Errorf("cannot attach to %s: not implemented", kind)
 		}
 	}
-	return f.PrintObject(cmd, obj, cmdOut)
+
+	outputFormat := cmdutil.GetFlagString(cmd, "output")
+	if outputFormat != "" {
+		return f.PrintObject(cmd, obj, cmdOut)
+	}
+	cmdutil.PrintSuccess(mapper, false, cmdOut, mapping.Resource, args[0], "created")
+	return nil
 }
 
 func waitForPodRunning(c *client.Client, pod *api.Pod, out io.Writer) error {


### PR DESCRIPTION
Use simple message instead of print result in `get` form.

https://github.com/kubernetes/kubernetes/issues/5906#issuecomment-117832140
