### PR TITLE
Remove deprecated NamespaceExists from config-default.sh and other files

### DIFF
--- a/cluster/aws/config-default.sh
+++ b/cluster/aws/config-default.sh
@@ -87,7 +87,7 @@ DNS_REPLICAS=1
 ENABLE_CLUSTER_UI="${KUBE_ENABLE_CLUSTER_UI:-true}"
 
 # Admission Controllers to invoke prior to persisting objects in cluster
-ADMISSION_CONTROL=NamespaceLifecycle,NamespaceExists,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota
+ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota
 
 # Optional: Enable/disable public IP assignment for minions.
 # Important Note: disable only if you have setup a NAT instance for internet access and configured appropriate routes!

--- a/cluster/aws/config-test.sh
+++ b/cluster/aws/config-test.sh
@@ -83,7 +83,7 @@ DNS_REPLICAS=1
 ENABLE_CLUSTER_UI="${KUBE_ENABLE_CLUSTER_UI:-true}"
 
 # Admission Controllers to invoke prior to persisting objects in cluster
-ADMISSION_CONTROL=NamespaceLifecycle,NamespaceExists,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota
+ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota
 
 # Optional: Enable/disable public IP assignment for minions.
 # Important Note: disable only if you have setup a NAT instance for internet access and configured appropriate routes!

--- a/cluster/azure/config-default.sh
+++ b/cluster/azure/config-default.sh
@@ -55,4 +55,4 @@ ENABLE_CLUSTER_MONITORING="${KUBE_ENABLE_CLUSTER_MONITORING:-influxdb}"
 ENABLE_CLUSTER_UI="${KUBE_ENABLE_CLUSTER_UI:-true}"
 
 # Admission Controllers to invoke prior to persisting objects in cluster
-ADMISSION_CONTROL=NamespaceLifecycle,NamespaceExists,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota
+ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota

--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -96,7 +96,7 @@ if [[ "${ENABLE_NODE_AUTOSCALER}" == "true" ]]; then
 fi
 
 # Admission Controllers to invoke prior to persisting objects in cluster
-ADMISSION_CONTROL=NamespaceLifecycle,NamespaceExists,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota
+ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota
 
 # Optional: if set to true kube-up will automatically check for existing resources and clean them up.
 KUBE_UP_AUTOMATIC_CLEANUP=${KUBE_UP_AUTOMATIC_CLEANUP:-false}

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -100,7 +100,7 @@ if [[ "${ENABLE_NODE_AUTOSCALER}" == "true" ]]; then
   TARGET_NODE_UTILIZATION="${KUBE_TARGET_NODE_UTILIZATION:-0.7}"
 fi
 
-ADMISSION_CONTROL=NamespaceLifecycle,NamespaceExists,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota
+ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota
 
 # Optional: if set to true kube-up will automatically check for existing resources and clean them up.
 KUBE_UP_AUTOMATIC_CLEANUP=${KUBE_UP_AUTOMATIC_CLEANUP:-false}

--- a/cluster/mesos/docker/docker-compose.yml
+++ b/cluster/mesos/docker/docker-compose.yml
@@ -89,7 +89,7 @@ apiserver:
     --external-hostname=apiserver
     --etcd-servers=http://etcd:4001
     --port=8888
-    --admission-control=NamespaceLifecycle,NamespaceExists,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota
+    --admission-control=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota
     --authorization-mode=AlwaysAllow
     --token-auth-file=/var/run/kubernetes/auth/token-users
     --basic-auth-file=/var/run/kubernetes/auth/basic-users

--- a/cluster/ubuntu/config-default.sh
+++ b/cluster/ubuntu/config-default.sh
@@ -35,7 +35,7 @@ export SERVICE_CLUSTER_IP_RANGE=${SERVICE_CLUSTER_IP_RANGE:-192.168.3.0/24}  # f
 export FLANNEL_NET=${FLANNEL_NET:-172.16.0.0/16}
 
 # Admission Controllers to invoke prior to persisting objects in cluster
-export ADMISSION_CONTROL=NamespaceLifecycle,NamespaceExists,LimitRanger,ServiceAccount,ResourceQuota,SecurityContextDeny
+export ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,SecurityContextDeny
 
 SERVICE_NODE_PORT_RANGE=${SERVICE_NODE_PORT_RANGE:-"30000-32767"}
 

--- a/cluster/vagrant/config-default.sh
+++ b/cluster/vagrant/config-default.sh
@@ -53,7 +53,7 @@ MASTER_USER=vagrant
 MASTER_PASSWD=vagrant
 
 # Admission Controllers to invoke prior to persisting objects in cluster
-ADMISSION_CONTROL=NamespaceLifecycle,NamespaceExists,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota
+ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota
 
 # Optional: Enable node logging.
 ENABLE_NODE_LOGGING=false

--- a/docs/admin/high-availability/kube-apiserver.yaml
+++ b/docs/admin/high-availability/kube-apiserver.yaml
@@ -11,7 +11,7 @@ spec:
     - /bin/sh
     - -c
     - /usr/local/bin/kube-apiserver --address=127.0.0.1 --etcd-servers=http://127.0.0.1:4001
-      --cloud-provider=gce   --admission-control=NamespaceLifecycle,NamespaceExists,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota
+      --cloud-provider=gce   --admission-control=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota
       --service-cluster-ip-range=10.0.0.0/16 --client-ca-file=/srv/kubernetes/ca.crt
       --basic-auth-file=/srv/kubernetes/basic_auth.csv --cluster-name=e2e-test-bburns
       --tls-cert-file=/srv/kubernetes/server.cert --tls-private-key-file=/srv/kubernetes/server.key


### PR DESCRIPTION
Since admission control plugin `NamespaceExists` is marked as **deprecated**, and the functionality of it has been merged into `NamespaceLifecycle`, So I removed it from `config-default.sh` and other related files.

Please check with [admission-controllers.md ](https://github.com/kubernetes/kubernetes/blob/master/docs/admin/admission-controllers.md) for more information.

> ##### NamespaceExists (deprecated)
> 
> This plug-in will observe all incoming requests that attempt to create a resource in a Kubernetes  Namespace  and reject the request if the  Namespace  was not previously created. We strongly recommend running this plug-in to ensure integrity of your data.
> The functionality of this admission controller has been merged into NamespaceLifecycle

Affected files for this PR are:
1. `~/kubernetes/cluster/aws/config-default.sh`
2. `~/kubernetes/cluster/aws/config-test.sh`
3. `~/kubernetes/cluster/azure/config-default.sh`
4. `~/kubernetes/cluster/gce/config-default.sh`
5. `~/kubernetes/cluster/gce/config-test.sh`
6. `~/kubernetes/cluster/mesos/docker/docker-compose.yml`
7. `~/kubernetes/cluster/ubuntu/config-default.sh`
8. `~/kubernetes/cluster/vagrant/config-default.sh`
9. `~/kubernetes/docs/admin/high-availability/kube-apiserver.yaml`
