### PR TITLE
Switch from gcr.io/_b_ prefix to b.gcr.io/ …

### DIFF
--- a/test/e2e/rc.go
+++ b/test/e2e/rc.go
@@ -41,7 +41,7 @@ var _ = Describe("ReplicationController", func() {
 		// requires private images
 		SkipUnlessProviderIs("gce", "gke")
 
-		ServeImageOrFail(framework, "private", "gcr.io/_b_k8s_authenticated_test/serve_hostname:1.1")
+		ServeImageOrFail(framework, "private", "b.gcr.io/k8s_authenticated_test/serve_hostname:1.1")
 	})
 })
 


### PR DESCRIPTION
to designate bring-your-own-bucket pulls.
