### PR TITLE
Use KUBE_MASTER_URL in conformance test

### DIFF
--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -93,7 +93,7 @@ fi
 export PATH=$(dirname "${e2e_test}"):"${PATH}"
 "${ginkgo}" "${ginkgo_args[@]:+${ginkgo_args[@]}}" "${e2e_test}" -- \
   "${auth_config[@]:+${auth_config[@]}}" \
-  --host="https://${KUBE_MASTER_IP-}" \
+  --host="${KUBE_MASTER_URL}" \
   --provider="${KUBERNETES_PROVIDER}" \
   --gce-project="${PROJECT:-}" \
   --gce-zone="${ZONE:-}" \


### PR DESCRIPTION
The current conformance-test-v1 branch does not use the KUBE_MASTER_URL extracted from the kubeconfig.

It looks like this change is already in master from: https://github.com/kubernetes/kubernetes/commit/29da889bbf0acbf579ea155e4cc66ae168705468

But looks like only part of that change was pulled into conformance-test-v1: https://github.com/kubernetes/kubernetes/commit/104aa5d361e624a2d11198ef00fd737dab588f60 
