### PR TITLE
MESOS: add flags for initial executor cpu and memory resources

### DIFF
--- a/contrib/mesos/pkg/scheduler/service/service.go
+++ b/contrib/mesos/pkg/scheduler/service/service.go
@@ -75,9 +75,8 @@ const (
 	defaultReconcileInterval = 300    // 5m default task reconciliation interval
 	defaultReconcileCooldown = 15 * time.Second
 	defaultFrameworkName     = "Kubernetes"
-
-	executorCPUs = mresource.CPUShares(0.25) // initial CPU allocated for executor
-	executorMem  = mresource.MegaBytes(64.0) // initial memory allocated for executor
+	defaultExecutorCPUs      = mresource.CPUShares(0.25)  // initial CPU allocated for executor
+	defaultExecutorMem       = mresource.MegaBytes(128.0) // initial memory allocated for executor
 )
 
 type SchedulerServer struct {
@@ -97,6 +96,8 @@ type SchedulerServer struct {
 	MesosAuthPrincipal  string
 	MesosAuthSecretFile string
 	MesosCgroupPrefix   string
+	MesosExecutorCPUs   mresource.CPUShares
+	MesosExecutorMem    mresource.MegaBytes
 	Checkpoint          bool
 	FailoverTimeout     float64
 
@@ -177,6 +178,8 @@ func NewSchedulerServer() *SchedulerServer {
 		MesosCgroupPrefix:      minioncfg.DefaultCgroupPrefix,
 		MesosMaster:            defaultMesosMaster,
 		MesosUser:              defaultMesosUser,
+		MesosExecutorCPUs:      defaultExecutorCPUs,
+		MesosExecutorMem:       defaultExecutorMem,
 		ReconcileInterval:      defaultReconcileInterval,
 		ReconcileCooldown:      defaultReconcileCooldown,
 		Checkpoint:             true,
@@ -221,6 +224,8 @@ func (s *SchedulerServer) addCoreFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.MesosAuthProvider, "mesos-authentication-provider", s.MesosAuthProvider, fmt.Sprintf("Authentication provider to use, default is SASL that supports mechanisms: %+v", mech.ListSupported()))
 	fs.StringVar(&s.DockerCfgPath, "dockercfg-path", s.DockerCfgPath, "Path to a dockercfg file that will be used by the docker instance of the minions.")
 	fs.StringVar(&s.MesosCgroupPrefix, "mesos-cgroup-prefix", s.MesosCgroupPrefix, "The cgroup prefix concatenated with MESOS_DIRECTORY must give the executor cgroup set by Mesos")
+	fs.Var(&s.MesosExecutorCPUs, "mesos-executor-cpus", "Initial CPU shares to allocate for each Mesos executor container.")
+	fs.Var(&s.MesosExecutorMem, "mesos-executor-mem", "Initial memory (MB) to allocate for each Mesos executor container.")
 	fs.BoolVar(&s.Checkpoint, "checkpoint", s.Checkpoint, "Enable/disable checkpointing for the kubernetes-mesos framework.")
 	fs.Float64Var(&s.FailoverTimeout, "failover-timeout", s.FailoverTimeout, fmt.Sprintf("Framework failover timeout, in sec."))
 	fs.UintVar(&s.DriverPort, "driver-port", s.DriverPort, "Port that the Mesos scheduler driver process should listen on.")
@@ -452,8 +457,8 @@ func (s *SchedulerServer) prepareExecutorInfo(hks hyperkube.Interface) (*mesos.E
 	}
 
 	execInfo.Resources = []*mesos.Resource{
-		mutil.NewScalarResource("cpus", float64(executorCPUs)+staticPodCPUs),
-		mutil.NewScalarResource("mem", float64(executorMem)+staticPodMem),
+		mutil.NewScalarResource("cpus", float64(s.MesosExecutorCPUs)+staticPodCPUs),
+		mutil.NewScalarResource("mem", float64(s.MesosExecutorMem)+staticPodMem),
 	}
 
 	// calculate ExecutorInfo hash to be used for validating compatibility

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -158,6 +158,8 @@ mesos-authentication-principal
 mesos-authentication-provider
 mesos-authentication-secret-file
 mesos-cgroup-prefix
+mesos-executor-cpus
+mesos-executor-mem
 mesos-master
 mesos-role
 mesos-user


### PR DESCRIPTION
Goal: Prevent the Mesos executor container, responsible for running several important procs (kubelet, kube-proxy) from running out of memory. The default resource allocations for the executor are OK only for a **very** limited number of pods.

New flags allow an administrator to specify higher initial allocations for the executor.

xref https://github.com/mesosphere/kubernetes-mesos/issues/480

/cc @sttts @karlkfi 
