### PR TITLE
Add an option to not delete namespace after an e2e test

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -53,6 +53,7 @@ current-replicas
 default-container-cpu-limit
 default-container-mem-limit
 delay-shutdown
+delete-namespace
 deleting-pods-burst
 deleting-pods-qps
 deployment-label-key

--- a/test/e2e/docker_containers.go
+++ b/test/e2e/docker_containers.go
@@ -39,8 +39,12 @@ var _ = Describe("Docker Containers", func() {
 	})
 
 	AfterEach(func() {
-		if err := deleteNS(c, ns); err != nil {
-			Failf("Couldn't delete ns %s", err)
+		if testContext.DeleteNamespace {
+			if err := deleteNS(c, ns); err != nil {
+				Failf("Couldn't delete ns %s", err)
+			}
+		} else {
+			Logf("Skipping namespace deletion!")
 		}
 	})
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -81,6 +81,7 @@ func init() {
 	flag.IntVar(&testContext.MinStartupPods, "minStartupPods", 0, "The number of pods which we need to see in 'Running' state with a 'Ready' condition of true, before we try running tests. This is useful in any cluster which needs some base pod-based services running before it can be used.")
 	flag.StringVar(&testContext.UpgradeTarget, "upgrade-target", "latest_ci", "Version to upgrade to (e.g. 'latest_stable', 'latest_release', 'latest_ci', '0.19.1', '0.19.1-669-gabac8c8') if doing an upgrade test.")
 	flag.StringVar(&testContext.PrometheusPushGateway, "prom-push-gateway", "", "The URL to prometheus gateway, so that metrics can be pushed during e2es and scraped by prometheus. Typically something like 127.0.0.1:9091.")
+	flag.BoolVar(&testContext.DeleteNamespace, "delete-namespace", true, "If set to false Framework won't delete a namespace after finishing the test. To be used only for debuggig.")
 }
 
 func TestE2E(t *testing.T) {

--- a/test/e2e/examples.go
+++ b/test/e2e/examples.go
@@ -62,9 +62,13 @@ var _ = Describe("Examples e2e", func() {
 	})
 
 	AfterEach(func() {
-		By(fmt.Sprintf("Destroying namespace for this suite %v", ns))
-		if err := deleteNS(c, ns); err != nil {
-			Failf("Couldn't delete ns %s", err)
+		if testContext.DeleteNamespace {
+			By(fmt.Sprintf("Destroying namespace for this suite %v", ns))
+			if err := deleteNS(c, ns); err != nil {
+				Failf("Couldn't delete ns %s", err)
+			}
+		} else {
+			Logf("Skipping namespace deletion!")
 		}
 	})
 
@@ -457,8 +461,13 @@ var _ = Describe("Examples e2e", func() {
 			for i := range namespaces {
 				var err error
 				namespaces[i], err = createTestingNS(fmt.Sprintf("dnsexample%d", i), c)
-				if namespaces[i] != nil {
-					defer deleteNS(c, namespaces[i].Name)
+				if testContext.DeleteNamespace {
+
+					if namespaces[i] != nil {
+						defer deleteNS(c, namespaces[i].Name)
+					}
+				} else {
+					Logf("Skipping namespace deletion!")
 				}
 				Expect(err).NotTo(HaveOccurred())
 			}

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -95,10 +95,14 @@ func (f *Framework) afterEach() {
 		Failf("All nodes should be ready after test, %v", err)
 	}
 
-	By(fmt.Sprintf("Destroying namespace %q for this suite.", f.Namespace.Name))
+	if testContext.DeleteNamespace {
+		By(fmt.Sprintf("Destroying namespace %q for this suite.", f.Namespace.Name))
 
-	if err := deleteNS(f.Client, f.Namespace.Name); err != nil {
-		Failf("Couldn't delete ns %q: %s", f.Namespace.Name, err)
+		if err := deleteNS(f.Client, f.Namespace.Name); err != nil {
+			Failf("Couldn't delete ns %q: %s", f.Namespace.Name, err)
+		}
+	} else {
+		Logf("Skipping namespace deletion!")
 	}
 	// Paranoia-- prevent reuse!
 	f.Namespace = nil

--- a/test/e2e/host_path.go
+++ b/test/e2e/host_path.go
@@ -50,9 +50,14 @@ var _ = Describe("hostPath", func() {
 	})
 
 	AfterEach(func() {
-		By(fmt.Sprintf("Destroying namespace for this suite %v", namespace.Name))
-		if err := deleteNS(c, namespace.Name); err != nil {
-			Failf("Couldn't delete ns %s", err)
+		if testContext.DeleteNamespace {
+			By(fmt.Sprintf("Destroying namespace for this suite %v", namespace.Name))
+			if err := deleteNS(c, namespace.Name); err != nil {
+				Failf("Couldn't delete ns %s", err)
+			}
+		} else {
+			Logf("Skipping namespace deletion!")
+
 		}
 	})
 

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -77,9 +77,13 @@ var _ = Describe("Kubectl client", func() {
 	})
 
 	AfterEach(func() {
-		By(fmt.Sprintf("Destroying namespace for this suite %v", ns))
-		if err := deleteNS(c, ns); err != nil {
-			Failf("Couldn't delete ns %s", err)
+		if testContext.DeleteNamespace {
+			By(fmt.Sprintf("Destroying namespace for this suite %v", ns))
+			if err := deleteNS(c, ns); err != nil {
+				Failf("Couldn't delete ns %s", err)
+			}
+		} else {
+			Logf("Skipping namespace deletion!")
 		}
 	})
 

--- a/test/e2e/persistent_volumes.go
+++ b/test/e2e/persistent_volumes.go
@@ -45,9 +45,13 @@ var _ = Describe("[Skipped] persistentVolumes", func() {
 	})
 
 	AfterEach(func() {
-		By(fmt.Sprintf("Destroying namespace for this suite %v", ns))
-		if err := deleteNS(c, ns); err != nil {
-			Failf("Couldn't delete ns %s", err)
+		if testContext.DeleteNamespace {
+			By(fmt.Sprintf("Destroying namespace for this suite %v", ns))
+			if err := deleteNS(c, ns); err != nil {
+				Failf("Couldn't delete ns %s", err)
+			}
+		} else {
+			Logf("Skipping namespace deletion!")
 		}
 	})
 

--- a/test/e2e/resize_nodes.go
+++ b/test/e2e/resize_nodes.go
@@ -421,12 +421,16 @@ var _ = Describe("Nodes", func() {
 		if err := allNodesReady(c, time.Minute); err != nil {
 			Failf("Not all nodes are ready: %v", err)
 		}
-		By(fmt.Sprintf("destroying namespace for this suite %s", ns))
-		if err := deleteNS(c, ns); err != nil {
-			Failf("Couldn't delete namespace '%s', %v", ns, err)
-		}
-		if err := deleteTestingNS(c); err != nil {
-			Failf("Couldn't delete testing namespaces '%s', %v", ns, err)
+		if testContext.DeleteNamespace {
+			By(fmt.Sprintf("destroying namespace for this suite %s", ns))
+			if err := deleteNS(c, ns); err != nil {
+				Failf("Couldn't delete namespace '%s', %v", ns, err)
+			}
+			if err := deleteTestingNS(c); err != nil {
+				Failf("Couldn't delete testing namespaces '%s', %v", ns, err)
+			}
+		} else {
+			Logf("Skipping namespace deletion!")
 		}
 	})
 

--- a/test/e2e/scheduler_predicates.go
+++ b/test/e2e/scheduler_predicates.go
@@ -169,9 +169,13 @@ var _ = Describe("SchedulerPredicates", func() {
 			expectNoError(err)
 		}
 
-		By(fmt.Sprintf("Destroying namespace for this suite %v", ns))
-		if err := deleteNS(c, ns); err != nil {
-			Failf("Couldn't delete ns %s", err)
+		if testContext.DeleteNamespace {
+			By(fmt.Sprintf("Destroying namespace for this suite %v", ns))
+			if err := deleteNS(c, ns); err != nil {
+				Failf("Couldn't delete ns %s", err)
+			}
+		} else {
+			Logf("Skipping namespace deletion!")
 		}
 	})
 

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -62,11 +62,15 @@ var _ = Describe("Services", func() {
 	})
 
 	AfterEach(func() {
-		for _, ns := range namespaces {
-			By(fmt.Sprintf("Destroying namespace %v", ns))
-			if err := deleteNS(c, ns); err != nil {
-				Failf("Couldn't delete namespace %s: %s", ns, err)
+		if testContext.DeleteNamespace {
+			for _, ns := range namespaces {
+				By(fmt.Sprintf("Destroying namespace %v", ns))
+				if err := deleteNS(c, ns); err != nil {
+					Failf("Couldn't delete namespace %s: %s", ns, err)
+				}
 			}
+		} else {
+			Logf("Skipping namespace deletion!")
 		}
 	})
 

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -121,6 +121,7 @@ type TestContextType struct {
 	MinStartupPods        int
 	UpgradeTarget         string
 	PrometheusPushGateway string
+	DeleteNamespace       bool
 }
 
 var testContext TestContextType

--- a/test/e2e/volumes.go
+++ b/test/e2e/volumes.go
@@ -233,10 +233,14 @@ var _ = Describe("Volumes", func() {
 	})
 
 	AfterEach(func() {
-		if clean {
-			if err := deleteNS(c, namespace.Name); err != nil {
-				Failf("Couldn't delete ns %s", err)
+		if testContext.DeleteNamespace {
+			if clean {
+				if err := deleteNS(c, namespace.Name); err != nil {
+					Failf("Couldn't delete ns %s", err)
+				}
 			}
+		} else {
+			Logf("Skipping namespace deletion!")
 		}
 	})
 


### PR DESCRIPTION
When debugging I'm often running single e2e test and I find it useful to not delete namespace after the test is complete, so I can easily browse events. Maybe someone else want to do this, so I added a flag that turns off namespace deletion.

cc @jszczepkowski @wojtek-t @quinton-hoole 
