### PR TITLE
Improve reliability of salt-minion on vagrant master

### DIFF
--- a/cluster/vagrant/util.sh
+++ b/cluster/vagrant/util.sh
@@ -199,6 +199,9 @@ function verify-cluster {
   local machine="master"
   local -a required_daemon=("salt-master" "salt-minion" "kubelet")
   local validated="1"
+  # This is a hack, but sometimes the salt-minion gets stuck on the master, so we just restart it
+  # to ensure that users never wait forever
+  vagrant ssh "$machine" -c "sudo systemctl restart salt-minion"
   until [[ "$validated" == "0" ]]; do
     validated="0"
     local daemon


### PR DESCRIPTION
I have run into the salt-minion just stalling on occasion on the vagrant master during provisioning which caused the validating steps to never complete.  There was no message in the log for salt explaining why things stalled.

I found that if I restart the salt-minion, it resolves any stall, and things finish provisioning as expected.  Typically, it stalled after docker was installed but before the kubelet gets laid down.

So while this is hackish, it fixes a reliability problem.
