### PR TITLE
Disable swap memory on vagrant nodes to support qos properly

### DIFF
--- a/cluster/vagrant/provision-minion.sh
+++ b/cluster/vagrant/provision-minion.sh
@@ -155,6 +155,10 @@ grains:
   docker_opts: '$(echo "$DOCKER_OPTS" | sed -e "s/'/''/g")'
 EOF
 
+# QoS support requires that swap memory is disabled on each of the minions
+echo "Disable swap memory to ensure proper QoS"
+swapoff -a
+
 # we will run provision to update code each time we test, so we do not want to do salt install each time
 if ! which salt-minion >/dev/null 2>&1; then
   # Install Salt


### PR DESCRIPTION
I want to be able to use the vagrant cluster to test Kubernetes QoS behaviors with OOM.

> > The QoS proposal assumes that swap memory is disabled. If swap is enabled, then resource guarantees (for pods that specify resource requirements) will not hold. For example, suppose 2 guaranteed pods have reached their memory limit. They can start allocating memory on swap space. Eventually, if there isn’t enough swap space, processes in the pods might get killed.
