### PR TITLE
Add PodPhase 'Unknown'

### DIFF
--- a/docs/user-guide/pod-states.md
+++ b/docs/user-guide/pod-states.md
@@ -47,6 +47,7 @@ The number and meanings of `PodPhase` values are tightly guarded.  Other than wh
 * Running: The pod has been bound to a node, and all of the containers have been created.  At least one container is still running, or is in the process of starting or restarting.
 * Succeeded: All containers in the pod have terminated in success, and will not be restarted.
 * Failed: All containers in the pod have terminated, at least one container has terminated in failure (exited with non-zero exit status or was terminated by the system).
+* Unknown: For some reason the state of the pod could not be obtained, typically due to an error in communicating with the host of the pod.
 
 ## Pod Conditions
 


### PR DESCRIPTION
Add PodPhase `Unknown` and its corresponding description.

Please refer to `~/kubernetes/pkg/api/types.go` for the definition of `PodPhase`:

``` go
// PodPhase is a label for the condition of a pod at the current time.
type PodPhase string

// These are the valid statuses of pods.
const (
    // PodPending means the pod has been accepted by the system, but one or more of the containers
    // has not been started. This includes time before being bound to a node, as well as time spent
    // pulling images onto the host.
    PodPending PodPhase = "Pending"
    // PodRunning means the pod has been bound to a node and all of the containers have been started.
    // At least one container is still running or is in the process of being restarted.
    PodRunning PodPhase = "Running"
    // PodSucceeded means that all containers in the pod have voluntarily terminated
    // with a container exit code of 0, and the system is not going to restart any of these containers.
    PodSucceeded PodPhase = "Succeeded"
    // PodFailed means that all containers in the pod have terminated, and at least one container has
    // terminated in a failure (exited with a non-zero exit code or was stopped by the system).
    PodFailed PodPhase = "Failed"
    // PodUnknown means that for some reason the state of the pod could not be obtained, typically due
    // to an error in communicating with the host of the pod.
    PodUnknown PodPhase = "Unknown"
)
```
