### PR TITLE
Add Fedora Cockpit to vagrant setup to administer/introspect kubernetes

### DIFF
--- a/cluster/vagrant/provision-master.sh
+++ b/cluster/vagrant/provision-master.sh
@@ -253,6 +253,19 @@ pushd /kube-install
   ./kubernetes/saltbase/install.sh "${server_binary_tar##*/}"
 popd
 
+# Enable Fedora Cockpit on host to support Kubernetes administration
+# Access it by going to <master-ip>:9090 and login as vagrant/vagrant
+if ! which /usr/libexec/cockpit-ws &>/dev/null; then
+  
+  pushd /etc/yum.repos.d
+    wget https://copr.fedoraproject.org/coprs/sgallagh/cockpit-preview/repo/fedora-21/sgallagh-cockpit-preview-fedora-21.repo
+    yum install -y cockpit cockpit-kubernetes  
+  popd
+
+  systemctl enable cockpit.socket
+  systemctl start cockpit.socket
+fi
+
 # we will run provision to update code each time we test, so we do not want to do salt installs each time
 if ! which salt-master &>/dev/null; then
 

--- a/cluster/vagrant/util.sh
+++ b/cluster/vagrant/util.sh
@@ -260,13 +260,21 @@ function verify-cluster {
     # ensures KUBECONFIG is set
     get-kubeconfig-basicauth
     echo
-    echo "Kubernetes cluster is running.  The master is running at:"
+    echo "Kubernetes cluster is running."
+    echo
+    echo "The master is running at:"
     echo
     echo "  https://${MASTER_IP}"
     echo
+    echo "Administer and visualize its resources using Cockpit:"
+    echo
+    echo "  https://${MASTER_IP}:9090"
+    echo
+    echo "For more information on Cockpit, visit http://cockpit-project.org"
+    echo 
     echo "The user name and password to use is located in ${KUBECONFIG}"
     echo
-    )
+  )
 }
 
 # Instantiate a kubernetes cluster


### PR DESCRIPTION
The Cockpit project provides a management interface for Fedora clusters.

It has support for introspecting Kubernetes clusters out of the box.

Adding it to our Fedora 21 installation by default.

For details on Cockpit:
http://cockpit-project.org/index.html

To use:
Direct browser to https://10.245.1.2:9090
Login as vagrant/vagrant
Click cluster tab,and enjoy introspecting all of Kubernetes

Screenshots:

**Cluster Overview:**

![screenshot from 2015-09-10 11 33 51](https://cloud.githubusercontent.com/assets/6233452/9792767/dc38b42a-57af-11e5-8571-f5d2876f5aed.png)

**Cluster Containers:**

![screenshot from 2015-09-10 11 34 55](https://cloud.githubusercontent.com/assets/6233452/9792791/07e57aa4-57b0-11e5-84bc-b9d516fab9f0.png)

**Cluster Topology:**

![screenshot from 2015-09-10 11 35 50](https://cloud.githubusercontent.com/assets/6233452/9792808/1d69e78e-57b0-11e5-99ad-c027856eefba.png)

**Cluster Details:**

![screenshot from 2015-09-10 11 36 20](https://cloud.githubusercontent.com/assets/6233452/9792821/2ede58e2-57b0-11e5-98f2-52911dd0d1bb.png)
