### PR TITLE
Allow pods to have dns

### DIFF
--- a/cluster/addons/dns/README.md
+++ b/cluster/addons/dns/README.md
@@ -23,7 +23,9 @@ The following sections detail the supported record types and layout that is
 supported.  Any other layout or names or queries that happen to work are
 considered implementation details and are subject to change without warning.
 
-### A records
+### Services
+
+#### A records
 "Normal" (not headless) Services are assigned a DNS A record for a name of the
 form `my-svc.my-namespace.svc.cluster.local`.  This resolves to the cluster IP
 of the Service.
@@ -49,6 +51,13 @@ of the form `auto-generated-name.my-svc.my-namespace.svc.cluster.local`.
 Previous versions of kube-dns made names of the for
 `my-svc.my-namespace.cluster.local` (the 'svc' level was added later).  This
 is no longer supported.
+
+### Pods
+
+#### A Records
+When enabled, pods are assigned a DNS A record in the form of `pod-ip-address.my-namespace.pod.cluster.local`.
+
+For example, a pod with ip `1.2.3.4` in the namespace `default` with a dns name of `cluster.local` would have an entry: `1-2-3-4.default.pod.cluster.local`.
 
 ## How do I find the DNS server?
 The DNS server itself runs as a Kubernetes Service.  This gives it a stable IP
@@ -126,7 +135,7 @@ Then create a pod using this file:
 kubectl create -f busybox.yaml
 ```
 
-### 2 Wait for this pod to go into the running state. 
+### 2 Wait for this pod to go into the running state.
 
 You can get its status with:
 ```

--- a/cluster/addons/dns/kube2sky/README.md
+++ b/cluster/addons/dns/kube2sky/README.md
@@ -17,11 +17,11 @@ description of `-domain` below.
 `-domain`: Set the domain under which all DNS names will be hosted.  For
 example, if this is set to `kubernetes.io`, then a service named "nifty" in the
 "default" namespace would be exposed through DNS as
-"nifty.default.kubernetes.io".
+"nifty.default.svc.kubernetes.io".
 
 `-v`: Set logging level
 
-`-etcd_mutation_timeout`: For how long the application will keep retrying etcd 
+`-etcd_mutation_timeout`: For how long the application will keep retrying etcd
 mutation (insertion or removal of a dns entry) before giving up and crashing.
 
 `-etcd-server`: The etcd server that is being used by skydns.

--- a/cluster/addons/dns/kube2sky/kube2sky.go
+++ b/cluster/addons/dns/kube2sky/kube2sky.go
@@ -61,6 +61,8 @@ const (
 	resyncPeriod = 30 * time.Minute
 	// A subdomain added to the user specified domain for all services.
 	serviceSubdomain = "svc"
+	// A subdomain added to the user specified dmoain for all pods.
+	podSubdomain = "pod"
 )
 
 type etcdClient interface {
@@ -222,6 +224,59 @@ func (ks *kube2sky) handleEndpointAdd(obj interface{}) {
 	}
 }
 
