### PR TITLE
MESOS: add labels to node api object from scheduler and update them from executor

### DIFF
--- a/contrib/mesos/pkg/node/doc.go
+++ b/contrib/mesos/pkg/node/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package node provides utilities to create and update nodes
+package node

--- a/contrib/mesos/pkg/node/node.go
+++ b/contrib/mesos/pkg/node/node.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+
+	log "github.com/golang/glog"
+	mesos "github.com/mesos/mesos-go/mesosproto"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/errors"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/util/validation"
+)
+
+const (
+	labelPrefix = "k8s.mesosphere.io/attribute-"
+)
+
+// Create creates a new node api object with the given hostname and labels
+func Create(client *client.Client, hostName string, labels map[string]string) (*api.Node, error) {
+	n := api.Node{
+		ObjectMeta: api.ObjectMeta{
+			Name:   hostName,
+			Labels: map[string]string{"kubernetes.io/hostname": hostName},
+		},
+		Spec: api.NodeSpec{
+			ExternalID: hostName,
+		},
+		Status: api.NodeStatus{
+			Phase: api.NodePending,
+		},
+	}
+	for k, v := range labels {
+		n.Labels[k] = v
+	}
+
+	// try to create
+	return client.Nodes().Create(&n)
+}
+
+// Update updates an existing node api object with new labels
+func Update(client *client.Client, n *api.Node, labels map[string]string) (*api.Node, error) {
+	patch := struct {
+		Metadata struct {
+			Labels map[string]string `json:"labels"`
+		} `json:"metadata"`
+	}{}
+	patch.Metadata.Labels = map[string]string{}
+	for k, v := range n.Labels {
+		if !IsSlaveAttributeLabel(k) {
+			patch.Metadata.Labels[k] = v
+		}
+	}
+	for k, v := range labels {
+		patch.Metadata.Labels[k] = v
+	}
+	patchJson, _ := json.Marshal(patch)
+	log.V(4).Infof("Patching labels of node %q: %v", n.Name, string(patchJson))
+	err := client.Patch(api.MergePatchType).RequestURI(n.SelfLink).Body(patchJson).Do().Error()
+	if err != nil {
+		return nil, fmt.Errorf("error updating labels of node %q: %v", n.Name, err)
+	}
+
+	newNode, err := api.Scheme.DeepCopy(n)
+	if err != nil {
+		return nil, err
+	}
+	newNode.(*api.Node).Labels = patch.Metadata.Labels
+
+	return newNode.(*api.Node), nil
+}
+
+// CreateOrUpdate tries to create a node api object or updates an already existing one
+func CreateOrUpdate(client *client.Client, hostName string, labels map[string]string) (*api.Node, error) {
+	n, err := Create(client, hostName, labels)
+	if err == nil {
+		return n, nil
+	}
+	if !errors.IsAlreadyExists(err) {
+		return nil, fmt.Errorf("unable to register %q with the apiserver: %v", hostName, err)
+	}
+
+	// fall back to update an old node with new labels
+	n, err = client.Nodes().Get(hostName)
+	if err != nil {
+		return nil, fmt.Errorf("error getting node %q: %v", hostName, err)
+	}
+	if n == nil {
+		return nil, fmt.Errorf("no node instance returned for %q", hostName)
+	}
+	return Update(client, n, labels)
+}
+
+// IsSlaveAttributeLabel returns true iff the given label is derived from a slave attribute
+func IsSlaveAttributeLabel(l string) bool {
+	return strings.HasPrefix(l, labelPrefix)
+}
+
+// IsUpToDate returns true iff the node's slave labels match the given attributes labels
+func IsUpToDate(n *api.Node, labels map[string]string) bool {
+	slaveLabels := map[string]string{}
+	for k, v := range n.Labels {
+		if IsSlaveAttributeLabel(k) {
+			slaveLabels[k] = v
+		}
+	}
+	return reflect.DeepEqual(slaveLabels, labels)
+}
+
+// SlaveAttributesToLabels converts slave attributes into string key/value labels
+func SlaveAttributesToLabels(attrs []*mesos.Attribute) map[string]string {
+	l := map[string]string{}
+	for _, a := range attrs {
+		if a == nil {
+			continue
+		}
+
+		var v string
+		k := labelPrefix + a.GetName()
+
+		switch a.GetType() {
+		case mesos.Value_TEXT:
+			v = a.GetText().GetValue()
+		case mesos.Value_SCALAR:
+			v = strconv.FormatFloat(a.GetScalar().GetValue(), 'G', -1, 64)
+		}
+
+		if !validation.IsQualifiedName(k) {
+			log.V(3).Infof("ignoring invalid node label name %q", k)
+			continue
+		}
+
+		if !validation.IsValidLabelValue(v) {
+			log.V(3).Infof("ignoring invalid node label %s value: %q", k, v)
+			continue
+		}
+
+		l[k] = v
+	}
+	return l
+}

