### PR TITLE
Block apiserver startup on certificate

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -505,23 +505,24 @@ func (s *APIServer) Run(_ []string) error {
 		}
 
 		glog.Infof("Serving securely on %s", secureLocation)
+		if s.TLSCertFile == "" && s.TLSPrivateKeyFile == "" {
+			s.TLSCertFile = path.Join(s.CertDirectory, "apiserver.crt")
+			s.TLSPrivateKeyFile = path.Join(s.CertDirectory, "apiserver.key")
+			// TODO (cjcullen): Is PublicAddress the right address to sign a cert with?
+			alternateIPs := []net.IP{config.ServiceReadWriteIP}
+			alternateDNS := []string{"kubernetes.default.svc", "kubernetes.default", "kubernetes"}
+			// It would be nice to set a fqdn subject alt name, but only the kubelets know, the apiserver is clueless
+			// alternateDNS = append(alternateDNS, "kubernetes.default.svc.CLUSTER.DNS.NAME")
+			if err := util.GenerateSelfSignedCert(config.PublicAddress.String(), s.TLSCertFile, s.TLSPrivateKeyFile, alternateIPs, alternateDNS); err != nil {
+				glog.Errorf("Unable to generate self signed cert: %v", err)
+			} else {
+				glog.Infof("Using self-signed cert (%s, %s)", s.TLSCertFile, s.TLSPrivateKeyFile)
+			}
+		}
+
 		go func() {
 			defer util.HandleCrash()
 			for {
-				if s.TLSCertFile == "" && s.TLSPrivateKeyFile == "" {
-					s.TLSCertFile = path.Join(s.CertDirectory, "apiserver.crt")
-					s.TLSPrivateKeyFile = path.Join(s.CertDirectory, "apiserver.key")
-					// TODO (cjcullen): Is PublicAddress the right address to sign a cert with?
-					alternateIPs := []net.IP{config.ServiceReadWriteIP}
-					alternateDNS := []string{"kubernetes.default.svc", "kubernetes.default", "kubernetes"}
-					// It would be nice to set a fqdn subject alt name, but only the kubelets know, the apiserver is clueless
-					// alternateDNS = append(alternateDNS, "kubernetes.default.svc.CLUSTER.DNS.NAME")
-					if err := util.GenerateSelfSignedCert(config.PublicAddress.String(), s.TLSCertFile, s.TLSPrivateKeyFile, alternateIPs, alternateDNS); err != nil {
-						glog.Errorf("Unable to generate self signed cert: %v", err)
-					} else {
-						glog.Infof("Using self-signed cert (%s, %s)", s.TLSCertFile, s.TLSPrivateKeyFile)
-					}
-				}
 				// err == systemd.SdNotifyNoSocket when not running on a systemd system
 				if err := systemd.SdNotify("READY=1\n"); err != nil && err != systemd.SdNotifyNoSocket {
 					glog.Errorf("Unable to send systemd daemon successful start message: %v\n", err)


### PR DESCRIPTION
Starting kubernetes for the first time can lead to an issue where the default service account and secrets in general don't get created. The problem seems to be that the controller manager needs `apiserver.crt` to exist but sometimes the apiserver starts listening on port 8080 before the cert is created.

This change just takes the certificate creation code out of the `go` so that the self-signed cert isn't created asynchronously. 

The problem doesn't reproduce every time, but following these steps a few times demonstrates the problem.
1. Delete the old cert with `sudo rm  -f /var/run/kubernetes/*`
2. Start a local cluster with `sudo ./hack/local-up-cluster.sh`
3. use `cluster/kubectl.sh get secrets` to see if the default api token was created. If `get secrets` returns no secrets, you've reproduced the problem.
