### PR TITLE
add capability limiter to the experimental api

### DIFF
--- a/pkg/expapi/types.go
+++ b/pkg/expapi/types.go
@@ -361,3 +361,34 @@ type ThirdPartyResourceDataList struct {
 	// Items is a list of third party objects
 	Items []ThirdPartyResourceData `json:"items"`
 }
+
+// LimitCapability defines the privilege and capability limits of PodSpecs in a namespace
+type LimitCapability struct {
+	api.TypeMeta   `json",inline"`
+	api.ObjectMeta `json:"metadata,omitempty"`
+
+	// Spec defines the limits enforced
+	Spec LimitCapabilitySpec
+}
+
+// LimitCapabilitySpec is the specification of a LimitCapability
+type LimitCapabilitySpec struct {
+	// AllowHostNetwork allows PodSPecs to use the host's network
+	AllowHostNetwork bool
+	// AllowHostDir allows PodSpecs to specify HostDir volumes
+	AllowHostDir bool
+	// AllowHostPort allows containers to specify host ports
+	AllowHostPort bool
+	// AllowPrivileged allows PodSpecs to specificy Privileged mode
+	AllowPrivileged bool
+	// CapabilitesWhitelist specifies the capabilies that can be added and dropped from a container's security context
+	AllowCapabilities api.Capabilities
+}
+
+// LimitCapabilityList is a collection of LimitCapabilities
+type LimitCapabilityList struct {
+	api.TypeMeta `json:",inline"`
+	api.ListMeta `json:"metadata,omitempty"`
+
+	Items []LimitCapability
+}

--- a/pkg/expapi/v1/types.go
+++ b/pkg/expapi/v1/types.go
@@ -347,3 +347,34 @@ type ThirdPartyResourceDataList struct {
 
 	Items []ThirdPartyResourceData `json:"items" description:"items is a list of third party objects"`
 }
+
+// LimitCapability defines the privilege and capability limits of PodSpecs in a namespace
+type LimitCapability struct {
+	v1.TypeMeta   `json",inline"`
+	v1.ObjectMeta `json:"metadata,omitempty"`
+
+	// Spec defines the limits enforced
+	Spec LimitCapabilitySpec
+}
+
+// LimitCapabilitySpec is the specification of a LimitCapability
+type LimitCapabilitySpec struct {
+	// AllowHostNetwork allows PodSPecs to use the host's network
+	AllowHostNetwork bool
+	// AllowHostDir allows PodSpecs to specify HostDir volumes
+	AllowHostDir bool
+	// AllowHostPort allows containers to specify host ports
+	AllowHostPort bool
+	// AllowPrivileged allows PodSpecs to specificy Privileged mode
+	AllowPrivileged bool
+	// CapabilitesWhitelist specifies the capabilies that can be added and dropped from a container's security context
+	AllowCapabilities v1.Capabilities
+}
+
+// LimitCapabilityList is a collection of LimitCapabilities
+type LimitCapabilityList struct {
+	v1.TypeMeta `json:",inline"`
+	v1.ListMeta `json:"metadata,omitempty"`
+
+	Items []LimitCapability
+}


### PR DESCRIPTION
We should push privilege and capabilities into admission control. This would be an API object that applies limits per namespace like ResourceQuota. Opening for discussion. @kubernetes/goog-control-plane @kubernetes/rh-platform-management @vishh 
