### PR TITLE
Specify how to do NFS demo for other providers

### DIFF
--- a/examples/nfs/README.md
+++ b/examples/nfs/README.md
@@ -53,6 +53,8 @@ $ vi cluster/saltbase/pillar/privilege.sls
 allow_privileged: true
 ```
 
+For other non-salt based provider, you can set `--allow-privileged=true` for both api-server and kubelet, and then restart these components.
+
 Rebuild the Kubernetes and spin up a cluster using your preferred KUBERNETES_PROVIDER.
 
 ### NFS server part


### PR DESCRIPTION
A very simple fix.

Many people asked me how to allow privileged mode for their own cluster, some even thought then need to re-compile k8s ...

We need to specify this in this doc.
