### PR TITLE
Removed expapi descriptions from internal types

### DIFF
--- a/pkg/expapi/types.go
+++ b/pkg/expapi/types.go
@@ -355,7 +355,9 @@ type DaemonList struct {
 
 type ThirdPartyResourceDataList struct {
 	api.TypeMeta `json:",inline"`
-	api.ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://docs.k8s.io/api-conventions.md#metadata"`
-
-	Items []ThirdPartyResourceData `json:"items" description:"items is a list of third party objects"`
+	// Standard list metadata
+	// More info: http://docs.k8s.io/api-conventions.md#metadata
+	api.ListMeta `json:"metadata,omitempty"`
+	// Items is a list of third party objects
+	Items []ThirdPartyResourceData `json:"items"`
 }


### PR DESCRIPTION
@brendandburns I noticed this in a different PR build fail.

```
$ hack/verify-description.sh 
+++ [0902 22:42:46] Building go targets for darwin/amd64:
    cmd/genswaggertypedocs
+++ [0902 22:42:46] Placing binaries
    Items []ThirdPartyResourceData `json:"items" description:"items is a list of third party objects"`
Internal API types should not contain descriptions
!!! Error in hack/verify-description.sh:27
  '"${KUBE_ROOT}/hack/after-build/verify-description.sh" "$@"' exited with status 1
Call stack:
  1: hack/verify-description.sh:27 main(...)
Exiting with status 1
```
