### PR TITLE
MESOS: Remove endpoints of terminating tasks

### DIFF
--- a/contrib/mesos/pkg/service/endpoints_controller.go
+++ b/contrib/mesos/pkg/service/endpoints_controller.go
@@ -308,6 +308,11 @@ func (e *endpointController) syncService(key string) {
 				glog.V(4).Infof("Failed to find a host IP for pod %s/%s", pod.Namespace, pod.Name)
 				continue
 			}
+			if pod.DeletionTimestamp != nil {
+				glog.V(5).Infof("Pod is being deleted %s/%s", pod.Namespace, pod.Name)
+				continue
+			}
+
 			if !api.IsPodReady(pod) {
 				glog.V(5).Infof("Pod is out of service: %v/%v", pod.Namespace, pod.Name)
 				continue


### PR DESCRIPTION
This change was added to the upstream endpoint controller in 2aaf8bddc253737fefb77e4d0306872c553ddbde.

This fixes https://github.com/mesosphere/kubernetes-mesos/issues/490.
