### PR TITLE
Stop supporting name field in resourcequota field selector

### DIFF
--- a/pkg/registry/resourcequota/strategy.go
+++ b/pkg/registry/resourcequota/strategy.go
@@ -109,7 +109,5 @@ func MatchResourceQuota(label labels.Selector, field fields.Selector) generic.Ma
 func ResourceQuotaToSelectableFields(resourcequota *api.ResourceQuota) labels.Set {
 	return labels.Set{
 		"metadata.name": resourcequota.Name,
-		// Having "name" is a bug, but it must be supported for v1 API backward compatibility.
-		"name": resourcequota.Name,
 	}
 }


### PR DESCRIPTION
We dont need to support name field selector since it is not exposed in our REST API.
Based on discussion https://github.com/kubernetes/kubernetes/pull/13380#discussion_r38340218

> I dont see any field label conversion funcs defined for ResourceQuotas: https://github.com/kubernetes/kubernetes/blob/master/pkg/api/v1/conversion.go#L41.
> Indeed `api/v1/watch/namespaces/default/resourcequotas?fieldSelector=name=foo` returns:
> 
> ```
> {
>   "kind": "Status",
>   "apiVersion": "v1",
>   "metadata": {},
>   "status": "Failure",
>   "message": "No field label conversion function found for version v1 and kind ResourceQuota",
>   "reason": "BadRequest",
>   "code": 400
> }
> ```
> 
> So this change will not break any external client using the REST API. This will still, however, break internal code that is directly calling storage.Watch(labels.Everything, fields.AsSelector(fields.Set{"name":"foo"})).
> I guess, we should be fine as long as all our tests pass.
