### PR TITLE
Fix IP conflict on master's cbr0 and host's virbr_kub_pods

### DIFF
--- a/cluster/libvirt-coreos/network_kubernetes_pods.xml
+++ b/cluster/libvirt-coreos/network_kubernetes_pods.xml
@@ -1,6 +1,6 @@
 <network>
   <name>kubernetes_pods</name>
   <bridge name='virbr_kub_pods' stp='off' delay='0'/>
-  <ip address='10.10.0.1' netmask='255.255.0.0'>
+  <ip address='10.10.0.100' netmask='255.255.0.0'>
   </ip>
 </network>


### PR DESCRIPTION
In `cluster/libvirt-coreos/network_kubernetes_pods.xml`, we can see the `virbr_kub_pods`'s IP is `10.10.0.1`.
In `cluster/libvirt-coreos/user_data.yml`, we can figure out the master cbr0 IP is 10.10.0.1 too.
That's conflict.
