### PR TITLE
Add pods/attach to long running requests, protect in admission for privileged pods

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -57,7 +57,7 @@ const (
 	// Set to a value larger than the timeouts in each watch server.
 	ReadWriteTimeout = time.Minute * 60
 	//TODO: This can be tightened up. It still matches objects named watch or proxy.
-	defaultLongRunningRequestRE = "(/|^)((watch|proxy)(/|$)|(logs|portforward|exec)/?$)"
+	defaultLongRunningRequestRE = "(/|^)((watch|proxy)(/|$)|(logs?|portforward|exec|attach)/?$)"
 )
 
 // APIServer runs a kubernetes api server.

--- a/cmd/kube-apiserver/app/server_test.go
+++ b/cmd/kube-apiserver/app/server_test.go
@@ -38,12 +38,16 @@ func TestLongRunningRequestRegexp(t *testing.T) {
 		"/api/v1/watch/stuff",
 		"/api/v1/default/service/proxy",
 		"/api/v1/pods/proxy/path/to/thing",
+		"/api/v1/namespaces/myns/pods/mypod/log",
 		"/api/v1/namespaces/myns/pods/mypod/logs",
 		"/api/v1/namespaces/myns/pods/mypod/portforward",
 		"/api/v1/namespaces/myns/pods/mypod/exec",
+		"/api/v1/namespaces/myns/pods/mypod/attach",
+		"/api/v1/namespaces/myns/pods/mypod/log/",
 		"/api/v1/namespaces/myns/pods/mypod/logs/",
 		"/api/v1/namespaces/myns/pods/mypod/portforward/",
 		"/api/v1/namespaces/myns/pods/mypod/exec/",
+		"/api/v1/namespaces/myns/pods/mypod/attach/",
 		"/api/v1/watch/namespaces/myns/pods",
 	}
 	for _, path := range dontMatch {

--- a/plugin/pkg/admission/exec/denyprivileged/admission.go
+++ b/plugin/pkg/admission/exec/denyprivileged/admission.go
@@ -45,8 +45,8 @@ func (d *denyExecOnPrivileged) Admit(a admission.Attributes) (err error) {
 	if !ok {
 		return errors.NewBadRequest("a connect request was received, but could not convert the request object.")
 	}
-	// Only handle exec requests on pods
-	if connectRequest.ResourcePath != "pods/exec" {
+	// Only handle exec or attach requests on pods
+	if connectRequest.ResourcePath != "pods/exec" && connectRequest.ResourcePath != "pods/attach" {
 		return nil
 	}
 	pod, err := d.client.Pods(a.GetNamespace()).Get(connectRequest.Name)
@@ -54,7 +54,7 @@ func (d *denyExecOnPrivileged) Admit(a admission.Attributes) (err error) {
 		return admission.NewForbidden(a, err)
 	}
 	if isPrivileged(pod) {
-		return admission.NewForbidden(a, fmt.Errorf("Cannot exec into a privileged container"))
+		return admission.NewForbidden(a, fmt.Errorf("Cannot exec into or attach to a privileged container"))
 	}
 	return nil
 }

--- a/plugin/pkg/admission/exec/denyprivileged/admission_test.go
+++ b/plugin/pkg/admission/exec/denyprivileged/admission_test.go
@@ -47,15 +47,30 @@ func testAdmission(t *testing.T, pod *api.Pod, shouldAccept bool) {
 	handler := &denyExecOnPrivileged{
 		client: mockClient,
 	}
-	req := &rest.ConnectRequest{Name: pod.Name, ResourcePath: "pods/exec"}
-	err := handler.Admit(admission.NewAttributesRecord(req, "Pod", "test", "name", "pods", "exec", admission.Connect, nil))
-	if shouldAccept && err != nil {
-		t.Errorf("Unexpected error returned from admission handler: %v", err)
-	}
-	if !shouldAccept && err == nil {
-		t.Errorf("An error was expected from the admission handler. Received nil")
+
+	// pods/exec
+	{
+		req := &rest.ConnectRequest{Name: pod.Name, ResourcePath: "pods/exec"}
+		err := handler.Admit(admission.NewAttributesRecord(req, "Pod", "test", "name", "pods", "exec", admission.Connect, nil))
+		if shouldAccept && err != nil {
+			t.Errorf("Unexpected error returned from admission handler: %v", err)
+		}
+		if !shouldAccept && err == nil {
+			t.Errorf("An error was expected from the admission handler. Received nil")
+		}
 	}
 
+	// pods/attach
+	{
+		req := &rest.ConnectRequest{Name: pod.Name, ResourcePath: "pods/attach"}
+		err := handler.Admit(admission.NewAttributesRecord(req, "Pod", "test", "name", "pods", "attach", admission.Connect, nil))
+		if shouldAccept && err != nil {
+			t.Errorf("Unexpected error returned from admission handler: %v", err)
+		}
+		if !shouldAccept && err == nil {
+			t.Errorf("An error was expected from the admission handler. Received nil")
+		}
+	}
 }
 
 func acceptPod(name string) *api.Pod {


### PR DESCRIPTION
`pods/attach` was added without some of the accompanying things `pods/exec` had. This PR:
- [x] Treats `pods/attach` as a long-running request
- [x] Protects `pods/attach` to privileged pods identically to `pods/exec` in admission
