### PR TITLE
Fix verify-descriptions.sh

### DIFF
--- a/hack/after-build/verify-description.sh
+++ b/hack/after-build/verify-description.sh
@@ -38,7 +38,10 @@ find_files() {
         -o -wholename '*/third_party/*' \
         -o -wholename '*/Godeps/*' \
       \) -prune \
-    \) -wholename '*pkg/api/v*/types.go'
+    \) \
+    \( -wholename '*pkg/api/v*/types.go' \
+       -o -wholename '*pkg/expapi/v*/types.go' \
+    \)
 }
 
 if [[ $# -eq 0 ]]; then

--- a/pkg/expapi/v1/types.go
+++ b/pkg/expapi/v1/types.go
@@ -71,7 +71,9 @@ type SubresourceReference struct {
 
 // ResourceConsumption is an object for specifying average resource consumption of a particular resource.
 type ResourceConsumption struct {
-	Resource v1.ResourceName   `json:"resource,omitempty"`
+	// Resource specifies either the name of the target resource when present in the spec, or the name of the observed resource when present in the status.
+	Resource v1.ResourceName `json:"resource,omitempty"`
+	// Quantity specifies either the target average consumption of the resource when present in the spec, or the observed average consumption when present in the status.
 	Quantity resource.Quantity `json:"quantity,omitempty"`
 }
 
@@ -109,7 +111,8 @@ type HorizontalPodAutoscalerStatus struct {
 
 // HorizontalPodAutoscaler represents the configuration of a horizontal pod autoscaler.
 type HorizontalPodAutoscaler struct {
-	v1.TypeMeta   `json:",inline"`
+	v1.TypeMeta `json:",inline"`
+	// Standard object metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata
 	v1.ObjectMeta `json:"metadata,omitempty"`
 
 	// Spec defines the behaviour of autoscaler. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status.
@@ -119,12 +122,13 @@ type HorizontalPodAutoscaler struct {
 	Status *HorizontalPodAutoscalerStatus `json:"status,omitempty"`
 }
 
-// HorizontalPodAutoscaler is a collection of pod autoscalers.
+// HorizontalPodAutoscalerList is a list of HorizontalPodAutoscalers.
 type HorizontalPodAutoscalerList struct {
 	v1.TypeMeta `json:",inline"`
+	// Standard list metadata.
 	v1.ListMeta `json:"metadata,omitempty"`
 
-	// Items is the list of horizontal pod autoscalers.
+	// Items is the list of HorizontalPodAutoscalers.
 	Items []HorizontalPodAutoscaler `json:"items"`
 }
 
@@ -143,13 +147,14 @@ type ThirdPartyResource struct {
 	Versions []APIVersion `json:"versions,omitempty"`
 }
 
+// ThirdPartyResourceList is a list of ThirdPartyResources.
 type ThirdPartyResourceList struct {
 	v1.TypeMeta `json:",inline"`
 
 	// Standard list metadata.
 	v1.ListMeta `json:"metadata,omitempty"`
 
-	// Items is the list of horizontal pod autoscalers.
+	// Items is the list of ThirdPartyResources.
 	Items []ThirdPartyResource `json:"items"`
 }
 
@@ -172,8 +177,10 @@ type ThirdPartyResourceData struct {
 	Data []byte `json:"name,omitempty"`
 }
 
+// Deployment enables declarative updates for Pods and ReplicationControllers.
 type Deployment struct {
-	v1.TypeMeta   `json:",inline"`
+	v1.TypeMeta `json:",inline"`
+	// Standard object metadata.
 	v1.ObjectMeta `json:"metadata,omitempty"`
 
 	// Specification of the desired behavior of the Deployment.
@@ -183,6 +190,7 @@ type Deployment struct {
 	Status DeploymentStatus `json:"status,omitempty"`
 }
 
+// DeploymentSpec is the specification of the desired behavior of the Deployment.
 type DeploymentSpec struct {
 	// Number of desired pods. This is a pointer to distinguish between explicit
 	// zero and not specified. Defaults to 1.
@@ -209,6 +217,7 @@ type DeploymentSpec struct {
 	UniqueLabelKey *string `json:"uniqueLabelKey,omitempty"`
 }
 
+// DeploymentStrategy describes how to replace existing pods with new ones.
 type DeploymentStrategy struct {
 	// Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
 	Type DeploymentType `json:"type,omitempty"`
@@ -263,6 +272,7 @@ type RollingUpdateDeployment struct {
 	MinReadySeconds int `json:"minReadySeconds,omitempty"`
 }
 
+// DeploymentStatus is the most recently observed status of the Deployment.
 type DeploymentStatus struct {
 	// Total number of ready pods targeted by this deployment (this
 	// includes both the old and new pods).
@@ -272,11 +282,13 @@ type DeploymentStatus struct {
 	UpdatedReplicas int `json:"updatedReplicas,omitempty"`
 }
 
+// DeploymentList is a list of Deployments.
 type DeploymentList struct {
 	v1.TypeMeta `json:",inline"`
+	// Standard list metadata.
 	v1.ListMeta `json:"metadata,omitempty"`
 
-	// Items is the list of deployments.
+	// Items is the list of Deployments.
 	Items []Deployment `json:"items"`
 }
 
@@ -330,23 +342,24 @@ type Daemon struct {
 	Status DaemonStatus `json:"status,omitempty"`
 }
 
-// DaemonList is a collection of daemon.
+// DaemonList is a list of Daemons.
 type DaemonList struct {
 	v1.TypeMeta `json:",inline"`
 	// Standard list metadata.
 	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata
 	v1.ListMeta `json:"metadata,omitempty"`
 
-	// Items is a list of daemons.
+	// Items is the list of Daemons.
 	Items []Daemon `json:"items"`
 }
 
+// ThirdPartyResrouceDataList is a list of ThirdPartyResourceData.
 type ThirdPartyResourceDataList struct {
 	v1.TypeMeta `json:",inline"`
 	// Standard list metadata
 	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata
 	v1.ListMeta `json:"metadata,omitempty"`
 
-	// Items is a list of third party objects
+	// Items is the list of ThirdpartyResourceData.
 	Items []ThirdPartyResourceData `json:"items"`
 }

--- a/pkg/expapi/v1/types_swagger_doc_generated.go
+++ b/pkg/expapi/v1/types_swagger_doc_generated.go
@@ -49,9 +49,9 @@ func (Daemon) SwaggerDoc() map[string]string {
 }
 
 var map_DaemonList = map[string]string{
-	"":         "DaemonList is a collection of daemon.",
+	"":         "DaemonList is a list of Daemons.",
 	"metadata": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-	"items":    "Items is a list of daemons.",
+	"items":    "Items is the list of Daemons.",
 }
 
 func (DaemonList) SwaggerDoc() map[string]string {
@@ -80,8 +80,10 @@ func (DaemonStatus) SwaggerDoc() map[string]string {
 }
 
 var map_Deployment = map[string]string{
-	"spec":   "Specification of the desired behavior of the Deployment.",
-	"status": "Most recently observed status of the Deployment.",
+	"":         "Deployment enables declarative updates for Pods and ReplicationControllers.",
+	"metadata": "Standard object metadata.",
+	"spec":     "Specification of the desired behavior of the Deployment.",
+	"status":   "Most recently observed status of the Deployment.",
 }
 
 func (Deployment) SwaggerDoc() map[string]string {
@@ -89,7 +91,9 @@ func (Deployment) SwaggerDoc() map[string]string {
 }
 
 var map_DeploymentList = map[string]string{
-	"items": "Items is the list of deployments.",
+	"":         "DeploymentList is a list of Deployments.",
+	"metadata": "Standard list metadata.",
+	"items":    "Items is the list of Deployments.",
 }
 
 func (DeploymentList) SwaggerDoc() map[string]string {
@@ -97,6 +101,7 @@ func (DeploymentList) SwaggerDoc() map[string]string {
 }
 
 var map_DeploymentSpec = map[string]string{
+	"":               "DeploymentSpec is the specification of the desired behavior of the Deployment.",
 	"replicas":       "Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.",
 	"selector":       "Label selector for pods. Existing ReplicationControllers whose pods are selected by this will be scaled down.",
 	"template":       "Template describes the pods that will be created.",
@@ -109,6 +114,7 @@ func (DeploymentSpec) SwaggerDoc() map[string]string {
 }
 
 var map_DeploymentStatus = map[string]string{
+	"":                "DeploymentStatus is the most recently observed status of the Deployment.",
 	"replicas":        "Total number of ready pods targeted by this deployment (this includes both the old and new pods).",
 	"updatedReplicas": "Total number of new ready pods with the desired template spec.",
 }
@@ -118,6 +124,7 @@ func (DeploymentStatus) SwaggerDoc() map[string]string {
 }
 
 var map_DeploymentStrategy = map[string]string{
+	"":              "DeploymentStrategy describes how to replace existing pods with new ones.",
 	"type":          "Type of deployment. Can be \"Recreate\" or \"RollingUpdate\". Default is RollingUpdate.",
 	"rollingUpdate": "Rolling update config params. Present only if DeploymentType = RollingUpdate.",
 }
@@ -127,9 +134,10 @@ func (DeploymentStrategy) SwaggerDoc() map[string]string {
 }
 
 var map_HorizontalPodAutoscaler = map[string]string{
-	"":       "HorizontalPodAutoscaler represents the configuration of a horizontal pod autoscaler.",
-	"spec":   "Spec defines the behaviour of autoscaler. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status.",
-	"status": "Status represents the current information about the autoscaler.",
+	"":         "HorizontalPodAutoscaler represents the configuration of a horizontal pod autoscaler.",
+	"metadata": "Standard object metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+	"spec":     "Spec defines the behaviour of autoscaler. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status.",
+	"status":   "Status represents the current information about the autoscaler.",
 }
 
 func (HorizontalPodAutoscaler) SwaggerDoc() map[string]string {
@@ -137,8 +145,9 @@ func (HorizontalPodAutoscaler) SwaggerDoc() map[string]string {
 }
 
 var map_HorizontalPodAutoscalerList = map[string]string{
-	"":      "HorizontalPodAutoscaler is a collection of pod autoscalers.",
-	"items": "Items is the list of horizontal pod autoscalers.",
+	"":         "HorizontalPodAutoscalerList is a list of HorizontalPodAutoscalers.",
+	"metadata": "Standard list metadata.",
+	"items":    "Items is the list of HorizontalPodAutoscalers.",
 }
 
 func (HorizontalPodAutoscalerList) SwaggerDoc() map[string]string {
@@ -178,7 +187,9 @@ func (ReplicationControllerDummy) SwaggerDoc() map[string]string {
 }
 
 var map_ResourceConsumption = map[string]string{
-	"": "ResourceConsumption is an object for specifying average resource consumption of a particular resource.",
+	"":         "ResourceConsumption is an object for specifying average resource consumption of a particular resource.",
+	"resource": "Resource specifies either the name of the target resource when present in the spec, or the name of the observed resource when present in the status.",
+	"quantity": "Quantity specifies either the target average consumption of the resource when present in the spec, or the observed average consumption when present in the status.",
 }
 
 func (ResourceConsumption) SwaggerDoc() map[string]string {
@@ -261,8 +272,9 @@ func (ThirdPartyResourceData) SwaggerDoc() map[string]string {
 }
 
 var map_ThirdPartyResourceDataList = map[string]string{
+	"":         "ThirdPartyResrouceDataList is a list of ThirdPartyResourceData.",
 	"metadata": "Standard list metadata More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-	"items":    "Items is a list of third party objects",
+	"items":    "Items is the list of ThirdpartyResourceData.",
 }
 
 func (ThirdPartyResourceDataList) SwaggerDoc() map[string]string {
@@ -270,8 +282,9 @@ func (ThirdPartyResourceDataList) SwaggerDoc() map[string]string {
 }
 
 var map_ThirdPartyResourceList = map[string]string{
+	"":         "ThirdPartyResourceList is a list of ThirdPartyResources.",
 	"metadata": "Standard list metadata.",
-	"items":    "Items is the list of horizontal pod autoscalers.",
+	"items":    "Items is the list of ThirdPartyResources.",
 }
 
 func (ThirdPartyResourceList) SwaggerDoc() map[string]string {


### PR DESCRIPTION
verify-description.sh will check (i) the types.go stops using the description tag,  and (ii) all fields/struct has a description in comment. We enable these checks for pkg/expapi/v1/types.go now.

I added the missing descriptions using the best of my knowledge. @jszczepkowski @brendandburns @nikhiljindal, please submit PR if my description is not accurate.

This PR will needs rebase once someone editing types.go. It's not a complicated PR. Let's try to merge this soon :)

@lavalamp 
