### PR TITLE
Bump to new example guestbook version

### DIFF
--- a/examples/guestbook/README.md
+++ b/examples/guestbook/README.md
@@ -413,7 +413,7 @@ spec:
     spec:
       containers:
       - name: php-redis
-        image: gcr.io/google_samples/gb-frontend:v2
+        image: gcr.io/google_samples/gb-frontend:v3
         env:
         - name: GET_HOSTS_FROM
           value: dns
@@ -441,7 +441,7 @@ Then, list all your replication controllers:
 ```console
 $ kubectl get rc
 CONTROLLER                             CONTAINER(S)            IMAGE(S)                                   SELECTOR                     REPLICAS
-frontend                               php-redis               kubernetes/example-guestbook-php-redis:v2  name=frontend                3
+frontend                               php-redis               kubernetes/example-guestbook-php-redis:v3  name=frontend                3
 redis-master                           master                  redis                                      name=redis-master            1
 redis-slave                            slave                   kubernetes/redis-slave:v2                  name=redis-slave             2
 ```

--- a/examples/guestbook/frontend-controller.yaml
+++ b/examples/guestbook/frontend-controller.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: php-redis
-        image: gcr.io/google_samples/gb-frontend:v2
+        image: gcr.io/google_samples/gb-frontend:v3
         env:
         - name: GET_HOSTS_FROM
           value: dns


### PR DESCRIPTION
**CAUTION**: gcr.io/google_samples/gb-frontend:v3 must be built and pushed before merging.
**NOTE**: e2e tests will fail until images are built

Merging https://github.com/kubernetes/kubernetes/pull/12497 has introduced an old version of the guestbook docker image, i.e. without the changes in https://github.com/kubernetes/kubernetes/pull/12199.

This PR bumps the version of the referenced docker image (which must be built and pushed first).
