### PR TITLE
Reduce the default apiserver timeout back down to 30 seconds.

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -345,8 +345,7 @@ func parseTimeout(str string) time.Duration {
 		}
 		glog.Errorf("Failed to parse %q: %v", str, err)
 	}
-	// TODO: change back to 30s once #5180 is fixed
-	return 2 * time.Minute
+	return 30 * time.Second
 }
 
 func readBody(req *http.Request) ([]byte, error) {

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -2145,10 +2145,10 @@ func TestUpdateChecksDecode(t *testing.T) {
 }
 
 func TestParseTimeout(t *testing.T) {
-	if d := parseTimeout(""); d != 2*time.Minute {
+	if d := parseTimeout(""); d != 30*time.Second {
 		t.Errorf("blank timeout produces %v", d)
 	}
-	if d := parseTimeout("not a timeout"); d != 2*time.Minute {
+	if d := parseTimeout("not a timeout"); d != 30*time.Second {
 		t.Errorf("bad timeout produces %v", d)
 	}
 	if d := parseTimeout("10s"); d != 10*time.Second {


### PR DESCRIPTION
It was originally raised due to slow load balancer creation (#5180), but that was fixed months ago.

@jayunit100 @lavalamp @smarterclayton 
