### PR TITLE
Simplify grafana config

### DIFF
--- a/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
@@ -41,10 +41,8 @@ spec:
               cpu: 100m
               memory: 100Mi
           env: 
-            - name: INFLUXDB_EXTERNAL_URL
-              value: /api/v1/proxy/namespaces/kube-system/services/monitoring-influxdb:api/db/
             - name: INFLUXDB_HOST
-              value: monitoring-influxdb
+              value: localhost
             - name: INFLUXDB_PORT
               value: "8086"
       volumes:


### PR DESCRIPTION
In the influxdb-grafana RC, the pod executes both services. Configure grafana to talk to influxdb on localhost rather than go through the api proxy redirection.
