### PR TITLE
kubectl resource builder: don't check extension for single files

### DIFF
--- a/examples/pod
+++ b/examples/pod
@@ -1,0 +1,13 @@
+# Copy of pod.yaml without file extension for test
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  labels:
+    name: nginx
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80

--- a/pkg/kubectl/resource/visitor.go
+++ b/pkg/kubectl/resource/visitor.go
@@ -381,7 +381,8 @@ func ExpandPathsToFileVisitors(mapper *Mapper, paths string, recursive bool, ext
 			}
 			return nil
 		}
-		if ignoreFile(path, extensions) {
+		// Don't check extension if the filepath was passed explicitly
+		if path != paths && ignoreFile(path, extensions) {
 			return nil
 		}
 


### PR DESCRIPTION
`kubectl create -f filename` doesn't need to check the extension
of filename. This fixes that behavior.
