### PR TITLE
Add Region and Endpoint Configuration Options to AWS CloudProvider

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -57,9 +57,9 @@ const MaxReadThenCreateRetries = 30
 
 // Abstraction over AWS, to allow mocking/other implementations
 type AWSServices interface {
-	Compute(region string) (EC2, error)
-	LoadBalancing(region string) (ELB, error)
-	Autoscaling(region string) (ASG, error)
+	Compute(region string, endpoint string) (EC2, error)
+	LoadBalancing(region string, endpoint string) (ELB, error)
+	Autoscaling(region string, endpoint string) (ASG, error)
 	Metadata() AWSMetadata
 }
 
@@ -177,6 +177,7 @@ type AWSCloud struct {
 	cfg              *AWSCloudConfig
 	availabilityZone string
 	region           string
+	endpoint         string
 
 	filterTags map[string]string
 
@@ -190,7 +191,9 @@ type AWSCloudConfig struct {
 	Global struct {
 		// TODO: Is there any use for this?  We can get it from the instance metadata service
 		// Maybe if we're not running on AWS, e.g. bootstrap; for now it is not very useful
-		Zone string
+		Zone     string
+		Region   string
+		Endpoint string
 
 		KubernetesClusterTag string
 	}
@@ -205,27 +208,30 @@ type awsSDKProvider struct {
 	creds *credentials.Credentials
 }
 
-func (p *awsSDKProvider) Compute(regionName string) (EC2, error) {
+func (p *awsSDKProvider) Compute(regionName string, endpoint string) (EC2, error) {
 	ec2 := &awsSdkEC2{
 		ec2: ec2.New(&aws.Config{
 			Region:      regionName,
+			Endpoint:    endpoint,
 			Credentials: p.creds,
 		}),
 	}
 	return ec2, nil
 }
 
-func (p *awsSDKProvider) LoadBalancing(regionName string) (ELB, error) {
+func (p *awsSDKProvider) LoadBalancing(regionName string, endpoint string) (ELB, error) {
 	elbClient := elb.New(&aws.Config{
 		Region:      regionName,
+		Endpoint:    endpoint,
 		Credentials: p.creds,
 	})
 	return elbClient, nil
 }
 
-func (p *awsSDKProvider) Autoscaling(regionName string) (ASG, error) {
+func (p *awsSDKProvider) Autoscaling(regionName string, endpoint string) (ASG, error) {
 	client := autoscaling.New(&aws.Config{
 		Region:      regionName,
+		Endpoint:    endpoint,
 		Credentials: p.creds,
 	})
 	return client, nil
@@ -536,24 +542,30 @@ func newAWSCloud(config io.Reader, awsServices AWSServices) (*AWSCloud, error) {
 	if len(zone) <= 1 {
 		return nil, fmt.Errorf("invalid AWS zone in config file: %s", zone)
 	}
-	regionName := zone[:len(zone)-1]
 
-	valid := isRegionValid(regionName)
-	if !valid {
-		return nil, fmt.Errorf("not a valid AWS zone (unknown region): %s", zone)
+	regionName := cfg.Global.Region
+	if len(regionName) <= 1 {
+		regionName = zone[:len(zone)-1]
 	}
 
-	ec2, err := awsServices.Compute(regionName)
+	endpoint := cfg.Global.Endpoint
+
+	valid := isRegionValid(regionName)
+	if len(cfg.Global.Region) <= 0 && !valid {
+		return nil, fmt.Errorf("not a valid AWS zone (unknown region): %s", regionName)
+	}
+
+	ec2, err := awsServices.Compute(regionName, endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("error creating AWS EC2 client: %v", err)
 	}
 
-	elb, err := awsServices.LoadBalancing(regionName)
+	elb, err := awsServices.LoadBalancing(regionName, endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("error creating AWS ELB client: %v", err)
 	}
 
-	asg, err := awsServices.Autoscaling(regionName)
+	asg, err := awsServices.Autoscaling(regionName, endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("error creating AWS autoscaling client: %v", err)
 	}
@@ -566,6 +578,7 @@ func newAWSCloud(config io.Reader, awsServices AWSServices) (*AWSCloud, error) {
 		cfg:              cfg,
 		region:           regionName,
 		availabilityZone: zone,
+		endpoint:         endpoint,
 	}
 
 	filterTags := map[string]string{}

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -538,21 +538,20 @@ func newAWSCloud(config io.Reader, awsServices AWSServices) (*AWSCloud, error) {
 		return nil, fmt.Errorf("unable to read AWS cloud provider config file: %v", err)
 	}
 
-	zone := cfg.Global.Zone
-	if len(zone) <= 1 {
-		return nil, fmt.Errorf("invalid AWS zone in config file: %s", zone)
-	}
-
 	regionName := cfg.Global.Region
-	if len(regionName) <= 1 {
-		regionName = zone[:len(zone)-1]
-	}
-
 	endpoint := cfg.Global.Endpoint
+	zone := cfg.Global.Zone
 
-	valid := isRegionValid(regionName)
-	if len(cfg.Global.Region) <= 0 && !valid {
-		return nil, fmt.Errorf("not a valid AWS zone (unknown region): %s", regionName)
+	if regionName == "" {
+		// Calculate region from availability zone
+		if len(zone) <= 1 {
+			return nil, fmt.Errorf("invalid AWS zone in config file: %s", zone)
+		}
+		regionName = zone[:len(zone)-1]
+
+		if !isRegionValid(regionName) {
+			return nil, fmt.Errorf("not a valid AWS zone (unknown region): %s", regionName)
+		}
 	}
 
 	ec2, err := awsServices.Compute(regionName, endpoint)

--- a/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_test.go
@@ -43,41 +43,53 @@ func TestReadAWSCloudConfig(t *testing.T) {
 
 		expectError bool
 		zone        string
+		region      string
+		endpoint    string
 	}{
 		{
 			"No config reader",
 			nil, nil,
-			true, "",
+			true, "", "", "",
 		},
 		{
 			"Empty config, no metadata",
 			strings.NewReader(""), nil,
-			true, "",
+			true, "", "", "",
 		},
 		{
 			"No zone in config, no metadata",
 			strings.NewReader("[global]\n"), nil,
-			true, "",
+			true, "", "", "",
 		},
 		{
 			"Zone in config, no metadata",
 			strings.NewReader("[global]\nzone = eu-west-1a"), nil,
-			false, "eu-west-1a",
+			false, "eu-west-1a", "", "",
 		},
 		{
 			"No zone in config, metadata does not have zone",
 			strings.NewReader("[global]\n"), NewFakeAWSServices().withAz(""),
-			true, "",
+			true, "", "", "",
 		},
 		{
 			"No zone in config, metadata has zone",
 			strings.NewReader("[global]\n"), NewFakeAWSServices(),
-			false, "us-east-1a",
+			false, "us-east-1a", "", "",
 		},
 		{
 			"Zone in config should take precedence over metadata",
 			strings.NewReader("[global]\nzone = eu-west-1a"), NewFakeAWSServices(),
-			false, "eu-west-1a",
+			false, "eu-west-1a", "", "",
+		},
+		{
+			"Region in config, no metadata",
+			strings.NewReader("[global]\nzone = eu-west-1a\nregion = europe"), nil,
+			false, "eu-west-1a", "europe", "",
+		},
+		{
+			"Endpoint in config, no metadata",
+			strings.NewReader("[global]\nzone = eu-west-1a\nendpoint = http://custom.endpoint.com"), nil,
+			false, "eu-west-1a", "", "http://custom.endpoint.com",
 		},
 	}
 
@@ -99,6 +111,14 @@ func TestReadAWSCloudConfig(t *testing.T) {
 			if cfg.Global.Zone != test.zone {
 				t.Errorf("Incorrect zone value (%s vs %s) for case: %s",
 					cfg.Global.Zone, test.zone, test.name)
+			}
+			if cfg.Global.Region != test.region {
+				t.Errorf("Incorrect region value (%s vs %s) for case: %s",
+					cfg.Global.Region, test.region, test.name)
+			}
+			if cfg.Global.Endpoint != test.endpoint {
+				t.Errorf("Incorrect endpoint value (%s vs %s) for case: %s",
+					cfg.Global.Endpoint, test.endpoint, test.name)
 			}
 		}
 	}
@@ -154,15 +174,15 @@ func (s *FakeAWSServices) withInstances(instances []*ec2.Instance) *FakeAWSServi
 	return s
 }
 
-func (s *FakeAWSServices) Compute(region string) (EC2, error) {
+func (s *FakeAWSServices) Compute(region string, endpoint string) (EC2, error) {
 	return s.ec2, nil
 }
 
-func (s *FakeAWSServices) LoadBalancing(region string) (ELB, error) {
+func (s *FakeAWSServices) LoadBalancing(region string, endpoint string) (ELB, error) {
 	return s.elb, nil
 }
 
-func (s *FakeAWSServices) Autoscaling(region string) (ASG, error) {
+func (s *FakeAWSServices) Autoscaling(region string, endpoint string) (ASG, error) {
 	return s.asg, nil
 }
 
@@ -197,34 +217,51 @@ func TestNewAWSCloud(t *testing.T) {
 
 		expectError bool
 		zone        string
+		region      string
+		endpoint    string
 	}{
 		{
 			"No config reader",
 			nil, NewFakeAWSServices().withAz(""),
-			true, "",
+			true, "", "", "",
 		},
 		{
 			"Config specified invalid zone",
 			strings.NewReader("[global]\nzone = blahonga"), NewFakeAWSServices(),
-			true, "",
+			true, "", "", "",
 		},
 		{
-			"Config specifies valid zone",
+			"Config specifies valid zone, calulate region",
 			strings.NewReader("[global]\nzone = eu-west-1a"), NewFakeAWSServices(),
-			false, "eu-west-1a",
+			false, "eu-west-1a", "eu-west-1", "",
 		},
-		{
-			"Gets zone from metadata when not in config",
 
+		{
+			"Gets zone from metadata when not in config, calulate region",
 			strings.NewReader("[global]\n"),
 			NewFakeAWSServices(),
-			false, "us-east-1a",
+			false, "us-east-1a", "us-east-1", "",
 		},
 		{
 			"No zone in config or metadata",
 			strings.NewReader("[global]\n"),
 			NewFakeAWSServices().withAz(""),
-			true, "",
+			true, "", "", "",
+		},
+		{
+			"Config specifies valid zone and region. region in config takes precedence over calculated region",
+			strings.NewReader("[global]\nzone = eu-west-1a\nregion = europe"), NewFakeAWSServices(),
+			false, "eu-west-1a", "europe", "",
+		},
+		{
+			"Gets zone from metadata when not in config, region in config takes precedence over calculated region",
+			strings.NewReader("[global]\nregion = europe"), NewFakeAWSServices(),
+			false, "us-east-1a", "europe", "",
+		},
+		{
+			"Config specifies endpoint",
+			strings.NewReader("[global]\nendpoint = http://custom.us-east-1.ec2.com"), NewFakeAWSServices(),
+			false, "us-east-1a", "us-east-1", "http://custom.us-east-1.ec2.com",
 		},
 	}
 
@@ -238,9 +275,19 @@ func TestNewAWSCloud(t *testing.T) {
 		} else {
 			if err != nil {
 				t.Errorf("Should succeed for case: %s, got %v", test.name, err)
-			} else if c.availabilityZone != test.zone {
-				t.Errorf("Incorrect zone value (%s vs %s) for case: %s",
-					c.availabilityZone, test.zone, test.name)
+			} else {
+				if c.availabilityZone != test.zone {
+					t.Errorf("Incorrect zone value (%s vs %s) for case: %s",
+						c.availabilityZone, test.zone, test.name)
+				}
+				if c.region != test.region {
+					t.Errorf("Incorrect region value (%s vs %s) for case: %s",
+						c.region, test.region, test.name)
+				}
+				if c.endpoint != test.endpoint {
+					t.Errorf("Incorrect endpoint value (%s vs %s) for case: %s",
+						c.endpoint, test.endpoint, test.name)
+				}
 			}
 		}
 	}

--- a/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_test.go
@@ -231,13 +231,13 @@ func TestNewAWSCloud(t *testing.T) {
 			true, "", "", "",
 		},
 		{
-			"Config specifies valid zone, calulate region",
+			"Config specifies valid zone, calculate region",
 			strings.NewReader("[global]\nzone = eu-west-1a"), NewFakeAWSServices(),
 			false, "eu-west-1a", "eu-west-1", "",
 		},
 
 		{
-			"Gets zone from metadata when not in config, calulate region",
+			"Gets zone from metadata when not in config, calculate region",
 			strings.NewReader("[global]\n"),
 			NewFakeAWSServices(),
 			false, "us-east-1a", "us-east-1", "",


### PR DESCRIPTION
The aws-sdk-go supports custom endpoints and regions for EC2 compatible clouds. This change allows to configure a region and endpoint in the aws cloud provider config. These parameters are passed through to the aws client.

A complete `cloud-config` file would look like:

```
[global]
zone = eu-de-1
region = europe
endpoint = https://eu-de-1.europe.ec2.acmecorp.com
```

Coincidentally, this also leads to the region validation to fail if the EC2 compatible cloud is, well not, 100% compatible and doesn't adhere to the Amazons naming scheme. The assumption is that the region can be calculated by striping the index of the availability zone. Since this is not always the case, an explicit region in the config will not be validated.
