### PR TITLE
Fix precision handling in validating LimitRange

### DIFF
--- a/pkg/api/resource/quantity.go
+++ b/pkg/api/resource/quantity.go
@@ -301,6 +301,27 @@ func (q *Quantity) String() string {
 	return number + string(suffix)
 }
 
+// Cmp compares q and y and returns:
+//
+//   -1 if q <  y
+//    0 if q == y
+//   +1 if q >  y
+//
+func (q *Quantity) Cmp(y Quantity) int {
+	num1 := q.Value()
+	num2 := y.Value()
+	if num1 < MaxMilliValue && num2 < MaxMilliValue {
+		num1 = q.MilliValue()
+		num2 = y.MilliValue()
+	}
+	if num1 < num2 {
+		return -1
+	} else if num1 > num2 {
+		return 1
+	}
+	return 0
+}
+
 func (q *Quantity) Add(y Quantity) error {
 	if q.Format != y.Format {
 		return fmt.Errorf("format mismatch: %v vs. %v", q.Format, y.Format)

--- a/pkg/api/resource/quantity_test.go
+++ b/pkg/api/resource/quantity_test.go
@@ -77,6 +77,26 @@ func TestQuantityCanocicalizeZero(t *testing.T) {
 	}
 }
 
+func TestQuantityCmp(t *testing.T) {
+	table := []struct {
+		x      string
+		y      string
+		expect int
+	}{
+		{"0", "0", 0},
+		{"100m", "50m", 1},
+		{"50m", "100m", -1},
+		{"10000T", "100Gi", 1},
+	}
+	for _, testCase := range table {
+		q1 := MustParse(testCase.x)
+		q2 := MustParse(testCase.y)
+		if result := q1.Cmp(q2); result != testCase.expect {
+			t.Errorf("X: %v, Y: %v, Expected: %v, Actual: %v", testCase.x, testCase.y, testCase.expect, result)
+		}
+	}
+}
+
 func TestQuantityParse(t *testing.T) {
 	table := []struct {
 		input  string


### PR DESCRIPTION
The validation of a LimitRange enforces the following constraints:

min <= defaultRequest <= defaultLimit <= max

We were not doing a proper comparison that took account units.

Fixed the code to move to millivalue precision, and updated the test case to use proper units.

Fixes https://github.com/kubernetes/kubernetes/issues/13714

Related bugzilla:
https://bugzilla.redhat.com/show_bug.cgi?id=1260384
