### PR TITLE
Fix mounting volumes in docker based kubernetes setup

### DIFF
--- a/cluster/images/hyperkube/Dockerfile
+++ b/cluster/images/hyperkube/Dockerfile
@@ -1,12 +1,15 @@
-FROM google/debian:wheezy
+FROM debian:jessie
 
 RUN apt-get update
-RUN apt-get -yy -q install iptables ca-certificates
+RUN apt-get -yy -q install iptables ca-certificates file util-linux
+
+RUN cp /usr/bin/nsenter /nsenter
+
 COPY hyperkube /hyperkube
 RUN chmod a+rx /hyperkube
 
-
 COPY master-multi.json /etc/kubernetes/manifests-multi/master.json
 COPY master.json /etc/kubernetes/manifests/master.json
+
 COPY safe_format_and_mount /usr/share/google/safe_format_and_mount
 RUN chmod a+rx /usr/share/google/safe_format_and_mount

--- a/pkg/util/mount/nsenter_mount.go
+++ b/pkg/util/mount/nsenter_mount.go
@@ -71,8 +71,8 @@ func NewNsenterMounter() *NsenterMounter {
 		// default to root
 		m.paths[binary] = filepath.Join("/", binary)
 		for _, path := range []string{"/bin", "/usr/sbin", "/usr/bin"} {
-			binPath := filepath.Join(hostRootFsPath, path, binary)
-			if _, err := os.Stat(binPath); err != nil {
+			binPath := filepath.Join(path, binary)
+			if _, err := os.Stat(filepath.Join(hostRootFsPath, binPath)); err != nil {
 				continue
 			}
 			m.paths[binary] = binPath
@@ -176,8 +176,9 @@ func (n *NsenterMounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	exec := exec.New()
 	out, err := exec.Command(nsenterPath, args...).CombinedOutput()
 	if err != nil {
-		// If findmnt didn't run, just claim it's not a mount point.
-		return true, nil
+		// If the command itself is correct, then if we encountered error
+		// then most likely this means that the directory does not exist.
+		return true, os.ErrNotExist
 	}
 	strOut := strings.TrimSuffix(string(out), "\n")
 


### PR DESCRIPTION
This fixes `nsenter_mounter` code which was using wrong paths for binaries. It also updates documentation for docker based single node k8s cluster setup to provide necessary flags to fix mounting volumes. The is still a problem with writing secrets (we can create tmpfs device for secrets but cannot write it).

@brendandburns (interested in simplifying cluster setup)
@resouer (working on docker based cluster setup)
@smarterclayton (author of nsenter_mounter)
#4869
