### PR TITLE
Validate LimitRange default and defaultRequest are not supported for limits of type Pod

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -1457,16 +1457,27 @@ func ValidateLimitRange(limitRange *api.LimitRange) errs.ValidationErrorList {
 			keys.Insert(string(k))
 			min[string(k)] = q
 		}
-		for k, q := range limit.Default {
-			allErrs = append(allErrs, validateResourceName(string(k), fmt.Sprintf("spec.limits[%d].default[%s]", i, k))...)
-			keys.Insert(string(k))
-			defaults[string(k)] = q
+
+		if limit.Type == api.LimitTypePod {
+			if len(limit.Default) > 0 {
+				allErrs = append(allErrs, errs.NewFieldInvalid("spec.limits[%d].default", limit.Default, "Default is not supported when limit type is Pod"))
+			}
+			if len(limit.DefaultRequest) > 0 {
+				allErrs = append(allErrs, errs.NewFieldInvalid("spec.limits[%d].defaultRequest", limit.DefaultRequest, "DefaultRequest is not supported when limit type is Pod"))
+			}
+		} else {
+			for k, q := range limit.Default {
+				allErrs = append(allErrs, validateResourceName(string(k), fmt.Sprintf("spec.limits[%d].default[%s]", i, k))...)
+				keys.Insert(string(k))
+				defaults[string(k)] = q
+			}
+			for k, q := range limit.DefaultRequest {
+				allErrs = append(allErrs, validateResourceName(string(k), fmt.Sprintf("spec.limits[%d].defaultRequest[%s]", i, k))...)
+				keys.Insert(string(k))
+				defaultRequests[string(k)] = q
+			}
 		}
-		for k, q := range limit.DefaultRequest {
-			allErrs = append(allErrs, validateResourceName(string(k), fmt.Sprintf("spec.limits[%d].defaultRequest[%s]", i, k))...)
-			keys.Insert(string(k))
-			defaultRequests[string(k)] = q
-		}
+
 		for k := range limit.MaxLimitRequestRatio {
 			allErrs = append(allErrs, validateResourceName(string(k), fmt.Sprintf("spec.limits[%d].maxLimitRequestRatio[%s]", i, k))...)
 		}

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -2910,6 +2910,12 @@ func TestValidateLimitRange(t *testing.T) {
 						Type:                 api.LimitTypePod,
 						Max:                  getResourceList("100m", "10000Mi"),
 						Min:                  getResourceList("5m", "100Mi"),
+						MaxLimitRequestRatio: getResourceList("10", ""),
+					},
+					{
+						Type:                 api.LimitTypeContainer,
+						Max:                  getResourceList("100m", "10000Mi"),
+						Min:                  getResourceList("5m", "100Mi"),
 						Default:              getResourceList("50m", "500Mi"),
 						DefaultRequest:       getResourceList("10m", "200Mi"),
 						MaxLimitRequestRatio: getResourceList("10", ""),
@@ -2922,7 +2928,7 @@ func TestValidateLimitRange(t *testing.T) {
 			spec: api.LimitRangeSpec{
 				Limits: []api.LimitRangeItem{
 					{
-						Type:                 api.LimitTypePod,
+						Type:                 api.LimitTypeContainer,
 						Max:                  getResourceList("100m", "10000T"),
 						Min:                  getResourceList("5m", "100Mi"),
 						Default:              getResourceList("50m", "500Mi"),
@@ -2977,6 +2983,32 @@ func TestValidateLimitRange(t *testing.T) {
 			}},
 			"",
 		},
+		"default-limit-type-pod": {
+			api.LimitRange{ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: "foo"}, Spec: api.LimitRangeSpec{
+				Limits: []api.LimitRangeItem{
+					{
+						Type:    api.LimitTypePod,
+						Max:     getResourceList("100m", "10000m"),
+						Min:     getResourceList("0m", "100m"),
+						Default: getResourceList("10m", "100m"),
+					},
+				},
+			}},
+			"Default is not supported when limit type is Pod",
+		},
+		"default-request-limit-type-pod": {
+			api.LimitRange{ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: "foo"}, Spec: api.LimitRangeSpec{
+				Limits: []api.LimitRangeItem{
+					{
+						Type:           api.LimitTypePod,
+						Max:            getResourceList("100m", "10000m"),
+						Min:            getResourceList("0m", "100m"),
+						DefaultRequest: getResourceList("10m", "100m"),
+					},
+				},
+			}},
+			"DefaultRequest is not supported when limit type is Pod",
+		},
 		"min value 100m is greater than max value 10m": {
 			api.LimitRange{ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: "foo"}, Spec: api.LimitRangeSpec{
 				Limits: []api.LimitRangeItem{
@@ -2993,7 +3025,7 @@ func TestValidateLimitRange(t *testing.T) {
 			api.LimitRange{ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: "foo"}, Spec: api.LimitRangeSpec{
 				Limits: []api.LimitRangeItem{
 					{
-						Type:    api.LimitTypePod,
+						Type:    api.LimitTypeContainer,
 						Max:     getResourceList("1", ""),
 						Min:     getResourceList("100m", ""),
 						Default: getResourceList("2000m", ""),
@@ -3006,7 +3038,7 @@ func TestValidateLimitRange(t *testing.T) {
 			api.LimitRange{ObjectMeta: api.ObjectMeta{Name: "abc", Namespace: "foo"}, Spec: api.LimitRangeSpec{
 				Limits: []api.LimitRangeItem{
 					{
-						Type:           api.LimitTypePod,
+						Type:           api.LimitTypeContainer,
 						Max:            getResourceList("1", ""),
 						Min:            getResourceList("100m", ""),
 						DefaultRequest: getResourceList("2000m", ""),


### PR DESCRIPTION
Reviewing the proposed doc update: https://github.com/kubernetes/kubernetes/pull/13724

Showed that we had a confusion on what Default and DefaultRequest meant on LimitRange for Pod-wide limits.  They have no meaning, and should have resulted in a validation error.

Fixes https://github.com/kubernetes/kubernetes/issues/13831

cc @hurf - in case you find the same thing ;-)
