### PR TITLE
dont kill pods till all sources have been seen and the cache is primed

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -575,6 +575,9 @@ type Kubelet struct {
 
 	// True if container cpu limits should be enforced via cgroup CFS quota
 	cpuCFSQuota bool
+
+	// True when all sources have checked in
+	sourcesReadyForUse bool
 }
 
 // getRootDir returns the full path to the directory under which kubelet can
@@ -1600,7 +1603,7 @@ func (kl *Kubelet) removeOrphanedPodStatuses(pods []*api.Pod, mirrorPods []*api.
 }
 
 func (kl *Kubelet) deletePod(uid types.UID) error {
-	if !kl.sourcesReady() {
+	if !kl.sourcesReadyForUse {
 		// If the sources aren't ready, skip deletion, as we may accidentally delete pods
 		// for sources that haven't reported yet.
 		return fmt.Errorf("skipping delete because sources aren't ready yet")
@@ -1632,7 +1635,7 @@ func (kl *Kubelet) deletePod(uid types.UID) error {
 // should not contain any blocking calls. Re-examine the function and decide
 // whether or not we should move it into a separte goroutine.
 func (kl *Kubelet) HandlePodCleanups() error {
-	if !kl.sourcesReady() {
+	if !kl.sourcesReadyForUse {
 		// If the sources aren't ready, skip deletion, as we may accidentally delete pods
 		// for sources that haven't reported yet.
 		glog.V(4).Infof("Skipping cleanup, sources aren't ready yet.")
@@ -1888,7 +1891,7 @@ func (kl *Kubelet) syncLoop(updates <-chan PodUpdate, handler SyncHandler) {
 		// housekeepingMinimumPeriod.
 		// TODO (#13418): Investigate whether we can/should spawn a dedicated
 		// goroutine for housekeeping
-		if housekeepingTimestamp.IsZero() || time.Since(housekeepingTimestamp) > housekeepingMinimumPeriod {
+		if time.Since(housekeepingTimestamp) > housekeepingMinimumPeriod {
 			glog.V(4).Infof("SyncLoop (housekeeping)")
 			if err := handler.HandlePodCleanups(); err != nil {
 				glog.Errorf("Failed cleaning pods: %v", err)
@@ -1982,6 +1985,7 @@ func (kl *Kubelet) HandlePodAdditions(pods []*api.Pod) {
 }
 
 func (kl *Kubelet) HandlePodUpdates(pods []*api.Pod) {
+	defer func(sourcesReadyValue bool) { kl.sourcesReadyForUse = sourcesReadyValue }(kl.sourcesReady())
 	start := time.Now()
 	for _, pod := range pods {
 		kl.podManager.UpdatePod(pod)

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -369,6 +369,7 @@ func TestSyncPodsStartPod(t *testing.T) {
 			},
 		},
 	}
+	kubelet.sourcesReadyForUse = true
 	kubelet.podManager.SetPods(pods)
 	kubelet.HandlePodSyncs(pods)
 	fakeRuntime.AssertStartedPods([]string{string(pods[0].UID)})
@@ -2246,7 +2247,9 @@ func TestPurgingObsoleteStatusMapEntries(t *testing.T) {
 		t.Fatalf("expected to have status cached for pod2")
 	}
 	// Sync with empty pods so that the entry in status map will be removed.
+	kl.sourcesReadyForUse = true
 	kl.podManager.SetPods([]*api.Pod{})
+	kl.sourcesReadyForUse = true
 	kl.HandlePodCleanups()
 	if _, found := kl.statusManager.GetPodStatus(podToTest.UID); found {
 		t.Fatalf("expected to not have status cached for pod2")
@@ -2775,6 +2778,7 @@ func TestDeleteOrphanedMirrorPods(t *testing.T) {
 
 	kl.podManager.SetPods(orphanPods)
 	// Sync with an empty pod list to delete all mirror pods.
+	kl.sourcesReadyForUse = true
 	kl.HandlePodCleanups()
 	if manager.NumOfPods() != 0 {
 		t.Errorf("expected zero mirror pods, got %v", manager.GetPods())
@@ -3307,6 +3311,7 @@ func TestDeletePodDirsForDeletedPods(t *testing.T) {
 		},
 	}
 
+	kl.sourcesReadyForUse = true
 	kl.podManager.SetPods(pods)
 	// Sync to create pod directories.
 	kl.HandlePodSyncs(kl.podManager.GetPods())
@@ -3330,6 +3335,7 @@ func TestDeletePodDirsForDeletedPods(t *testing.T) {
 func syncAndVerifyPodDir(t *testing.T, testKubelet *TestKubelet, pods []*api.Pod, podsToCheck []*api.Pod, shouldExist bool) {
 	kl := testKubelet.kubelet
 
+	kl.sourcesReadyForUse = true
 	kl.podManager.SetPods(pods)
 	kl.HandlePodSyncs(pods)
 	kl.HandlePodCleanups()


### PR DESCRIPTION
on kubelet start-up there is a race between the pods getting loaded into the podManager cache, kl.sourcesReady being set and pods getting killed by the housekeeping task

This has `handler.HandlePodUpdates` set sourcesReady after processing the input, and ``PodConfig` sending a gratuitous update when the sources change.
