### PR TITLE
Fixed a markdown error in rackspace.md

### DIFF
--- a/docs/getting-started-guides/rackspace.md
+++ b/docs/getting-started-guides/rackspace.md
@@ -79,6 +79,7 @@ The current cluster design is inspired by:
 ## Cluster
 
 There is a specific `cluster/rackspace` directory with the scripts for the following steps:
+
 1. A cloud network will be created and all instances will be attached to this network.
   - flanneld uses this network for next hop routing. These routes allow the containers running on each node to communicate with one another on this private network.
 2. A SSH key will be created and uploaded if needed. This key must be used to ssh into the machines (we do not capture the password).


### PR DESCRIPTION
Fixed a markdown error in `rackspace.md`. 

If you cannot see clearly, please use `Display the rich diff` rather than `Display the source diff` to see the effect.
