### PR TITLE
backoff image pulling on failure

### DIFF
--- a/pkg/kubelet/container/fake_runtime.go
+++ b/pkg/kubelet/container/fake_runtime.go
@@ -41,6 +41,7 @@ type FakeRuntime struct {
 	KilledContainers  []string
 	VersionInfo       string
 	Err               error
+	InspectErr        error
 }
 
 // FakeRuntime should implement Runtime.
@@ -94,6 +95,7 @@ func (f *FakeRuntime) ClearCalls() {
 	f.KilledContainers = []string{}
 	f.VersionInfo = ""
 	f.Err = nil
+	f.InspectErr = nil
 }
 
 func (f *FakeRuntime) assertList(expect []string, test []string) error {
@@ -264,10 +266,10 @@ func (f *FakeRuntime) IsImagePresent(image ImageSpec) (bool, error) {
 	f.CalledFunctions = append(f.CalledFunctions, "IsImagePresent")
 	for _, i := range f.ImageList {
 		if i.ID == image.Image {
-			return true, f.Err
+			return true, nil
 		}
 	}
-	return false, f.Err
+	return false, f.InspectErr
 }
 
 func (f *FakeRuntime) ListImages() ([]Image, error) {

--- a/pkg/kubelet/container/image_puller_test.go
+++ b/pkg/kubelet/container/image_puller_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package container
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/record"
+	"k8s.io/kubernetes/pkg/util"
+)
+
+func TestPuller(t *testing.T) {
+	pod := &api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "test_pod",
+			Namespace:       "test-ns",
+			UID:             "bar",
+			ResourceVersion: "42",
+			SelfLink:        "/api/v1/pods/foo",
+		}}
+
+	cases := []struct {
+		containerImage  string
+		policy          api.PullPolicy
+		calledFunctions []string
+		inspectErr      error
+		pullerErr       error
+		expectedErr     []error
+	}{
+		{ // pull missing image
+			containerImage:  "missing_image",
+			policy:          api.PullIfNotPresent,
+			calledFunctions: []string{"IsImagePresent", "PullImage"},
+			inspectErr:      nil,
+			pullerErr:       nil,
+			expectedErr:     []error{nil}},
+
+		{ // image present, dont pull
+			containerImage:  "present_image",
+			policy:          api.PullIfNotPresent,
+			calledFunctions: []string{"IsImagePresent"},
+			inspectErr:      nil,
+			pullerErr:       nil,
+			expectedErr:     []error{nil, nil, nil}},
+		// image present, pull it
+		{containerImage: "present_image",
+			policy:          api.PullAlways,
+			calledFunctions: []string{"IsImagePresent", "PullImage"},
+			inspectErr:      nil,
+			pullerErr:       nil,
+			expectedErr:     []error{nil, nil, nil}},
+		// missing image, error PullNever
+		{containerImage: "missing_image",
+			policy:          api.PullNever,
+			calledFunctions: []string{"IsImagePresent"},
+			inspectErr:      nil,
+			pullerErr:       nil,
+			expectedErr:     []error{ErrImageNeverPull, ErrImageNeverPull, ErrImageNeverPull}},
+		// missing image, unable to inspect
+		{containerImage: "missing_image",
+			policy:          api.PullIfNotPresent,
+			calledFunctions: []string{"IsImagePresent"},
+			inspectErr:      errors.New("unknown inspectError"),
+			pullerErr:       nil,
+			expectedErr:     []error{ErrImageInspect, ErrImageInspect, ErrImageInspect}},
+		// missing image, unable to fetch
+		{containerImage: "typo_image",
+			policy:          api.PullIfNotPresent,
+			calledFunctions: []string{"IsImagePresent", "PullImage"},
+			inspectErr:      nil,
+			pullerErr:       errors.New("404"),
+			expectedErr:     []error{ErrImagePull, ErrImagePull, ErrImagePullBackOff, ErrImagePull, ErrImagePullBackOff, ErrImagePullBackOff}},
+	}
+
+	for i, c := range cases {
+		container := &api.Container{
+			Name:            "container_name",
+			Image:           c.containerImage,
+			ImagePullPolicy: c.policy,
+		}
+
+		backOff := util.NewBackOff(time.Second, time.Minute)
+		fakeClock := &util.FakeClock{Time: time.Now()}
+		backOff.Clock = fakeClock
+
+		fakeRuntime := &FakeRuntime{}
+		fakeRecorder := &record.FakeRecorder{}
+		puller := NewImagePuller(fakeRecorder, fakeRuntime, backOff)
+
+		fakeRuntime.ImageList = []Image{{"present_image", nil, 0}}
+		fakeRuntime.Err = c.pullerErr
+		fakeRuntime.InspectErr = c.inspectErr
+
+		for tick, expected := range c.expectedErr {
+			fakeClock.Step(time.Second)
+			err, _ := puller.PullImage(pod, container, nil)
+			fakeRuntime.AssertCalls(c.calledFunctions)
+			assert.Equal(t, expected, err, "in test %d tick=%d", i, tick)
+		}
+	}
+}

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -32,6 +32,22 @@ import (
 // Container Terminated and Kubelet is backing off the restart
 var ErrCrashLoopBackOff = errors.New("CrashLoopBackOff")
 
+var (
+	// Container image pull failed, kubelet is backing off image pull
+	ErrImagePullBackOff = errors.New("ImagePullBackOff")
+
+	// Unable to inspect image
+	ErrImageInspect = errors.New("ImageInspectError")
+
+	// General image pull error
+	ErrImagePull = errors.New("ErrImagePull")
+
+	// Required Image is absent on host and PullPolicy is NeverPullImage
+	ErrImageNeverPull = errors.New("ErrImageNeverPull")
+)
+
+var ErrRunContainer = errors.New("RunContainerError")
+
 type Version interface {
 	// Compare compares two versions of the runtime. On success it returns -1
 	// if the version is less than the other, 1 if it is greater than the other,
@@ -109,7 +125,7 @@ type ContainerCommandRunner interface {
 // It will check the presence of the image, and report the 'image pulling',
 // 'image pulled' events correspondingly.
 type ImagePuller interface {
-	PullImage(pod *api.Pod, container *api.Container, pullSecrets []api.Secret) error
+	PullImage(pod *api.Pod, container *api.Container, pullSecrets []api.Secret) (error, string)
 }
 
 // Pod is a group of containers, with the status of the pod.

--- a/pkg/kubelet/dockertools/docker_test.go
+++ b/pkg/kubelet/dockertools/docker_test.go
@@ -669,7 +669,8 @@ func TestFindContainersByPod(t *testing.T) {
 	}
 	fakeClient := &FakeDockerClient{}
 	np, _ := network.InitNetworkPlugin([]network.NetworkPlugin{}, "", network.NewFakeHost(nil))
-	containerManager := NewFakeDockerManager(fakeClient, &record.FakeRecorder{}, nil, nil, &cadvisorApi.MachineInfo{}, PodInfraContainerImage, 0, 0, "", kubecontainer.FakeOS{}, np, nil, nil)
+	// image back-off is set to nil, this test shouldnt pull images
+	containerManager := NewFakeDockerManager(fakeClient, &record.FakeRecorder{}, nil, nil, &cadvisorApi.MachineInfo{}, PodInfraContainerImage, 0, 0, "", kubecontainer.FakeOS{}, np, nil, nil, nil)
 	for i, test := range tests {
 		fakeClient.ContainerList = test.containerList
 		fakeClient.ExitedContainerList = test.exitedContainerList

--- a/pkg/kubelet/dockertools/fake_manager.go
+++ b/pkg/kubelet/dockertools/fake_manager.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/network"
 	"k8s.io/kubernetes/pkg/kubelet/prober"
 	kubeletTypes "k8s.io/kubernetes/pkg/kubelet/types"
+	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/oom"
 	"k8s.io/kubernetes/pkg/util/procfs"
 )
@@ -40,13 +41,13 @@ func NewFakeDockerManager(
 	osInterface kubecontainer.OSInterface,
 	networkPlugin network.NetworkPlugin,
 	generator kubecontainer.RunContainerOptionsGenerator,
-	httpClient kubeletTypes.HttpGetter) *DockerManager {
+	httpClient kubeletTypes.HttpGetter, imageBackOff *util.Backoff) *DockerManager {
 
 	fakeOOMAdjuster := oom.NewFakeOOMAdjuster()
 	fakeProcFs := procfs.NewFakeProcFs()
 	dm := NewDockerManager(client, recorder, prober, containerRefManager, machineInfo, podInfraContainerImage, qps,
 		burst, containerLogsDir, osInterface, networkPlugin, generator, httpClient, &NativeExecHandler{},
-		fakeOOMAdjuster, fakeProcFs, false)
+		fakeOOMAdjuster, fakeProcFs, false, imageBackOff)
 	dm.dockerPuller = &FakeDockerPuller{}
 	return dm
 }

--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -158,7 +158,9 @@ func NewDockerManager(
 	execHandler ExecHandler,
 	oomAdjuster *oom.OOMAdjuster,
 	procFs procfs.ProcFsInterface,
-	cpuCFSQuota bool) *DockerManager {
+	cpuCFSQuota bool,
+	imageBackOff *util.Backoff) *DockerManager {
+
 	// Work out the location of the Docker runtime, defaulting to /var/lib/docker
 	// if there are any problems.
 	dockerRoot := "/var/lib/docker"
@@ -211,7 +213,7 @@ func NewDockerManager(
 		cpuCFSQuota:            cpuCFSQuota,
 	}
 	dm.runner = lifecycle.NewHandlerRunner(httpClient, dm, dm)
-	dm.imagePuller = kubecontainer.NewImagePuller(recorder, dm)
+	dm.imagePuller = kubecontainer.NewImagePuller(recorder, dm, imageBackOff)
 
 	return dm
 }
@@ -509,9 +511,12 @@ func (dm *DockerManager) GetPodStatus(pod *api.Pod) (*api.PodStatus, error) {
 					}
 				}
 				containerStatus.LastTerminationState = containerStatus.State
-				containerStatus.State.Waiting = &api.ContainerStateWaiting{Reason: reasonInfo.reason,
-					Message: reasonInfo.message}
-				containerStatus.State.Running = nil
+				containerStatus.State = api.ContainerState{
+					Waiting: &api.ContainerStateWaiting{
+						Reason:  reasonInfo.reason,
+						Message: reasonInfo.message,
+					},
+				}
 			}
 			continue
 		}
