### PR TITLE
Fluentd config cleanups

### DIFF
--- a/cluster/saltbase/salt/fluentd-es/fluentd-es.yaml
+++ b/cluster/saltbase/salt/fluentd-es/fluentd-es.yaml
@@ -11,7 +11,7 @@ spec:
       limits:
         cpu: 100m
     args:
-    - -qq
+    - -q
     volumeMounts:
     - name: varlog
       mountPath: /var/log

--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
@@ -19,6 +19,7 @@ spec:
       mountPath: /varlog
     - name: containers
       mountPath: /var/lib/docker/containers
+      readOnly: true
   terminationGracePeriodSeconds: 30
   volumes:
   - name: varlog

--- a/docs/getting-started-guides/logging.md
+++ b/docs/getting-started-guides/logging.md
@@ -182,6 +182,7 @@ spec:
       mountPath: /varlog
     - name: containers
       mountPath: /var/lib/docker/containers
+      readOnly: true
   terminationGracePeriodSeconds: 30
   volumes:
   - name: varlog


### PR DESCRIPTION
They haven't been used in months, ever since we started relying on named symlinks created by the kubelet under /var/log/containers in #7123. This came up in issue #13313.

While I'm here, also switch fluentd-es from only logging error messages (-qq) to logging warning messages as well (-q), which makes debugging problems with it much easier.

@jimmidyson @iterion 
