### PR TITLE
Move util.StringSet into its own package

### DIFF
--- a/cmd/genconversion/conversion.go
+++ b/cmd/genconversion/conversion.go
@@ -30,7 +30,7 @@ import (
 	_ "k8s.io/kubernetes/pkg/expapi"
 	_ "k8s.io/kubernetes/pkg/expapi/v1"
 	pkg_runtime "k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 
 	"github.com/golang/glog"
 	flag "github.com/spf13/pflag"
@@ -84,7 +84,7 @@ func main() {
 			glog.Errorf("error while generating conversion functions for %v: %v", knownType, err)
 		}
 	}
-	generator.RepackImports(util.NewStringSet())
+	generator.RepackImports(sets.NewString())
 	if err := generator.WriteImports(data); err != nil {
 		glog.Fatalf("error while writing imports: %v", err)
 	}

--- a/cmd/gendeepcopy/deep_copy.go
+++ b/cmd/gendeepcopy/deep_copy.go
@@ -30,7 +30,7 @@ import (
 	_ "k8s.io/kubernetes/pkg/expapi"
 	_ "k8s.io/kubernetes/pkg/expapi/v1"
 	pkg_runtime "k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 
 	"github.com/golang/glog"
 	flag "github.com/spf13/pflag"
@@ -80,7 +80,7 @@ func main() {
 	}
 
 	versionPath := path.Join(pkgBase, group, version)
-	generator := pkg_runtime.NewDeepCopyGenerator(api.Scheme.Raw(), versionPath, util.NewStringSet("k8s.io/kubernetes"))
+	generator := pkg_runtime.NewDeepCopyGenerator(api.Scheme.Raw(), versionPath, sets.NewString("k8s.io/kubernetes"))
 	generator.AddImport(path.Join(pkgBase, "api"))
 
 	if len(*overwrites) > 0 {

--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -55,6 +55,7 @@ import (
 	"k8s.io/kubernetes/pkg/master"
 	"k8s.io/kubernetes/pkg/tools/etcdtest"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/volume/empty_dir"
 	"k8s.io/kubernetes/plugin/pkg/admission/admit"
@@ -738,7 +739,7 @@ func runMasterServiceTest(client *client.Client) {
 		glog.Fatalf("unexpected error listing services: %v", err)
 	}
 	var foundRW bool
-	found := util.StringSet{}
+	found := sets.String{}
 	for i := range svcList.Items {
 		found.Insert(svcList.Items[i].Name)
 		if svcList.Items[i].Name == "kubernetes" {
@@ -864,7 +865,7 @@ func runServiceTest(client *client.Client) {
 	if err != nil {
 		glog.Fatalf("Failed to list services across namespaces: %v", err)
 	}
-	names := util.NewStringSet()
+	names := sets.NewString()
 	for _, svc := range svcList.Items {
 		names.Insert(fmt.Sprintf("%s/%s", svc.Namespace, svc.Name))
 	}
@@ -1011,7 +1012,7 @@ func main() {
 	// Check that kubelet tried to make the containers.
 	// Using a set to list unique creation attempts. Our fake is
 	// really stupid, so kubelet tries to create these multiple times.
-	createdConts := util.StringSet{}
+	createdConts := sets.String{}
 	for _, p := range fakeDocker1.Created {
 		// The last 8 characters are random, so slice them off.
 		if n := len(p); n > 8 {

--- a/contrib/mesos/pkg/offers/offers.go
+++ b/contrib/mesos/pkg/offers/offers.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/kubernetes/contrib/mesos/pkg/queue"
 	"k8s.io/kubernetes/contrib/mesos/pkg/runtime"
 	"k8s.io/kubernetes/pkg/client/unversioned/cache"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 const (
@@ -453,7 +453,7 @@ func (s *offerStorage) nextListener() *offerListener {
 // notify listeners if we find an acceptable offer for them. listeners
 // are garbage collected after a certain age (see offerListenerMaxAge).
 // ids lists offer IDs that are retrievable from offer storage.
-func (s *offerStorage) notifyListeners(ids func() (util.StringSet, uint64)) {
+func (s *offerStorage) notifyListeners(ids func() (sets.String, uint64)) {
 	listener := s.nextListener() // blocking
 
 	offerIds, version := ids()
@@ -493,8 +493,8 @@ func (s *offerStorage) Init(done <-chan struct{}) {
 
 	// cached offer ids for the purposes of listener notification
 	idCache := &stringsCache{
-		refill: func() util.StringSet {
-			result := util.NewStringSet()
+		refill: func() sets.String {
+			result := sets.NewString()
 			for _, v := range s.offers.List() {
 				if offer, ok := v.(Perishable); ok {
 					result.Insert(offer.Id())
@@ -510,14 +510,14 @@ func (s *offerStorage) Init(done <-chan struct{}) {
 
 type stringsCache struct {
 	expiresAt time.Time
-	cached    util.StringSet
+	cached    sets.String
 	ttl       time.Duration
-	refill    func() util.StringSet
+	refill    func() sets.String
 	version   uint64
 }
 
 // not thread-safe
-func (c *stringsCache) Strings() (util.StringSet, uint64) {
+func (c *stringsCache) Strings() (sets.String, uint64) {
 	now := time.Now()
 	if c.expiresAt.Before(now) {
 		old := c.cached
@@ -549,8 +549,8 @@ func (self *slaveStorage) add(slaveId, offerId string) {
 }
 
 // delete the slave-offer mappings for slaveId, returns the IDs of the offers that were unmapped
-func (self *slaveStorage) deleteSlave(slaveId string) util.StringSet {
-	offerIds := util.NewStringSet()
+func (self *slaveStorage) deleteSlave(slaveId string) sets.String {
+	offerIds := sets.NewString()
 	self.Lock()
 	defer self.Unlock()
 	for oid, sid := range self.index {

--- a/contrib/mesos/pkg/queue/delay.go
+++ b/contrib/mesos/pkg/queue/delay.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 type qitem struct {
@@ -277,13 +277,13 @@ func (f *DelayFIFO) List() []UniqueID {
 	return list
 }
 
-// ContainedIDs returns a util.StringSet containing all IDs of the stored items.
+// ContainedIDs returns a stringset.StringSet containing all IDs of the stored items.
 // This is a snapshot of a moment in time, and one should keep in mind that
 // other go routines can add or remove items after you call this.
-func (c *DelayFIFO) ContainedIDs() util.StringSet {
+func (c *DelayFIFO) ContainedIDs() sets.String {
 	c.rlock()
 	defer c.runlock()
-	set := util.StringSet{}
+	set := sets.String{}
 	for id := range c.items {
 		set.Insert(id)
 	}

--- a/contrib/mesos/pkg/queue/historical.go
+++ b/contrib/mesos/pkg/queue/historical.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 type entry struct {
@@ -177,13 +177,13 @@ func (f *HistoricalFIFO) ListKeys() []string {
 	return list
 }
 
-// ContainedIDs returns a util.StringSet containing all IDs of the stored items.
+// ContainedIDs returns a stringset.StringSet containing all IDs of the stored items.
 // This is a snapshot of a moment in time, and one should keep in mind that
 // other go routines can add or remove items after you call this.
-func (c *HistoricalFIFO) ContainedIDs() util.StringSet {
+func (c *HistoricalFIFO) ContainedIDs() sets.String {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	set := util.StringSet{}
+	set := sets.String{}
 	for id, entry := range c.items {
 		if entry.Is(DELETE_EVENT | POP_EVENT) {
 			continue

--- a/contrib/mesos/pkg/scheduler/scheduler.go
+++ b/contrib/mesos/pkg/scheduler/scheduler.go
@@ -47,7 +47,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/tools"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 type Slave struct {
@@ -711,7 +711,7 @@ func (k *KubernetesScheduler) explicitlyReconcileTasks(driver bindings.Scheduler
 
 	// tell mesos to send us the latest status updates for all the non-terminal tasks that we know about
 	statusList := []*mesos.TaskStatus{}
-	remaining := util.KeySet(reflect.ValueOf(taskToSlave))
+	remaining := sets.KeySet(reflect.ValueOf(taskToSlave))
 	for taskId, slaveId := range taskToSlave {
 		if slaveId == "" {
 			delete(taskToSlave, taskId)

--- a/contrib/mesos/pkg/service/endpoints_controller.go
+++ b/contrib/mesos/pkg/service/endpoints_controller.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/util/workqueue"
 	"k8s.io/kubernetes/pkg/watch"
 
@@ -132,8 +133,8 @@ func (e *endpointController) Run(workers int, stopCh <-chan struct{}) {
 	e.queue.ShutDown()
 }
 
-func (e *endpointController) getPodServiceMemberships(pod *api.Pod) (util.StringSet, error) {
-	set := util.StringSet{}
+func (e *endpointController) getPodServiceMemberships(pod *api.Pod) (sets.String, error) {
+	set := sets.String{}
 	services, err := e.serviceStore.GetPodServices(pod)
 	if err != nil {
 		// don't log this error because this function makes pointless

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -194,6 +194,7 @@ path-override
 pod-cidr
 pod-eviction-timeout
 pod-infra-container-image
+pod-running
 policy-config-file
 poll-interval
 portal-net

--- a/pkg/admission/handler.go
+++ b/pkg/admission/handler.go
@@ -17,13 +17,13 @@ limitations under the License.
 package admission
 
 import (
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 // Handler is a base for admission control handlers that
 // support a predefined set of operations
 type Handler struct {
-	operations util.StringSet
+	operations sets.String
 }
 
 // Handles returns true for methods that this handler supports
@@ -34,7 +34,7 @@ func (h *Handler) Handles(operation Operation) bool {
 // NewHandler creates a new base handler that handles the passed
 // in operations
 func NewHandler(ops ...Operation) *Handler {
-	operations := util.NewStringSet()
+	operations := sets.NewString()
 	for _, op := range ops {
 		operations.Insert(string(op))
 	}

--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 
 	"github.com/davecgh/go-spew/spew"
 )
@@ -77,7 +78,7 @@ var Semantic = conversion.EqualitiesOrDie(
 	},
 )
 
-var standardResources = util.NewStringSet(
+var standardResources = sets.NewString(
 	string(ResourceMemory),
 	string(ResourceCPU),
 	string(ResourcePods),
@@ -111,7 +112,7 @@ func IsServiceIPRequested(service *Service) bool {
 	return service.Spec.ClusterIP == ""
 }
 
-var standardFinalizers = util.NewStringSet(
+var standardFinalizers = sets.NewString(
 	string(FinalizerKubernetes))
 
 func IsStandardFinalizerName(str string) bool {

--- a/pkg/api/latest/latest.go
+++ b/pkg/api/latest/latest.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/registered"
 	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 // Version is the string that represents the current external default version.
@@ -79,7 +79,7 @@ func init() {
 
 	// the list of kinds that are scoped at the root of the api hierarchy
 	// if a kind is not enumerated here, it is assumed to have a namespace scope
-	rootScoped := util.NewStringSet(
+	rootScoped := sets.NewString(
 		"Node",
 		"Minion",
 		"Namespace",
@@ -87,7 +87,7 @@ func init() {
 	)
 
 	// these kinds should be excluded from the list of resources
-	ignoredKinds := util.NewStringSet(
+	ignoredKinds := sets.NewString(
 		"ListOptions",
 		"DeleteOptions",
 		"Status",

--- a/pkg/api/mapper.go
+++ b/pkg/api/mapper.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 
 	"k8s.io/kubernetes/pkg/api/meta"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 var RESTMapper meta.RESTMapper
@@ -34,7 +34,7 @@ func RegisterRESTMapper(m meta.RESTMapper) {
 }
 
 func NewDefaultRESTMapper(group string, versions []string, interfacesFunc meta.VersionInterfacesFunc,
-	importPathPrefix string, ignoredKinds, rootScoped util.StringSet) *meta.DefaultRESTMapper {
+	importPathPrefix string, ignoredKinds, rootScoped sets.String) *meta.DefaultRESTMapper {
 
 	mapper := meta.NewDefaultRESTMapper(group, versions, interfacesFunc)
 	// enumerate all supported versions, get the kinds, and register with the mapper how to address

--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -31,6 +31,7 @@ import (
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 
 	_ "k8s.io/kubernetes/pkg/expapi"
 	_ "k8s.io/kubernetes/pkg/expapi/v1"
@@ -87,7 +88,7 @@ func roundTrip(t *testing.T, codec runtime.Codec, item runtime.Object) {
 
 // roundTripSame verifies the same source object is tested in all API versions.
 func roundTripSame(t *testing.T, item runtime.Object, except ...string) {
-	set := util.NewStringSet(except...)
+	set := sets.NewString(except...)
 	seed := rand.Int63()
 	fuzzInternalObject(t, "", item, seed)
 	version := testapi.Default.Version()
@@ -119,8 +120,8 @@ func TestList(t *testing.T) {
 	roundTripSame(t, item)
 }
 
-var nonRoundTrippableTypes = util.NewStringSet()
-var nonInternalRoundTrippableTypes = util.NewStringSet("List", "ListOptions", "PodExecOptions", "PodAttachOptions")
+var nonRoundTrippableTypes = sets.NewString()
+var nonInternalRoundTrippableTypes = sets.NewString("List", "ListOptions", "PodExecOptions", "PodAttachOptions")
 var nonRoundTrippableTypesByVersion = map[string][]string{}
 
 func TestRoundTripTypes(t *testing.T) {

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -30,6 +30,7 @@ import (
 	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/util/fielderrors"
 	errors "k8s.io/kubernetes/pkg/util/fielderrors"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 func expectPrefix(t *testing.T, prefix string, errs fielderrors.ValidationErrorList) {
@@ -769,7 +770,7 @@ func TestValidateEnv(t *testing.T) {
 }
 
 func TestValidateVolumeMounts(t *testing.T) {
-	volumes := util.NewStringSet("abc", "123", "abc-123")
+	volumes := sets.NewString("abc", "123", "abc-123")
 
 	successCase := []api.VolumeMount{
 		{Name: "abc", MountPath: "/foo"},
@@ -896,7 +897,7 @@ func getResourceLimits(cpu, memory string) api.ResourceList {
 }
 
 func TestValidateContainers(t *testing.T) {
-	volumes := util.StringSet{}
+	volumes := sets.String{}
 	capabilities.SetForTests(capabilities.Capabilities{
 		AllowPrivileged: true,
 	})

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/util/flushwriter"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/version"
 
 	"github.com/emicklei/go-restful"
@@ -115,7 +116,7 @@ const (
 // It is expected that the provided path root prefix will serve all operations. Root MUST NOT end
 // in a slash. A restful WebService is created for the group and version.
 func (g *APIGroupVersion) InstallREST(container *restful.Container) error {
-	info := &APIRequestInfoResolver{util.NewStringSet(strings.TrimPrefix(g.Root, "/")), g.Mapper}
+	info := &APIRequestInfoResolver{sets.NewString(strings.TrimPrefix(g.Root, "/")), g.Mapper}
 
 	prefix := path.Join(g.Root, g.Version)
 	installer := &APIInstaller{

--- a/pkg/apiserver/handlers.go
+++ b/pkg/apiserver/handlers.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/kubernetes/pkg/auth/authorizer"
 	"k8s.io/kubernetes/pkg/httplog"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 // specialVerbs contains just strings which are used in REST paths for special actions that don't fall under the normal
@@ -351,7 +352,7 @@ type requestAttributeGetter struct {
 
 // NewAttributeGetter returns an object which implements the RequestAttributeGetter interface.
 func NewRequestAttributeGetter(requestContextMapper api.RequestContextMapper, restMapper meta.RESTMapper, apiRoots ...string) RequestAttributeGetter {
-	return &requestAttributeGetter{requestContextMapper, &APIRequestInfoResolver{util.NewStringSet(apiRoots...), restMapper}}
+	return &requestAttributeGetter{requestContextMapper, &APIRequestInfoResolver{sets.NewString(apiRoots...), restMapper}}
 }
 
 func (r *requestAttributeGetter) GetAttribs(req *http.Request) authorizer.Attributes {
@@ -417,7 +418,7 @@ type APIRequestInfo struct {
 }
 
 type APIRequestInfoResolver struct {
-	APIPrefixes util.StringSet
+	APIPrefixes sets.String
 	RestMapper  meta.RESTMapper
 }
 

--- a/pkg/apiserver/handlers_test.go
+++ b/pkg/apiserver/handlers_test.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/api/testapi"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 type fakeRL bool
@@ -246,7 +246,7 @@ func TestGetAPIRequestInfo(t *testing.T) {
 		{"PUT", "/namespaces/other/finalize", "update", "", "other", "finalize", "", "", "", []string{"finalize"}},
 	}
 
-	apiRequestInfoResolver := &APIRequestInfoResolver{util.NewStringSet("api"), latest.RESTMapper}
+	apiRequestInfoResolver := &APIRequestInfoResolver{sets.NewString("api"), latest.RESTMapper}
 
 	for _, successCase := range successCases {
 		req, _ := http.NewRequest(successCase.method, successCase.url, nil)

--- a/pkg/client/unversioned/cache/delta_fifo.go
+++ b/pkg/client/unversioned/cache/delta_fifo.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"sync"
 
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 
 	"github.com/golang/glog"
 )
@@ -319,7 +319,7 @@ func (f *DeltaFIFO) Replace(list []interface{}, resourceVersion string) error {
 		return nil
 	}
 
-	keySet := make(util.StringSet, len(list))
+	keySet := make(sets.String, len(list))
 	for _, item := range list {
 		key, err := f.KeyOf(item)
 		if err != nil {

--- a/pkg/client/unversioned/cache/expiration_cache_fakes.go
+++ b/pkg/client/unversioned/cache/expiration_cache_fakes.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 type fakeThreadSafeMap struct {
@@ -32,7 +33,7 @@ func (c *fakeThreadSafeMap) Delete(key string) {
 }
 
 type FakeExpirationPolicy struct {
-	NeverExpire     util.StringSet
+	NeverExpire     sets.String
 	RetrieveKeyFunc KeyFunc
 }
 

--- a/pkg/client/unversioned/cache/expiration_cache_test.go
+++ b/pkg/client/unversioned/cache/expiration_cache_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 func TestTTLExpirationBasic(t *testing.T) {
@@ -30,7 +31,7 @@ func TestTTLExpirationBasic(t *testing.T) {
 	ttlStore := NewFakeExpirationStore(
 		testStoreKeyFunc, deleteChan,
 		&FakeExpirationPolicy{
-			NeverExpire: util.NewStringSet(),
+			NeverExpire: sets.NewString(),
 			RetrieveKeyFunc: func(obj interface{}) (string, error) {
 				return obj.(*timestampedEntry).obj.(testStoreObject).id, nil
 			},
@@ -66,14 +67,14 @@ func TestTTLList(t *testing.T) {
 		{id: "foo1", val: "bar1"},
 		{id: "foo2", val: "bar2"},
 	}
-	expireKeys := util.NewStringSet(testObjs[0].id, testObjs[2].id)
+	expireKeys := sets.NewString(testObjs[0].id, testObjs[2].id)
 	deleteChan := make(chan string)
 	defer close(deleteChan)
 
 	ttlStore := NewFakeExpirationStore(
 		testStoreKeyFunc, deleteChan,
 		&FakeExpirationPolicy{
-			NeverExpire: util.NewStringSet(testObjs[1].id),
+			NeverExpire: sets.NewString(testObjs[1].id),
 			RetrieveKeyFunc: func(obj interface{}) (string, error) {
 				return obj.(*timestampedEntry).obj.(testStoreObject).id, nil
 			},

--- a/pkg/client/unversioned/cache/index.go
+++ b/pkg/client/unversioned/cache/index.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	"k8s.io/kubernetes/pkg/api/meta"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 // Indexer is a storage interface that lets you list objects using multiple indexing functions
@@ -63,7 +63,7 @@ func MetaNamespaceIndexFunc(obj interface{}) ([]string, error) {
 }
 
 // Index maps the indexed value to a set of keys in the store that match on that value
-type Index map[string]util.StringSet
+type Index map[string]sets.String
 
 // Indexers maps a name to a IndexFunc
 type Indexers map[string]IndexFunc

--- a/pkg/client/unversioned/cache/listers_test.go
+++ b/pkg/client/unversioned/cache/listers_test.go
@@ -22,12 +22,12 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/expapi"
 	"k8s.io/kubernetes/pkg/labels"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 func TestStoreToMinionLister(t *testing.T) {
 	store := NewStore(MetaNamespaceKeyFunc)
-	ids := util.NewStringSet("foo", "bar", "baz")
+	ids := sets.NewString("foo", "bar", "baz")
 	for id := range ids {
 		store.Add(&api.Node{ObjectMeta: api.ObjectMeta{Name: id}})
 	}
@@ -52,7 +52,7 @@ func TestStoreToReplicationControllerLister(t *testing.T) {
 	testCases := []struct {
 		inRCs      []*api.ReplicationController
 		list       func() ([]api.ReplicationController, error)
-		outRCNames util.StringSet
+		outRCNames sets.String
 		expectErr  bool
 	}{
 		// Basic listing with all labels and no selectors
@@ -63,7 +63,7 @@ func TestStoreToReplicationControllerLister(t *testing.T) {
 			list: func() ([]api.ReplicationController, error) {
 				return lister.List()
 			},
-			outRCNames: util.NewStringSet("basic"),
+			outRCNames: sets.NewString("basic"),
 		},
 		// No pod labels
 		{
@@ -81,7 +81,7 @@ func TestStoreToReplicationControllerLister(t *testing.T) {
 				}
 				return lister.GetPodControllers(pod)
 			},
-			outRCNames: util.NewStringSet(),
+			outRCNames: sets.NewString(),
 			expectErr:  true,
 		},
 		// No RC selectors
@@ -101,7 +101,7 @@ func TestStoreToReplicationControllerLister(t *testing.T) {
 				}
 				return lister.GetPodControllers(pod)
 			},
-			outRCNames: util.NewStringSet(),
+			outRCNames: sets.NewString(),
 			expectErr:  true,
 		},
 		// Matching labels to selectors and namespace
@@ -130,7 +130,7 @@ func TestStoreToReplicationControllerLister(t *testing.T) {
 				}
 				return lister.GetPodControllers(pod)
 			},
-			outRCNames: util.NewStringSet("bar"),
+			outRCNames: sets.NewString("bar"),
 		},
 	}
 	for _, c := range testCases {
@@ -162,7 +162,7 @@ func TestStoreToDaemonSetLister(t *testing.T) {
 	testCases := []struct {
 		inDSs             []*expapi.DaemonSet
 		list              func() ([]expapi.DaemonSet, error)
-		outDaemonSetNames util.StringSet
+		outDaemonSetNames sets.String
 		expectErr         bool
 	}{
 		// Basic listing
@@ -173,7 +173,7 @@ func TestStoreToDaemonSetLister(t *testing.T) {
 			list: func() ([]expapi.DaemonSet, error) {
 				return lister.List()
 			},
-			outDaemonSetNames: util.NewStringSet("basic"),
+			outDaemonSetNames: sets.NewString("basic"),
 		},
 		// Listing multiple daemon sets
 		{
@@ -185,7 +185,7 @@ func TestStoreToDaemonSetLister(t *testing.T) {
 			list: func() ([]expapi.DaemonSet, error) {
 				return lister.List()
 			},
-			outDaemonSetNames: util.NewStringSet("basic", "complex", "complex2"),
+			outDaemonSetNames: sets.NewString("basic", "complex", "complex2"),
 		},
 		// No pod labels
 		{
@@ -203,7 +203,7 @@ func TestStoreToDaemonSetLister(t *testing.T) {
 				}
 				return lister.GetPodDaemonSets(pod)
 			},
-			outDaemonSetNames: util.NewStringSet(),
+			outDaemonSetNames: sets.NewString(),
 			expectErr:         true,
 		},
 		// No DS selectors
@@ -223,7 +223,7 @@ func TestStoreToDaemonSetLister(t *testing.T) {
 				}
 				return lister.GetPodDaemonSets(pod)
 			},
-			outDaemonSetNames: util.NewStringSet(),
+			outDaemonSetNames: sets.NewString(),
 			expectErr:         true,
 		},
 		// Matching labels to selectors and namespace
@@ -252,7 +252,7 @@ func TestStoreToDaemonSetLister(t *testing.T) {
 				}
 				return lister.GetPodDaemonSets(pod)
 			},
-			outDaemonSetNames: util.NewStringSet("bar"),
+			outDaemonSetNames: sets.NewString("bar"),
 		},
 	}
 	for _, c := range testCases {

--- a/pkg/client/unversioned/cache/store_test.go
+++ b/pkg/client/unversioned/cache/store_test.go
@@ -19,7 +19,7 @@ package cache
 import (
 	"testing"
 
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 // Test public interface
@@ -54,7 +54,7 @@ func doTestStore(t *testing.T, store Store) {
 	store.Add(mkObj("c", "d"))
 	store.Add(mkObj("e", "e"))
 	{
-		found := util.StringSet{}
+		found := sets.String{}
 		for _, item := range store.List() {
 			found.Insert(item.(testStoreObject).val)
 		}
@@ -73,7 +73,7 @@ func doTestStore(t *testing.T, store Store) {
 	}, "0")
 
 	{
-		found := util.StringSet{}
+		found := sets.String{}
 		for _, item := range store.List() {
 			found.Insert(item.(testStoreObject).val)
 		}
@@ -93,17 +93,17 @@ func doTestIndex(t *testing.T, indexer Indexer) {
 	}
 
 	// Test Index
-	expected := map[string]util.StringSet{}
-	expected["b"] = util.NewStringSet("a", "c")
-	expected["f"] = util.NewStringSet("e")
-	expected["h"] = util.NewStringSet("g")
+	expected := map[string]sets.String{}
+	expected["b"] = sets.NewString("a", "c")
+	expected["f"] = sets.NewString("e")
+	expected["h"] = sets.NewString("g")
 	indexer.Add(mkObj("a", "b"))
 	indexer.Add(mkObj("c", "b"))
 	indexer.Add(mkObj("e", "f"))
 	indexer.Add(mkObj("g", "h"))
 	{
 		for k, v := range expected {
-			found := util.StringSet{}
+			found := sets.String{}
 			indexResults, err := indexer.Index("by_val", mkObj("", k))
 			if err != nil {
 				t.Errorf("Unexpected error %v", err)

--- a/pkg/client/unversioned/cache/thread_safe_store.go
+++ b/pkg/client/unversioned/cache/thread_safe_store.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"sync"
 
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 // ThreadSafeStore is an interface that allows concurrent access to a storage backend.
@@ -142,7 +142,7 @@ func (c *threadSafeMap) Index(indexName string, obj interface{}) ([]interface{},
 	index := c.indices[indexName]
 
 	// need to de-dupe the return list.  Since multiple keys are allowed, this can happen.
-	returnKeySet := util.StringSet{}
+	returnKeySet := sets.String{}
 	for _, indexKey := range indexKeys {
 		set := index[indexKey]
 		for _, key := range set.List() {
@@ -208,7 +208,7 @@ func (c *threadSafeMap) updateIndices(oldObj interface{}, newObj interface{}, ke
 		for _, indexValue := range indexValues {
 			set := index[indexValue]
 			if set == nil {
-				set = util.StringSet{}
+				set = sets.String{}
 				index[indexValue] = set
 			}
 			set.Insert(key)

--- a/pkg/client/unversioned/debugging.go
+++ b/pkg/client/unversioned/debugging.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/golang/glog"
 
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 // RequestInfo keeps track of information about a request/response combination
@@ -75,7 +75,7 @@ func (r RequestInfo) ToCurl() string {
 type DebuggingRoundTripper struct {
 	delegatedRoundTripper http.RoundTripper
 
-	Levels util.StringSet
+	Levels sets.String
 }
 
 const (
@@ -88,7 +88,7 @@ const (
 )
 
 func NewDebuggingRoundTripper(rt http.RoundTripper, levels ...string) *DebuggingRoundTripper {
-	return &DebuggingRoundTripper{rt, util.NewStringSet(levels...)}
+	return &DebuggingRoundTripper{rt, sets.NewString(levels...)}
 }
 
 func (rt *DebuggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/pkg/client/unversioned/flags_test.go
+++ b/pkg/client/unversioned/flags_test.go
@@ -20,12 +20,12 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 type fakeFlagSet struct {
 	t   *testing.T
-	set util.StringSet
+	set sets.String
 }
 
 func (f *fakeFlagSet) StringVar(p *string, name, value, usage string) {

--- a/pkg/client/unversioned/helper.go
+++ b/pkg/client/unversioned/helper.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/version"
 )
 
@@ -187,7 +188,7 @@ func NegotiateVersion(client *Client, c *Config, version string, clientRegistere
 			return "", err
 		}
 	}
-	clientVersions := util.StringSet{}
+	clientVersions := sets.String{}
 	for _, v := range clientRegisteredVersions {
 		clientVersions.Insert(v)
 	}
@@ -195,7 +196,7 @@ func NegotiateVersion(client *Client, c *Config, version string, clientRegistere
 	if err != nil {
 		return "", fmt.Errorf("couldn't read version from server: %v", err)
 	}
-	serverVersions := util.StringSet{}
+	serverVersions := sets.String{}
 	for _, v := range apiVersions.Versions {
 		serverVersions.Insert(v)
 	}

--- a/pkg/client/unversioned/request.go
+++ b/pkg/client/unversioned/request.go
@@ -39,13 +39,14 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/httpstream"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/watch"
 	watchjson "k8s.io/kubernetes/pkg/watch/json"
 )
 
 // specialParams lists parameters that are handled specially and which users of Request
 // are therefore not allowed to set manually.
-var specialParams = util.NewStringSet("timeout")
+var specialParams = sets.NewString("timeout")
 
 // HTTPClient is an interface for testing a request object.
 type HTTPClient interface {

--- a/pkg/cloudprovider/providers/aws/aws_loadbalancer.go
+++ b/pkg/cloudprovider/providers/aws/aws_loadbalancer.go
@@ -24,7 +24,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/golang/glog"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 func (s *AWSCloud) ensureLoadBalancer(region, name string, listeners []*elb.Listener, subnetIDs []string, securityGroupIDs []string) (*elb.LoadBalancerDescription, error) {
@@ -61,7 +61,7 @@ func (s *AWSCloud) ensureLoadBalancer(region, name string, listeners []*elb.List
 	} else {
 		{
 			// Sync subnets
-			expected := util.NewStringSet(subnetIDs...)
+			expected := sets.NewString(subnetIDs...)
 			actual := stringSetFromPointers(loadBalancer.Subnets)
 
 			additions := expected.Difference(actual)
@@ -94,7 +94,7 @@ func (s *AWSCloud) ensureLoadBalancer(region, name string, listeners []*elb.List
 
 		{
 			// Sync security groups
-			expected := util.NewStringSet(securityGroupIDs...)
+			expected := sets.NewString(securityGroupIDs...)
 			actual := stringSetFromPointers(loadBalancer.SecurityGroups)
 
 			if !expected.Equal(actual) {
@@ -255,12 +255,12 @@ func (s *AWSCloud) ensureLoadBalancerHealthCheck(region string, loadBalancer *el
 
 // Makes sure that exactly the specified hosts are registered as instances with the load balancer
 func (s *AWSCloud) ensureLoadBalancerInstances(elbClient ELB, loadBalancerName string, lbInstances []*elb.Instance, instances []*ec2.Instance) error {
-	expected := util.NewStringSet()
+	expected := sets.NewString()
 	for _, instance := range instances {
 		expected.Insert(orEmpty(instance.InstanceID))
 	}
 
-	actual := util.NewStringSet()
+	actual := sets.NewString()
 	for _, lbInstance := range lbInstances {
 		actual.Insert(orEmpty(lbInstance.InstanceID))
 	}

--- a/pkg/cloudprovider/providers/aws/aws_utils.go
+++ b/pkg/cloudprovider/providers/aws/aws_utils.go
@@ -18,10 +18,10 @@ package aws_cloud
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
-func stringSetToPointers(in util.StringSet) []*string {
+func stringSetToPointers(in sets.String) []*string {
 	if in == nil {
 		return nil
 	}
@@ -32,11 +32,11 @@ func stringSetToPointers(in util.StringSet) []*string {
 	return out
 }
 
-func stringSetFromPointers(in []*string) util.StringSet {
+func stringSetFromPointers(in []*string) sets.String {
 	if in == nil {
 		return nil
 	}
-	out := util.NewStringSet()
+	out := sets.NewString()
 	for i := range in {
 		out.Insert(orEmpty(in[i]))
 	}

--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -28,7 +28,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/cloudprovider"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/util/wait"
 
 	"github.com/golang/glog"
@@ -464,7 +464,7 @@ func (gce *GCECloud) UpdateTCPLoadBalancer(name, region string, hosts []string) 
 	if err != nil {
 		return err
 	}
-	existing := util.NewStringSet()
+	existing := sets.NewString()
 	for _, instance := range pool.Instances {
 		existing.Insert(hostURLToComparablePath(instance))
 	}

--- a/pkg/controller/controller_utils_test.go
+++ b/pkg/controller/controller_utils_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/securitycontext"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 // NewFakeControllerExpectationsLookup creates a fake store for PodExpectations.
@@ -224,13 +225,13 @@ func TestActivePodFiltering(t *testing.T) {
 	podList := newPodList(nil, 5, api.PodRunning, rc)
 	podList.Items[0].Status.Phase = api.PodSucceeded
 	podList.Items[1].Status.Phase = api.PodFailed
-	expectedNames := util.NewStringSet()
+	expectedNames := sets.NewString()
 	for _, pod := range podList.Items[2:] {
 		expectedNames.Insert(pod.Name)
 	}
 
 	got := FilterActivePods(podList.Items)
-	gotNames := util.NewStringSet()
+	gotNames := sets.NewString()
 	for _, pod := range got {
 		gotNames.Insert(pod.Name)
 	}

--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/util/workqueue"
 	"k8s.io/kubernetes/pkg/watch"
 
@@ -141,8 +142,8 @@ func (e *EndpointController) Run(workers int, stopCh <-chan struct{}) {
 	e.queue.ShutDown()
 }
 
-func (e *EndpointController) getPodServiceMemberships(pod *api.Pod) (util.StringSet, error) {
-	set := util.StringSet{}
+func (e *EndpointController) getPodServiceMemberships(pod *api.Pod) (sets.String, error) {
+	set := sets.String{}
 	services, err := e.serviceStore.GetPodServices(pod)
 	if err != nil {
 		// don't log this error because this function makes pointless

--- a/pkg/controller/framework/controller_test.go
+++ b/pkg/controller/framework/controller_test.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/kubernetes/pkg/client/unversioned/cache"
 	"k8s.io/kubernetes/pkg/controller/framework"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 
 	"github.com/google/gofuzz"
 )
@@ -104,7 +104,7 @@ func Example() {
 	}
 
 	// Let's wait for the controller to process the things we just added.
-	outputSet := util.StringSet{}
+	outputSet := sets.String{}
 	for i := 0; i < len(testIDs); i++ {
 		outputSet.Insert(<-deletionCounter)
 	}
@@ -161,7 +161,7 @@ func ExampleInformer() {
 	}
 
 	// Let's wait for the controller to process the things we just added.
-	outputSet := util.StringSet{}
+	outputSet := sets.String{}
 	for i := 0; i < len(testIDs); i++ {
 		outputSet.Insert(<-deletionCounter)
 	}
@@ -235,7 +235,7 @@ func TestHammerController(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			// Let's add a few objects to the source.
-			currentNames := util.StringSet{}
+			currentNames := sets.String{}
 			rs := rand.NewSource(rand.Int63())
 			f := fuzz.New().NilChance(.5).NumElements(0, 2).RandSource(rs)
 			r := rand.New(rs) // Mustn't use r and f concurrently!

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/watch"
 
 	"github.com/golang/glog"
@@ -128,7 +129,7 @@ func finalize(kubeClient client.Interface, namespace api.Namespace) (*api.Namesp
 	namespaceFinalize := api.Namespace{}
 	namespaceFinalize.ObjectMeta = namespace.ObjectMeta
 	namespaceFinalize.Spec = namespace.Spec
-	finalizerSet := util.NewStringSet()
+	finalizerSet := sets.NewString()
 	for i := range namespace.Spec.Finalizers {
 		if namespace.Spec.Finalizers[i] != api.FinalizerKubernetes {
 			finalizerSet.Insert(string(namespace.Spec.Finalizers[i]))

--- a/pkg/controller/namespace/namespace_controller_test.go
+++ b/pkg/controller/namespace/namespace_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 func TestFinalized(t *testing.T) {
@@ -90,7 +91,7 @@ func testSyncNamespaceThatIsTerminating(t *testing.T, experimentalMode bool) {
 		t.Errorf("Unexpected error when synching namespace %v", err)
 	}
 	// TODO: Reuse the constants for all these strings from testclient
-	expectedActionSet := util.NewStringSet(
+	expectedActionSet := sets.NewString(
 		strings.Join([]string{"list", "replicationcontrollers", ""}, "-"),
 		strings.Join([]string{"list", "services", ""}, "-"),
 		strings.Join([]string{"list", "pods", ""}, "-"),
@@ -112,7 +113,7 @@ func testSyncNamespaceThatIsTerminating(t *testing.T, experimentalMode bool) {
 		)
 	}
 
-	actionSet := util.NewStringSet()
+	actionSet := sets.NewString()
 	for _, action := range mockClient.Actions() {
 		actionSet.Insert(strings.Join([]string{action.GetVerb(), action.GetResource(), action.GetSubresource()}, "-"))
 	}

--- a/pkg/controller/node/rate_limited_queue.go
+++ b/pkg/controller/node/rate_limited_queue.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 // TimedValue is a value that should be processed at a designated time.
@@ -58,7 +59,7 @@ func (h *TimedQueue) Pop() interface{} {
 type UniqueQueue struct {
 	lock  sync.Mutex
 	queue TimedQueue
-	set   util.StringSet
+	set   sets.String
 }
 
 // Adds a new value to the queue if it wasn't added before, or was explicitly removed by the
@@ -143,7 +144,7 @@ func NewRateLimitedTimedQueue(limiter util.RateLimiter) *RateLimitedTimedQueue {
 	return &RateLimitedTimedQueue{
 		queue: UniqueQueue{
 			queue: TimedQueue{},
-			set:   util.NewStringSet(),
+			set:   sets.NewString(),
 		},
 		limiter: limiter,
 	}

--- a/pkg/controller/node/rate_limited_queue_test.go
+++ b/pkg/controller/node/rate_limited_queue_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 func CheckQueueEq(lhs []string, rhs TimedQueue) bool {
@@ -33,7 +34,7 @@ func CheckQueueEq(lhs []string, rhs TimedQueue) bool {
 	return true
 }
 
-func CheckSetEq(lhs, rhs util.StringSet) bool {
+func CheckSetEq(lhs, rhs sets.String) bool {
 	return lhs.HasAll(rhs.List()...) && rhs.HasAll(lhs.List()...)
 }
 
@@ -51,7 +52,7 @@ func TestAddNode(t *testing.T) {
 		t.Errorf("Invalid queue. Got %v, expected %v", evictor.queue.queue, queuePattern)
 	}
 
-	setPattern := util.NewStringSet("first", "second", "third")
+	setPattern := sets.NewString("first", "second", "third")
 	if len(evictor.queue.set) != len(setPattern) {
 		t.Fatalf("Map %v should have length %d", evictor.queue.set, len(setPattern))
 	}
@@ -75,7 +76,7 @@ func TestDelNode(t *testing.T) {
 		t.Errorf("Invalid queue. Got %v, expected %v", evictor.queue.queue, queuePattern)
 	}
 
-	setPattern := util.NewStringSet("second", "third")
+	setPattern := sets.NewString("second", "third")
 	if len(evictor.queue.set) != len(setPattern) {
 		t.Fatalf("Map %v should have length %d", evictor.queue.set, len(setPattern))
 	}
@@ -97,7 +98,7 @@ func TestDelNode(t *testing.T) {
 		t.Errorf("Invalid queue. Got %v, expected %v", evictor.queue.queue, queuePattern)
 	}
 
-	setPattern = util.NewStringSet("first", "third")
+	setPattern = sets.NewString("first", "third")
 	if len(evictor.queue.set) != len(setPattern) {
 		t.Fatalf("Map %v should have length %d", evictor.queue.set, len(setPattern))
 	}
@@ -119,7 +120,7 @@ func TestDelNode(t *testing.T) {
 		t.Errorf("Invalid queue. Got %v, expected %v", evictor.queue.queue, queuePattern)
 	}
 
-	setPattern = util.NewStringSet("first", "second")
+	setPattern = sets.NewString("first", "second")
 	if len(evictor.queue.set) != len(setPattern) {
 		t.Fatalf("Map %v should have length %d", evictor.queue.set, len(setPattern))
 	}
@@ -135,13 +136,13 @@ func TestTry(t *testing.T) {
 	evictor.Add("third")
 	evictor.Remove("second")
 
-	deletedMap := util.NewStringSet()
+	deletedMap := sets.NewString()
 	evictor.Try(func(value TimedValue) (bool, time.Duration) {
 		deletedMap.Insert(value.Value)
 		return true, 0
 	})
 
-	setPattern := util.NewStringSet("first", "third")
+	setPattern := sets.NewString("first", "third")
 	if len(deletedMap) != len(setPattern) {
 		t.Fatalf("Map %v should have length %d", evictor.queue.set, len(setPattern))
 	}

--- a/pkg/controller/replication/replication_controller_test.go
+++ b/pkg/controller/replication/replication_controller_test.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/securitycontext"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/watch"
 )
@@ -626,7 +627,7 @@ func TestUpdatePods(t *testing.T) {
 	// both controllers
 	manager.updatePod(&pod1, &pod2)
 
-	expected := util.NewStringSet(testControllerSpec1.Name, testControllerSpec2.Name)
+	expected := sets.NewString(testControllerSpec1.Name, testControllerSpec2.Name)
 	for _, name := range expected.List() {
 		t.Logf("Expecting update for %+v", name)
 		select {

--- a/pkg/controller/resourcequota/resource_quota_controller_test.go
+++ b/pkg/controller/resourcequota/resource_quota_controller_test.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 func getResourceList(cpu, memory string) api.ResourceList {
@@ -103,11 +103,11 @@ func TestFilterQuotaPods(t *testing.T) {
 			Status: api.PodStatus{Phase: api.PodFailed},
 		},
 	}
-	expectedResults := util.NewStringSet("pod-running",
+	expectedResults := sets.NewString("pod-running",
 		"pod-pending", "pod-unknown", "pod-failed-with-restart-always",
 		"pod-failed-with-restart-on-failure")
 
-	actualResults := util.StringSet{}
+	actualResults := sets.String{}
 	result := FilterQuotaPods(pods)
 	for i := range result {
 		actualResults.Insert(result[i].Name)

--- a/pkg/controller/serviceaccount/serviceaccounts_controller.go
+++ b/pkg/controller/serviceaccount/serviceaccounts_controller.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/watch"
 )
 
@@ -45,7 +45,7 @@ func nameIndexFunc(obj interface{}) ([]string, error) {
 // ServiceAccountsControllerOptions contains options for running a ServiceAccountsController
 type ServiceAccountsControllerOptions struct {
 	// Names is the set of service account names to ensure exist in every namespace
-	Names util.StringSet
+	Names sets.String
 
 	// ServiceAccountResync is the interval between full resyncs of ServiceAccounts.
 	// If non-zero, all service accounts will be re-listed this often.
@@ -59,7 +59,7 @@ type ServiceAccountsControllerOptions struct {
 }
 
 func DefaultServiceAccountsControllerOptions() ServiceAccountsControllerOptions {
-	return ServiceAccountsControllerOptions{Names: util.NewStringSet("default")}
+	return ServiceAccountsControllerOptions{Names: sets.NewString("default")}
 }
 
 // NewServiceAccountsController returns a new *ServiceAccountsController.
@@ -117,7 +117,7 @@ type ServiceAccountsController struct {
 	stopChan chan struct{}
 
 	client client.Interface
-	names  util.StringSet
+	names  sets.String
 
 	serviceAccounts cache.Indexer
 	namespaces      cache.Indexer

--- a/pkg/controller/serviceaccount/serviceaccounts_controller_test.go
+++ b/pkg/controller/serviceaccount/serviceaccounts_controller_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 type serverResponse struct {
@@ -101,7 +102,7 @@ func TestServiceAccountCreation(t *testing.T) {
 		"new active namespace missing serviceaccounts": {
 			ExistingServiceAccounts:      []*api.ServiceAccount{},
 			AddedNamespace:               activeNS,
-			ExpectCreatedServiceAccounts: util.NewStringSet(defaultName, managedName).List(),
+			ExpectCreatedServiceAccounts: sets.NewString(defaultName, managedName).List(),
 		},
 		"new active namespace missing serviceaccount": {
 			ExistingServiceAccounts:      []*api.ServiceAccount{managedServiceAccount},
@@ -123,7 +124,7 @@ func TestServiceAccountCreation(t *testing.T) {
 		"updated active namespace missing serviceaccounts": {
 			ExistingServiceAccounts:      []*api.ServiceAccount{},
 			UpdatedNamespace:             activeNS,
-			ExpectCreatedServiceAccounts: util.NewStringSet(defaultName, managedName).List(),
+			ExpectCreatedServiceAccounts: sets.NewString(defaultName, managedName).List(),
 		},
 		"updated active namespace missing serviceaccount": {
 			ExistingServiceAccounts:      []*api.ServiceAccount{defaultServiceAccount},
@@ -170,7 +171,7 @@ func TestServiceAccountCreation(t *testing.T) {
 	for k, tc := range testcases {
 		client := testclient.NewSimpleFake(defaultServiceAccount, managedServiceAccount)
 		options := DefaultServiceAccountsControllerOptions()
-		options.Names = util.NewStringSet(defaultName, managedName)
+		options.Names = sets.NewString(defaultName, managedName)
 		controller := NewServiceAccountsController(client, options)
 
 		if tc.ExistingNamespace != nil {

--- a/pkg/controller/serviceaccount/tokens_controller.go
+++ b/pkg/controller/serviceaccount/tokens_controller.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/registry/secret"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/watch"
 )
 
@@ -495,8 +495,8 @@ func serviceAccountNameAndUID(secret *api.Secret) (string, string) {
 	return secret.Annotations[api.ServiceAccountNameKey], secret.Annotations[api.ServiceAccountUIDKey]
 }
 
-func getSecretReferences(serviceAccount *api.ServiceAccount) util.StringSet {
-	references := util.NewStringSet()
+func getSecretReferences(serviceAccount *api.ServiceAccount) sets.String {
+	references := sets.NewString()
 	for _, secret := range serviceAccount.Secrets {
 		references.Insert(secret.Name)
 	}

--- a/pkg/credentialprovider/keyring.go
+++ b/pkg/credentialprovider/keyring.go
@@ -28,7 +28,7 @@ import (
 	"github.com/golang/glog"
 
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 // DockerKeyring tracks a set of docker registry credentials, maintaining a
@@ -90,7 +90,7 @@ func (dk *BasicDockerKeyring) Add(cfg DockerConfig) {
 		}
 	}
 
-	eliminateDupes := util.NewStringSet(dk.index...)
+	eliminateDupes := sets.NewString(dk.index...)
 	dk.index = eliminateDupes.List()
 
 	// Update the index used to identify which credentials to use for a given

--- a/pkg/expapi/latest/latest.go
+++ b/pkg/expapi/latest/latest.go
@@ -26,7 +26,7 @@ import (
 	_ "k8s.io/kubernetes/pkg/expapi"
 	"k8s.io/kubernetes/pkg/expapi/v1"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 var (
@@ -51,9 +51,9 @@ func init() {
 
 	// the list of kinds that are scoped at the root of the api hierarchy
 	// if a kind is not enumerated here, it is assumed to have a namespace scope
-	rootScoped := util.NewStringSet()
+	rootScoped := sets.NewString()
 
-	ignoredKinds := util.NewStringSet()
+	ignoredKinds := sets.NewString()
 
 	RESTMapper = api.NewDefaultRESTMapper("experimental", Versions, InterfacesFor, importPrefix, ignoredKinds, rootScoped)
 	api.RegisterRESTMapper(RESTMapper)

--- a/pkg/expapi/validation/validation.go
+++ b/pkg/expapi/validation/validation.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/util"
 	errs "k8s.io/kubernetes/pkg/util/fielderrors"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 // ValidateHorizontalPodAutoscaler can be used to check whether the given autoscaler name is valid.
@@ -79,7 +80,7 @@ func ValidateThirdPartyResource(obj *expapi.ThirdPartyResource) errs.ValidationE
 	if len(obj.Name) == 0 {
 		allErrs = append(allErrs, errs.NewFieldInvalid("name", obj.Name, "name must be non-empty"))
 	}
-	versions := util.StringSet{}
+	versions := sets.String{}
 	for ix := range obj.Versions {
 		version := &obj.Versions[ix]
 		if len(version.Name) == 0 {

--- a/pkg/kubectl/cmd/config/navigation_step_parser.go
+++ b/pkg/kubectl/cmd/config/navigation_step_parser.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 type navigationSteps struct {
@@ -55,7 +55,7 @@ func newNavigationSteps(path string) (*navigationSteps, error) {
 			if err != nil {
 				return nil, err
 			}
-			nextPart := findNameStep(individualParts[currPartIndex:], util.KeySet(reflect.ValueOf(mapValueOptions)))
+			nextPart := findNameStep(individualParts[currPartIndex:], sets.KeySet(reflect.ValueOf(mapValueOptions)))
 
 			steps = append(steps, navigationStep{nextPart, mapValueType})
 			currPartIndex += len(strings.Split(nextPart, "."))
@@ -103,7 +103,7 @@ func (s *navigationSteps) moreStepsRemaining() bool {
 
 // findNameStep takes the list of parts and a set of valid tags that can be used after the name.  It then walks the list of parts
 // until it find a valid "next" tag or until it reaches the end of the parts and then builds the name back up out of the individual parts
-func findNameStep(parts []string, typeOptions util.StringSet) string {
+func findNameStep(parts []string, typeOptions sets.String) string {
 	if len(parts) == 0 {
 		return ""
 	}
@@ -141,7 +141,7 @@ func getPotentialTypeValues(typeValue reflect.Type) (map[string]reflect.Type, er
 	return ret, nil
 }
 
-func findKnownValue(parts []string, valueOptions util.StringSet) int {
+func findKnownValue(parts []string, valueOptions sets.String) int {
 	for i := range parts {
 		if valueOptions.Has(parts[i]) {
 			return i

--- a/pkg/kubectl/cmd/log.go
+++ b/pkg/kubectl/cmd/log.go
@@ -26,7 +26,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/kubernetes/pkg/api"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
-	libutil "k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 const (
@@ -42,7 +42,7 @@ $ kubectl logs -f 123456-7890 ruby-container`
 
 func selectContainer(pod *api.Pod, in io.Reader, out io.Writer) string {
 	fmt.Fprintf(out, "Please select a container:\n")
-	options := libutil.StringSet{}
+	options := sets.String{}
 	for ix := range pod.Spec.Containers {
 		fmt.Fprintf(out, "[%d] %s\n", ix+1, pod.Spec.Containers[ix].Name)
 		options.Insert(pod.Spec.Containers[ix].Name)

--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/types"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 // Describer generates output for the named resource or an error
@@ -933,7 +933,7 @@ func describeService(service *api.Service, endpoints *api.Endpoints, events *api
 			if sp.NodePort != 0 {
 				fmt.Fprintf(out, "NodePort:\t%s\t%d/%s\n", name, sp.NodePort, sp.Protocol)
 			}
-			fmt.Fprintf(out, "Endpoints:\t%s\n", formatEndpoints(endpoints, util.NewStringSet(sp.Name)))
+			fmt.Fprintf(out, "Endpoints:\t%s\n", formatEndpoints(endpoints, sets.NewString(sp.Name)))
 		}
 		fmt.Fprintf(out, "Session Affinity:\t%s\n", service.Spec.SessionAffinity)
 		if events != nil {

--- a/pkg/kubectl/resource/builder.go
+++ b/pkg/kubectl/resource/builder.go
@@ -28,8 +28,8 @@ import (
 	"k8s.io/kubernetes/pkg/api/validation"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/errors"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 var FileExtensions = []string{".json", ".stdin", ".yaml", ".yml"}
@@ -685,7 +685,7 @@ func (b *Builder) Do() *Result {
 // strings in the original order.
 func SplitResourceArgument(arg string) []string {
 	out := []string{}
-	set := util.NewStringSet()
+	set := sets.NewString()
 	for _, s := range strings.Split(arg, ",") {
 		if set.Has(s) {
 			continue

--- a/pkg/kubectl/resource/result.go
+++ b/pkg/kubectl/resource/result.go
@@ -24,8 +24,8 @@ import (
 	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/errors"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/watch"
 )
 
@@ -123,7 +123,7 @@ func (r *Result) Object() (runtime.Object, error) {
 		return nil, err
 	}
 
-	versions := util.StringSet{}
+	versions := sets.String{}
 	objects := []runtime.Object{}
 	for _, info := range infos {
 		if info.Object != nil {

--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/jsonpath"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 // GetPrinter takes a format type, an optional format argument. It will return true
@@ -435,7 +436,7 @@ func (h *HumanReadablePrinter) printHeader(columnNames []string, w io.Writer) er
 }
 
 // Pass ports=nil for all ports.
-func formatEndpoints(endpoints *api.Endpoints, ports util.StringSet) string {
+func formatEndpoints(endpoints *api.Endpoints, ports sets.String) string {
 	if len(endpoints.Subsets) == 0 {
 		return "<none>"
 	}

--- a/pkg/kubectl/resource_printer_test.go
+++ b/pkg/kubectl/resource_printer_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/kubernetes/pkg/expapi"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 
 	"github.com/ghodss/yaml"
 )
@@ -484,9 +485,9 @@ func TestPrinters(t *testing.T) {
 			}}},
 	}
 	// map of printer name to set of objects it should fail on.
-	expectedErrors := map[string]util.StringSet{
-		"template2": util.NewStringSet("pod", "emptyPodList", "endpoints"),
-		"jsonpath":  util.NewStringSet("emptyPodList", "nonEmptyPodList", "endpoints"),
+	expectedErrors := map[string]sets.String{
+		"template2": sets.NewString("pod", "emptyPodList", "endpoints"),
+		"jsonpath":  sets.NewString("emptyPodList", "nonEmptyPodList", "endpoints"),
 	}
 
 	for pName, p := range printers {

--- a/pkg/kubectl/rolling_updater_test.go
+++ b/pkg/kubectl/rolling_updater_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 func oldRc(replicas int, original int) *api.ReplicationController {
@@ -1140,7 +1141,7 @@ func TestAddDeploymentHash(t *testing.T) {
 		},
 	}
 
-	seen := util.StringSet{}
+	seen := sets.String{}
 	updatedRc := false
 	fakeClient := &client.FakeRESTClient{
 		Codec: codec,

--- a/pkg/kubelet/config/config.go
+++ b/pkg/kubelet/config/config.go
@@ -29,10 +29,10 @@ import (
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	kubeletTypes "k8s.io/kubernetes/pkg/kubelet/types"
 	kubeletUtil "k8s.io/kubernetes/pkg/kubelet/util"
-	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/config"
 	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/util/fielderrors"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 // PodConfigNotificationMode describes how changes are sent to the update channel.
@@ -61,7 +61,7 @@ type PodConfig struct {
 
 	// contains the list of all configured sources
 	sourcesLock sync.Mutex
-	sources     util.StringSet
+	sources     sets.String
 }
 
 // NewPodConfig creates an object that can merge many configuration sources into a stream
@@ -73,7 +73,7 @@ func NewPodConfig(mode PodConfigNotificationMode, recorder record.EventRecorder)
 		pods:    storage,
 		mux:     config.NewMux(storage),
 		updates: updates,
-		sources: util.StringSet{},
+		sources: sets.String{},
 	}
 	return podConfig
 }
@@ -124,7 +124,7 @@ type podStorage struct {
 
 	// contains the set of all sources that have sent at least one SET
 	sourcesSeenLock sync.Mutex
-	sourcesSeen     util.StringSet
+	sourcesSeen     sets.String
 
 	// the EventRecorder to use
 	recorder record.EventRecorder
@@ -138,7 +138,7 @@ func newPodStorage(updates chan<- kubelet.PodUpdate, mode PodConfigNotificationM
 		pods:        make(map[string]map[string]*api.Pod),
 		mode:        mode,
 		updates:     updates,
-		sourcesSeen: util.StringSet{},
+		sourcesSeen: sets.String{},
 		recorder:    recorder,
 	}
 }
@@ -306,7 +306,7 @@ func (s *podStorage) seenSources(sources ...string) bool {
 }
 
 func filterInvalidPods(pods []*api.Pod, source string, recorder record.EventRecorder) (filtered []*api.Pod) {
-	names := util.StringSet{}
+	names := sets.String{}
 	for i, pod := range pods {
 		var errlist []error
 		if errs := validation.ValidatePod(pod); len(errs) != 0 {

--- a/pkg/kubelet/dockertools/fake_docker_client.go
+++ b/pkg/kubelet/dockertools/fake_docker_client.go
@@ -27,7 +27,7 @@ import (
 	docker "github.com/fsouza/go-dockerclient"
 
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 // FakeDockerClient is a simple fake docker client, so that kubelet can be run for testing without requiring a real docker setup.
@@ -45,7 +45,7 @@ type FakeDockerClient struct {
 	pulled              []string
 	Created             []string
 	Removed             []string
-	RemovedImages       util.StringSet
+	RemovedImages       sets.String
 	VersionInfo         docker.Env
 	Information         docker.Env
 	ExecInspect         *docker.ExecInspect

--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -51,6 +51,7 @@ import (
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/oom"
 	"k8s.io/kubernetes/pkg/util/procfs"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 const (
@@ -402,7 +403,7 @@ func (dm *DockerManager) GetPodStatus(pod *api.Pod) (*api.PodStatus, error) {
 		return nil, err
 	}
 
-	containerDone := util.NewStringSet()
+	containerDone := sets.NewString()
 	// Loop through list of running and exited docker containers to construct
 	// the statuses. We assume docker returns a list of containers sorted in
 	// reverse by time.

--- a/pkg/kubelet/dockertools/manager_test.go
+++ b/pkg/kubelet/dockertools/manager_test.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util"
 	uexec "k8s.io/kubernetes/pkg/util/exec"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 type fakeHTTP struct {
@@ -74,7 +75,7 @@ func (*fakeOptionGenerator) GenerateRunContainerOptions(pod *api.Pod, container 
 }
 
 func newTestDockerManagerWithHTTPClient(fakeHTTPClient *fakeHTTP) (*DockerManager, *FakeDockerClient) {
-	fakeDocker := &FakeDockerClient{VersionInfo: docker.Env{"Version=1.1.3", "ApiVersion=1.15"}, Errors: make(map[string]error), RemovedImages: util.StringSet{}}
+	fakeDocker := &FakeDockerClient{VersionInfo: docker.Env{"Version=1.1.3", "ApiVersion=1.15"}, Errors: make(map[string]error), RemovedImages: sets.String{}}
 	fakeRecorder := &record.FakeRecorder{}
 	readinessManager := kubecontainer.NewReadinessManager()
 	containerRefManager := kubecontainer.NewRefManager()
@@ -324,14 +325,14 @@ func TestGetPods(t *testing.T) {
 func TestListImages(t *testing.T) {
 	manager, fakeDocker := newTestDockerManager()
 	dockerImages := []docker.APIImages{{ID: "1111"}, {ID: "2222"}, {ID: "3333"}}
-	expected := util.NewStringSet([]string{"1111", "2222", "3333"}...)
+	expected := sets.NewString([]string{"1111", "2222", "3333"}...)
 
 	fakeDocker.Images = dockerImages
 	actualImages, err := manager.ListImages()
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
 	}
-	actual := util.NewStringSet()
+	actual := sets.NewString()
 	for _, i := range actualImages {
 		actual.Insert(i.ID)
 	}

--- a/pkg/kubelet/image_manager.go
+++ b/pkg/kubelet/image_manager.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cadvisor"
 	"k8s.io/kubernetes/pkg/kubelet/dockertools"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 // Manages lifecycle of all images.
@@ -141,14 +142,14 @@ func (im *realImageManager) detectImages(detected time.Time) error {
 	}
 
 	// Make a set of images in use by containers.
-	imagesInUse := util.NewStringSet()
+	imagesInUse := sets.NewString()
 	for _, container := range containers {
 		imagesInUse.Insert(container.Image)
 	}
 
 	// Add new images and record those being used.
 	now := time.Now()
-	currentImages := util.NewStringSet()
+	currentImages := sets.NewString()
 	im.imageRecordsLock.Lock()
 	defer im.imageRecordsLock.Unlock()
 	for _, image := range images {
@@ -286,7 +287,7 @@ func (ev byLastUsedAndDetected) Less(i, j int) bool {
 	}
 }
 
-func isImageUsed(image *docker.APIImages, imagesInUse util.StringSet) bool {
+func isImageUsed(image *docker.APIImages, imagesInUse sets.String) bool {
 	// Check the image ID and all the RepoTags.
 	if _, ok := imagesInUse[image.ID]; ok {
 		return true

--- a/pkg/kubelet/image_manager_test.go
+++ b/pkg/kubelet/image_manager_test.go
@@ -28,14 +28,14 @@ import (
 	"k8s.io/kubernetes/pkg/client/unversioned/record"
 	"k8s.io/kubernetes/pkg/kubelet/cadvisor"
 	"k8s.io/kubernetes/pkg/kubelet/dockertools"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 var zero time.Time
 
 func newRealImageManager(policy ImageGCPolicy) (*realImageManager, *dockertools.FakeDockerClient, *cadvisor.Mock) {
 	fakeDocker := &dockertools.FakeDockerClient{
-		RemovedImages: util.NewStringSet(),
+		RemovedImages: sets.NewString(),
 	}
 	mockCadvisor := new(cadvisor.Mock)
 	return &realImageManager{

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -64,6 +64,7 @@ import (
 	nodeutil "k8s.io/kubernetes/pkg/util/node"
 	"k8s.io/kubernetes/pkg/util/oom"
 	"k8s.io/kubernetes/pkg/util/procfs"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/version"
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/watch"
@@ -983,7 +984,7 @@ func (kl *Kubelet) GenerateRunContainerOptions(pod *api.Pod, container *api.Cont
 	return opts, nil
 }
 
-var masterServices = util.NewStringSet("kubernetes")
+var masterServices = sets.NewString("kubernetes")
 
 // getServiceEnvVarMap makes a map[string]string of env vars for services a pod in namespace ns should see
 func (kl *Kubelet) getServiceEnvVarMap(ns string) (map[string]string, error) {
@@ -1408,7 +1409,7 @@ func getDesiredVolumes(pods []*api.Pod) map[string]api.Volume {
 // cleanupOrphanedPodDirs removes a pod directory if the pod is not in the
 // desired set of pods and there is no running containers in the pod.
 func (kl *Kubelet) cleanupOrphanedPodDirs(pods []*api.Pod, runningPods []*kubecontainer.Pod) error {
-	active := util.NewStringSet()
+	active := sets.NewString()
 	for _, pod := range pods {
 		active.Insert(string(pod.UID))
 	}
@@ -1446,7 +1447,7 @@ func (kl *Kubelet) cleanupBandwidthLimits(allPods []*api.Pod) error {
 	if err != nil {
 		return err
 	}
-	possibleCIDRs := util.StringSet{}
+	possibleCIDRs := sets.String{}
 	for ix := range allPods {
 		pod := allPods[ix]
 		ingress, egress, err := extractBandwidthResources(pod)
@@ -1486,7 +1487,7 @@ func (kl *Kubelet) cleanupOrphanedVolumes(pods []*api.Pod, runningPods []*kubeco
 	desiredVolumes := getDesiredVolumes(pods)
 	currentVolumes := kl.getPodVolumesFromDisk()
 
-	runningSet := util.StringSet{}
+	runningSet := sets.String{}
 	for _, pod := range runningPods {
 		runningSet.Insert(string(pod.ID))
 	}
@@ -1724,7 +1725,7 @@ func (kl *Kubelet) HandlePodCleanups() error {
 // podKiller launches a goroutine to kill a pod received from the channel if
 // another goroutine isn't already in action.
 func (kl *Kubelet) podKiller() {
-	killing := util.NewStringSet()
+	killing := sets.NewString()
 	resultCh := make(chan types.UID)
 	defer close(resultCh)
 	for {
@@ -1771,7 +1772,7 @@ func (s podsByCreationTime) Less(i, j int) bool {
 
 // checkHostPortConflicts detects pods with conflicted host ports.
 func hasHostPortConflicts(pods []*api.Pod) bool {
-	ports := util.StringSet{}
+	ports := sets.String{}
 	for _, pod := range pods {
 		if errs := validation.AccumulateUniqueHostPorts(pod.Spec.Containers, &ports); len(errs) > 0 {
 			glog.Errorf("Pod %q: HostPort is already allocated, ignoring: %v", kubecontainer.GetPodFullName(pod), errs)

--- a/pkg/kubelet/mirror_client_test.go
+++ b/pkg/kubelet/mirror_client_test.go
@@ -22,14 +22,14 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 type fakeMirrorClient struct {
 	mirrorPodLock sync.RWMutex
 	// Note that a real mirror manager does not store the mirror pods in
 	// itself. This fake manager does this to track calls.
-	mirrorPods   util.StringSet
+	mirrorPods   sets.String
 	createCounts map[string]int
 	deleteCounts map[string]int
 }
@@ -53,7 +53,7 @@ func (fmc *fakeMirrorClient) DeleteMirrorPod(podFullName string) error {
 
 func newFakeMirrorClient() *fakeMirrorClient {
 	m := fakeMirrorClient{}
-	m.mirrorPods = util.NewStringSet()
+	m.mirrorPods = sets.NewString()
 	m.createCounts = make(map[string]int)
 	m.deleteCounts = make(map[string]int)
 	return &m

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -79,6 +79,7 @@ import (
 	"k8s.io/kubernetes/pkg/tools"
 	"k8s.io/kubernetes/pkg/ui"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 
 	daemonetcd "k8s.io/kubernetes/pkg/registry/daemonset/etcd"
 	horizontalpodautoscaleretcd "k8s.io/kubernetes/pkg/registry/horizontalpodautoscaler/etcd"
@@ -566,7 +567,7 @@ func (m *Master) init(c *Config) {
 	apiserver.InstallSupport(m.muxHelper, m.rootWebService, c.EnableProfiling, healthzChecks...)
 	apiserver.AddApiWebService(m.handlerContainer, c.APIPrefix, apiVersions)
 	defaultVersion := m.defaultAPIGroupVersion()
-	requestInfoResolver := &apiserver.APIRequestInfoResolver{APIPrefixes: util.NewStringSet(strings.TrimPrefix(defaultVersion.Root, "/")), RestMapper: defaultVersion.Mapper}
+	requestInfoResolver := &apiserver.APIRequestInfoResolver{APIPrefixes: sets.NewString(strings.TrimPrefix(defaultVersion.Root, "/")), RestMapper: defaultVersion.Mapper}
 	apiserver.InstallServiceErrorHandler(m.handlerContainer, requestInfoResolver, apiVersions)
 
 	if m.exp {
@@ -575,7 +576,7 @@ func (m *Master) init(c *Config) {
 			glog.Fatalf("Unable to setup experimental api: %v", err)
 		}
 		apiserver.AddApiWebService(m.handlerContainer, c.ExpAPIPrefix, []string{expVersion.Version})
-		expRequestInfoResolver := &apiserver.APIRequestInfoResolver{APIPrefixes: util.NewStringSet(strings.TrimPrefix(expVersion.Root, "/")), RestMapper: expVersion.Mapper}
+		expRequestInfoResolver := &apiserver.APIRequestInfoResolver{APIPrefixes: sets.NewString(strings.TrimPrefix(expVersion.Root, "/")), RestMapper: expVersion.Mapper}
 		apiserver.InstallServiceErrorHandler(m.handlerContainer, expRequestInfoResolver, []string{expVersion.Version})
 	}
 
@@ -784,7 +785,7 @@ func (m *Master) InstallThirdPartyAPI(rsrc *expapi.ThirdPartyResource) error {
 	}
 	thirdPartyPrefix := "/thirdparty/" + group + "/"
 	apiserver.AddApiWebService(m.handlerContainer, thirdPartyPrefix, []string{rsrc.Versions[0].Name})
-	thirdPartyRequestInfoResolver := &apiserver.APIRequestInfoResolver{APIPrefixes: util.NewStringSet(strings.TrimPrefix(group, "/")), RestMapper: thirdparty.Mapper}
+	thirdPartyRequestInfoResolver := &apiserver.APIRequestInfoResolver{APIPrefixes: sets.NewString(strings.TrimPrefix(group, "/")), RestMapper: thirdparty.Mapper}
 	apiserver.InstallServiceErrorHandler(m.handlerContainer, thirdPartyRequestInfoResolver, []string{thirdparty.Version})
 	return nil
 }

--- a/pkg/registry/generic/etcd/etcd_test.go
+++ b/pkg/registry/generic/etcd/etcd_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/kubernetes/pkg/tools/etcdtest"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/fielderrors"
+	"k8s.io/kubernetes/pkg/util/sets"
 
 	"github.com/coreos/go-etcd/etcd"
 )
@@ -93,7 +94,7 @@ func NewTestGenericEtcdRegistry(t *testing.T) (*tools.FakeEtcdClient, *Etcd) {
 // setMatcher is a matcher that matches any pod with id in the set.
 // Makes testing simpler.
 type setMatcher struct {
-	util.StringSet
+	sets.String
 }
 
 func (sm setMatcher) Matches(obj runtime.Object) (bool, error) {
@@ -189,7 +190,7 @@ func TestEtcdList(t *testing.T) {
 				R: singleElemListResp,
 				E: nil,
 			},
-			m:       setMatcher{util.NewStringSet("foo")},
+			m:       setMatcher{sets.NewString("foo")},
 			out:     &api.PodList{Items: []api.Pod{*podA}},
 			succeed: true,
 		},
@@ -198,7 +199,7 @@ func TestEtcdList(t *testing.T) {
 				R: normalListResp,
 				E: nil,
 			},
-			m:       setMatcher{util.NewStringSet("foo", "makeMatchSingleReturnFalse")},
+			m:       setMatcher{sets.NewString("foo", "makeMatchSingleReturnFalse")},
 			out:     &api.PodList{Items: []api.Pod{*podA}},
 			succeed: true,
 		},
@@ -560,8 +561,8 @@ func TestEtcdDelete(t *testing.T) {
 
 func TestEtcdWatch(t *testing.T) {
 	table := map[string]generic.Matcher{
-		"single": setMatcher{util.NewStringSet("foo")},
-		"multi":  setMatcher{util.NewStringSet("foo", "bar")},
+		"single": setMatcher{sets.NewString("foo")},
+		"multi":  setMatcher{sets.NewString("foo", "bar")},
 	}
 
 	for name, m := range table {

--- a/pkg/registry/service/ipallocator/allocator_test.go
+++ b/pkg/registry/service/ipallocator/allocator_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 func TestAllocate(t *testing.T) {
@@ -34,7 +34,7 @@ func TestAllocate(t *testing.T) {
 	if f := r.Free(); f != 254 {
 		t.Errorf("unexpected free %d", f)
 	}
-	found := util.NewStringSet()
+	found := sets.NewString()
 	count := 0
 	for r.Free() > 0 {
 		ip, err := r.AllocateNext()
@@ -118,7 +118,7 @@ func TestAllocateSmall(t *testing.T) {
 	if f := r.Free(); f != 2 {
 		t.Errorf("free: %d", f)
 	}
-	found := util.NewStringSet()
+	found := sets.NewString()
 	for i := 0; i < 2; i++ {
 		ip, err := r.AllocateNext()
 		if err != nil {

--- a/pkg/registry/service/portallocator/allocator_test.go
+++ b/pkg/registry/service/portallocator/allocator_test.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 func TestAllocate(t *testing.T) {
@@ -34,7 +35,7 @@ func TestAllocate(t *testing.T) {
 	if f := r.Free(); f != 201 {
 		t.Errorf("unexpected free %d", f)
 	}
-	found := util.NewStringSet()
+	found := sets.NewString()
 	count := 0
 	for r.Free() > 0 {
 		p, err := r.AllocateNext()

--- a/pkg/runtime/conversion_generator.go
+++ b/pkg/runtime/conversion_generator.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 
 	"k8s.io/kubernetes/pkg/conversion"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 type ConversionGenerator interface {
@@ -33,7 +33,7 @@ type ConversionGenerator interface {
 	WriteConversionFunctions(w io.Writer) error
 	RegisterConversionFunctions(w io.Writer, pkg string) error
 	AddImport(pkg string) string
-	RepackImports(exclude util.StringSet)
+	RepackImports(exclude sets.String)
 	WriteImports(w io.Writer) error
 	OverwritePackage(pkg, overwrite string)
 	AssumePrivateConversions()
@@ -279,7 +279,7 @@ func (g *conversionGenerator) targetPackage(pkg string) {
 	g.shortImports[""] = pkg
 }
 
-func (g *conversionGenerator) RepackImports(exclude util.StringSet) {
+func (g *conversionGenerator) RepackImports(exclude sets.String) {
 	var packages []string
 	for key := range g.imports {
 		packages = append(packages, key)

--- a/pkg/runtime/deep_copy_generator.go
+++ b/pkg/runtime/deep_copy_generator.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 
 	"k8s.io/kubernetes/pkg/conversion"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 // TODO(wojtek-t): As suggested in #8320, we should consider the strategy
@@ -69,7 +69,7 @@ type DeepCopyGenerator interface {
 	OverwritePackage(pkg, overwrite string)
 }
 
-func NewDeepCopyGenerator(scheme *conversion.Scheme, targetPkg string, include util.StringSet) DeepCopyGenerator {
+func NewDeepCopyGenerator(scheme *conversion.Scheme, targetPkg string, include sets.String) DeepCopyGenerator {
 	g := &deepCopyGenerator{
 		scheme:        scheme,
 		targetPkg:     targetPkg,
@@ -100,7 +100,7 @@ type deepCopyGenerator struct {
 	shortImports  map[string]string
 	pkgOverwrites map[string]string
 	replace       map[pkgPathNamePair]reflect.Type
-	include       util.StringSet
+	include       sets.String
 }
 
 func (g *deepCopyGenerator) addImportByPath(pkg string) string {

--- a/pkg/storage/cacher_test.go
+++ b/pkg/storage/cacher_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/kubernetes/pkg/tools"
 	"k8s.io/kubernetes/pkg/tools/etcdtest"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/watch"
 )
@@ -160,7 +161,7 @@ func TestListFromMemory(t *testing.T) {
 	if len(result.Items) != 2 {
 		t.Errorf("unexpected list result: %d", len(result.Items))
 	}
-	keys := util.StringSet{}
+	keys := sets.String{}
 	for _, item := range result.Items {
 		keys.Insert(item.ObjectMeta.Name)
 	}

--- a/pkg/storage/watch_cache_test.go
+++ b/pkg/storage/watch_cache_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/pkg/client/unversioned/cache"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/watch"
 )
 
@@ -76,7 +77,7 @@ func TestWatchCacheBasic(t *testing.T) {
 	store.Add(makeTestPod("pod2", 5))
 	store.Add(makeTestPod("pod3", 6))
 	{
-		podNames := util.StringSet{}
+		podNames := sets.String{}
 		for _, item := range store.List() {
 			podNames.Insert(item.(*api.Pod).ObjectMeta.Name)
 		}
@@ -94,7 +95,7 @@ func TestWatchCacheBasic(t *testing.T) {
 		makeTestPod("pod5", 8),
 	}, "8")
 	{
-		podNames := util.StringSet{}
+		podNames := sets.String{}
 		for _, item := range store.List() {
 			podNames.Insert(item.(*api.Pod).ObjectMeta.Name)
 		}

--- a/pkg/util/bandwidth/linux.go
+++ b/pkg/util/bandwidth/linux.go
@@ -25,8 +25,8 @@ import (
 	"strings"
 
 	"k8s.io/kubernetes/pkg/api/resource"
-	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/exec"
+	"k8s.io/kubernetes/pkg/util/sets"
 
 	"github.com/golang/glog"
 )
@@ -65,7 +65,7 @@ func (t *tcShaper) nextClassID() (int, error) {
 	}
 
 	scanner := bufio.NewScanner(bytes.NewBuffer(data))
-	classes := util.StringSet{}
+	classes := sets.String{}
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		// skip empty lines

--- a/pkg/util/iptables/iptables.go
+++ b/pkg/util/iptables/iptables.go
@@ -26,8 +26,8 @@ import (
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/golang/glog"
-	"k8s.io/kubernetes/pkg/util"
 	utilexec "k8s.io/kubernetes/pkg/util/exec"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 type RulePosition string
@@ -352,7 +352,7 @@ func (runner *runner) checkRuleWithoutCheck(table Table, chain Chain, args ...st
 		tmpField := strings.Trim(args[i], "\"")
 		argsCopy = append(argsCopy, strings.Fields(tmpField)...)
 	}
-	argset := util.NewStringSet(argsCopy...)
+	argset := sets.NewString(argsCopy...)
 
 	for _, line := range strings.Split(string(out), "\n") {
 		var fields = strings.Fields(line)
@@ -370,7 +370,7 @@ func (runner *runner) checkRuleWithoutCheck(table Table, chain Chain, args ...st
 		}
 
 		// TODO: This misses reorderings e.g. "-x foo ! -y bar" will match "! -x foo -y bar"
-		if util.NewStringSet(fields...).IsSuperset(argset) {
+		if sets.NewString(fields...).IsSuperset(argset) {
 			return true, nil
 		}
 		glog.V(5).Infof("DBG: fields is not a superset of args: fields=%v  args=%v", fields, args)

--- a/pkg/util/iptables/iptables_test.go
+++ b/pkg/util/iptables/iptables_test.go
@@ -20,8 +20,8 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/exec"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 func getIptablesCommand(protocol Protocol) string {
@@ -68,7 +68,7 @@ func testEnsureChain(t *testing.T, protocol Protocol) {
 		t.Errorf("expected 2 CombinedOutput() calls, got %d", fcmd.CombinedOutputCalls)
 	}
 	cmd := getIptablesCommand(protocol)
-	if !util.NewStringSet(fcmd.CombinedOutputLog[1]...).HasAll(cmd, "-t", "nat", "-N", "FOOBAR") {
+	if !sets.NewString(fcmd.CombinedOutputLog[1]...).HasAll(cmd, "-t", "nat", "-N", "FOOBAR") {
 		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[1])
 	}
 	// Exists.
@@ -121,7 +121,7 @@ func TestFlushChain(t *testing.T) {
 	if fcmd.CombinedOutputCalls != 2 {
 		t.Errorf("expected 2 CombinedOutput() calls, got %d", fcmd.CombinedOutputCalls)
 	}
-	if !util.NewStringSet(fcmd.CombinedOutputLog[1]...).HasAll("iptables", "-t", "nat", "-F", "FOOBAR") {
+	if !sets.NewString(fcmd.CombinedOutputLog[1]...).HasAll("iptables", "-t", "nat", "-F", "FOOBAR") {
 		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[1])
 	}
 	// Failure.
@@ -158,7 +158,7 @@ func TestDeleteChain(t *testing.T) {
 	if fcmd.CombinedOutputCalls != 2 {
 		t.Errorf("expected 2 CombinedOutput() calls, got %d", fcmd.CombinedOutputCalls)
 	}
-	if !util.NewStringSet(fcmd.CombinedOutputLog[1]...).HasAll("iptables", "-t", "nat", "-X", "FOOBAR") {
+	if !sets.NewString(fcmd.CombinedOutputLog[1]...).HasAll("iptables", "-t", "nat", "-X", "FOOBAR") {
 		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[1])
 	}
 	// Failure.
@@ -196,7 +196,7 @@ func TestEnsureRuleAlreadyExists(t *testing.T) {
 	if fcmd.CombinedOutputCalls != 2 {
 		t.Errorf("expected 2 CombinedOutput() calls, got %d", fcmd.CombinedOutputCalls)
 	}
-	if !util.NewStringSet(fcmd.CombinedOutputLog[1]...).HasAll("iptables", "-t", "nat", "-C", "OUTPUT", "abc", "123") {
+	if !sets.NewString(fcmd.CombinedOutputLog[1]...).HasAll("iptables", "-t", "nat", "-C", "OUTPUT", "abc", "123") {
 		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[1])
 	}
 }
@@ -232,7 +232,7 @@ func TestEnsureRuleNew(t *testing.T) {
 	if fcmd.CombinedOutputCalls != 3 {
 		t.Errorf("expected 3 CombinedOutput() calls, got %d", fcmd.CombinedOutputCalls)
 	}
-	if !util.NewStringSet(fcmd.CombinedOutputLog[2]...).HasAll("iptables", "-t", "nat", "-A", "OUTPUT", "abc", "123") {
+	if !sets.NewString(fcmd.CombinedOutputLog[2]...).HasAll("iptables", "-t", "nat", "-A", "OUTPUT", "abc", "123") {
 		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[2])
 	}
 }
@@ -319,7 +319,7 @@ func TestDeleteRuleAlreadyExists(t *testing.T) {
 	if fcmd.CombinedOutputCalls != 2 {
 		t.Errorf("expected 2 CombinedOutput() calls, got %d", fcmd.CombinedOutputCalls)
 	}
-	if !util.NewStringSet(fcmd.CombinedOutputLog[1]...).HasAll("iptables", "-t", "nat", "-C", "OUTPUT", "abc", "123") {
+	if !sets.NewString(fcmd.CombinedOutputLog[1]...).HasAll("iptables", "-t", "nat", "-C", "OUTPUT", "abc", "123") {
 		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[1])
 	}
 }
@@ -352,7 +352,7 @@ func TestDeleteRuleNew(t *testing.T) {
 	if fcmd.CombinedOutputCalls != 3 {
 		t.Errorf("expected 3 CombinedOutput() calls, got %d", fcmd.CombinedOutputCalls)
 	}
-	if !util.NewStringSet(fcmd.CombinedOutputLog[2]...).HasAll("iptables", "-t", "nat", "-D", "OUTPUT", "abc", "123") {
+	if !sets.NewString(fcmd.CombinedOutputLog[2]...).HasAll("iptables", "-t", "nat", "-D", "OUTPUT", "abc", "123") {
 		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[2])
 	}
 }
@@ -484,7 +484,7 @@ COMMIT
 	if fcmd.CombinedOutputCalls != 1 {
 		t.Errorf("expected 1 CombinedOutput() call, got %d", fcmd.CombinedOutputCalls)
 	}
-	if !util.NewStringSet(fcmd.CombinedOutputLog[0]...).HasAll("iptables-save", "-t", "nat") {
+	if !sets.NewString(fcmd.CombinedOutputLog[0]...).HasAll("iptables-save", "-t", "nat") {
 		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[0])
 	}
 }
@@ -522,7 +522,7 @@ COMMIT
 	if fcmd.CombinedOutputCalls != 1 {
 		t.Errorf("expected 1 CombinedOutput() call, got %d", fcmd.CombinedOutputCalls)
 	}
-	if !util.NewStringSet(fcmd.CombinedOutputLog[0]...).HasAll("iptables-save", "-t", "nat") {
+	if !sets.NewString(fcmd.CombinedOutputLog[0]...).HasAll("iptables-save", "-t", "nat") {
 		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[0])
 	}
 }
@@ -573,7 +573,7 @@ func TestWaitFlagUnavailable(t *testing.T) {
 	if fcmd.CombinedOutputCalls != 2 {
 		t.Errorf("expected 2 CombinedOutput() calls, got %d", fcmd.CombinedOutputCalls)
 	}
-	if util.NewStringSet(fcmd.CombinedOutputLog[1]...).HasAny("-w", "-w2") {
+	if sets.NewString(fcmd.CombinedOutputLog[1]...).HasAny("-w", "-w2") {
 		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[1])
 	}
 }
@@ -601,10 +601,10 @@ func TestWaitFlagOld(t *testing.T) {
 	if fcmd.CombinedOutputCalls != 2 {
 		t.Errorf("expected 2 CombinedOutput() calls, got %d", fcmd.CombinedOutputCalls)
 	}
-	if !util.NewStringSet(fcmd.CombinedOutputLog[1]...).HasAll("iptables", "-w") {
+	if !sets.NewString(fcmd.CombinedOutputLog[1]...).HasAll("iptables", "-w") {
 		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[1])
 	}
-	if util.NewStringSet(fcmd.CombinedOutputLog[1]...).HasAny("-w2") {
+	if sets.NewString(fcmd.CombinedOutputLog[1]...).HasAny("-w2") {
 		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[1])
 	}
 }
@@ -632,10 +632,10 @@ func TestWaitFlagNew(t *testing.T) {
 	if fcmd.CombinedOutputCalls != 2 {
 		t.Errorf("expected 2 CombinedOutput() calls, got %d", fcmd.CombinedOutputCalls)
 	}
-	if !util.NewStringSet(fcmd.CombinedOutputLog[1]...).HasAll("iptables", "-w2") {
+	if !sets.NewString(fcmd.CombinedOutputLog[1]...).HasAll("iptables", "-w2") {
 		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[1])
 	}
-	if util.NewStringSet(fcmd.CombinedOutputLog[1]...).HasAny("-w") {
+	if sets.NewString(fcmd.CombinedOutputLog[1]...).HasAny("-w") {
 		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[1])
 	}
 }

--- a/pkg/util/proxy/transport.go
+++ b/pkg/util/proxy/transport.go
@@ -31,38 +31,38 @@ import (
 	"golang.org/x/net/html"
 	"golang.org/x/net/html/atom"
 
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 // atomsToAttrs states which attributes of which tags require URL substitution.
 // Sources: http://www.w3.org/TR/REC-html40/index/attributes.html
 //          http://www.w3.org/html/wg/drafts/html/master/index.html#attributes-1
-var atomsToAttrs = map[atom.Atom]util.StringSet{
-	atom.A:          util.NewStringSet("href"),
-	atom.Applet:     util.NewStringSet("codebase"),
-	atom.Area:       util.NewStringSet("href"),
-	atom.Audio:      util.NewStringSet("src"),
-	atom.Base:       util.NewStringSet("href"),
-	atom.Blockquote: util.NewStringSet("cite"),
-	atom.Body:       util.NewStringSet("background"),
-	atom.Button:     util.NewStringSet("formaction"),
-	atom.Command:    util.NewStringSet("icon"),
-	atom.Del:        util.NewStringSet("cite"),
-	atom.Embed:      util.NewStringSet("src"),
-	atom.Form:       util.NewStringSet("action"),
-	atom.Frame:      util.NewStringSet("longdesc", "src"),
-	atom.Head:       util.NewStringSet("profile"),
-	atom.Html:       util.NewStringSet("manifest"),
-	atom.Iframe:     util.NewStringSet("longdesc", "src"),
-	atom.Img:        util.NewStringSet("longdesc", "src", "usemap"),
-	atom.Input:      util.NewStringSet("src", "usemap", "formaction"),
-	atom.Ins:        util.NewStringSet("cite"),
-	atom.Link:       util.NewStringSet("href"),
-	atom.Object:     util.NewStringSet("classid", "codebase", "data", "usemap"),
-	atom.Q:          util.NewStringSet("cite"),
-	atom.Script:     util.NewStringSet("src"),
-	atom.Source:     util.NewStringSet("src"),
-	atom.Video:      util.NewStringSet("poster", "src"),
+var atomsToAttrs = map[atom.Atom]sets.String{
+	atom.A:          sets.NewString("href"),
+	atom.Applet:     sets.NewString("codebase"),
+	atom.Area:       sets.NewString("href"),
+	atom.Audio:      sets.NewString("src"),
+	atom.Base:       sets.NewString("href"),
+	atom.Blockquote: sets.NewString("cite"),
+	atom.Body:       sets.NewString("background"),
+	atom.Button:     sets.NewString("formaction"),
+	atom.Command:    sets.NewString("icon"),
+	atom.Del:        sets.NewString("cite"),
+	atom.Embed:      sets.NewString("src"),
+	atom.Form:       sets.NewString("action"),
+	atom.Frame:      sets.NewString("longdesc", "src"),
+	atom.Head:       sets.NewString("profile"),
+	atom.Html:       sets.NewString("manifest"),
+	atom.Iframe:     sets.NewString("longdesc", "src"),
+	atom.Img:        sets.NewString("longdesc", "src", "usemap"),
+	atom.Input:      sets.NewString("src", "usemap", "formaction"),
+	atom.Ins:        sets.NewString("cite"),
+	atom.Link:       sets.NewString("href"),
+	atom.Object:     sets.NewString("classid", "codebase", "data", "usemap"),
+	atom.Q:          sets.NewString("cite"),
+	atom.Script:     sets.NewString("src"),
+	atom.Source:     sets.NewString("src"),
+	atom.Video:      sets.NewString("poster", "src"),
 
 	// TODO: css URLs hidden in style elements.
 }

--- a/pkg/util/sets/set.go
+++ b/pkg/util/sets/set.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package sets
 
 import (
 	"reflect"
@@ -26,19 +26,19 @@ import (
 type Empty struct{}
 
 // StringSet is a set of strings, implemented via map[string]struct{} for minimal memory consumption.
-type StringSet map[string]Empty
+type String map[string]Empty
 
-// NewStringSet creates a StringSet from a list of values.
-func NewStringSet(items ...string) StringSet {
-	ss := StringSet{}
+// New creates a StringSet from a list of values.
+func NewString(items ...string) String {
+	ss := String{}
 	ss.Insert(items...)
 	return ss
 }
 
 // KeySet creates a StringSet from a keys of a map[string](? extends interface{}).  Since you can't describe that map type in the Go type system
 // the reflected value is required.
-func KeySet(theMap reflect.Value) StringSet {
-	ret := StringSet{}
+func KeySet(theMap reflect.Value) String {
+	ret := String{}
 
 	for _, keyValue := range theMap.MapKeys() {
 		ret.Insert(keyValue.String())
@@ -48,27 +48,27 @@ func KeySet(theMap reflect.Value) StringSet {
 }
 
 // Insert adds items to the set.
-func (s StringSet) Insert(items ...string) {
+func (s String) Insert(items ...string) {
 	for _, item := range items {
 		s[item] = Empty{}
 	}
 }
 
 // Delete removes all items from the set.
-func (s StringSet) Delete(items ...string) {
+func (s String) Delete(items ...string) {
 	for _, item := range items {
 		delete(s, item)
 	}
 }
 
 // Has returns true iff item is contained in the set.
-func (s StringSet) Has(item string) bool {
+func (s String) Has(item string) bool {
 	_, contained := s[item]
 	return contained
 }
 
 // HasAll returns true iff all items are contained in the set.
-func (s StringSet) HasAll(items ...string) bool {
+func (s String) HasAll(items ...string) bool {
 	for _, item := range items {
 		if !s.Has(item) {
 			return false
@@ -78,7 +78,7 @@ func (s StringSet) HasAll(items ...string) bool {
 }
 
 // HasAny returns true if any items are contained in the set.
-func (s StringSet) HasAny(items ...string) bool {
+func (s String) HasAny(items ...string) bool {
 	for _, item := range items {
 		if s.Has(item) {
 			return true
@@ -93,8 +93,8 @@ func (s StringSet) HasAny(items ...string) bool {
 // s2 = {1, 2, 4, 5}
 // s1.Difference(s2) = {3}
 // s2.Difference(s1) = {4, 5}
-func (s StringSet) Difference(s2 StringSet) StringSet {
-	result := NewStringSet()
+func (s String) Difference(s2 String) String {
+	result := NewString()
 	for key := range s {
 		if !s2.Has(key) {
 			result.Insert(key)
@@ -110,8 +110,8 @@ func (s StringSet) Difference(s2 StringSet) StringSet {
 // s2 = {3, 4}
 // s1.Union(s2) = {1, 2, 3, 4}
 // s2.Union(s1) = {1, 2, 3, 4}
-func (s1 StringSet) Union(s2 StringSet) StringSet {
-	result := NewStringSet()
+func (s1 String) Union(s2 String) String {
+	result := NewString()
 	for key := range s1 {
 		result.Insert(key)
 	}
@@ -122,7 +122,7 @@ func (s1 StringSet) Union(s2 StringSet) StringSet {
 }
 
 // IsSuperset returns true iff s1 is a superset of s2.
-func (s1 StringSet) IsSuperset(s2 StringSet) bool {
+func (s1 String) IsSuperset(s2 String) bool {
 	for item := range s2 {
 		if !s1.Has(item) {
 			return false
@@ -134,7 +134,7 @@ func (s1 StringSet) IsSuperset(s2 StringSet) bool {
 // Equal returns true iff s1 is equal (as a set) to s2.
 // Two sets are equal if their membership is identical.
 // (In practice, this means same elements, order doesn't matter)
-func (s1 StringSet) Equal(s2 StringSet) bool {
+func (s1 String) Equal(s2 String) bool {
 	if len(s1) != len(s2) {
 		return false
 	}
@@ -147,7 +147,7 @@ func (s1 StringSet) Equal(s2 StringSet) bool {
 }
 
 // List returns the contents as a sorted string slice.
-func (s StringSet) List() []string {
+func (s String) List() []string {
 	res := make([]string, 0, len(s))
 	for key := range s {
 		res = append(res, key)
@@ -157,7 +157,7 @@ func (s StringSet) List() []string {
 }
 
 // Returns a single element from the set.
-func (s StringSet) PopAny() (string, bool) {
+func (s String) PopAny() (string, bool) {
 	for key := range s {
 		s.Delete(key)
 		return key, true
@@ -166,6 +166,6 @@ func (s StringSet) PopAny() (string, bool) {
 }
 
 // Len returns the size of the set.
-func (s StringSet) Len() int {
+func (s String) Len() int {
 	return len(s)
 }

--- a/pkg/util/sets/set_test.go
+++ b/pkg/util/sets/set_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package sets
 
 import (
 	"reflect"
@@ -22,8 +22,8 @@ import (
 )
 
 func TestStringSet(t *testing.T) {
-	s := StringSet{}
-	s2 := StringSet{}
+	s := String{}
+	s2 := String{}
 	if len(s) != 0 {
 		t.Errorf("Expected len=0: %d", len(s))
 	}
@@ -60,7 +60,7 @@ func TestStringSet(t *testing.T) {
 }
 
 func TestStringSetDeleteMultiples(t *testing.T) {
-	s := StringSet{}
+	s := String{}
 	s.Insert("a", "b", "c")
 	if len(s) != 3 {
 		t.Errorf("Expected len=3: %d", len(s))
@@ -83,7 +83,7 @@ func TestStringSetDeleteMultiples(t *testing.T) {
 }
 
 func TestNewStringSet(t *testing.T) {
-	s := NewStringSet("a", "b", "c")
+	s := NewString("a", "b", "c")
 	if len(s) != 3 {
 		t.Errorf("Expected len=3: %d", len(s))
 	}
@@ -93,15 +93,15 @@ func TestNewStringSet(t *testing.T) {
 }
 
 func TestStringSetList(t *testing.T) {
-	s := NewStringSet("z", "y", "x", "a")
+	s := NewString("z", "y", "x", "a")
 	if !reflect.DeepEqual(s.List(), []string{"a", "x", "y", "z"}) {
 		t.Errorf("List gave unexpected result: %#v", s.List())
 	}
 }
 
 func TestStringSetDifference(t *testing.T) {
-	a := NewStringSet("1", "2", "3")
-	b := NewStringSet("1", "2", "4", "5")
+	a := NewString("1", "2", "3")
+	b := NewString("1", "2", "4", "5")
 	c := a.Difference(b)
 	d := b.Difference(a)
 	if len(c) != 1 {
@@ -119,7 +119,7 @@ func TestStringSetDifference(t *testing.T) {
 }
 
 func TestStringSetHasAny(t *testing.T) {
-	a := NewStringSet("1", "2", "3")
+	a := NewString("1", "2", "3")
 
 	if !a.HasAny("1", "4") {
 		t.Errorf("expected true, got false")
@@ -132,37 +132,37 @@ func TestStringSetHasAny(t *testing.T) {
 
 func TestStringSetEquals(t *testing.T) {
 	// Simple case (order doesn't matter)
-	a := NewStringSet("1", "2")
-	b := NewStringSet("2", "1")
+	a := NewString("1", "2")
+	b := NewString("2", "1")
 	if !a.Equal(b) {
 		t.Errorf("Expected to be equal: %v vs %v", a, b)
 	}
 
 	// It is a set; duplicates are ignored
-	b = NewStringSet("2", "2", "1")
+	b = NewString("2", "2", "1")
 	if !a.Equal(b) {
 		t.Errorf("Expected to be equal: %v vs %v", a, b)
 	}
 
 	// Edge cases around empty sets / empty strings
-	a = NewStringSet()
-	b = NewStringSet()
+	a = NewString()
+	b = NewString()
 	if !a.Equal(b) {
 		t.Errorf("Expected to be equal: %v vs %v", a, b)
 	}
 
-	b = NewStringSet("1", "2", "3")
+	b = NewString("1", "2", "3")
 	if a.Equal(b) {
 		t.Errorf("Expected to be not-equal: %v vs %v", a, b)
 	}
 
-	b = NewStringSet("1", "2", "")
+	b = NewString("1", "2", "")
 	if a.Equal(b) {
 		t.Errorf("Expected to be not-equal: %v vs %v", a, b)
 	}
 
 	// Check for equality after mutation
-	a = NewStringSet()
+	a = NewString()
 	a.Insert("1")
 	if a.Equal(b) {
 		t.Errorf("Expected to be not-equal: %v vs %v", a, b)

--- a/pkg/volume/gce_pd/gce_util.go
+++ b/pkg/volume/gce_pd/gce_util.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/exec"
 	"k8s.io/kubernetes/pkg/util/operationmanager"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 const (
@@ -62,7 +63,7 @@ func (diskUtil *GCEDiskUtil) AttachAndMountDisk(b *gcePersistentDiskBuilder, glo
 	if err != nil {
 		glog.Errorf("Error filepath.Glob(\"%s\"): %v\r\n", diskSDPattern, err)
 	}
-	sdBeforeSet := util.NewStringSet(sdBefore...)
+	sdBeforeSet := sets.NewString(sdBefore...)
 
 	devicePath, err := attachDiskAndVerify(b, sdBeforeSet)
 	if err != nil {
@@ -120,7 +121,7 @@ func (util *GCEDiskUtil) DetachDisk(c *gcePersistentDiskCleaner) error {
 }
 
 // Attaches the specified persistent disk device to node, verifies that it is attached, and retries if it fails.
-func attachDiskAndVerify(b *gcePersistentDiskBuilder, sdBeforeSet util.StringSet) (string, error) {
+func attachDiskAndVerify(b *gcePersistentDiskBuilder, sdBeforeSet sets.String) (string, error) {
 	devicePaths := getDiskByIdPaths(b.gcePersistentDisk)
 	var gce cloudprovider.Interface
 	for numRetries := 0; numRetries < maxRetries; numRetries++ {
@@ -287,7 +288,7 @@ func pathExists(path string) (bool, error) {
 
 // Calls "udevadm trigger --action=change" for newly created "/dev/sd*" drives (exist only in after set).
 // This is workaround for Issue #7972. Once the underlying issue has been resolved, this may be removed.
-func udevadmChangeToNewDrives(sdBeforeSet util.StringSet) error {
+func udevadmChangeToNewDrives(sdBeforeSet sets.String) error {
 	sdAfter, err := filepath.Glob(diskSDPattern)
 	if err != nil {
 		return fmt.Errorf("Error filepath.Glob(\"%s\"): %v\r\n", diskSDPattern, err)

--- a/plugin/pkg/admission/namespace/lifecycle/admission.go
+++ b/plugin/pkg/admission/namespace/lifecycle/admission.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/watch"
 )
 
@@ -46,7 +46,7 @@ type lifecycle struct {
 	*admission.Handler
 	client             client.Interface
 	store              cache.Store
-	immortalNamespaces util.StringSet
+	immortalNamespaces sets.String
 }
 
 func (l *lifecycle) Admit(a admission.Attributes) (err error) {
@@ -120,6 +120,6 @@ func NewLifecycle(c client.Interface) admission.Interface {
 		Handler:            admission.NewHandler(admission.Create, admission.Update, admission.Delete),
 		client:             c,
 		store:              store,
-		immortalNamespaces: util.NewStringSet(api.NamespaceDefault),
+		immortalNamespaces: sets.NewString(api.NamespaceDefault),
 	}
 }

--- a/plugin/pkg/admission/serviceaccount/admission.go
+++ b/plugin/pkg/admission/serviceaccount/admission.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/watch"
 )
 
@@ -249,7 +249,7 @@ func (s *serviceAccount) getReferencedServiceAccountToken(serviceAccount *api.Se
 		return "", err
 	}
 
-	references := util.NewStringSet()
+	references := sets.NewString()
 	for _, secret := range serviceAccount.Secrets {
 		references.Insert(secret.Name)
 	}
@@ -293,7 +293,7 @@ func (s *serviceAccount) getServiceAccountTokens(serviceAccount *api.ServiceAcco
 
 func (s *serviceAccount) limitSecretReferences(serviceAccount *api.ServiceAccount, pod *api.Pod) error {
 	// Ensure all secrets the pod references are allowed by the service account
-	mountableSecrets := util.NewStringSet()
+	mountableSecrets := sets.NewString()
 	for _, s := range serviceAccount.Secrets {
 		mountableSecrets.Insert(s.Name)
 	}
@@ -309,7 +309,7 @@ func (s *serviceAccount) limitSecretReferences(serviceAccount *api.ServiceAccoun
 	}
 
 	// limit pull secret references as well
-	pullSecrets := util.NewStringSet()
+	pullSecrets := sets.NewString()
 	for _, s := range serviceAccount.ImagePullSecrets {
 		pullSecrets.Insert(s.Name)
 	}
@@ -340,7 +340,7 @@ func (s *serviceAccount) mountServiceAccountToken(serviceAccount *api.ServiceAcc
 	// Find the volume and volume name for the ServiceAccountTokenSecret if it already exists
 	tokenVolumeName := ""
 	hasTokenVolume := false
-	allVolumeNames := util.NewStringSet()
+	allVolumeNames := sets.NewString()
 	for _, volume := range pod.Spec.Volumes {
 		allVolumeNames.Insert(volume.Name)
 		if volume.Secret != nil && volume.Secret.SecretName == serviceAccountToken {

--- a/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
+++ b/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
@@ -18,7 +18,7 @@ limitations under the License.
 package defaults
 
 import (
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/plugin/pkg/scheduler"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm/predicates"
@@ -48,8 +48,8 @@ func init() {
 	)
 }
 
-func defaultPredicates() util.StringSet {
-	return util.NewStringSet(
+func defaultPredicates() sets.String {
+	return sets.NewString(
 		// Fit is defined based on the absence of port conflicts.
 		factory.RegisterFitPredicate("PodFitsPorts", predicates.PodFitsPorts),
 		// Fit is determined by resource availability.
@@ -73,8 +73,8 @@ func defaultPredicates() util.StringSet {
 	)
 }
 
-func defaultPriorities() util.StringSet {
-	return util.NewStringSet(
+func defaultPriorities() sets.String {
+	return sets.NewString(
 		// Prioritize nodes by least requested utilization.
 		factory.RegisterPriorityFunction("LeastRequestedPriority", priorities.LeastRequestedPriority, 1),
 		// Prioritizes nodes to help achieve balanced resource usage

--- a/plugin/pkg/scheduler/factory/factory.go
+++ b/plugin/pkg/scheduler/factory/factory.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/kubernetes/pkg/controller/framework"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/plugin/pkg/scheduler"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm"
 	schedulerapi "k8s.io/kubernetes/plugin/pkg/scheduler/api"
@@ -137,13 +138,13 @@ func (f *ConfigFactory) CreateFromConfig(policy schedulerapi.Policy) (*scheduler
 		return nil, err
 	}
 
-	predicateKeys := util.NewStringSet()
+	predicateKeys := sets.NewString()
 	for _, predicate := range policy.Predicates {
 		glog.V(2).Infof("Registering predicate: %s", predicate.Name)
 		predicateKeys.Insert(RegisterCustomFitPredicate(predicate))
 	}
 
-	priorityKeys := util.NewStringSet()
+	priorityKeys := sets.NewString()
 	for _, priority := range policy.Priorities {
 		glog.V(2).Infof("Registering priority: %s", priority.Name)
 		priorityKeys.Insert(RegisterCustomPriorityFunction(priority))
@@ -153,7 +154,7 @@ func (f *ConfigFactory) CreateFromConfig(policy schedulerapi.Policy) (*scheduler
 }
 
 // Creates a scheduler from a set of registered fit predicate keys and priority keys.
-func (f *ConfigFactory) CreateFromKeys(predicateKeys, priorityKeys util.StringSet) (*scheduler.Config, error) {
+func (f *ConfigFactory) CreateFromKeys(predicateKeys, priorityKeys sets.String) (*scheduler.Config, error) {
 	glog.V(2).Infof("creating scheduler with fit predicates '%v' and priority functions '%v", predicateKeys, priorityKeys)
 	pluginArgs := PluginFactoryArgs{
 		PodLister:        f.PodLister,

--- a/plugin/pkg/scheduler/factory/plugins.go
+++ b/plugin/pkg/scheduler/factory/plugins.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"sync"
 
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm/predicates"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm/priorities"
@@ -66,8 +66,8 @@ const (
 )
 
 type AlgorithmProviderConfig struct {
-	FitPredicateKeys     util.StringSet
-	PriorityFunctionKeys util.StringSet
+	FitPredicateKeys     sets.String
+	PriorityFunctionKeys sets.String
 }
 
 // RegisterFitPredicate registers a fit predicate with the algorithm
@@ -209,7 +209,7 @@ func IsPriorityFunctionRegistered(name string) bool {
 
 // Registers a new algorithm provider with the algorithm registry. This should
 // be called from the init function in a provider plugin.
-func RegisterAlgorithmProvider(name string, predicateKeys, priorityKeys util.StringSet) string {
+func RegisterAlgorithmProvider(name string, predicateKeys, priorityKeys sets.String) string {
 	schedulerFactoryMutex.Lock()
 	defer schedulerFactoryMutex.Unlock()
 	validateAlgorithmNameOrDie(name)
@@ -234,7 +234,7 @@ func GetAlgorithmProvider(name string) (*AlgorithmProviderConfig, error) {
 	return &provider, nil
 }
 
-func getFitPredicateFunctions(names util.StringSet, args PluginFactoryArgs) (map[string]algorithm.FitPredicate, error) {
+func getFitPredicateFunctions(names sets.String, args PluginFactoryArgs) (map[string]algorithm.FitPredicate, error) {
 	schedulerFactoryMutex.Lock()
 	defer schedulerFactoryMutex.Unlock()
 
@@ -249,7 +249,7 @@ func getFitPredicateFunctions(names util.StringSet, args PluginFactoryArgs) (map
 	return predicates, nil
 }
 
-func getPriorityFunctionConfigs(names util.StringSet, args PluginFactoryArgs) ([]algorithm.PriorityConfig, error) {
+func getPriorityFunctionConfigs(names sets.String, args PluginFactoryArgs) ([]algorithm.PriorityConfig, error) {
 	schedulerFactoryMutex.Lock()
 	defer schedulerFactoryMutex.Unlock()
 

--- a/plugin/pkg/scheduler/generic_scheduler.go
+++ b/plugin/pkg/scheduler/generic_scheduler.go
@@ -25,12 +25,12 @@ import (
 
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm/predicates"
 )
 
-type FailedPredicateMap map[string]util.StringSet
+type FailedPredicateMap map[string]sets.String
 
 type FitError struct {
 	Pod              *api.Pod
@@ -124,7 +124,7 @@ func findNodesThatFit(pod *api.Pod, podLister algorithm.PodLister, predicateFunc
 			if !fit {
 				fits = false
 				if _, found := failedPredicateMap[node.Name]; !found {
-					failedPredicateMap[node.Name] = util.StringSet{}
+					failedPredicateMap[node.Name] = sets.String{}
 				}
 				if predicates.FailedResourceType != "" {
 					failedPredicateMap[node.Name].Insert(predicates.FailedResourceType)

--- a/plugin/pkg/scheduler/generic_scheduler_test.go
+++ b/plugin/pkg/scheduler/generic_scheduler_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm"
 )
 
@@ -101,7 +101,7 @@ func TestSelectHost(t *testing.T) {
 	scheduler := genericScheduler{random: rand.New(rand.NewSource(0))}
 	tests := []struct {
 		list          algorithm.HostPriorityList
-		possibleHosts util.StringSet
+		possibleHosts sets.String
 		expectsErr    bool
 	}{
 		{
@@ -109,7 +109,7 @@ func TestSelectHost(t *testing.T) {
 				{Host: "machine1.1", Score: 1},
 				{Host: "machine2.1", Score: 2},
 			},
-			possibleHosts: util.NewStringSet("machine2.1"),
+			possibleHosts: sets.NewString("machine2.1"),
 			expectsErr:    false,
 		},
 		// equal scores
@@ -120,7 +120,7 @@ func TestSelectHost(t *testing.T) {
 				{Host: "machine1.3", Score: 2},
 				{Host: "machine2.1", Score: 2},
 			},
-			possibleHosts: util.NewStringSet("machine1.2", "machine1.3", "machine2.1"),
+			possibleHosts: sets.NewString("machine1.2", "machine1.3", "machine2.1"),
 			expectsErr:    false,
 		},
 		// out of order scores
@@ -132,13 +132,13 @@ func TestSelectHost(t *testing.T) {
 				{Host: "machine3.1", Score: 1},
 				{Host: "machine1.3", Score: 3},
 			},
-			possibleHosts: util.NewStringSet("machine1.1", "machine1.2", "machine1.3"),
+			possibleHosts: sets.NewString("machine1.1", "machine1.2", "machine1.3"),
 			expectsErr:    false,
 		},
 		// empty priorityList
 		{
 			list:          []algorithm.HostPriority{},
-			possibleHosts: util.NewStringSet(),
+			possibleHosts: sets.NewString(),
 			expectsErr:    true,
 		},
 	}

--- a/test/e2e/daemon_restart.go
+++ b/test/e2e/daemon_restart.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/kubernetes/pkg/master/ports"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/watch"
 
@@ -140,7 +141,7 @@ func getContainerRestarts(c *client.Client, ns string, labelSelector labels.Sele
 	pods, err := c.Pods(ns).List(labelSelector, fields.Everything())
 	expectNoError(err)
 	failedContainers := 0
-	containerRestartNodes := util.NewStringSet()
+	containerRestartNodes := sets.NewString()
 	for _, p := range pods.Items {
 		for _, v := range FailedContainers(&p) {
 			failedContainers = failedContainers + v.restarts
@@ -224,8 +225,8 @@ var _ = Describe("DaemonRestart", func() {
 
 		// Only check the keys, the pods can be different if the kubelet updated it.
 		// TODO: Can it really?
-		existingKeys := util.NewStringSet()
-		newKeys := util.NewStringSet()
+		existingKeys := sets.NewString()
+		newKeys := sets.NewString()
 		for _, k := range existingPods.ListKeys() {
 			existingKeys.Insert(k)
 		}

--- a/test/e2e/density.go
+++ b/test/e2e/density.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/watch"
 
 	. "github.com/onsi/ginkgo"
@@ -148,7 +149,7 @@ var _ = Describe("Density", func() {
 		expectNoError(writePerfData(c, fmt.Sprintf(testContext.OutputDir+"/%s", uuid), "after"))
 
 		// Verify latency metrics
-		highLatencyRequests, err := HighLatencyRequests(c, 3*time.Second, util.NewStringSet("events"))
+		highLatencyRequests, err := HighLatencyRequests(c, 3*time.Second, sets.NewString("events"))
 		expectNoError(err)
 		Expect(highLatencyRequests).NotTo(BeNumerically(">", 0), "There should be no high-latency requests")
 	})

--- a/test/e2e/kubelet_stats.go
+++ b/test/e2e/kubelet_stats.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/master/ports"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 
 	"github.com/prometheus/client_golang/extraction"
 	"github.com/prometheus/client_golang/model"
@@ -66,7 +67,7 @@ func (a KubeletMetricByLatency) Less(i, j int) bool { return a[i].Latency > a[j]
 type kubeletMetricIngester []KubeletMetric
 
 func (k *kubeletMetricIngester) Ingest(samples model.Samples) error {
-	acceptedMethods := util.NewStringSet(
+	acceptedMethods := sets.NewString(
 		metrics.PodWorkerLatencyKey,
 		metrics.PodWorkerStartLatencyKey,
 		metrics.SyncPodsLatencyKey,

--- a/test/e2e/load.go
+++ b/test/e2e/load.go
@@ -26,7 +26,7 @@ import (
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -86,7 +86,7 @@ var _ = Describe("Load capacity", func() {
 		}
 
 		// Verify latency metrics
-		highLatencyRequests, err := HighLatencyRequests(c, 3*time.Second, util.NewStringSet("events"))
+		highLatencyRequests, err := HighLatencyRequests(c, 3*time.Second, sets.NewString("events"))
 		expectNoError(err, "Too many instances metrics above the threshold")
 		Expect(highLatencyRequests).NotTo(BeNumerically(">", 0))
 	})

--- a/test/e2e/service_latency.go
+++ b/test/e2e/service_latency.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/watch"
 
 	. "github.com/onsi/ginkgo"
@@ -70,7 +71,7 @@ var _ = Describe("Service endpoints latency", func() {
 		f.Client.RESTClient.Throttle = util.NewFakeRateLimiter()
 		defer func() { f.Client.RESTClient.Throttle = oldThrottle }()
 
-		failing := util.NewStringSet()
+		failing := sets.NewString()
 		d, err := runServiceLatencies(f, parallelTrials, totalTrials)
 		if err != nil {
 			failing.Insert(fmt.Sprintf("Not all RC/pod/service trials succeeded: %v", err))

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/watch"
 
@@ -1096,7 +1097,7 @@ type podInfo struct {
 type PodDiff map[string]*podInfo
 
 // Print formats and prints the give PodDiff.
-func (p PodDiff) Print(ignorePhases util.StringSet) {
+func (p PodDiff) Print(ignorePhases sets.String) {
 	for name, info := range p {
 		if ignorePhases.Has(info.phase) {
 			continue
@@ -1258,7 +1259,7 @@ func RunRC(config RCConfig) error {
 		unknown := 0
 		inactive := 0
 		failedContainers := 0
-		containerRestartNodes := util.NewStringSet()
+		containerRestartNodes := sets.NewString()
 
 		pods := podStore.List()
 		created := []*api.Pod{}
@@ -1312,7 +1313,7 @@ func RunRC(config RCConfig) error {
 			//	- diagnose by comparing the previous "2 Pod states" lines for inactive pods
 			errorStr := fmt.Sprintf("Number of reported pods changed: %d vs %d", len(pods), len(oldPods))
 			Logf("%v, pods that changed since the last iteration:", errorStr)
-			Diff(oldPods, pods).Print(util.NewStringSet())
+			Diff(oldPods, pods).Print(sets.NewString())
 			return fmt.Errorf(errorStr)
 		}
 
@@ -1342,7 +1343,7 @@ func RunRC(config RCConfig) error {
 }
 
 func dumpPodDebugInfo(c *client.Client, pods []*api.Pod) {
-	badNodes := util.NewStringSet()
+	badNodes := sets.NewString()
 	for _, p := range pods {
 		if p.Status.Phase != api.PodRunning {
 			if p.Spec.NodeName != "" {
@@ -1851,8 +1852,8 @@ func ReadLatencyMetrics(c *client.Client) ([]LatencyMetric, error) {
 
 // Prints summary metrics for request types with latency above threshold
 // and returns number of such request types.
-func HighLatencyRequests(c *client.Client, threshold time.Duration, ignoredResources util.StringSet) (int, error) {
-	ignoredVerbs := util.NewStringSet("WATCHLIST", "PROXY")
+func HighLatencyRequests(c *client.Client, threshold time.Duration, ignoredResources sets.String) (int, error) {
+	ignoredVerbs := sets.NewString("WATCHLIST", "PROXY")
 
 	metrics, err := ReadLatencyMetrics(c)
 	if err != nil {

--- a/test/images/network-tester/webserver.go
+++ b/test/images/network-tester/webserver.go
@@ -45,7 +45,7 @@ import (
 	"time"
 
 	client "k8s.io/kubernetes/pkg/client/unversioned"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
 var (
@@ -235,7 +235,7 @@ func contactOthers(state *State) {
 			time.Sleep(time.Duration(1+rand.Intn(10)) * time.Second)
 		}
 
-		eps := util.StringSet{}
+		eps := sets.String{}
 		for _, ss := range endpoints.Subsets {
 			for _, a := range ss.Addresses {
 				for _, p := range ss.Ports {

--- a/test/integration/service_account_test.go
+++ b/test/integration/service_account_test.go
@@ -45,7 +45,7 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/master"
 	"k8s.io/kubernetes/pkg/tools/etcdtest"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/util/wait"
 	serviceaccountadmission "k8s.io/kubernetes/plugin/pkg/admission/serviceaccount"
 	"k8s.io/kubernetes/plugin/pkg/auth/authenticator/request/union"
@@ -170,7 +170,7 @@ func TestServiceAccountTokenAutoCreate(t *testing.T) {
 	}
 
 	// Wait for tokens to be deleted
-	tokensToCleanup := util.NewStringSet(token1Name, token2Name, token3Name)
+	tokensToCleanup := sets.NewString(token1Name, token2Name, token3Name)
 	err = wait.Poll(time.Second, 10*time.Second, func() (bool, error) {
 		// Get all secrets in the namespace
 		secrets, err := c.Secrets(ns).List(labels.Everything(), fields.Everything())


### PR DESCRIPTION
This is part of #13698 (see also #3486 and #4851). Most of it was done using `gofmt -r` and sed. This contribution is under the corporate CLA signed by Square Inc.

Summary of changes:
- move util/set.go and util/set_test.go into their own package, util/stringset
- rename util.NewStringSet to stringset.New
- update references to the moved identifiers
- update imports
