### PR TITLE
Fix incorrect replacement of util.CheckErr for resource.NewBuild in RunGet function of kubectl get command

### DIFF
--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -130,6 +130,7 @@ func RunGet(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string
 			SingleResourceType().
 			Latest().
 			Do()
+		err := r.Err()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Commit cd7d78b6969a9ccd9fc370e5c8d79b7ae9114095 replaced use of

``` vim
util.CheckErr(err)
```

with

``` vim
if err != nil {
    return err
}
```

One replacement is incorrect. The current call of resource.NewBuilder is returned in r variable. Which was tested with util.CheckErr(r.Err()) before cd7d78b6969a9ccd9fc370e5c8d79b7ae9114095 commit. It was replaced by

``` vim
if err != nil {
    return err
}
```

which is incorrect as err is not set by resource.NewBuilder call. The correct use is

``` vim
err := r.Err()
if err != nil {
    return err
}
```
