### PR TITLE
Add svc and fix typos in namespaces.md

### DIFF
--- a/docs/admin/namespaces.md
+++ b/docs/admin/namespaces.md
@@ -122,7 +122,7 @@ See [Admission control: Limit Range](../design/admission_control_limit_range.md)
 
 A namespace can be in one of two phases:
    * `Active` the namespace is in use
-   * ```Terminating`` the namespace is being deleted, and can not be used for new objects
+   * `Terminating` the namespace is being deleted, and can not be used for new objects
 
 See the [design doc](../design/namespaces.md#phases) for more details.
 
@@ -166,8 +166,8 @@ This delete is asynchronous, so for a time you will see the namespace in the `Te
 
 ## Namespaces and DNS
 
-When you create a [Service](../../docs/user-guide/services.md), it creates a corresponding [DNS entry](dns.md)1.
-This entry is of the form `<service-name>.<namespace-name>.cluster.local`, which means
+When you create a [Service](../../docs/user-guide/services.md), it creates a corresponding [DNS entry](dns.md).
+This entry is of the form `<service-name>.<namespace-name>.svc.cluster.local`, which means
 that if a container just uses `<service-name>` it will resolve to the service which
 is local to a namespace.  This is useful for using the same configuration across
 multiple namespaces such as Development, Staging and Production.  If you want to reach

--- a/docs/user-guide/namespaces.md
+++ b/docs/user-guide/namespaces.md
@@ -105,7 +105,7 @@ $ kubectl config set-context $(CONTEXT) --namespace=<insert-namespace-name-here>
 ## Namespaces and DNS
 
 When you create a [Service](services.md), it creates a corresponding [DNS entry](../admin/dns.md).
-This entry is of the form `<service-name>.<namespace-name>.cluster.local`, which means
+This entry is of the form `<service-name>.<namespace-name>.svc.cluster.local`, which means
 that if a container just uses `<service-name>` it will resolve to the service which
 is local to a namespace.  This is useful for using the same configuration across
 multiple namespaces such as Development, Staging and Production.  If you want to reach


### PR DESCRIPTION
Add `svc.` before `cluster.local` and fix some typos in `namespaces.md`.
1. add `svc.` before `cluster.local`
2. fix ``Terminating` to `Terminating`
3. fix `DNS entry1` to `DNS entry`

Files affected:
1. `~/kubernetes/docs/admin/namespaces.md`
2. `~/kubernetes/docs/user-guide/namespaces.md`

Why add `svc.` before `cluster.local`? According to `~/kubernetes/cluster/addons/dns/README.md`:

> ### Backwards compatibility
> 
> Previous versions of kube-dns made names of the for
> `my-svc.my-namespace.cluster.local` (**the 'svc' level was added later**).  For
> compatibility, kube-dns supports both names for the time being.  Users should
> avoid creating a namespace named 'svc', to avoid conflicts.  The old name
> format is deprecated and will be removed in a future release.
