### PR TITLE
Add cloud provider node labels

### DIFF
--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -113,6 +113,8 @@ type Instances interface {
 	// Returns the name of the node we are currently running on
 	// On most clouds (e.g. GCE) this is the hostname, so we provide the hostname
 	CurrentNodeName(hostname string) (string, error)
+	// Labels returns cloud provider node labels of the specified instance.
+	Labels(name string) (map[string]string, error)
 }
 
 // Route is a representation of an advanced routing rule.

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -687,6 +687,11 @@ func (aws *AWSCloud) ExternalID(name string) (string, error) {
 	return orEmpty(instance.InstanceID), nil
 }
 
+// Labels returns the cloud provider node labels of the specified instance.
+func (aws *AWSCloud) Labels(name string) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
 // InstanceID returns the cloud provider ID of the specified instance.
 func (aws *AWSCloud) InstanceID(name string) (string, error) {
 	// TODO: Do we need to verify it exists, or can we just construct it knowing our AZ (or via caching?)

--- a/pkg/cloudprovider/providers/fake/fake.go
+++ b/pkg/cloudprovider/providers/fake/fake.go
@@ -177,6 +177,11 @@ func (f *FakeCloud) ExternalID(instance string) (string, error) {
 	return f.ExtID[instance], f.Err
 }
 
+// Labels returns the cloud provider node labels of the specified instance.
+func (f *FakeCloud) Labels(name string) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
 // InstanceID returns the cloud provider ID of the specified instance.
 func (f *FakeCloud) InstanceID(instance string) (string, error) {
 	f.addCall("instance-id")

--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -669,6 +669,11 @@ func (gce *GCECloud) ExternalID(instance string) (string, error) {
 	return strconv.FormatUint(inst.Id, 10), nil
 }
 
+// Labels returns the cloud provider node labels of the specified instance.
+func (gce *GCECloud) Labels(name string) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
 // InstanceID returns the cloud provider ID of the specified instance.
 func (gce *GCECloud) InstanceID(instance string) (string, error) {
 	return gce.projectID + "/" + gce.zone + "/" + canonicalizeInstanceName(instance), nil

--- a/pkg/cloudprovider/providers/mesos/mesos.go
+++ b/pkg/cloudprovider/providers/mesos/mesos.go
@@ -184,6 +184,11 @@ func (c *MesosCloud) ExternalID(instance string) (string, error) {
 	return ip.String(), nil
 }
 
+// Labels returns the cloud provider node labels of the specified instance.
+func (c *MesosCloud) Labels(name string) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
 // InstanceID returns the cloud provider ID of the specified instance.
 func (c *MesosCloud) InstanceID(name string) (string, error) {
 	return "", nil

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -379,6 +379,11 @@ func (i *Instances) ExternalID(name string) (string, error) {
 	return srv.ID, nil
 }
 
+// Labels returns the cloud provider node labels of the specified instance.
+func (i *Instances) Labels(name string) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
 // InstanceID returns the cloud provider ID of the specified instance.
 func (i *Instances) InstanceID(name string) (string, error) {
 	srv, err := getServerByName(i.compute, name)

--- a/pkg/cloudprovider/providers/ovirt/ovirt.go
+++ b/pkg/cloudprovider/providers/ovirt/ovirt.go
@@ -177,6 +177,11 @@ func (v *OVirtCloud) ExternalID(name string) (string, error) {
 	return instance.UUID, nil
 }
 
+// Labels returns the cloud provider node labels of the specified instance.
+func (v *OVirtCloud) Labels(name string) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
 // InstanceID returns the cloud provider ID of the specified instance.
 func (v *OVirtCloud) InstanceID(name string) (string, error) {
 	instance, err := v.fetchInstance(name)

--- a/pkg/cloudprovider/providers/rackspace/rackspace.go
+++ b/pkg/cloudprovider/providers/rackspace/rackspace.go
@@ -339,6 +339,11 @@ func (i *Instances) ExternalID(name string) (string, error) {
 	return "", fmt.Errorf("unimplemented")
 }
 
+// Labels returns the cloud provider node labels of the specified instance.
+func (i *Instances) Labels(name string) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
 // InstanceID returns the cloud provider ID of the specified instance.
 func (i *Instances) InstanceID(name string) (string, error) {
 	return "", nil

--- a/pkg/cloudprovider/providers/vagrant/vagrant.go
+++ b/pkg/cloudprovider/providers/vagrant/vagrant.go
@@ -161,6 +161,11 @@ func (v *VagrantCloud) ExternalID(instance string) (string, error) {
 	return minion.IP, nil
 }
 
+// Labels returns the cloud provider node labels of the specified instance.
+func (v *VagrantCloud) Labels(name string) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
 // InstanceID returns the cloud provider ID of the specified instance.
 func (v *VagrantCloud) InstanceID(instance string) (string, error) {
 	minion, err := v.getInstanceByAddress(instance)

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -817,6 +817,14 @@ func (kl *Kubelet) initialNodeStatus() (*api.Node, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		labels, err := instances.Labels(kl.nodeName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get labels from cloud provider: %v", err)
+		}
+		for k, v := range labels {
+			node.ObjectMeta.Labels[k] = v
+		}
 	} else {
 		node.Spec.ExternalID = kl.hostname
 	}


### PR DESCRIPTION
This patch adds a `Labels` function to the cloud provider interface. The kubelet applies the returned labels when creating a new node api object.

**Use Case:**

The cloud environment assigns labels to VMs. These should be automatically available as k8s node labels.

**Background:**

The node labels are matched with the NodeSelector of a pod spec by the scheduler. In addition the kubelet itself will check that its node labels match the NodeSelector before admitting a pod to be launched.

The Mesos scheduler will take the NodeSelector into account when selecting a host for a pod. It uses the Mesos provided slave labels as k8s node labels. The first scheduled pod for a host will trigger the launch of the kubelet. The kubelet creates the api node object. It has to know about the node labels at this point because pods sent from the Mesos executor to the kubelet will be matched against the node labels when a NodeSelector is defined in the pod spec. If labels are not applied yet, such a pod is rejected.

**Alternatives:**
- node-label-controller
  
  Node labels could be added to new nodes asynchronously by some kind of node-label-controller. Unfortunately, being asynchronous means that for a short time the node will exist without the labels. When a pod is scheduled onto that node in this moment, the kubelet will reject it because the NodeSelector does not match.
- kubelet command line flag `--labels`
  
  Node labels could be provided by a command line flag of the kubelet. This way the logic to retrieve the labels from the cloud environments is moved to the launcher of the kubelet. In the case of Mesos this would be the Mesos executor. In the case of other environments it might be some configuration management tool like salt or ansible.
  
  For Mesos this alternative would work as well.

The actual Mesos support to retrieve node labels in its cloud provider will be part of https://github.com/kubernetes/kubernetes/pull/13036.

This seems to have been proposed in #9044