--- a/contrib/mesos/pkg/node/registrator.go
+++ b/contrib/mesos/pkg/node/registrator.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"fmt"
+	"time"
+
+	log "github.com/golang/glog"
+	"k8s.io/kubernetes/contrib/mesos/pkg/queue"
+	"k8s.io/kubernetes/contrib/mesos/pkg/runtime"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/errors"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+)
+
+type Registrator interface {
+	// Register checks whether the node is registered with the given labels. If it
+	// is not, it is created or updated on the apiserver. If an the node was up-to-date,
+	// false is returned.
+	Register(hostName string, labels map[string]string) (bool, error)
+
+	// Start the registration loop and return immediately.
+	Run(terminate <-chan struct{}) error
+}
+
+type registration struct {
+	hostName string
+	labels   map[string]string
+}
+
+func (r *registration) Copy() queue.Copyable {
+	return &registration{
+		hostName: r.hostName,
+		labels:   r.labels, // labels are never changed, no need to clone
+	}
+}
+
+func (r *registration) GetUID() string {
+	return r.hostName
+}
+
+func (r *registration) Value() queue.UniqueCopyable {
+	return r
+}
+
+type LookupFunc func(hostName string) *api.Node
+
+type clientRegistrator struct {
+	lookupNode LookupFunc
+	client     *client.Client
+	queue      *queue.HistoricalFIFO
+}
+
+func NewRegistrator(client *client.Client, lookupNode LookupFunc) *clientRegistrator {
+	return &clientRegistrator{
+		lookupNode: lookupNode,
+		client:     client,
+		queue:      queue.NewHistorical(nil),
+	}
+}
+
+func (r *clientRegistrator) Run(terminate <-chan struct{}) error {
+	loop := func() {
+	RegistrationLoop:
+		for {
+			obj := r.queue.CancelablePop(terminate)
+			if obj == nil {
+				break RegistrationLoop
+			}
+			select {
+			case <-terminate:
+				break RegistrationLoop
+			default:
+			}
+
+			rg := obj.(*registration)
+			n, needsUpdate := r.updateNecessary(rg.hostName, rg.labels)
+			if !needsUpdate {
+				continue
+			}
+
+			if n == nil {
+				log.V(2).Infof("creating node %s with labels %v", rg.hostName, rg.labels)
+				_, err := CreateOrUpdate(r.client, rg.hostName, rg.labels)
+				if err != nil {
+					log.Errorf("error creating the node %s: %v", rg.hostName, rg.labels)
+				}
+			} else {
+				log.V(2).Infof("updating node %s with labels %v", rg.hostName, rg.labels)
+				_, err := Update(r.client, n, rg.labels)
+				if err != nil && errors.IsNotFound(err) {
+					// last chance when our store was out of date
+					_, err = Create(r.client, rg.hostName, rg.labels)
+				}
+				if err != nil {
+					log.Errorf("error updating the node %s: %v", rg.hostName, rg.labels)
+				}
+			}
+		}
+	}
+	go runtime.Until(loop, time.Second, terminate)
+
+	return nil
+}
+
+func (r *clientRegistrator) Register(hostName string, labels map[string]string) (bool, error) {
+	_, needsUpdate := r.updateNecessary(hostName, labels)
+
+	if needsUpdate {
+		log.V(5).Infof("queuing registration for node %s with labels %v", hostName, labels)
+		err := r.queue.Update(&registration{
+			hostName: hostName,
+			labels:   labels,
+		})
+		if err != nil {
+			return false, fmt.Errorf("cannot register node %s: %v", hostName, err)
+		}
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// updateNecessary retrieves the node with the given hostname and checks whether the given
+// labels would mean any update to the node. The unmodified node is returned, plus
+// true iff an update is necessary.
+func (r *clientRegistrator) updateNecessary(hostName string, labels map[string]string) (*api.Node, bool) {
+	if r.lookupNode == nil {
+		return nil, true
+	}
+	n := r.lookupNode(hostName)
+	return n, n == nil || !IsUpToDate(n, labels)
+}

--- a/contrib/mesos/pkg/scheduler/plugin.go
+++ b/contrib/mesos/pkg/scheduler/plugin.go
@@ -548,7 +548,11 @@ func (k *errorHandler) handleSchedulingError(pod *api.Pod, schedulingErr error) 
 				defer k.api.Unlock()
 				switch task, state := k.api.tasks().Get(task.ID); state {
 				case podtask.StatePending:
-					return !task.Has(podtask.Launched) && k.api.algorithm().FitPredicate()(task, offer)
+					// Assess fitness of pod with the current offer. The scheduler normally
+					// "backs off" when it can't find an offer that matches up with a pod.
+					// The backoff period for a pod can terminate sooner if an offer becomes
+					// available that matches up.
+					return !task.Has(podtask.Launched) && k.api.algorithm().FitPredicate()(task, offer, nil)
 				default:
 					// no point in continuing to check for matching offers
 					return true

--- a/contrib/mesos/pkg/scheduler/podtask/minimal.go
+++ b/contrib/mesos/pkg/scheduler/podtask/minimal.go
@@ -19,6 +19,7 @@ package podtask
 import (
 	log "github.com/golang/glog"
 	mesos "github.com/mesos/mesos-go/mesosproto"
+	"k8s.io/kubernetes/pkg/api"
 )
 
 // bogus numbers that we use to make sure that there's some set of minimal offered resources on the slave
@@ -43,7 +44,7 @@ var (
 	}).Procure
 )
 
-func MinimalPodResourcesPredicate(t *T, offer *mesos.Offer) bool {
+func MinimalPodResourcesPredicate(t *T, offer *mesos.Offer, _ *api.Node) bool {
 	var (
 		offeredCpus float64
 		offeredMem  float64

--- a/contrib/mesos/pkg/scheduler/podtask/pod_task_test.go
+++ b/contrib/mesos/pkg/scheduler/podtask/pod_task_test.go
@@ -146,10 +146,10 @@ func TestEmptyOffer(t *testing.T) {
 	mresource.LimitPodCPU(&task.Pod, mresource.DefaultDefaultContainerCPULimit)
 	mresource.LimitPodMem(&task.Pod, mresource.DefaultDefaultContainerMemLimit)
 
-	if ok := DefaultPredicate(task, nil); ok {
+	if ok := DefaultPredicate(task, nil, nil); ok {
 		t.Fatalf("accepted nil offer")
 	}
-	if ok := DefaultPredicate(task, &mesos.Offer{}); ok {
+	if ok := DefaultPredicate(task, &mesos.Offer{}, nil); ok {
 		t.Fatalf("accepted empty offer")
 	}
 }
@@ -176,7 +176,7 @@ func TestNoPortsInPodOrOffer(t *testing.T) {
 			mutil.NewScalarResource("mem", 0.001),
 		},
 	}
-	if ok := DefaultPredicate(task, offer); ok {
+	if ok := DefaultPredicate(task, offer, nil); ok {
 		t.Fatalf("accepted offer %v:", offer)
 	}
 
@@ -186,7 +186,7 @@ func TestNoPortsInPodOrOffer(t *testing.T) {
 			mutil.NewScalarResource("mem", t_min_mem),
 		},
 	}
-	if ok := DefaultPredicate(task, offer); !ok {
+	if ok := DefaultPredicate(task, offer, nil); !ok {
 		t.Fatalf("did not accepted offer %v:", offer)
 	}
 }
@@ -203,7 +203,7 @@ func TestAcceptOfferPorts(t *testing.T) {
 			rangeResource("ports", []uint64{1, 1}),
 		},
 	}
-	if ok := DefaultPredicate(task, offer); !ok {
+	if ok := DefaultPredicate(task, offer, nil); !ok {
 		t.Fatalf("did not accepted offer %v:", offer)
 	}
 
@@ -218,17 +218,17 @@ func TestAcceptOfferPorts(t *testing.T) {
 	mresource.LimitPodCPU(&task.Pod, mresource.DefaultDefaultContainerCPULimit)
 	mresource.LimitPodMem(&task.Pod, mresource.DefaultDefaultContainerMemLimit)
 
-	if ok := DefaultPredicate(task, offer); ok {
+	if ok := DefaultPredicate(task, offer, nil); ok {
 		t.Fatalf("accepted offer %v:", offer)
 	}
 
 	pod.Spec.Containers[0].Ports[0].HostPort = 1
-	if ok := DefaultPredicate(task, offer); !ok {
+	if ok := DefaultPredicate(task, offer, nil); !ok {
 		t.Fatalf("did not accepted offer %v:", offer)
 	}
 
 	pod.Spec.Containers[0].Ports[0].HostPort = 0
-	if ok := DefaultPredicate(task, offer); !ok {
+	if ok := DefaultPredicate(task, offer, nil); !ok {
 		t.Fatalf("did not accepted offer %v:", offer)
 	}
 
@@ -236,12 +236,12 @@ func TestAcceptOfferPorts(t *testing.T) {
 		mutil.NewScalarResource("cpus", t_min_cpu),
 		mutil.NewScalarResource("mem", t_min_mem),
 	}
-	if ok := DefaultPredicate(task, offer); ok {
+	if ok := DefaultPredicate(task, offer, nil); ok {
 		t.Fatalf("accepted offer %v:", offer)
 	}
 
 	pod.Spec.Containers[0].Ports[0].HostPort = 1
-	if ok := DefaultPredicate(task, offer); ok {
+	if ok := DefaultPredicate(task, offer, nil); ok {
 		t.Fatalf("accepted offer %v:", offer)
 	}
 }
@@ -270,21 +270,61 @@ func TestGeneratePodName(t *testing.T) {
 func TestNodeSelector(t *testing.T) {
 	t.Parallel()
 
-	sel1 := map[string]string{"rack": "a"}
-	sel2 := map[string]string{"rack": "a", "gen": "2014"}
+	sel1 := map[string]string{"k8s.mesosphere.io/attribute-rack": "a"}
+	sel2 := map[string]string{"k8s.mesosphere.io/attribute-rack": "a", "k8s.mesosphere.io/attribute-gen": "2014"}
+	sel3 := map[string]string{"kubernetes.io/hostname": "node1"}
+	sel4 := map[string]string{"kubernetes.io/hostname": "node2"}
+	sel5 := map[string]string{"k8s.mesosphere.io/attribute-old": "42"}
+	sel6 := map[string]string{"some.other/label": "43"}
+
+	newNode := func(hostName string, l map[string]string) *api.Node {
+		nodeLabels := map[string]string{"kubernetes.io/hostname": hostName}
+		if l != nil {
+			for k, v := range l {
+				nodeLabels[k] = v
+			}
+		}
+		return &api.Node{
+			ObjectMeta: api.ObjectMeta{
+				Name:   hostName,
+				Labels: nodeLabels,
+			},
+			Spec: api.NodeSpec{
+				ExternalID: hostName,
+			},
+		}
+	}
+	node1 := newNode("node1", nil)
+	node2 := newNode("node2", nil)
+	node3 := newNode("node3", map[string]string{
+		"k8s.mesosphere.io/attribute-old": "42",
+		"k8s.mesosphere.io/attribute-gen": "2015",
+		"some.other/label":                "43",
+	})
 
 	tests := []struct {
 		selector map[string]string
 		attrs    []*mesos.Attribute
+		node     *api.Node
 		ok       bool
+		desc     string
 	}{
-		{sel1, []*mesos.Attribute{newTextAttribute("rack", "a")}, true},
-		{sel1, []*mesos.Attribute{newTextAttribute("rack", "b")}, false},
-		{sel1, []*mesos.Attribute{newTextAttribute("rack", "a"), newTextAttribute("gen", "2014")}, true},
-		{sel1, []*mesos.Attribute{newTextAttribute("rack", "a"), newScalarAttribute("num", 42.0)}, true},
-		{sel1, []*mesos.Attribute{newScalarAttribute("rack", 42.0)}, false},
-		{sel2, []*mesos.Attribute{newTextAttribute("rack", "a"), newTextAttribute("gen", "2014")}, true},
-		{sel2, []*mesos.Attribute{newTextAttribute("rack", "a"), newTextAttribute("gen", "2015")}, false},
+		{sel1, []*mesos.Attribute{newTextAttribute("rack", "a")}, node1, true, "label value matches"},
+		{sel1, []*mesos.Attribute{newTextAttribute("rack", "b")}, node1, false, "label value does not match"},
+		{sel1, []*mesos.Attribute{newTextAttribute("rack", "a"), newTextAttribute("gen", "2014")}, node1, true, "required labels match"},
+		{sel1, []*mesos.Attribute{newTextAttribute("rack", "a"), newScalarAttribute("num", 42.0)}, node1, true, "scalar label matches"},
+		{sel1, []*mesos.Attribute{newScalarAttribute("rack", 42.0)}, node1, false, "scalar label does not match"},
+		{sel2, []*mesos.Attribute{newTextAttribute("rack", "a"), newTextAttribute("gen", "2014")}, node1, true, "all labels match"},
+		{sel2, []*mesos.Attribute{newTextAttribute("rack", "a"), newTextAttribute("gen", "2015")}, node1, false, "one label does not match"},
+
+		{sel3, []*mesos.Attribute{}, node1, true, "hostname label matches"},
+		{sel4, []*mesos.Attribute{}, node1, false, "hostname label does not match"},
+		{sel4, []*mesos.Attribute{}, node2, true, "hostname label does not match"},
+
+		{sel5, []*mesos.Attribute{}, node3, false, "old slave attribute is removed"},
+		{sel6, []*mesos.Attribute{}, node1, false, "non-slave attribute does not match"},
+		{sel6, []*mesos.Attribute{}, node3, true, "non-slave attribute matches"},
+		{sel2, []*mesos.Attribute{newTextAttribute("rack", "a"), newTextAttribute("gen", "2014")}, node3, true, "old slave attributes are overwritten"},
 	}
 
 	for _, ts := range tests {
@@ -296,9 +336,10 @@ func TestNodeSelector(t *testing.T) {
 				mutil.NewScalarResource("mem", t_min_mem),
 			},
 			Attributes: ts.attrs,
+			Hostname:   &ts.node.Name,
 		}
-		if got, want := DefaultPredicate(task, offer), ts.ok; got != want {
-			t.Fatalf("expected acceptance of offer %v for selector %v to be %v, got %v:", want, got, ts.attrs, ts.selector)
+		if got, want := DefaultPredicate(task, offer, ts.node), ts.ok; got != want {
+			t.Fatalf("expected acceptance of offer for selector %v to be %v, got %v: %q", ts.selector, want, got, ts.desc)
 		}
 	}
 }

--- a/contrib/mesos/pkg/scheduler/podtask/predicate.go
+++ b/contrib/mesos/pkg/scheduler/podtask/predicate.go
@@ -19,7 +19,9 @@ package podtask
 import (
 	log "github.com/golang/glog"
 	mesos "github.com/mesos/mesos-go/mesosproto"
+	"k8s.io/kubernetes/contrib/mesos/pkg/node"
 	mresource "k8s.io/kubernetes/contrib/mesos/pkg/scheduler/resource"
+	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/labels"
 )
 
@@ -31,25 +33,25 @@ var DefaultPredicate = RequireAllPredicate([]FitPredicate{
 }).Fit
 
 // FitPredicate implementations determine if the given task "fits" into offered Mesos resources.
-// Neither the task or offer should be modified.
-type FitPredicate func(*T, *mesos.Offer) bool
+// Neither the task or offer should be modified. Note that the node can be nil.
+type FitPredicate func(*T, *mesos.Offer, *api.Node) bool
 
 type RequireAllPredicate []FitPredicate
 
-func (f RequireAllPredicate) Fit(t *T, offer *mesos.Offer) bool {
+func (f RequireAllPredicate) Fit(t *T, offer *mesos.Offer, n *api.Node) bool {
 	for _, p := range f {
-		if !p(t, offer) {
+		if !p(t, offer, n) {
 			return false
 		}
 	}
 	return true
 }
 
-func ValidationPredicate(t *T, offer *mesos.Offer) bool {
+func ValidationPredicate(t *T, offer *mesos.Offer, _ *api.Node) bool {
 	return t != nil && offer != nil
 }
 
-func NodeSelectorPredicate(t *T, offer *mesos.Offer) bool {
+func NodeSelectorPredicate(t *T, offer *mesos.Offer, n *api.Node) bool {
 	// if the user has specified a target host, make sure this offer is for that host
 	if t.Pod.Spec.NodeName != "" && offer.GetHostname() != t.Pod.Spec.NodeName {
 		return false
@@ -57,21 +59,29 @@ func NodeSelectorPredicate(t *T, offer *mesos.Offer) bool {
 
 	// check the NodeSelector
 	if len(t.Pod.Spec.NodeSelector) > 0 {
-		slaveLabels := map[string]string{}
-		for _, a := range offer.Attributes {
-			if a.GetType() == mesos.Value_TEXT {
-				slaveLabels[a.GetName()] = a.GetText().GetValue()
+		l := map[string]string{
+			"kubernetes.io/hostname": offer.GetHostname(),
+		}
+		if n != nil && n.Labels != nil {
+			for k, v := range n.Labels {
+				if !node.IsSlaveAttributeLabel(k) {
+					l[k] = v
+				}
 			}
 		}
+		for k, v := range node.SlaveAttributesToLabels(offer.Attributes) {
+			l[k] = v
+		}
+
 		selector := labels.SelectorFromSet(t.Pod.Spec.NodeSelector)
-		if !selector.Matches(labels.Set(slaveLabels)) {
+		if !selector.Matches(labels.Set(l)) {
 			return false
 		}
 	}
 	return true
 }
 
-func PortsPredicate(t *T, offer *mesos.Offer) bool {
+func PortsPredicate(t *T, offer *mesos.Offer, _ *api.Node) bool {
 	// check ports
 	if _, err := t.mapper.Generate(t, offer); err != nil {
 		log.V(3).Info(err)
@@ -80,7 +90,7 @@ func PortsPredicate(t *T, offer *mesos.Offer) bool {
 	return true
 }
 
-func PodFitsResourcesPredicate(t *T, offer *mesos.Offer) bool {
+func PodFitsResourcesPredicate(t *T, offer *mesos.Offer, _ *api.Node) bool {
 	// find offered cpu and mem
 	var (
 		offeredCpus mresource.CPUShares

--- a/test/e2e/mesos.go
+++ b/test/e2e/mesos.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/labels"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/kubernetes/pkg/fields"
+)
+
+var _ = Describe("Mesos", func() {
+	framework := NewFramework("pods")
+
+	BeforeEach(func() {
+		SkipUnlessProviderIs("mesos/docker")
+	})
+
+	It("applies slave attributes as labels", func() {
+		nodeClient := framework.Client.Nodes()
+
+		rackA := labels.SelectorFromSet(map[string]string{"k8s.mesosphere.io/attribute-rack": "1"})
+		nodes, err := nodeClient.List(rackA, fields.Everything())
+		if err != nil {
+			Failf("Failed to query for node: %v", err)
+		}
+		Expect(len(nodes.Items)).To(Equal(1))
+
+		var addr string
+		for _, a := range nodes.Items[0].Status.Addresses {
+			if a.Type == api.NodeInternalIP {
+				addr = a.Address
+			}
+		}
+		Expect(len(addr)).NotTo(Equal(""))
+	})
+})


### PR DESCRIPTION
This PR converts Mesos slave attributes into k8s node labels, using the `k8s.mesosphere.io/*` label namespace.

I.e. a slave with attribute `rack: a` will get the k8s node label `k8s.mesosphere.io/rack: a`.

Node labels must be synchronously applied to a node before a pod is launched because the kubelet will check whether the labels match to a pod's NodeSelector.  Therefore, the nodes are pre-created from the scheduler. Until that is done, offers are declined.

The overall picture is this:
- an offer comes in
- the scheduler starts registering or updating the node asynchronously with the given labels
- the offer is declined
- another offer comes in
- if the node is registered now, the offer is used to launch a task. Otherwise, it's declined again.
- Mesos will launch the minion.
- the executor is launched by the minion. It instantiates the kubelet (later the kubelet will be launched out-of-process by the minion)
- the kubelet will get the node with the right labels from the apiserver
- the executor registers or reregisters with Mesos and gets slave attributes. The executor then will update the node object (necessary in case the labels changed e.g. because the slave was restarted with new attributes).
- the kubelet watches the node object on the apiserver and will notice label changes.

xref https://github.com/mesosphere/kubernetes-mesos/issues/452
