### PR TITLE
Filter List in Storage level to avoid additional copies.

### DIFF
--- a/pkg/registry/generic/matcher_test.go
+++ b/pkg/registry/generic/matcher_test.go
@@ -18,7 +18,6 @@ package generic
 
 import (
 	"errors"
-	"reflect"
 	"testing"
 
 	"k8s.io/kubernetes/pkg/fields"
@@ -115,44 +114,6 @@ func TestSelectionPredicate(t *testing.T) {
 				t.Errorf("%v: expected %v, got %v", name, e, a)
 			}
 		}
-	}
-}
-
-func TestFilterList(t *testing.T) {
-	try := &IgnoredList{
-		Items: []Ignored{
-			{"foo"},
-			{"bar"},
-			{"baz"},
-			{"qux"},
-			{"zot"},
-		},
-	}
-	expect := &IgnoredList{
-		Items: []Ignored{
-			{"bar"},
-			{"baz"},
-		},
-	}
-
-	m := MatcherFunc(func(obj runtime.Object) (bool, error) {
-		i, ok := obj.(*Ignored)
-		if !ok {
-			return false, errors.New("wrong type")
-		}
-		return i.ID[0] == 'b', nil
-	})
-	if _, matchesSingleObject := m.MatchesSingle(); matchesSingleObject {
-		t.Errorf("matcher unexpectedly matches only a single object.")
-	}
-
-	got, err := FilterList(try, m, nil)
-	if err != nil {
-		t.Fatalf("Unexpected error %v", err)
-	}
-
-	if e, a := expect, got; !reflect.DeepEqual(e, a) {
-		t.Errorf("Expected %#v, got %#v", e, a)
 	}
 }
 

--- a/pkg/storage/cacher.go
+++ b/pkg/storage/cacher.go
@@ -213,13 +213,13 @@ func (c *Cacher) Get(key string, objPtr runtime.Object, ignoreNotFound bool) err
 }
 
 // Implements storage.Interface.
-func (c *Cacher) GetToList(key string, listObj runtime.Object) error {
-	return c.storage.GetToList(key, listObj)
+func (c *Cacher) GetToList(key string, filter FilterFunc, listObj runtime.Object) error {
+	return c.storage.GetToList(key, filter, listObj)
 }
 
 // Implements storage.Interface.
-func (c *Cacher) List(key string, listObj runtime.Object) error {
-	return c.storage.List(key, listObj)
+func (c *Cacher) List(key string, filter FilterFunc, listObj runtime.Object) error {
+	return c.storage.List(key, filter, listObj)
 }
 
 // ListFromMemory implements list operation (the same signature as List method)
@@ -303,7 +303,7 @@ func filterFunction(key string, keyFunc func(runtime.Object) (string, error), fi
 	return func(obj runtime.Object) bool {
 		objKey, err := keyFunc(obj)
 		if err != nil {
-			glog.Errorf("Invalid object for filter: %v", obj)
+			glog.Errorf("invalid object for filter: %v", obj)
 			return false
 		}
 		if !strings.HasPrefix(objKey, key) {
@@ -343,7 +343,7 @@ func newCacherListerWatcher(storage Interface, resourcePrefix string, newListFun
 // Implements cache.ListerWatcher interface.
 func (lw *cacherListerWatcher) List() (runtime.Object, error) {
 	list := lw.newListFunc()
-	if err := lw.storage.List(lw.resourcePrefix, list); err != nil {
+	if err := lw.storage.List(lw.resourcePrefix, Everything, list); err != nil {
 		return nil, err
 	}
 	return list, nil

--- a/pkg/storage/interfaces.go
+++ b/pkg/storage/interfaces.go
@@ -111,11 +111,11 @@ type Interface interface {
 
 	// GetToList unmarshals json found at key and opaque it into *List api object
 	// (an object that satisfies the runtime.IsList definition).
-	GetToList(key string, listObj runtime.Object) error
+	GetToList(key string, filter FilterFunc, listObj runtime.Object) error
 
 	// List unmarshalls jsons found at directory defined by key and opaque them
 	// into *List api object (an object that satisfies runtime.IsList definition).
-	List(key string, listObj runtime.Object) error
+	List(key string, filter FilterFunc, listObj runtime.Object) error
 
 	// GuaranteedUpdate keeps calling 'tryUpdate()' to update key 'key' (of type 'ptrToType')
 	// retrying the update until success if there is index conflict.


### PR DESCRIPTION
This will also simplify detecting bottlenecks in LIST operations.

cc @kubernetes/goog-csi @lavalamp @smarterclayton 
