### PR TITLE
Save integration test results in junit-style XML report on Shippable

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -7,6 +7,7 @@ matrix:
     - go: 1.4
       env:
         - KUBE_TEST_API_VERSIONS=v1 KUBE_TEST_ETCD_PREFIXES=registry
+        - KUBE_JUNIT_REPORT_DIR="${SHIPPABLE_REPO_DIR}/shippable/testresults"
         - CI_NAME="shippable"
         - CI_BUILD_NUMBER="$BUILD_NUMBER"
         - CI_BUILD_URL="$BUILD_URL"
@@ -17,6 +18,7 @@ matrix:
     - go: 1.3
       env:
         - KUBE_TEST_API_VERSIONS=v1 KUBE_TEST_ETCD_PREFIXES=kubernetes.io/registry
+        - KUBE_JUNIT_REPORT_DIR="${SHIPPABLE_REPO_DIR}/shippable/testresults"
         - CI_NAME="shippable"
         - CI_BUILD_NUMBER="$BUILD_NUMBER"
         - CI_BUILD_URL="$BUILD_URL"
@@ -48,7 +50,7 @@ install:
 
 script:
   # Disable coverage collection on pull requests
-  - KUBE_RACE="-race" KUBE_COVER=$([[ "$PULL_REQUEST" =~ ^[0-9]+$ ]] && echo "n" || echo "y") KUBE_GOVERALLS_BIN="$GOPATH/bin/goveralls" KUBE_TIMEOUT='-timeout 300s' KUBE_COVERPROCS=8 KUBE_TEST_ETCD_PREFIXES="${KUBE_TEST_ETCD_PREFIXES}" KUBE_TEST_API_VERSIONS="${KUBE_TEST_API_VERSIONS}" KUBE_JUNIT_REPORT_DIR="$(pwd)/shippable/testresults" ./hack/test-go.sh -- -p=2
+  - KUBE_RACE="-race" KUBE_COVER=$([[ "$PULL_REQUEST" =~ ^[0-9]+$ ]] && echo "n" || echo "y") KUBE_GOVERALLS_BIN="$GOPATH/bin/goveralls" KUBE_TIMEOUT='-timeout 300s' KUBE_COVERPROCS=8 KUBE_TEST_ETCD_PREFIXES="${KUBE_TEST_ETCD_PREFIXES}" KUBE_TEST_API_VERSIONS="${KUBE_TEST_API_VERSIONS}" ./hack/test-go.sh -- -p=2
   - ./hack/test-cmd.sh
   - KUBE_TEST_API_VERSIONS="${KUBE_TEST_API_VERSIONS}" KUBE_INTEGRATION_TEST_MAX_CONCURRENCY=4 LOG_LEVEL=4 ./hack/test-integration.sh
   - ./hack/test-update-storage-objects.sh


### PR DESCRIPTION
This is basically a follow-on to #13114. It appears to work correctly locally.

cc @kubernetes/goog-testing
