### PR TITLE
Fix typo for milicores to millicores

### DIFF
--- a/test/e2e/autoscaling_utils.go
+++ b/test/e2e/autoscaling_utils.go
@@ -54,7 +54,7 @@ type ResourceConsumer struct {
 }
 
 // NewResourceConsumer creates new ResourceConsumer
-// cpu argument is in milicores
+// cpu argument is in millicores
 func NewResourceConsumer(name string, replicas int, cpu int, framework *Framework) *ResourceConsumer {
 	runServiceAndRCForResourceConsumer(framework.Client, framework.Namespace.Name, name, replicas)
 	rc := &ResourceConsumer{
@@ -69,8 +69,8 @@ func NewResourceConsumer(name string, replicas int, cpu int, framework *Framewor
 }
 
 // ConsumeCPU consumes given number of CPU
-func (rc *ResourceConsumer) ConsumeCPU(milicores int) {
-	rc.channel <- milicores
+func (rc *ResourceConsumer) ConsumeCPU(millicores int) {
+	rc.channel <- millicores
 }
 
 func (rc *ResourceConsumer) makeConsumeCPURequests() {
@@ -79,9 +79,9 @@ func (rc *ResourceConsumer) makeConsumeCPURequests() {
 	var rest int
 	for {
 		select {
-		case milicores := <-rc.channel:
-			count = milicores / requestSizeInMilicores
-			rest = milicores - count*requestSizeInMilicores
+		case millicores := <-rc.channel:
+			count = millicores / requestSizeInMilicores
+			rest = millicores - count*requestSizeInMilicores
 		case <-time.After(sleepTime):
 			if count > 0 {
 				rc.sendConsumeCPUrequests(count, requestSizeInMilicores, consumptionTimeInSeconds)
@@ -95,21 +95,21 @@ func (rc *ResourceConsumer) makeConsumeCPURequests() {
 	}
 }
 
-func (rc *ResourceConsumer) sendConsumeCPUrequests(requests, milicores, durationSec int) {
+func (rc *ResourceConsumer) sendConsumeCPUrequests(requests, millicores, durationSec int) {
 	for i := 0; i < requests; i++ {
-		go rc.sendOneConsumeCPUrequest(milicores, durationSec)
+		go rc.sendOneConsumeCPUrequest(millicores, durationSec)
 	}
 }
 
 // sendOneConsumeCPUrequest sends POST request for cpu consumption
-func (rc *ResourceConsumer) sendOneConsumeCPUrequest(milicores int, durationSec int) {
+func (rc *ResourceConsumer) sendOneConsumeCPUrequest(millicores int, durationSec int) {
 	_, err := rc.framework.Client.Post().
 		Prefix("proxy").
 		Namespace(rc.framework.Namespace.Name).
 		Resource("services").
 		Name(rc.name).
 		Suffix("ConsumeCPU").
-		Param("milicores", strconv.Itoa(milicores)).
+		Param("millicores", strconv.Itoa(millicores)).
 		Param("durationSec", strconv.Itoa(durationSec)).
 		Do().
 		Raw()

--- a/test/images/resource-consumer/consume-cpu/consume_cpu.go
+++ b/test/images/resource-consumer/consume-cpu/consume_cpu.go
@@ -34,20 +34,20 @@ func doSomething() {
 }
 
 var (
-	milicores   = flag.Int("milicores", 0, "milicores number")
+	millicores  = flag.Int("millicores", 0, "millicores number")
 	durationSec = flag.Int("duration-sec", 0, "duration time in seconds")
 )
 
 func main() {
 	flag.Parse()
-	// converte milicores to percentage
-	milicoresPct := float64(*milicores) / float64(10)
+	// convert millicores to percentage
+	millicoresPct := float64(*millicores) / float64(10)
 	duration := time.Duration(*durationSec) * time.Second
 	start := time.Now()
 	first := systemstat.GetProcCPUSample()
 	for time.Now().Sub(start) < duration {
 		cpu := systemstat.GetProcCPUAverage(first, systemstat.GetProcCPUSample(), systemstat.GetUptime().Uptime)
-		if cpu.TotalPct < milicoresPct {
+		if cpu.TotalPct < millicoresPct {
 			doSomething()
 		} else {
 			time.Sleep(sleep)

--- a/test/images/resource-consumer/utils.go
+++ b/test/images/resource-consumer/utils.go
@@ -24,10 +24,10 @@ import (
 
 const consumeCPUBinary = "./consume-cpu/consume-cpu"
 
-func ConsumeCPU(milicores int, durationSec int) {
-	log.Printf("ConsumeCPU milicores: %v, durationSec: %v", milicores, durationSec)
+func ConsumeCPU(millicores int, durationSec int) {
+	log.Printf("ConsumeCPU millicores: %v, durationSec: %v", millicores, durationSec)
 	// creating new consume cpu process
-	arg1 := fmt.Sprintf("-milicores=%d", milicores)
+	arg1 := fmt.Sprintf("-millicores=%d", millicores)
 	arg2 := fmt.Sprintf("-duration-sec=%d", durationSec)
 	consumeCPU := exec.Command(consumeCPUBinary, arg1, arg2)
 	consumeCPU.Start()


### PR DESCRIPTION
There was a typo that pervaded the resource consumer daemon.

Fixing before it cascades further.
