### PR TITLE
Fix kubectl for namespaced users

### DIFF
--- a/pkg/apiserver/handlers.go
+++ b/pkg/apiserver/handlers.go
@@ -351,6 +351,19 @@ func NewRequestAttributeGetter(requestContextMapper api.RequestContextMapper, ap
 	return &requestAttributeGetter{requestContextMapper, apiRequestInfoResolver}
 }
 
+func isAPIResourceRequest(apiPrefixes sets.String, req *http.Request) bool {
+	// Slice the first / of the path off (in apiRoots they're stored w/o leading /)
+	parts := strings.Split(req.URL.Path, "/")[1:]
+	// Paths with only one fragment won't have a prefix.
+	for i := 1; i < len(parts); i++ {
+		prefix := strings.Join(parts[:i], "/")
+		if apiPrefixes.Has(prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 func (r *requestAttributeGetter) GetAttribs(req *http.Request) authorizer.Attributes {
 	attribs := authorizer.AttributesRecord{}
 
@@ -363,18 +376,24 @@ func (r *requestAttributeGetter) GetAttribs(req *http.Request) authorizer.Attrib
 	}
 
 	apiRequestInfo, _ := r.apiRequestInfoResolver.GetAPIRequestInfo(req)
-
-	attribs.APIGroup = apiRequestInfo.APIGroup
 	attribs.Verb = apiRequestInfo.Verb
 
-	// If a path follows the conventions of the REST object store, then
-	// we can extract the resource.  Otherwise, not.
-	attribs.Resource = apiRequestInfo.Resource
+	// Check whether meaningful api information can be resolved for the current path
+	if isAPIResourceRequest(r.apiRequestInfoResolver.APIPrefixes, req) {
+		attribs.APIGroup = apiRequestInfo.APIGroup
 
-	// If the request specifies a namespace, then the namespace is filled in.
-	// Assumes there is no empty string namespace.  Unspecified results
-	// in empty (does not understand defaulting rules.)
-	attribs.Namespace = apiRequestInfo.Namespace
+		// If a path follows the conventions of the REST object store, then
+		// we can extract the resource.  Otherwise, not.
+		attribs.Resource = apiRequestInfo.Resource
+
+		// If the request specifies a namespace, then the namespace is filled in.
+		// Assumes there is no empty string namespace.  Unspecified results
+		// in empty (does not understand defaulting rules.)
+		attribs.Namespace = apiRequestInfo.Namespace
+	} else {
+		// If a request does not fall into an api namespace/resource pattern, it's a special path.
+		attribs.NonResourcePath = req.URL.Path
+	}
 
 	return &attribs
 }

--- a/pkg/auth/authorizer/abac/abac.go
+++ b/pkg/auth/authorizer/abac/abac.go
@@ -51,9 +51,10 @@ type policy struct {
 	// the API, we don't have to add lots of policy?
 
 	// TODO: make this a proper REST object with its own registry.
-	Readonly  bool   `json:"readonly,omitempty"`
-	Resource  string `json:"resource,omitempty"`
-	Namespace string `json:"namespace,omitempty"`
+	Readonly        bool   `json:"readonly,omitempty"`
+	Resource        string `json:"resource,omitempty"`
+	Namespace       string `json:"namespace,omitempty"`
+	NonResourcePath string `json:"nonResourcePath,omitempty"`
 
 	// TODO: "expires" string in RFC3339 format.
 
@@ -100,13 +101,20 @@ func NewFromFile(path string) (policyList, error) {
 func (p policy) matches(a authorizer.Attributes) bool {
 	if p.subjectMatches(a) {
 		if p.Readonly == false || (p.Readonly == a.IsReadOnly()) {
-			if p.Resource == "" || (p.Resource == a.GetResource()) {
+			switch {
+			case p.NonResourcePath != "":
+				if p.NonResourcePath == a.GetNonResourcePath() {
+					return true
+				}
+			// When the path is a non-resource path it cannot match.
+			case len(a.GetNonResourcePath()) == 0 && (p.Resource == "" || (p.Resource == a.GetResource())):
 				if p.Namespace == "" || (p.Namespace == a.GetNamespace()) {
 					return true
 				}
 			}
 		}
 	}
+
 	return false
 }
 

--- a/pkg/auth/authorizer/abac/example_policy_file.jsonl
+++ b/pkg/auth/authorizer/abac/example_policy_file.jsonl
@@ -1,9 +1,13 @@
 {"user":"admin"}
+{"readonly": true, "nonResourcePath": "/api"}
+{"readonly": true, "nonResourcePath": "/swaggerapi/api/v1"}
+{"readonly": true, "nonResourcePath": "/swaggerapi/experimental/v1"}
+{"readonly": true, "nonResourcePath": "/version"}
 {"user":"scheduler", "readonly": true, "resource": "pods"}
 {"user":"scheduler", "resource": "bindings"}
-{"user":"kubelet",  "readonly": true, "resource": "pods"}
-{"user":"kubelet",  "readonly": true, "resource": "services"}
-{"user":"kubelet",  "readonly": true, "resource": "endpoints"}
+{"user":"kubelet", "readonly": true, "resource": "pods"}
+{"user":"kubelet", "readonly": true, "resource": "services"}
+{"user":"kubelet", "readonly": true, "resource": "endpoints"}
 {"user":"kubelet", "resource": "events"}
 {"user":"alice", "namespace": "projectCaribou"}
 {"user":"bob", "readonly": true, "namespace": "projectCaribou"}

--- a/pkg/auth/authorizer/interfaces.go
+++ b/pkg/auth/authorizer/interfaces.go
@@ -48,6 +48,10 @@ type Attributes interface {
 
 	// The group of the resource, if a request is for a REST object.
 	GetAPIGroup() string
+
+	// In case a special endpoint like /api, /healthz has been called. This can
+	// only yield a value when both GetNamespace() & GetResource() return none.
+	GetNonResourcePath() string
 }
 
 // Authorizer makes an authorization decision based on information gained by making
@@ -65,11 +69,12 @@ func (f AuthorizerFunc) Authorize(a Attributes) error {
 
 // AttributesRecord implements Attributes interface.
 type AttributesRecord struct {
-	User      user.Info
-	Verb      string
-	Namespace string
-	APIGroup  string
-	Resource  string
+	User            user.Info
+	Verb            string
+	Namespace       string
+	APIGroup        string
+	Resource        string
+	NonResourcePath string
 }
 
 func (a AttributesRecord) GetUserName() string {
@@ -98,4 +103,8 @@ func (a AttributesRecord) GetResource() string {
 
 func (a AttributesRecord) GetAPIGroup() string {
 	return a.APIGroup
+}
+
+func (a AttributesRecord) GetNonResourcePath() string {
+	return a.NonResourcePath
 }


### PR DESCRIPTION
This is an attempt at fixing #13097. Currently users locked in a namespace by the ABAC authorization module cannot use kubectl at all, since kubectl does a version negotiation using /api which is not covered by the ABAC ontologies. So I ended up creating a MetaResource type, representing "/api" and "/healthz" currently. When a user has set "kubectl: true" as a property in the authorization policy file, calls to "/api" by that user will be allowed.
