### PR TITLE
[mesos] Make Mesos endpoint annotation e2e workaround cluster provider independent

### DIFF
--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -1049,18 +1049,15 @@ func getContainerPortsByPodUID(endpoints *api.Endpoints) PortsByPodUID {
 
 				// use endpoint annotations to recover the container port in a Mesos setup
 				// compare contrib/mesos/pkg/service/endpoints_controller.syncService
-				if providerIs("mesos/docker") {
-					key := fmt.Sprintf("k8s.mesosphere.io/containerPort_%s_%s_%d", port.Protocol, addr.IP, hostPort)
-					containerPortString := endpoints.Annotations[key]
-					if containerPortString == "" {
-						continue
-					}
+				key := fmt.Sprintf("k8s.mesosphere.io/containerPort_%s_%s_%d", port.Protocol, addr.IP, hostPort)
+				mesosContainerPortString := endpoints.Annotations[key]
+				if mesosContainerPortString != "" {
 					var err error
-					containerPort, err = strconv.Atoi(containerPortString)
+					containerPort, err = strconv.Atoi(mesosContainerPortString)
 					if err != nil {
 						continue
 					}
-					Logf("Mapped mesos host port %d to container port %d via annotation %s=%s", hostPort, containerPort, key, containerPortString)
+					Logf("Mapped mesos host port %d to container port %d via annotation %s=%s", hostPort, containerPort, key, mesosContainerPortString)
 				}
 
 				Logf("Found pod %v, host port %d and container port %d", addr.TargetRef.UID, hostPort, containerPort)


### PR DESCRIPTION
In `test/e2e/service.go` a workaround is implemented for Mesos to find the container port through the help of endpoint annotations. This workaround is only active when `KUBERNETES_PROVIDER=mesos/docker` is set. This leads to failing conformance tests.

This patch removes the provider comparison and checks directly for the `k8s.mesosphere.io/containerPort` annotation.

**Note**: this workaround is _not about an actual feature_ that is checked by the conformance tests. It's only _about the tests themselves_ to work.

Fixes https://github.com/mesosphere/kubernetes-mesos/issues/450
