### PR TITLE
Change 'random' to 'round robin' for the choice of a service backend

### DIFF
--- a/docs/user-guide/services.md
+++ b/docs/user-guide/services.md
@@ -219,7 +219,7 @@ appropriate backend without the clients knowing anything about Kubernetes or
 
 ![Services overview diagram](services-overview.png)
 
-By default, the choice of backend is random.  Client-IP based session affinity
+By default, the choice of backend is round robin.  Client-IP based session affinity
 can be selected by setting `service.spec.sessionAffinity` to `"ClientIP"` (the
 default is `"None"`).
 


### PR DESCRIPTION
Change `random` to `round robin` for the choice of a service backend.

It is said `By default, the choice of backend is random`. But by reading the source code, the service endpoint is chosen using the round-robin algorithm. Please correct me if I am wrong.

Please refer to the following code segments:

1.`~\kubernetes\pkg\proxy\userspace\roundrobin.go`:

``` go
// NextEndpoint returns a service endpoint.
// The service endpoint is chosen using the round-robin algorithm.
func (lb *LoadBalancerRR) NextEndpoint(svcPort proxy.ServicePortName, srcAddr net.Addr) (string, error) {
... ...
    // Take the next endpoint.
    endpoint := state.endpoints[state.index]
    state.index = (state.index + 1) % len(state.endpoints)

    if sessionAffinityEnabled {
        ... ...
    }

    return endpoint, nil
}
```

2.`~\kubernetes\pkg\proxy\userspace\proxysocket.go`:

``` go
func tryConnect(service proxy.ServicePortName, srcAddr net.Addr, protocol string, proxier *Proxier) (out net.Conn, err error) {
    for _, retryTimeout := range endpointDialTimeout {
        endpoint, err := proxier.loadBalancer.NextEndpoint(service, srcAddr)
        ... ...
}
```
