### PR TITLE
Change variables to environment variables when describe containers

### DIFF
--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -725,7 +725,7 @@ func describeContainers(pod *api.Pod, out io.Writer) {
 		}
 		fmt.Fprintf(out, "    Ready:\t%v\n", printBool(status.Ready))
 		fmt.Fprintf(out, "    Restart Count:\t%d\n", status.RestartCount)
-		fmt.Fprintf(out, "    Variables:\n")
+		fmt.Fprintf(out, "    Environment Variables:\n")
 		for _, e := range container.Env {
 			if e.ValueFrom != nil && e.ValueFrom.FieldRef != nil {
 				valueFrom := envValueFrom(pod, e)


### PR DESCRIPTION
Variables is a little ugly when describe containers' environment variables, so I changed it to Environment Variables
