### PR TITLE
Fix conversion error in limit request ratio enforcement

### DIFF
--- a/plugin/pkg/admission/limitranger/admission.go
+++ b/plugin/pkg/admission/limitranger/admission.go
@@ -239,7 +239,11 @@ func maxConstraint(limitType api.LimitType, resourceName api.ResourceName, enfor
 func limitRequestRatioConstraint(limitType api.LimitType, resourceName api.ResourceName, enforced resource.Quantity, request api.ResourceList, limit api.ResourceList) error {
 	req, reqExists := request[resourceName]
 	lim, limExists := limit[resourceName]
-	observedReqValue, observedLimValue, enforcedValue := requestLimitEnforcedValues(req, lim, enforced)
+	observedReqValue, observedLimValue, _ := requestLimitEnforcedValues(req, lim, enforced)
+
+	// the enforced value for ratio is normalized as a number and should not be converted to millivalue units
+	// so for example, 1 is 1 and not 1000
+	enforcedValue := enforced.Value()
 
 	if !reqExists || (observedReqValue == int64(0)) {
 		return fmt.Errorf("%s max limit to request ratio per %s is %s, but no request is specified or request is 0.", resourceName, limitType, enforced.String())

--- a/plugin/pkg/admission/limitranger/admission_test.go
+++ b/plugin/pkg/admission/limitranger/admission_test.go
@@ -404,3 +404,20 @@ func TestLimitRangerIgnoresSubresource(t *testing.T) {
 	}
 
 }
+
+func TestLimitRequestRatioConstraint(t *testing.T) {
+	limitType := api.LimitTypeContainer
+	resourceName := api.ResourceCPU
+	enforced := resource.MustParse("10")
+	request := getResourceList("100m", "")
+	limit := getResourceList("1100m", "")
+	err := limitRequestRatioConstraint(limitType, resourceName, enforced, request, limit)
+	if err == nil {
+		t.Errorf("Expected an error because the ratio of limit/request exceeds 10")
+	}
+	enforced = resource.MustParse("11")
+	err = limitRequestRatioConstraint(limitType, resourceName, enforced, request, limit)
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
+}


### PR DESCRIPTION
The code that enforced the ratio between limit and request had a precision bug.

For example:

request was 100m
limit was 1
maxLimitRequestRatio was 5

We should have got an error because the ratio between limit and request was 10, but we were computing a value of 5000 as what should be enforced.  As a result, 10 was always < 5000.

Fixed the code to not have this precision bug when enforcing ratio and added test case to enforce func.