+func (ks *kube2sky) handlePodCreate(obj interface{}) {
+	if e, ok := obj.(*kapi.Pod); ok {
+		// If the pod ip is not yet available, do not attempt to create.
+		if e.Status.PodIP != "" {
+			name := buildDNSNameString(ks.domain, podSubdomain, e.Namespace, santizeIP(e.Status.PodIP))
+			ks.mutateEtcdOrDie(func() error { return ks.generateRecordsForPod(name, e) })
+		}
+	}
+}
+
+func (ks *kube2sky) handlePodUpdate(old interface{}, new interface{}) {
+	oldPod, okOld := old.(*kapi.Pod)
+	newPod, okNew := new.(*kapi.Pod)
+
+	// Validate that the objects are good
+	if okOld && okNew {
+		if oldPod.Status.PodIP != newPod.Status.PodIP {
+			ks.handlePodDelete(oldPod)
+			ks.handlePodCreate(newPod)
+		}
+	} else if okNew {
+		ks.handlePodCreate(newPod)
+	} else if okOld {
+		ks.handlePodDelete(oldPod)
+	}
+}
+
+func (ks *kube2sky) handlePodDelete(obj interface{}) {
+	if e, ok := obj.(*kapi.Pod); ok {
+		if e.Status.PodIP != "" {
+			name := buildDNSNameString(ks.domain, podSubdomain, e.Namespace, santizeIP(e.Status.PodIP))
+			ks.mutateEtcdOrDie(func() error { return ks.removeDNS(name) })
+		}
+	}
+}
+
+func (ks *kube2sky) generateRecordsForPod(subdomain string, service *kapi.Pod) error {
+	b, err := json.Marshal(getSkyMsg(service.Status.PodIP, 0))
+	if err != nil {
+		return err
+	}
+	recordValue := string(b)
+	recordLabel := getHash(recordValue)
+	recordKey := buildDNSNameString(subdomain, recordLabel)
+
+	glog.V(2).Infof("Setting DNS record: %v -> %q, with recordKey: %v\n", subdomain, recordValue, recordKey)
+	if err := ks.writeSkyRecord(recordKey, recordValue); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (ks *kube2sky) generateRecordsForPortalService(subdomain string, service *kapi.Service) error {
 	b, err := json.Marshal(getSkyMsg(service.Spec.ClusterIP, 0))
 	if err != nil {
@@ -247,6 +302,10 @@ func (ks *kube2sky) generateRecordsForPortalService(subdomain string, service *k
 		}
 	}
 	return nil
+}
+
+func santizeIP(ip string) string {
+	return strings.Replace(ip, ".", "-", -1)
 }
 
 func buildPortSegmentString(portName string, portProtocol kapi.Protocol) string {
@@ -326,6 +385,11 @@ func createServiceLW(kubeClient *kclient.Client) *kcache.ListWatch {
 // Returns a cache.ListWatch that gets all changes to endpoints.
 func createEndpointsLW(kubeClient *kclient.Client) *kcache.ListWatch {
 	return kcache.NewListWatchFromClient(kubeClient, "endpoints", kapi.NamespaceAll, kSelector.Everything())
+}
+
+// Returns a cache.ListWatch that gets all changes to pods.
+func createEndpointsPodLW(kubeClient *kclient.Client) *kcache.ListWatch {
+	return kcache.NewListWatchFromClient(kubeClient, "pods", kapi.NamespaceAll, kSelector.Everything())
 }
 
 func (ks *kube2sky) newService(obj interface{}) {
@@ -411,6 +475,7 @@ func newKubeClient() (*kclient.Client, error) {
 			return nil, err
 		}
 	}
+
 	if masterURL != "" && *argKubecfgFile == "" {
 		// Only --kube_master_url was provided.
 		config = &kclient.Config{
@@ -470,6 +535,24 @@ func watchEndpoints(kubeClient *kclient.Client, ks *kube2sky) kcache.Store {
 	return eStore
 }
 
+func watchPods(kubeClient *kclient.Client, ks *kube2sky) kcache.Store {
+	eStore, eController := kframework.NewInformer(
+		createEndpointsPodLW(kubeClient),
+		&kapi.Pod{},
+		resyncPeriod,
+		kframework.ResourceEventHandlerFuncs{
+			AddFunc: ks.handlePodCreate,
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				ks.handlePodUpdate(oldObj, newObj)
+			},
+			DeleteFunc: ks.handlePodDelete,
+		},
+	)
+
+	go eController.Run(util.NeverStop)
+	return eStore
+}
+
 func getHash(text string) string {
 	h := fnv.New32a()
 	h.Write([]byte(text))
@@ -499,6 +582,7 @@ func main() {
 
 	ks.endpointsStore = watchEndpoints(kubeClient, &ks)
 	ks.servicesStore = watchForServices(kubeClient, &ks)
+	ks.servicesStore = watchPods(kubeClient, &ks)
 
 	select {}
 }


### PR DESCRIPTION
This is in reference to #13552 which will give pods dns in the form of `<podIP>.<namespace>.pod.<clusterSuffix>` Currently can be disabled, but is either on for all pods or off.  Potentially could add logic to only apply to labels. 
