### PR TITLE
Update open file limit for etcd

### DIFF
--- a/cluster/ubuntu/master/init_conf/etcd.conf
+++ b/cluster/ubuntu/master/init_conf/etcd.conf
@@ -7,6 +7,9 @@ start on (net-device-up
 
 respawn
 
+# set max open files
+limit nofile 2048 4096
+
 pre-start script
 	# see also https://github.com/jainvipin/kubernetes-ubuntu-start
 	ETCD=/opt/bin/$UPSTART_JOB


### PR DESCRIPTION
etcd was constantly restarting with too many open files until I gave it more room on Ubuntu 14.04

https://gist.github.com/darron/2aadb8f30f3dd6f580bf

This may be a more sensible default - but it may not be enough depending on how many minion nodes there are.
