### PR TITLE
Some minor doc fixes

### DIFF
--- a/docs/admin/node.md
+++ b/docs/admin/node.md
@@ -222,7 +222,7 @@ you are doing [manual node administration](#manual-node-administration), then yo
 capacity when adding a node.
 
 The Kubernetes scheduler ensures that there are enough resources for all the pods on a node.  It
-checks that the sum of the limits of containers on the node is no greater than than the node capacity.  It
+checks that the sum of the limits of containers on the node is no greater than the node capacity.  It
 includes all containers started by kubelet, but not containers started directly by docker, nor
 processes not in containers.
 

--- a/docs/getting-started-guides/cloudstack.md
+++ b/docs/getting-started-guides/cloudstack.md
@@ -108,7 +108,7 @@ Once the playbook as finished, it will print out the IP of the Kubernetes master
 
 SSH to it using the key that was created and using the _core_ user and you can list the machines in your cluster:
 
-    $ ssh -i ~/.ssh/id_rsa_k8s core@<maste IP>
+    $ ssh -i ~/.ssh/id_rsa_k8s core@<master IP>
     $ fleetctl list-machines
     MACHINE		IP		       METADATA
     a017c422...	<node #1 IP>   role=node

--- a/docs/user-guide/service-accounts.md
+++ b/docs/user-guide/service-accounts.md
@@ -144,7 +144,7 @@ secrets/build-robot-secret
 Now you can confirm that the newly built secret is populated with an API token for the "build-robot" service account.
 
 ```console
-kubectl describe secrets/build-robot-secret 
+$ kubectl describe secrets/build-robot-secret 
 Name:   build-robot-secret
 Namespace:  default
 Labels:   <none>


### PR DESCRIPTION
Some minor doc fixes:
1. remove duplicate `than`
2. fixed a typo `<maste IP>` to `<master IP>`
3. add a `$` before the `kubelet` command to keep align with others in the document
