### PR TITLE
Horizontal Pod Autoscaler is deleted along with namespace

### DIFF
--- a/test/e2e/autoscaling_utils.go
+++ b/test/e2e/autoscaling_utils.go
@@ -203,7 +203,6 @@ func (rc *ResourceConsumer) CleanUp() {
 	rc.stopMem <- 0
 	expectNoError(DeleteRC(rc.framework.Client, rc.framework.Namespace.Name, rc.name))
 	expectNoError(rc.framework.Client.Services(rc.framework.Namespace.Name).Delete(rc.name))
-	expectNoError(rc.framework.Client.Experimental().HorizontalPodAutoscalers(rc.framework.Namespace.Name).Delete(rc.name, api.NewDeleteOptions(0)))
 }
 
 func runServiceAndRCForResourceConsumer(c *client.Client, ns, name string, replicas int, cpuLimitMillis, memLimitMb int64) {


### PR DESCRIPTION
Part of #11570 

@piosz 
@mwielgus 
