### PR TITLE
add docker labels to containers

### DIFF
--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -238,6 +238,14 @@ func deepCopy_api_Container(in Container, out *Container, c *conversion.Cloner) 
 	}
 	out.Stdin = in.Stdin
 	out.TTY = in.TTY
+	if in.Labels != nil {
+		out.Labels = make(map[string]string)
+		for key, val := range in.Labels {
+			out.Labels[key] = val
+		}
+	} else {
+		out.Labels = nil
+	}
 	return nil
 }
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -793,6 +793,9 @@ type Container struct {
 	// and shouldn't be used for general purpose containers.
 	Stdin bool `json:"stdin,omitempty"`
 	TTY   bool `json:"tty,omitempty"`
+
+	// Optional: Docker labels
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // Handler defines a specific action that should be taken

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -261,6 +261,14 @@ func convert_api_Container_To_v1_Container(in *api.Container, out *Container, s 
 	}
 	out.Stdin = in.Stdin
 	out.TTY = in.TTY
+	if in.Labels != nil {
+		out.Labels = make(map[string]string)
+		for key, val := range in.Labels {
+			out.Labels[key] = val
+		}
+	} else {
+		out.Labels = nil
+	}
 	return nil
 }
 
@@ -2663,6 +2671,14 @@ func convert_v1_Container_To_api_Container(in *Container, out *api.Container, s 
 	}
 	out.Stdin = in.Stdin
 	out.TTY = in.TTY
+	if in.Labels != nil {
+		out.Labels = make(map[string]string)
+		for key, val := range in.Labels {
+			out.Labels[key] = val
+		}
+	} else {
+		out.Labels = nil
+	}
 	return nil
 }
 

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -253,6 +253,14 @@ func deepCopy_v1_Container(in Container, out *Container, c *conversion.Cloner) e
 	}
 	out.Stdin = in.Stdin
 	out.TTY = in.TTY
+	if in.Labels != nil {
+		out.Labels = make(map[string]string)
+		for key, val := range in.Labels {
+			out.Labels[key] = val
+		}
+	} else {
+		out.Labels = nil
+	}
 	return nil
 }
 

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -988,6 +988,9 @@ type Container struct {
 	// Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
 	// Default is false.
 	TTY bool `json:"tty,omitempty"`
+
+	// Optional: Docker labels
+	Labels map[string]string `json:"labels,omitempty" description:"map of string keys and values to be set as Docker labels"`
 }
 
 // Handler defines a specific action that should be taken

--- a/pkg/expapi/deep_copy_generated.go
+++ b/pkg/expapi/deep_copy_generated.go
@@ -175,6 +175,14 @@ func deepCopy_api_Container(in api.Container, out *api.Container, c *conversion.
 	}
 	out.Stdin = in.Stdin
 	out.TTY = in.TTY
+	if in.Labels != nil {
+		out.Labels = make(map[string]string)
+		for key, val := range in.Labels {
+			out.Labels[key] = val
+		}
+	} else {
+		out.Labels = nil
+	}
 	return nil
 }
 

--- a/pkg/expapi/v1/conversion_generated.go
+++ b/pkg/expapi/v1/conversion_generated.go
@@ -190,6 +190,14 @@ func convert_api_Container_To_v1_Container(in *api.Container, out *v1.Container,
 	}
 	out.Stdin = in.Stdin
 	out.TTY = in.TTY
+	if in.Labels != nil {
+		out.Labels = make(map[string]string)
+		for key, val := range in.Labels {
+			out.Labels[key] = val
+		}
+	} else {
+		out.Labels = nil
+	}
 	return nil
 }
 
@@ -957,6 +965,14 @@ func convert_v1_Container_To_api_Container(in *v1.Container, out *api.Container,
 	}
 	out.Stdin = in.Stdin
 	out.TTY = in.TTY
+	if in.Labels != nil {
+		out.Labels = make(map[string]string)
+		for key, val := range in.Labels {
+			out.Labels[key] = val
+		}
+	} else {
+		out.Labels = nil
+	}
 	return nil
 }
 

--- a/pkg/expapi/v1/deep_copy_generated.go
+++ b/pkg/expapi/v1/deep_copy_generated.go
@@ -192,6 +192,14 @@ func deepCopy_v1_Container(in v1.Container, out *v1.Container, c *conversion.Clo
 	}
 	out.Stdin = in.Stdin
 	out.TTY = in.TTY
+	if in.Labels != nil {
+		out.Labels = make(map[string]string)
+		for key, val := range in.Labels {
+			out.Labels[key] = val
+		}
+	} else {
+		out.Labels = nil
+	}
 	return nil
 }
 

--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -651,6 +651,9 @@ func (dm *DockerManager) runContainer(
 	labels := map[string]string{
 		kubernetesNameLabel: namespacedName.String(),
 	}
+	for k, v := range container.Labels {
+		labels[k] = v
+	}
 	if pod.Spec.TerminationGracePeriodSeconds != nil {
 		labels[kubernetesTerminationGracePeriodLabel] = strconv.FormatInt(*pod.Spec.TerminationGracePeriodSeconds, 10)
 	}


### PR DESCRIPTION
Docker has recently added labels and label-based filtering mechanism to containers, similar to Kubernetes labels. However, when trying to create a POD and defining labels to its containers, Kubernetes currently does not honor those Docker labels and does nothing with them. This PR is to allow one to define Docker labels to containers in a POD.
