### PR TITLE
[mesos] Speed-up mesos-docker container build by only including the km binary

### DIFF
--- a/cluster/mesos/docker/km/build.sh
+++ b/cluster/mesos/docker/km/build.sh
@@ -67,7 +67,7 @@ echo "Copying files to workspace"
 mkdir -p "${workspace}/bin"
 #cp "${script_dir}/bin/"* "${workspace}/bin/"
 cp "${common_bin_path}/"* "${workspace}/bin/"
-cp "${kube_bin_path}/"* "${workspace}/bin/"
+cp "${kube_bin_path}/km" "${workspace}/bin/"
 
 # config
 mkdir -p "${workspace}/opt"


### PR DESCRIPTION
Only km is needed in the mesos-docker km container, no need for all other k8s binaries. This reduces the size of the docker build context (from >600MB to around 50MB) and also the km container itself a lot.
