### PR TITLE
Deletion of experimental objects when Namespace is removed.

### DIFF
--- a/contrib/mesos/pkg/controllermanager/controllermanager.go
+++ b/contrib/mesos/pkg/controllermanager/controllermanager.go
@@ -144,7 +144,7 @@ func (s *CMServer) Run(_ []string) error {
 	resourceQuotaController := resourcequotacontroller.NewResourceQuotaController(kubeClient)
 	resourceQuotaController.Run(s.ResourceQuotaSyncPeriod)
 
-	namespaceController := namespacecontroller.NewNamespaceController(kubeClient, s.NamespaceSyncPeriod)
+	namespaceController := namespacecontroller.NewNamespaceController(kubeClient, false, s.NamespaceSyncPeriod)
 	namespaceController.Run()
 
 	pvclaimBinder := volumeclaimbinder.NewPersistentVolumeClaimBinder(kubeClient, s.PVClaimBinderSyncPeriod)

--- a/pkg/client/unversioned/testclient/fake_deployments.go
+++ b/pkg/client/unversioned/testclient/fake_deployments.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/expapi"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeDeployments implements DeploymentsInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the methods you want to test easier.
+type FakeDeployments struct {
+	Fake      *FakeExperimental
+	Namespace string
+}
+
+func (c *FakeDeployments) Get(name string) (*expapi.Deployment, error) {
+	obj, err := c.Fake.Invokes(NewGetAction("deployments", c.Namespace, name), &expapi.Deployment{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*expapi.Deployment), err
+}
+
+func (c *FakeDeployments) List(label labels.Selector, field fields.Selector) (*expapi.DeploymentList, error) {
+	obj, err := c.Fake.Invokes(NewListAction("deployments", c.Namespace, label, field), &expapi.DeploymentList{})
+	if obj == nil {
+		return nil, err
+	}
+	list := &expapi.DeploymentList{}
+	for _, deployment := range obj.(*expapi.DeploymentList).Items {
+		if label.Matches(labels.Set(deployment.Labels)) {
+			list.Items = append(list.Items, deployment)
+		}
+	}
+	return list, err
+}
+
+func (c *FakeDeployments) Create(deployment *expapi.Deployment) (*expapi.Deployment, error) {
+	obj, err := c.Fake.Invokes(NewCreateAction("deployments", c.Namespace, deployment), deployment)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*expapi.Deployment), err
+}
+
+func (c *FakeDeployments) Update(deployment *expapi.Deployment) (*expapi.Deployment, error) {
+	obj, err := c.Fake.Invokes(NewUpdateAction("deployments", c.Namespace, deployment), deployment)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*expapi.Deployment), err
+}
+
+func (c *FakeDeployments) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.Invokes(NewDeleteAction("deployments", c.Namespace, name), &expapi.Deployment{})
+	return err
+}
+
+func (c *FakeDeployments) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.Fake.InvokesWatch(NewWatchAction("deployments", c.Namespace, label, field, resourceVersion))
+}

--- a/pkg/client/unversioned/testclient/fake_horizontal_pod_autoscalers.go
+++ b/pkg/client/unversioned/testclient/fake_horizontal_pod_autoscalers.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/expapi"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeHorizontalPodAutoscalers implements HorizontalPodAutoscalerInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the methods you want to test easier.
+type FakeHorizontalPodAutoscalers struct {
+	Fake      *FakeExperimental
+	Namespace string
+}
+
+func (c *FakeHorizontalPodAutoscalers) Get(name string) (*expapi.HorizontalPodAutoscaler, error) {
+	obj, err := c.Fake.Invokes(NewGetAction("horizontalpodautoscalers", c.Namespace, name), &expapi.HorizontalPodAutoscaler{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*expapi.HorizontalPodAutoscaler), err
+}
+
+func (c *FakeHorizontalPodAutoscalers) List(label labels.Selector, field fields.Selector) (*expapi.HorizontalPodAutoscalerList, error) {
+	obj, err := c.Fake.Invokes(NewListAction("horizontalpodautoscalers", c.Namespace, label, field), &expapi.HorizontalPodAutoscalerList{})
+	if obj == nil {
+		return nil, err
+	}
+	list := &expapi.HorizontalPodAutoscalerList{}
+	for _, a := range obj.(*expapi.HorizontalPodAutoscalerList).Items {
+		if label.Matches(labels.Set(a.Labels)) {
+			list.Items = append(list.Items, a)
+		}
+	}
+	return list, err
+}
+
+func (c *FakeHorizontalPodAutoscalers) Create(a *expapi.HorizontalPodAutoscaler) (*expapi.HorizontalPodAutoscaler, error) {
+	obj, err := c.Fake.Invokes(NewCreateAction("horizontalpodautoscalers", c.Namespace, a), a)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*expapi.HorizontalPodAutoscaler), err
+}
+
+func (c *FakeHorizontalPodAutoscalers) Update(a *expapi.HorizontalPodAutoscaler) (*expapi.HorizontalPodAutoscaler, error) {
+	obj, err := c.Fake.Invokes(NewUpdateAction("horizontalpodautoscalers", c.Namespace, a), a)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*expapi.HorizontalPodAutoscaler), err
+}
+
+func (c *FakeHorizontalPodAutoscalers) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.Invokes(NewDeleteAction("horizontalpodautoscalers", c.Namespace, name), &expapi.HorizontalPodAutoscaler{})
+	return err
+}
+
+func (c *FakeHorizontalPodAutoscalers) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.Fake.InvokesWatch(NewWatchAction("horizontalpodautoscalers", c.Namespace, label, field, resourceVersion))
+}

