### PR TITLE
file and http source allow custom applyDefaults funcs

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -725,13 +725,13 @@ func makePodSourceConfig(kc *KubeletConfig) *config.PodConfig {
 	// define file config source
 	if kc.ConfigFile != "" {
 		glog.Infof("Adding manifest file: %v", kc.ConfigFile)
-		config.NewSourceFile(kc.ConfigFile, kc.NodeName, kc.FileCheckFrequency, cfg.Channel(kubelet.FileSource))
+		config.NewSourceFile(kc.ConfigFile, kc.NodeName, kc.FileCheckFrequency, cfg.Channel(kubelet.FileSource), nil)
 	}
 
 	// define url config source
 	if kc.ManifestURL != "" {
 		glog.Infof("Adding manifest url %q with HTTP header %v", kc.ManifestURL, kc.ManifestURLHeader)
-		config.NewSourceURL(kc.ManifestURL, kc.ManifestURLHeader, kc.NodeName, kc.HTTPCheckFrequency, cfg.Channel(kubelet.HTTPSource))
+		config.NewSourceURL(kc.ManifestURL, kc.ManifestURLHeader, kc.NodeName, kc.HTTPCheckFrequency, cfg.Channel(kubelet.HTTPSource), nil)
 	}
 	if kc.KubeClient != nil {
 		glog.Infof("Watching apiserver")

--- a/contrib/mesos/pkg/executor/executor_test.go
+++ b/contrib/mesos/pkg/executor/executor_test.go
@@ -505,7 +505,7 @@ func TestExecutorStaticPods(t *testing.T) {
 	executor := New(config)
 	hostname := "h1"
 	go executor.InitializeStaticPodsSource(func() {
-		kconfig.NewSourceFile(staticPodsConfigPath, hostname, 1*time.Second, updates)
+		kconfig.NewSourceFile(staticPodsConfigPath, hostname, 1*time.Second, updates, nil)
 	})
 
 	// create ExecutorInfo with static pod zip in data field

--- a/contrib/mesos/pkg/executor/service/service.go
+++ b/contrib/mesos/pkg/executor/service/service.go
@@ -370,7 +370,7 @@ func (ks *KubeletExecutorServer) createAndInitKubelet(
 		// Create file source only when we are called back. Otherwise, it is never marked unseen.
 		fileSourceUpdates := pc.Channel(kubelet.FileSource)
 
-		kconfig.NewSourceFile(staticPodsConfigPath, kc.Hostname, kc.FileCheckFrequency, fileSourceUpdates)
+		kconfig.NewSourceFile(staticPodsConfigPath, kc.Hostname, kc.FileCheckFrequency, fileSourceUpdates, nil)
 	})
 
 	k := &kubeletExecutor{

--- a/pkg/kubelet/config/common.go
+++ b/pkg/kubelet/config/common.go
@@ -38,7 +38,7 @@ func generatePodName(name, nodeName string) string {
 	return fmt.Sprintf("%s-%s", name, nodeName)
 }
 
-func applyDefaults(pod *api.Pod, source string, isFile bool, nodeName string) error {
+func ApplyDefaults(pod *api.Pod, source string, isFile bool, nodeName string) error {
 	if len(pod.UID) == 0 {
 		hasher := md5.New()
 		if isFile {

--- a/pkg/kubelet/config/file_test.go
+++ b/pkg/kubelet/config/file_test.go
@@ -32,7 +32,8 @@ import (
 
 func TestExtractFromNonExistentFile(t *testing.T) {
 	ch := make(chan interface{}, 1)
-	c := sourceFile{"/some/fake/file", "localhost", ch}
+	c := sourceFile{path: "/some/fake/file", nodeName: "localhost", updates: ch}
+	c.applyDefaults = c.defaultApplyDefaults
 	err := c.extractFromPath()
 	if err == nil {
 		t.Errorf("Expected error")
@@ -41,7 +42,7 @@ func TestExtractFromNonExistentFile(t *testing.T) {
 
 func TestUpdateOnNonExistentFile(t *testing.T) {
 	ch := make(chan interface{})
-	NewSourceFile("random_non_existent_path", "localhost", time.Millisecond, ch)
+	NewSourceFile("random_non_existent_path", "localhost", time.Millisecond, ch, nil)
 	select {
 	case got := <-ch:
 		update := got.(kubelet.PodUpdate)
@@ -130,7 +131,7 @@ func TestReadPodsFromFile(t *testing.T) {
 			defer os.Remove(file.Name())
 
 			ch := make(chan interface{})
-			NewSourceFile(file.Name(), hostname, time.Millisecond, ch)
+			NewSourceFile(file.Name(), hostname, time.Millisecond, ch, nil)
 			select {
 			case got := <-ch:
 				update := got.(kubelet.PodUpdate)
@@ -154,7 +155,8 @@ func TestExtractFromBadDataFile(t *testing.T) {
 	defer os.Remove(file.Name())
 
 	ch := make(chan interface{}, 1)
-	c := sourceFile{file.Name(), "localhost", ch}
+	c := sourceFile{path: file.Name(), nodeName: "localhost", updates: ch}
+	c.applyDefaults = c.defaultApplyDefaults
 	err := c.extractFromPath()
 	if err == nil {
 		t.Fatalf("Expected error")
@@ -170,7 +172,8 @@ func TestExtractFromEmptyDir(t *testing.T) {
 	defer os.RemoveAll(dirName)
 
 	ch := make(chan interface{}, 1)
-	c := sourceFile{dirName, "localhost", ch}
+	c := sourceFile{path: dirName, nodeName: "localhost", updates: ch}
+	c.applyDefaults = c.defaultApplyDefaults
 	err = c.extractFromPath()
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)

--- a/pkg/kubelet/config/http_test.go
+++ b/pkg/kubelet/config/http_test.go
@@ -34,7 +34,7 @@ import (
 
 func TestURLErrorNotExistNoUpdate(t *testing.T) {
 	ch := make(chan interface{})
-	NewSourceURL("http://localhost:49575/_not_found_", http.Header{}, "localhost", time.Millisecond, ch)
+	NewSourceURL("http://localhost:49575/_not_found_", http.Header{}, "localhost", time.Millisecond, ch, nil)
 	select {
 	case got := <-ch:
 		t.Errorf("Expected no update, Got %#v", got)
@@ -44,7 +44,8 @@ func TestURLErrorNotExistNoUpdate(t *testing.T) {
 
 func TestExtractFromHttpBadness(t *testing.T) {
 	ch := make(chan interface{}, 1)
-	c := sourceURL{"http://localhost:49575/_not_found_", http.Header{}, "other", ch, nil, 0}
+	c := sourceURL{url: "http://localhost:49575/_not_found_", header: http.Header{}, nodeName: "other", updates: ch}
+	c.applyDefaults = c.defaultApplyDefaults
 	if err := c.extractFromURL(); err == nil {
 		t.Errorf("Expected error")
 	}
@@ -113,7 +114,8 @@ func TestExtractInvalidPods(t *testing.T) {
 		testServer := httptest.NewServer(&fakeHandler)
 		defer testServer.Close()
 		ch := make(chan interface{}, 1)
-		c := sourceURL{testServer.URL, http.Header{}, "localhost", ch, nil, 0}
+		c := sourceURL{url: testServer.URL, header: http.Header{}, nodeName: "localhost", updates: ch}
+		c.applyDefaults = c.defaultApplyDefaults
 		if err := c.extractFromURL(); err == nil {
 			t.Errorf("%s: Expected error", testCase.desc)
 		}
@@ -267,7 +269,8 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 		testServer := httptest.NewServer(&fakeHandler)
 		defer testServer.Close()
 		ch := make(chan interface{}, 1)
-		c := sourceURL{testServer.URL, http.Header{}, hostname, ch, nil, 0}
+		c := sourceURL{url: testServer.URL, header: http.Header{}, nodeName: hostname, updates: ch}
+		c.applyDefaults = c.defaultApplyDefaults
 		if err := c.extractFromURL(); err != nil {
 			t.Errorf("%s: Unexpected error: %v", testCase.desc, err)
 			continue
@@ -314,7 +317,8 @@ func TestURLWithHeader(t *testing.T) {
 	ch := make(chan interface{}, 1)
 	header := make(http.Header)
 	header.Set("Metadata-Flavor", "Google")
-	c := sourceURL{testServer.URL, header, "localhost", ch, nil, 0}
+	c := sourceURL{url: testServer.URL, header: header, nodeName: "localhost", updates: ch}
+	c.applyDefaults = c.defaultApplyDefaults
 	if err := c.extractFromURL(); err != nil {
 		t.Fatalf("Unexpected error extracting from URL: %v", err)
 	}


### PR DESCRIPTION
this patch allows callers to customize the api.Pod objects generated by the file and http sources via an optional `applyDefaults` func. If no such func is specified, the default `applyDefaults` func is used.

`ApplyDefaults` was also exposed so that callers could leverage it when defining custom funcs.

This is useful in cases where custom kubelet integrations need to apply annotations to static pods, for example in the mesos integration.
