### PR TITLE
Enhance error message for scale's replicas operation

### DIFF
--- a/pkg/kubectl/cmd/scale.go
+++ b/pkg/kubectl/cmd/scale.go
@@ -76,8 +76,8 @@ func NewCmdScale(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().String("resource-version", "", "Precondition for resource version. Requires that the current resource version match this value in order to scale.")
 	cmd.Flags().Int("current-replicas", -1, "Precondition for current size. Requires that the current size of the replication controller match this value in order to scale.")
 	cmd.Flags().Int("replicas", -1, "The new desired number of replicas. Required.")
-	cmd.Flags().Duration("timeout", 0, "The length of time to wait before giving up on a scale operation, zero means don't wait.")
 	cmd.MarkFlagRequired("replicas")
+	cmd.Flags().Duration("timeout", 0, "The length of time to wait before giving up on a scale operation, zero means don't wait.")
 	cmdutil.AddOutputFlagsForMutation(cmd)
 
 	usage := "Filename, directory, or URL to a file identifying the replication controller to set a new size"
@@ -93,7 +93,7 @@ func RunScale(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []stri
 
 	count := cmdutil.GetFlagInt(cmd, "replicas")
 	if count < 0 {
-		return cmdutil.UsageError(cmd, "--replicas=COUNT TYPE NAME")
+		return cmdutil.UsageError(cmd, "--replicas=COUNT is required, and COUNT must be greater than or equal to 0")
 	}
 
 	cmdNamespace, enforceNamespace, err := f.DefaultNamespace()


### PR DESCRIPTION
Just enhance error message for scale's replicas operation when user don't set it, or less than 0
