### PR TITLE
Moved Volumes interface from AWS volume to CloudProvider pkg

### DIFF
--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -37,6 +37,8 @@ type Interface interface {
 	Clusters() (Clusters, bool)
 	// Routes returns a routes interface along with whether the interface is supported.
 	Routes() (Routes, bool)
+	// Volumes returns a volumes interface along with whether the interface is supported.
+	Volumes() (Volumes, bool)
 	// ProviderName returns the cloud provider ID.
 	ProviderName() string
 }
@@ -139,6 +141,24 @@ type Routes interface {
 	// Delete the specified managed route
 	// Route should be as returned by ListRoutes
 	DeleteRoute(clusterName string, route *Route) error
+}
+
+// Volumes is an interface for managing cloud-provisioned volumes
+type Volumes interface {
+	// Attach the disk to the specified instance
+	// instanceName can be empty to mean "the instance on which we are running"
+	// Returns the device (e.g. /dev/xvdf) where we attached the volume
+	AttachDisk(instanceName string, volumeName string, readOnly bool) (string, error)
+	// Detach the disk from the specified instance
+	// instanceName can be empty to mean "the instance on which we are running"
+	DetachDisk(instanceName string, volumeName string) error
+	// Create a volume with the specified options
+	CreateVolume(volumeOptions *VolumeOptions) (volumeName string, err error)
+	DeleteVolume(volumeName string) error
+}
+
+type VolumeOptions struct {
+	CapacityMB int
 }
 
 var InstanceNotFound = errors.New("instance not found")

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -133,26 +133,6 @@ type AWSMetadata interface {
 	GetMetaData(key string) ([]byte, error)
 }
 
