### PR TITLE
Revert "Don't take the proxy mutex in the traffic path"

### DIFF
--- a/pkg/proxy/userspace/proxier.go
+++ b/pkg/proxy/userspace/proxier.go
@@ -41,7 +41,6 @@ type portal struct {
 }
 
 type serviceInfo struct {
-	isAliveAtomic       int32 // Only access this with atomic ops
 	portal              portal
 	protocol            api.Protocol
 	proxyPort           int
@@ -54,18 +53,6 @@ type serviceInfo struct {
 	stickyMaxAgeMinutes int
 	// Deprecated, but required for back-compat (including e2e)
 	externalIPs []string
-}
-
-func (info *serviceInfo) setAlive(b bool) {
-	var i int32
-	if b {
-		i = 1
-	}
-	atomic.StoreInt32(&info.isAliveAtomic, i)
-}
-
-func (info *serviceInfo) isAlive() bool {
-	return atomic.LoadInt32(&info.isAliveAtomic) != 0
 }
 
 func logTimeout(err error) bool {
@@ -269,7 +256,6 @@ func (proxier *Proxier) stopProxy(service proxy.ServicePortName, info *serviceIn
 // This assumes proxier.mu is locked.
 func (proxier *Proxier) stopProxyInternal(service proxy.ServicePortName, info *serviceInfo) error {
 	delete(proxier.serviceMap, service)
-	info.setAlive(false)
 	err := info.socket.Close()
 	port := info.socket.ListenPort()
 	proxier.proxyPorts.Release(port)
@@ -308,7 +294,6 @@ func (proxier *Proxier) addServiceOnPort(service proxy.ServicePortName, protocol
 		return nil, err
 	}
 	si := &serviceInfo{
-		isAliveAtomic:       1,
 		proxyPort:           portNum,
 		protocol:            protocol,
 		socket:              sock,

--- a/pkg/proxy/userspace/proxier_test.go
+++ b/pkg/proxy/userspace/proxier_test.go
@@ -429,9 +429,6 @@ func TestTCPProxyStop(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error adding new service: %#v", err)
 	}
-	if !svcInfo.isAlive() {
-		t.Fatalf("wrong value for isAlive(): expected true")
-	}
 	conn, err := net.Dial("tcp", joinHostPort("", svcInfo.proxyPort))
 	if err != nil {
 		t.Fatalf("error connecting to proxy: %v", err)
@@ -440,9 +437,6 @@ func TestTCPProxyStop(t *testing.T) {
 	waitForNumProxyLoops(t, p, 1)
 
 	stopProxyByName(p, service)
-	if svcInfo.isAlive() {
-		t.Fatalf("wrong value for isAlive(): expected false")
-	}
 	// Wait for the port to really close.
 	if err := waitForClosedPortTCP(p, svcInfo.proxyPort); err != nil {
 		t.Fatalf(err.Error())

--- a/pkg/proxy/userspace/proxysocket.go
+++ b/pkg/proxy/userspace/proxysocket.go
@@ -111,7 +111,7 @@ func tryConnect(service proxy.ServicePortName, srcAddr net.Addr, protocol string
 
 func (tcp *tcpProxySocket) ProxyLoop(service proxy.ServicePortName, myInfo *serviceInfo, proxier *Proxier) {
 	for {
-		if !myInfo.isAlive() {
+		if info, exists := proxier.getServiceInfo(service); !exists || info != myInfo {
 			// The service port was closed or replaced.
 			return
 		}
@@ -125,7 +125,7 @@ func (tcp *tcpProxySocket) ProxyLoop(service proxy.ServicePortName, myInfo *serv
 			if isClosedError(err) {
 				return
 			}
-			if !myInfo.isAlive() {
+			if info, exists := proxier.getServiceInfo(service); !exists || info != myInfo {
 				// Then the service port was just closed so the accept failure is to be expected.
 				return
 			}
@@ -198,7 +198,7 @@ func newClientCache() *clientCache {
 func (udp *udpProxySocket) ProxyLoop(service proxy.ServicePortName, myInfo *serviceInfo, proxier *Proxier) {
 	var buffer [4096]byte // 4KiB should be enough for most whole-packets
 	for {
-		if !myInfo.isAlive() {
+		if info, exists := proxier.getServiceInfo(service); !exists || info != myInfo {
 			// The service port was closed or replaced.
 			break
 		}


### PR DESCRIPTION
Reverts kubernetes/kubernetes#13345

It caused flaky shippable runs.