--- a/pkg/client/unversioned/testclient/fake_scales.go
+++ b/pkg/client/unversioned/testclient/fake_scales.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"k8s.io/kubernetes/pkg/expapi"
+)
+
+// FakeScales implements ScaleInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the methods you want to test easier.
+type FakeScales struct {
+	Fake      *FakeExperimental
+	Namespace string
+}
+
+func (c *FakeScales) Get(kind string, name string) (result *expapi.Scale, err error) {
+	action := GetActionImpl{}
+	action.Verb = "get"
+	action.Namespace = c.Namespace
+	action.Resource = kind
+	action.Subresource = "scale"
+	action.Name = name
+	obj, err := c.Fake.Invokes(action, &expapi.Scale{})
+	result = obj.(*expapi.Scale)
+	return
+}
+
+func (c *FakeScales) Update(kind string, scale *expapi.Scale) (result *expapi.Scale, err error) {
+	action := UpdateActionImpl{}
+	action.Verb = "update"
+	action.Namespace = c.Namespace
+	action.Resource = kind
+	action.Subresource = "scale"
+	action.Object = scale
+	obj, err := c.Fake.Invokes(action, scale)
+	result = obj.(*expapi.Scale)
+	return
+}

--- a/pkg/client/unversioned/testclient/testclient.go
+++ b/pkg/client/unversioned/testclient/testclient.go
@@ -251,13 +251,13 @@ func (c *FakeExperimental) Daemons(namespace string) client.DaemonInterface {
 }
 
 func (c *FakeExperimental) HorizontalPodAutoscalers(namespace string) client.HorizontalPodAutoscalerInterface {
-	panic("unimplemented")
-}
-
-func (c *FakeExperimental) Scales(namespace string) client.ScaleInterface {
-	panic("unimplemented")
+	return &FakeHorizontalPodAutoscalers{Fake: c, Namespace: namespace}
 }
 
 func (c *FakeExperimental) Deployments(namespace string) client.DeploymentInterface {
-	panic("unimplemented")
+	return &FakeDeployments{Fake: c, Namespace: namespace}
+}
+
+func (c *FakeExperimental) Scales(namespace string) client.ScaleInterface {
+	return &FakeScales{Fake: c, Namespace: namespace}
 }

--- a/pkg/controller/autoscaler/horizontalpodautoscaler_controller_test.go
+++ b/pkg/controller/autoscaler/horizontalpodautoscaler_controller_test.go
@@ -177,14 +177,12 @@ func TestSyncEndpointsItemsPreserveNoSelector(t *testing.T) {
 
 	defer testServer.Close()
 	kubeClient := client.NewOrDie(&client.Config{Host: testServer.URL, Version: testapi.Experimental.Version()})
-	expClient := client.NewExperimentalOrDie(&client.Config{Host: testServer.URL, Version: testapi.Experimental.Version()})
-
 	fakeRC := fakeResourceConsumptionClient{metrics: map[api.ResourceName]expapi.ResourceConsumption{
 		api.ResourceCPU: {Resource: api.ResourceCPU, Quantity: resource.MustParse("650m")},
 	}}
 	fake := fakeMetricsClient{consumption: &fakeRC}
 
-	hpaController := New(kubeClient, expClient, &fake)
+	hpaController := New(kubeClient, &fake)
 
 	err := hpaController.reconcileAutoscalers()
 	if err != nil {
@@ -193,7 +191,7 @@ func TestSyncEndpointsItemsPreserveNoSelector(t *testing.T) {
 	for _, h := range handlers {
 		h.ValidateRequestCount(t, 1)
 	}
-	obj, err := expClient.Codec.Decode([]byte(handlers[updateHpaHandler].RequestBody))
+	obj, err := kubeClient.Codec.Decode([]byte(handlers[updateHpaHandler].RequestBody))
 	if err != nil {
 		t.Fatal("Failed to decode: %v %v", err)
 	}


### PR DESCRIPTION
Implemented removal of Deployments, Daemons & HorizontalPodAutoscalers when Namespace is removed. Added unittest. Fixes #12735.