@@ -524,20 +529,27 @@ func (dm *DockerManager) GetPodStatus(pod *api.Pod) (*api.PodStatus, error) {
 			containerStatus.RestartCount = oldStatus.RestartCount
 			containerStatus.LastTerminationState = oldStatus.LastTerminationState
 		}
-		//Check image is ready on the node or not.
-		image := container.Image
 		// TODO(dchen1107): docker/docker/issues/8365 to figure out if the image exists
-		_, err := dm.client.InspectImage(image)
-		if err == nil {
-			containerStatus.State.Waiting = &api.ContainerStateWaiting{
-				Message: fmt.Sprintf("Image: %s is ready, container is creating", image),
-				Reason:  "ContainerCreating",
+		reasonInfo, ok := dm.reasonCache.Get(uid, container.Name)
+		if !ok {
+			// default position for a container
+			// At this point there are no active or dead containers, the reasonCache is empty (no entry or the entry has expired)
+			// its reasonable to say the container is being created till a more accurate reason is logged
+			containerStatus.State = api.ContainerState{
+				Waiting: &api.ContainerStateWaiting{
+					Reason:  fmt.Sprintf("ContainerCreating"),
+					Message: fmt.Sprintf("Image: %s is ready, container is creating", container.Image),
+				},
 			}
-		} else if err == docker.ErrNoSuchImage {
-			containerStatus.State.Waiting = &api.ContainerStateWaiting{
-				Message: fmt.Sprintf("Image: %s is not ready on the node", image),
-				Reason:  "ImageNotReady",
-			}
+		} else if reasonInfo.reason == kubecontainer.ErrImagePullBackOff.Error() ||
+			reasonInfo.reason == kubecontainer.ErrImageInspect.Error() ||
+			reasonInfo.reason == kubecontainer.ErrImagePull.Error() ||
+			reasonInfo.reason == kubecontainer.ErrImageNeverPull.Error() {
+			// mark it as waiting, reason will be filled bellow
+			containerStatus.State = api.ContainerState{Waiting: &api.ContainerStateWaiting{}}
+		} else if reasonInfo.reason == kubecontainer.ErrRunContainer.Error() {
+			// mark it as waiting, reason will be filled bellow
+			containerStatus.State = api.ContainerState{Waiting: &api.ContainerStateWaiting{}}
 		}
 		statuses[container.Name] = &containerStatus
 	}
@@ -545,6 +557,7 @@ func (dm *DockerManager) GetPodStatus(pod *api.Pod) (*api.PodStatus, error) {
 	podStatus.ContainerStatuses = make([]api.ContainerStatus, 0)
 	for containerName, status := range statuses {
 		if status.State.Waiting != nil {
+			status.State.Running = nil
 			// For containers in the waiting state, fill in a specific reason if it is recorded.
 			if reasonInfo, ok := dm.reasonCache.Get(uid, containerName); ok {
 				status.State.Waiting.Reason = reasonInfo.reason
@@ -1603,7 +1616,8 @@ func (dm *DockerManager) createPodInfraContainer(pod *api.Pod) (kubeletTypes.Doc
 	}
 
 	// No pod secrets for the infra container.
-	if err := dm.imagePuller.PullImage(pod, container, nil); err != nil {
+	// The message isnt needed for the Infra container
+	if err, _ := dm.imagePuller.PullImage(pod, container, nil); err != nil {
 		return "", err
 	}
 
@@ -1845,10 +1859,9 @@ func (dm *DockerManager) SyncPod(pod *api.Pod, runningPod kubecontainer.Pod, pod
 			continue
 		}
 		glog.V(4).Infof("Creating container %+v in pod %v", container, podFullName)
-		err := dm.imagePuller.PullImage(pod, container, pullSecrets)
-		dm.updateReasonCache(pod, container, "PullImageError", err)
+		err, msg := dm.imagePuller.PullImage(pod, container, pullSecrets)
 		if err != nil {
-			glog.Warningf("Failed to pull image %q from pod %q and container %q: %v", container.Image, kubecontainer.GetPodFullName(pod), container.Name, err)
+			dm.updateReasonCache(pod, container, err.Error(), errors.New(msg))
 			continue
 		}
 
@@ -1868,7 +1881,7 @@ func (dm *DockerManager) SyncPod(pod *api.Pod, runningPod kubecontainer.Pod, pod
 		// See createPodInfraContainer for infra container setup.
 		namespaceMode := fmt.Sprintf("container:%v", podInfraContainerID)
 		_, err = dm.runContainerInPod(pod, container, namespaceMode, namespaceMode, getPidMode(pod))
-		dm.updateReasonCache(pod, container, "RunContainerError", err)
+		dm.updateReasonCache(pod, container, kubecontainer.ErrRunContainer.Error(), err)
 		if err != nil {
 			// TODO(bburns) : Perhaps blacklist a container after N failures?
 			glog.Errorf("Error running pod %q container %q: %v", kubecontainer.GetPodFullName(pod), container.Name, err)

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -309,7 +309,7 @@ func NewMainKubelet(
 	}
 
 	procFs := procfs.NewProcFs()
-
+	imageBackOff := util.NewBackOff(resyncInterval, maxContainerBackOff)
 	// Initialize the runtime.
 	switch containerRuntime {
 	case "docker":
@@ -331,7 +331,9 @@ func NewMainKubelet(
 			dockerExecHandler,
 			oomAdjuster,
 			procFs,
-			klet.cpuCFSQuota)
+			klet.cpuCFSQuota,
+			imageBackOff)
+
 	case "rkt":
 		conf := &rkt.Config{
 			Path:               rktPath,
@@ -344,7 +346,8 @@ func NewMainKubelet(
 			recorder,
 			containerRefManager,
 			klet, // prober
-			klet.volumeManager)
+			klet.volumeManager,
+			imageBackOff)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/kubelet/network/cni/cni_test.go
+++ b/pkg/kubelet/network/cni/cni_test.go
@@ -157,6 +157,7 @@ func newTestDockerManager() (*dockertools.DockerManager, *dockertools.FakeDocker
 		kubecontainer.FakeOS{},
 		networkPlugin,
 		nil,
+		nil,
 		nil)
 
 	return dockerManager, fakeDocker

--- a/pkg/kubelet/pod_workers_test.go
+++ b/pkg/kubelet/pod_workers_test.go
@@ -45,7 +45,7 @@ func newPod(uid, name string) *api.Pod {
 func createFakeRuntimeCache(fakeRecorder *record.FakeRecorder) kubecontainer.RuntimeCache {
 	fakeDocker := &dockertools.FakeDockerClient{}
 	np, _ := network.InitNetworkPlugin([]network.NetworkPlugin{}, "", network.NewFakeHost(nil))
-	dockerManager := dockertools.NewFakeDockerManager(fakeDocker, fakeRecorder, nil, nil, &cadvisorApi.MachineInfo{}, dockertools.PodInfraContainerImage, 0, 0, "", kubecontainer.FakeOS{}, np, nil, nil)
+	dockerManager := dockertools.NewFakeDockerManager(fakeDocker, fakeRecorder, nil, nil, &cadvisorApi.MachineInfo{}, dockertools.PodInfraContainerImage, 0, 0, "", kubecontainer.FakeOS{}, np, nil, nil, nil)
 	return kubecontainer.NewFakeRuntimeCache(dockerManager)
 }
 
@@ -193,7 +193,7 @@ func TestFakePodWorkers(t *testing.T) {
 	fakeDocker := &dockertools.FakeDockerClient{}
 	fakeRecorder := &record.FakeRecorder{}
 	np, _ := network.InitNetworkPlugin([]network.NetworkPlugin{}, "", network.NewFakeHost(nil))
-	dockerManager := dockertools.NewFakeDockerManager(fakeDocker, fakeRecorder, nil, nil, &cadvisorApi.MachineInfo{}, dockertools.PodInfraContainerImage, 0, 0, "", kubecontainer.FakeOS{}, np, nil, nil)
+	dockerManager := dockertools.NewFakeDockerManager(fakeDocker, fakeRecorder, nil, nil, &cadvisorApi.MachineInfo{}, dockertools.PodInfraContainerImage, 0, 0, "", kubecontainer.FakeOS{}, np, nil, nil, nil)
 	fakeRuntimeCache := kubecontainer.NewFakeRuntimeCache(dockerManager)
 
 	kubeletForRealWorkers := &simpleFakeKubelet{}

--- a/pkg/util/backoff_test.go
+++ b/pkg/util/backoff_test.go
@@ -123,3 +123,72 @@ func TestBackoffGC(t *testing.T) {
 		t.Errorf("expected GC of entry after %s got entry %v", tc.Now().Sub(lastUpdate), r)
 	}
 }
+
+func TestIsInBackOffSinceUpdate(t *testing.T) {
+	id := "_idIsInBackOffSinceUpdate"
+	tc := &FakeClock{Time: time.Now()}
+	step := time.Second
+	maxDuration := 10 * step
+	b := NewFakeBackOff(step, maxDuration, tc)
+	startTime := tc.Now()
+
+	cases := []struct {
+		tick      time.Duration
+		inBackOff bool
+		value     int
+	}{
+		{tick: 0, inBackOff: false, value: 0},
+		{tick: 1, inBackOff: false, value: 1},
+		{tick: 2, inBackOff: true, value: 2},
+		{tick: 3, inBackOff: false, value: 2},
+		{tick: 4, inBackOff: true, value: 4},
+		{tick: 5, inBackOff: true, value: 4},
+		{tick: 6, inBackOff: true, value: 4},
+		{tick: 7, inBackOff: false, value: 4},
+		{tick: 8, inBackOff: true, value: 8},
+		{tick: 9, inBackOff: true, value: 8},
+		{tick: 10, inBackOff: true, value: 8},
+		{tick: 11, inBackOff: true, value: 8},
+		{tick: 12, inBackOff: true, value: 8},
+		{tick: 13, inBackOff: true, value: 8},
+		{tick: 14, inBackOff: true, value: 8},
+		{tick: 15, inBackOff: false, value: 8},
+		{tick: 16, inBackOff: true, value: 10},
+		{tick: 17, inBackOff: true, value: 10},
+		{tick: 18, inBackOff: true, value: 10},
+		{tick: 19, inBackOff: true, value: 10},
+		{tick: 20, inBackOff: true, value: 10},
+		{tick: 21, inBackOff: true, value: 10},
+		{tick: 22, inBackOff: true, value: 10},
+		{tick: 23, inBackOff: true, value: 10},
+		{tick: 24, inBackOff: true, value: 10},
+		{tick: 25, inBackOff: false, value: 10},
+		{tick: 26, inBackOff: true, value: 10},
+		{tick: 27, inBackOff: true, value: 10},
+		{tick: 28, inBackOff: true, value: 10},
+		{tick: 29, inBackOff: true, value: 10},
+		{tick: 30, inBackOff: true, value: 10},
+		{tick: 31, inBackOff: true, value: 10},
+		{tick: 32, inBackOff: true, value: 10},
+		{tick: 33, inBackOff: true, value: 10},
+		{tick: 34, inBackOff: true, value: 10},
+		{tick: 35, inBackOff: false, value: 10},
+		{tick: 56, inBackOff: false, value: 0},
+		{tick: 57, inBackOff: false, value: 1},
+	}
+
+	for _, c := range cases {
+		tc.Time = startTime.Add(c.tick * step)
+		if c.inBackOff != b.IsInBackOffSinceUpdate(id, tc.Now()) {
+			t.Errorf("expected IsInBackOffSinceUpdate %v got %v at tick %s", c.inBackOff, b.IsInBackOffSinceUpdate(id, tc.Now()), c.tick*step)
+		}
+
+		if c.inBackOff && (time.Duration(c.value)*step != b.Get(id)) {
+			t.Errorf("expected backoff value=%s got %s at tick %s", time.Duration(c.value)*step, b.Get(id), c.tick*step)
+		}
+
+		if !c.inBackOff {
+			b.Next(id, tc.Now())
+		}
+	}
+}


### PR DESCRIPTION
fixes #4121
This implements a back-off when kublet fails to pull an image, the back-off is keyed to the pod/image
and  changing the "reason" to a short string, #11007 is adding a message field. don't know if that's the right order.
