### PR TITLE
Fix a typo '1m0s' to '60s' for '--node-startup-grace-period'

### DIFF
--- a/docs/admin/kube-controller-manager.md
+++ b/docs/admin/kube-controller-manager.md
@@ -67,7 +67,7 @@ controller, and serviceaccounts controller.
       --namespace-sync-period=0: The period for syncing namespace life-cycle updates
       --node-monitor-grace-period=40s: Amount of time which we allow running Node to be unresponsive before marking it unhealthy. Must be N times more than kubelet's nodeStatusUpdateFrequency, where N means number of retries allowed for kubelet to post node status.
       --node-monitor-period=5s: The period for syncing NodeStatus in NodeController.
-      --node-startup-grace-period=1m0s: Amount of time which we allow starting Node to be unresponsive before marking it unhealthy.
+      --node-startup-grace-period=60s: Amount of time which we allow starting Node to be unresponsive before marking it unhealthy.
       --node-sync-period=0: The period for syncing nodes from cloudprovider. Longer periods will result in fewer calls to cloud provider, but may delay addition of new nodes to cluster.
       --pod-eviction-timeout=0: The grace period for deleting pods on failed nodes.
       --port=0: The port that the controller-manager's http service runs on


### PR DESCRIPTION
Fix a typo `1m0s` to `60s` for `--node-startup-grace-period`.
Please refer to `kubernetes/cmd/kube-controller-manager/app/controllermanager.go` for the default value:

``` go
fs.DurationVar(&s.NodeStartupGracePeriod, "node-startup-grace-period", 60*time.Second,
        "Amount of time which we allow starting Node to be unresponsive before marking it unhealty.")
```
