### PR TITLE
fix broken local var assignment in hack/test-go.sh

### DIFF
--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -136,7 +136,7 @@ junitFilenamePrefix() {
     return
   fi
   mkdir -p "${KUBE_JUNIT_REPORT_DIR}"
-  local KUBE_TEST_API_NO_SLASH=echo "${KUBE_TEST_API//\//-}"
+  local KUBE_TEST_API_NO_SLASH="${KUBE_TEST_API//\//-}"
   echo "${KUBE_JUNIT_REPORT_DIR}/junit_${KUBE_TEST_API_NO_SLASH}_$(kube::util::sortable_date)"
 }
 


### PR DESCRIPTION
Extraneous `echo` causing input to be misinterpreted as a variable name. Fixes issue reported [here ](https://github.com/kubernetes/kubernetes/pull/13833#issuecomment-140210151)
