### PR TITLE
Fixed error handling of cloud init.

### DIFF
--- a/pkg/cloudprovider/plugins.go
+++ b/pkg/cloudprovider/plugins.go
@@ -65,15 +65,16 @@ func GetCloudProvider(name string, config io.Reader) (Interface, error) {
 // InitCloudProvider creates an instance of the named cloud provider.
 func InitCloudProvider(name string, configFilePath string) (Interface, error) {
 	var cloud Interface
+	var err error
 
 	if name == "" {
 		glog.Info("No cloud provider specified.")
 		return nil, nil
 	}
 
-	var err error
 	if configFilePath != "" {
-		config, err := os.Open(configFilePath)
+		var config *os.File
+		config, err = os.Open(configFilePath)
 		if err != nil {
 			glog.Fatalf("Couldn't open cloud provider configuration %s: %#v",
 				configFilePath, err)


### PR DESCRIPTION
Avoid creating a new 'err' variable in the 'if'-branch, shadowing the one
in the outer scope.

Any error from subsequent 'cloud, err = GetCloudProvider()' was not propagated
to 'err' variable in the outer scope and thus errors were never returned from
this function.

This is hard to debug error on OpenStack, when content of --cloud-config=
file is wrong or connection to OpenStack fails. Such error is never logged
and Kubernetes thinks everything is OK.