-type VolumeOptions struct {
-	CapacityMB int
-}
-
-// Volumes is an interface for managing cloud-provisioned volumes
-// TODO: Allow other clouds to implement this
-type Volumes interface {
-	// Attach the disk to the specified instance
-	// instanceName can be empty to mean "the instance on which we are running"
-	// Returns the device (e.g. /dev/xvdf) where we attached the volume
-	AttachDisk(instanceName string, volumeName string, readOnly bool) (string, error)
-	// Detach the disk from the specified instance
-	// instanceName can be empty to mean "the instance on which we are running"
-	DetachDisk(instanceName string, volumeName string) error
-
-	// Create a volume with the specified options
-	CreateVolume(volumeOptions *VolumeOptions) (volumeName string, err error)
-	DeleteVolume(volumeName string) error
-}
-
 // InstanceGroups is an interface for managing cloud-managed instance groups / autoscaling instance groups
 // TODO: Allow other clouds to implement this
 type InstanceGroups interface {
@@ -636,6 +616,11 @@ func (aws *AWSCloud) Zones() (cloudprovider.Zones, bool) {
 
 // Routes returns an implementation of Routes for Amazon Web Services.
 func (aws *AWSCloud) Routes() (cloudprovider.Routes, bool) {
+	return aws, true
+}
+
+// Volumes returns an implementation of Volumes for Amazon Web Services.
+func (aws *AWSCloud) Volumes() (cloudprovider.Volumes, bool) {
 	return aws, true
 }
 
@@ -1201,7 +1186,7 @@ func (aws *AWSCloud) DetachDisk(instanceName string, diskName string) error {
 }
 
 // Implements Volumes.CreateVolume
-func (aws *AWSCloud) CreateVolume(volumeOptions *VolumeOptions) (string, error) {
+func (aws *AWSCloud) CreateVolume(volumeOptions *cloudprovider.VolumeOptions) (string, error) {
 	// TODO: Should we tag this with the cluster id (so it gets deleted when the cluster does?)
 	// This is only used for testing right now
 

--- a/pkg/cloudprovider/providers/fake/fake.go
+++ b/pkg/cloudprovider/providers/fake/fake.go
@@ -115,6 +115,11 @@ func (f *FakeCloud) Routes() (cloudprovider.Routes, bool) {
 	return f, true
 }
 
+// Volumes returns an implementation of Volumes for Amazon Web Services.
+func (f *FakeCloud) Volumes() (cloudprovider.Volumes, bool) {
+	return f, true
+}
+
 // GetTCPLoadBalancer is a stub implementation of TCPLoadBalancer.GetTCPLoadBalancer.
 func (f *FakeCloud) GetTCPLoadBalancer(name, region string) (*api.LoadBalancerStatus, bool, error) {
 	status := &api.LoadBalancerStatus{}
@@ -242,5 +247,21 @@ func (f *FakeCloud) DeleteRoute(clusterName string, route *cloudprovider.Route) 
 		return f.Err
 	}
 	delete(f.RouteMap, name)
+	return nil
+}
+
+func (f *FakeCloud) AttachDisk(instanceName string, volumeName string, readOnly bool) (string, error) {
+	return "/some/fake/path", nil
+}
+
+func (f *FakeCloud) DetachDisk(instanceName string, volumeName string) error {
+	return nil
+}
+
+func (f *FakeCloud) CreateVolume(volumeOptions *cloudprovider.VolumeOptions) (volumeName string, err error) {
+	return "foo", nil
+}
+
+func (f *FakeCloud) DeleteVolume(volumeName string) error {
 	return nil
 }

--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -212,6 +212,11 @@ func (gce *GCECloud) Routes() (cloudprovider.Routes, bool) {
 	return gce, true
 }
 
+// Volumes returns an implementation of Volumes for Google Compute Engine.
+func (gce *GCECloud) Volumes() (cloudprovider.Volumes, bool) {
+	return nil, false
+}
+
 func makeHostURL(projectID, zone, host string) string {
 	host = canonicalizeInstanceName(host)
 	return fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/%s/instances/%s",

--- a/pkg/cloudprovider/providers/mesos/mesos.go
+++ b/pkg/cloudprovider/providers/mesos/mesos.go
@@ -119,6 +119,11 @@ func (c *MesosCloud) Routes() (cloudprovider.Routes, bool) {
 	return nil, false
 }
 
+// Volumes returns an implementation of Volumes for Mesos
+func (gce *MesosCloud) Volumes() (cloudprovider.Volumes, bool) {
+	return nil, false
+}
+
 // ProviderName returns the cloud provider ID.
 func (c *MesosCloud) ProviderName() string {
 	return ProviderName

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -768,6 +768,11 @@ func (os *OpenStack) Routes() (cloudprovider.Routes, bool) {
 	return nil, false
 }
 
+// Volumes returns an implementation of Volumes for OpenStack
+func (gce *OpenStack) Volumes() (cloudprovider.Volumes, bool) {
+	return nil, false
+}
+
 // Attaches given cinder volume to the compute running kubelet
 func (os *OpenStack) AttachDisk(diskName string) (string, error) {
 	disk, err := os.getVolume(diskName)

--- a/pkg/cloudprovider/providers/ovirt/ovirt.go
+++ b/pkg/cloudprovider/providers/ovirt/ovirt.go
@@ -143,6 +143,11 @@ func (v *OVirtCloud) Routes() (cloudprovider.Routes, bool) {
 	return nil, false
 }
 
+// Volumes returns an implementation of Volumes for OVirtCloud
+func (gce *OVirtCloud) Volumes() (cloudprovider.Volumes, bool) {
+	return nil, false
+}
+
 // NodeAddresses returns the NodeAddresses of a particular machine instance
 func (v *OVirtCloud) NodeAddresses(name string) ([]api.NodeAddress, error) {
 	instance, err := v.fetchInstance(name)

--- a/pkg/cloudprovider/providers/rackspace/rackspace.go
+++ b/pkg/cloudprovider/providers/rackspace/rackspace.go
@@ -376,6 +376,11 @@ func (os *Rackspace) Routes() (cloudprovider.Routes, bool) {
 	return nil, false
 }
 
+// Volumes returns an implementation of Volumes for Rackspace
+func (os *Rackspace) Volumes() (cloudprovider.Volumes, bool) {
+	return nil, false
+}
+
 func (os *Rackspace) GetZone() (cloudprovider.Zone, error) {
 	glog.V(1).Infof("Current zone is %v", os.region)
 

--- a/pkg/cloudprovider/providers/vagrant/vagrant.go
+++ b/pkg/cloudprovider/providers/vagrant/vagrant.go
@@ -111,6 +111,11 @@ func (v *VagrantCloud) Routes() (cloudprovider.Routes, bool) {
 	return nil, false
 }
 
+// Volumes returns an implementation of Volumes for VagrantCloud
+func (os *VagrantCloud) Volumes() (cloudprovider.Volumes, bool) {
+	return nil, false
+}
+
 // getInstanceByAddress retuns
 func (v *VagrantCloud) getInstanceByAddress(address string) (*SaltMinion, error) {
 	token, err := v.saltLogin()

--- a/pkg/volume/aws_ebs/aws_ebs.go
+++ b/pkg/volume/aws_ebs/aws_ebs.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/cloudprovider/providers/aws"
+	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/exec"
@@ -154,9 +154,9 @@ func detachDiskLogError(ebs *awsElasticBlockStore) {
 }
 
 // getVolumeProvider returns the AWS Volumes interface
-func (ebs *awsElasticBlockStore) getVolumeProvider() (aws_cloud.Volumes, error) {
+func (ebs *awsElasticBlockStore) getVolumeProvider() (cloudprovider.Volumes, error) {
 	cloud := ebs.plugin.host.GetCloudProvider()
-	volumes, ok := cloud.(aws_cloud.Volumes)
+	volumes, ok := cloud.Volumes()
 	if !ok {
 		return nil, fmt.Errorf("Cloud provider does not support volumes")
 	}

--- a/test/e2e/pd.go
+++ b/test/e2e/pd.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/api/resource"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
-	"k8s.io/kubernetes/pkg/cloudprovider/providers/aws"
+	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/util"
@@ -268,11 +268,11 @@ func createPD() (string, error) {
 		}
 		return pdName, nil
 	} else {
-		volumes, ok := testContext.CloudConfig.Provider.(aws_cloud.Volumes)
+		volumes, ok := testContext.CloudConfig.Provider.(cloudprovider.Volumes)
 		if !ok {
 			return "", fmt.Errorf("Provider does not support volumes")
 		}
-		volumeOptions := &aws_cloud.VolumeOptions{}
+		volumeOptions := &cloudprovider.VolumeOptions{}
 		volumeOptions.CapacityMB = 10 * 1024
 		return volumes.CreateVolume(volumeOptions)
 	}
@@ -290,7 +290,7 @@ func deletePD(pdName string) error {
 		}
 		return err
 	} else {
-		volumes, ok := testContext.CloudConfig.Provider.(aws_cloud.Volumes)
+		volumes, ok := testContext.CloudConfig.Provider.(cloudprovider.Volumes)
 		if !ok {
 			return fmt.Errorf("Provider does not support volumes")
 		}
@@ -307,7 +307,7 @@ func detachPD(hostName, pdName string) error {
 		// TODO: make this hit the compute API directly.
 		return exec.Command("gcloud", "compute", "--project="+testContext.CloudConfig.ProjectID, "detach-disk", "--zone="+zone, "--disk="+pdName, instanceName).Run()
 	} else {
-		volumes, ok := testContext.CloudConfig.Provider.(aws_cloud.Volumes)
+		volumes, ok := testContext.CloudConfig.Provider.(cloudprovider.Volumes)
 		if !ok {
 			return fmt.Errorf("Provider does not support volumes")
 		}


### PR DESCRIPTION
Justin implemented a Volumes interface in the AWS plugin with a TODO to move it to CloudProvider.

This PR is required for the new PersistentVolumeProvisioner controller I am adding.  The controller requires a common interface for volumes among cloud providers.

AWS is the only working implementation.

@justinsb @saad-ali @thockin 
