### PR TITLE
fixed a markdown error in the title of getting-into-containers.md

### DIFF
--- a/docs/user-guide/getting-into-containers.md
+++ b/docs/user-guide/getting-into-containers.md
@@ -30,7 +30,9 @@ Documentation for other releases can be found at
 <!-- END STRIP_FOR_RELEASE -->
 
 <!-- END MUNGE: UNVERSIONED_WARNING -->
-﻿#Getting into containers: kubectl exec
+
+# Getting into containers: kubectl exec
+
 Developers can use `kubectl exec` to run commands in a container. This guide demonstrates two use cases.
 
 ## Using kubectl exec to check the environment variables of a container


### PR DESCRIPTION
By deleting the leading `.` in `.#Getting into containers: kubectl exec`

If you cannot see clearly, please use `Display the rich diff` rather than `Display the source diff` to see the effect.
