### PR TITLE
Move REST Path  /experimental to /apis/experimental/..

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -164,7 +164,7 @@ func startComponents(firstManifestURL, secondManifestURL string) (string, string
 		EnableLogsSupport:     false,
 		EnableProfiling:       true,
 		APIPrefix:             "/api",
-		ExpAPIPrefix:          "/experimental",
+		APIGroupPrefix:        "/apis",
 		Authorizer:            apiserver.NewAlwaysAllowAuthorizer(),
 		AdmissionControl:      admit.NewAlwaysAdmit(),
 		ReadWritePort:         portNumber,

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -71,7 +71,7 @@ type APIServer struct {
 	TLSPrivateKeyFile          string
 	CertDirectory              string
 	APIPrefix                  string
-	ExpAPIPrefix               string
+	APIGroupPrefix             string
 	StorageVersion             string
 	ExpStorageVersion          string
 	CloudProvider              string
@@ -121,7 +121,7 @@ func NewAPIServer() *APIServer {
 		BindAddress:            net.ParseIP("0.0.0.0"),
 		SecurePort:             6443,
 		APIPrefix:              "/api",
-		ExpAPIPrefix:           "/experimental",
+		APIGroupPrefix:         "/apis",
 		EventTTL:               1 * time.Hour,
 		AuthorizationMode:      "AlwaysAllow",
 		AdmissionControl:       "AlwaysAdmit",
@@ -180,7 +180,7 @@ func (s *APIServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.CertDirectory, "cert-dir", s.CertDirectory, "The directory where the TLS certs are located (by default /var/run/kubernetes). "+
 		"If --tls-cert-file and --tls-private-key-file are provided, this flag will be ignored.")
 	fs.StringVar(&s.APIPrefix, "api-prefix", s.APIPrefix, "The prefix for API requests on the server. Default '/api'.")
-	fs.StringVar(&s.ExpAPIPrefix, "experimental-prefix", s.ExpAPIPrefix, "The prefix for experimental API requests on the server. Default '/experimental'.")
+	fs.MarkDeprecated("api-prefix", "--api-prefix is deprecated and will be removed when the v1 API is retired")
 	fs.StringVar(&s.StorageVersion, "storage-version", s.StorageVersion, "The version to store resources with. Defaults to server preferred")
 	fs.StringVar(&s.CloudProvider, "cloud-provider", s.CloudProvider, "The provider for cloud services.  Empty string for no provider.")
 	fs.StringVar(&s.CloudConfigFile, "cloud-config", s.CloudConfigFile, "The path to the cloud provider configuration file.  Empty string for no configuration file.")
@@ -437,7 +437,7 @@ func (s *APIServer) Run(_ []string) error {
 		EnableWatchCache:       s.EnableWatchCache,
 		EnableIndex:            true,
 		APIPrefix:              s.APIPrefix,
-		ExpAPIPrefix:           s.ExpAPIPrefix,
+		APIGroupPrefix:         s.APIGroupPrefix,
 		CorsAllowedOriginList:  s.CorsAllowedOriginList,
 		ReadWritePort:          s.SecurePort,
 		PublicAddress:          s.AdvertiseAddress,

--- a/pkg/api/testapi/testapi.go
+++ b/pkg/api/testapi/testapi.go
@@ -162,9 +162,9 @@ func (g TestGroup) SelfLink(resource, name string) string {
 		// TODO: will need a /apis prefix once we have proper multi-group
 		// support
 		if name == "" {
-			return fmt.Sprintf("/%s/%s/%s", g.Group, g.Version(), resource)
+			return fmt.Sprintf("/apis/%s/%s/%s", g.Group, g.Version(), resource)
 		}
-		return fmt.Sprintf("/%s/%s/%s/%s", g.Group, g.Version(), resource, name)
+		return fmt.Sprintf("/apis/%s/%s/%s/%s", g.Group, g.Version(), resource, name)
 	}
 }
 
@@ -178,7 +178,7 @@ func (g TestGroup) ResourcePathWithPrefix(prefix, resource, namespace, name stri
 	} else {
 		// TODO: switch back once we have proper multiple group support
 		// path = "/apis/" + g.Group + "/" + Version(group...)
-		path = "/" + g.Group + "/" + g.Version()
+		path = "/apis/" + g.Group + "/" + g.Version()
 	}
 
 	if prefix != "" {

--- a/pkg/client/unversioned/experimental.go
+++ b/pkg/client/unversioned/experimental.go
@@ -124,7 +124,7 @@ func setExperimentalDefaults(config *Config) error {
 	if err != nil {
 		return err
 	}
-	config.Prefix = "/experimental"
+	config.Prefix = "apis/" + g.Group
 	if config.UserAgent == "" {
 		config.UserAgent = DefaultKubernetesUserAgent()
 	}

--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -89,16 +89,16 @@ func makeTestServer(t *testing.T, responses map[string]*serverResponse) (*httpte
 	}
 
 	if responses[hpaListHandler] != nil {
-		handlers[hpaListHandler] = mkHandler("/experimental/v1/horizontalpodautoscalers", *responses[hpaListHandler])
+		handlers[hpaListHandler] = mkHandler("/apis/experimental/v1/horizontalpodautoscalers", *responses[hpaListHandler])
 	}
 
 	if responses[scaleHandler] != nil {
 		handlers[scaleHandler] = mkHandler(
-			fmt.Sprintf("/experimental/v1/namespaces/%s/replicationcontrollers/%s/scale", namespace, rcName), *responses[scaleHandler])
+			fmt.Sprintf("/apis/experimental/v1/namespaces/%s/replicationcontrollers/%s/scale", namespace, rcName), *responses[scaleHandler])
 	}
 
 	if responses[updateHpaHandler] != nil {
-		handlers[updateHpaHandler] = mkHandler(fmt.Sprintf("/experimental/v1/namespaces/%s/horizontalpodautoscalers/%s", namespace, hpaName),
+		handlers[updateHpaHandler] = mkHandler(fmt.Sprintf("/apis/experimental/v1/namespaces/%s/horizontalpodautoscalers/%s", namespace, hpaName),
 			*responses[updateHpaHandler])
 	}
 
@@ -121,7 +121,7 @@ func TestSyncEndpointsItemsPreserveNoSelector(t *testing.T) {
 				ObjectMeta: api.ObjectMeta{
 					Name:      hpaName,
 					Namespace: namespace,
-					SelfLink:  "experimental/v1/namespaces/" + namespace + "/horizontalpodautoscalers/" + hpaName,
+					SelfLink:  "/apis/experimental/v1/namespaces/" + namespace + "/horizontalpodautoscalers/" + hpaName,
 				},
 				Spec: experimental.HorizontalPodAutoscalerSpec{
 					ScaleRef: &experimental.SubresourceReference{

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -30,6 +30,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/registered"
 	"k8s.io/kubernetes/pkg/api/validation"
@@ -353,7 +354,11 @@ func (c *clientSwaggerSchema) ValidateBytes(data []byte) error {
 	//       instead of trying everything.
 	err = getSchemaAndValidate(c.c.RESTClient, data, "api", version, c.cacheDir)
 	if err != nil && c.ec != nil {
-		errExp := getSchemaAndValidate(c.ec.RESTClient, data, "experimental", version, c.cacheDir)
+		g, err := latest.Group("experimental")
+		if err != nil {
+			return err
+		}
+		errExp := getSchemaAndValidate(c.ec.RESTClient, data, "apis"+"/"+g.Group, version, c.cacheDir)
 		if errExp == nil {
 			return nil
 		}

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -117,7 +117,7 @@ type Config struct {
 	EnableProfiling       bool
 	EnableWatchCache      bool
 	APIPrefix             string
-	ExpAPIPrefix          string
+	APIGroupPrefix        string
 	CorsAllowedOriginList []string
 	Authenticator         authenticator.Request
 	// TODO(roberthbailey): Remove once the server no longer supports http basic auth.
@@ -195,7 +195,7 @@ type Master struct {
 	enableProfiling       bool
 	enableWatchCache      bool
 	apiPrefix             string
-	expAPIPrefix          string
+	apiGroupPrefix        string
 	corsAllowedOriginList []string
 	authenticator         authenticator.Request
 	authorizer            authorizer.Authorizer
@@ -354,7 +354,7 @@ func New(c *Config) *Master {
 		enableProfiling:       c.EnableProfiling,
 		enableWatchCache:      c.EnableWatchCache,
 		apiPrefix:             c.APIPrefix,
-		expAPIPrefix:          c.ExpAPIPrefix,
+		apiGroupPrefix:        c.APIGroupPrefix,
 		corsAllowedOriginList: c.CorsAllowedOriginList,
 		authenticator:         c.Authenticator,
 		authorizer:            c.Authorizer,
@@ -575,7 +575,7 @@ func (m *Master) init(c *Config) {
 		if err := expVersion.InstallREST(m.handlerContainer); err != nil {
 			glog.Fatalf("Unable to setup experimental api: %v", err)
 		}
-		apiserver.AddApiWebService(m.handlerContainer, c.ExpAPIPrefix, []string{expVersion.Version})
+		apiserver.AddApiWebService(m.handlerContainer, c.APIGroupPrefix+"/"+latest.GroupOrDie("experimental").Group+"/", []string{expVersion.Version})
 		expRequestInfoResolver := &apiserver.APIRequestInfoResolver{APIPrefixes: sets.NewString(strings.TrimPrefix(expVersion.Root, "/")), RestMapper: expVersion.Mapper}
 		apiserver.InstallServiceErrorHandler(m.handlerContainer, expRequestInfoResolver, []string{expVersion.Version})
 	}
@@ -840,7 +840,7 @@ func (m *Master) experimental(c *Config) *apiserver.APIGroupVersion {
 	}
 
 	return &apiserver.APIGroupVersion{
-		Root: m.expAPIPrefix,
+		Root: m.apiGroupPrefix + "/" + latest.GroupOrDie("experimental").Group,
 
 		Creater:   api.Scheme,
 		Convertor: api.Scheme,

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -81,7 +81,7 @@ func TestNew(t *testing.T) {
 	assert.Equal(master.enableSwaggerSupport, config.EnableSwaggerSupport)
 	assert.Equal(master.enableProfiling, config.EnableProfiling)
 	assert.Equal(master.apiPrefix, config.APIPrefix)
-	assert.Equal(master.expAPIPrefix, config.ExpAPIPrefix)
+	assert.Equal(master.apiGroupPrefix, config.APIGroupPrefix)
 	assert.Equal(master.corsAllowedOriginList, config.CorsAllowedOriginList)
 	assert.Equal(master.authenticator, config.Authenticator)
 	assert.Equal(master.authorizer, config.Authorizer)
@@ -281,7 +281,7 @@ func TestExpapi(t *testing.T) {
 	master, config, assert := setUp(t)
 
 	expAPIGroup := master.experimental(&config)
-	assert.Equal(expAPIGroup.Root, master.expAPIPrefix)
+	assert.Equal(expAPIGroup.Root, master.apiGroupPrefix+"/"+latest.GroupOrDie("experimental").Group)
 	assert.Equal(expAPIGroup.Mapper, latest.GroupOrDie("experimental").RESTMapper)
 	assert.Equal(expAPIGroup.Codec, latest.GroupOrDie("experimental").Codec)
 	assert.Equal(expAPIGroup.Linker, latest.GroupOrDie("experimental").SelfLinker)

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -147,7 +147,7 @@ func startMasterOrDie(masterConfig *master.Config) (*master.Master, *httptest.Se
 			EnableProfiling:    true,
 			EnableUISupport:    false,
 			APIPrefix:          "/api",
-			ExpAPIPrefix:       "/experimental",
+			APIGroupPrefix:     "/apis",
 			Authorizer:         apiserver.NewAlwaysAllowAuthorizer(),
 			AdmissionControl:   admit.NewAlwaysAdmit(),
 		}
@@ -285,7 +285,7 @@ func RunAMaster(t *testing.T) (*master.Master, *httptest.Server) {
 		EnableProfiling:    true,
 		EnableUISupport:    false,
 		APIPrefix:          "/api",
-		ExpAPIPrefix:       "/experimental",
+		APIGroupPrefix:     "/apis",
 		EnableExp:          true,
 		Authorizer:         apiserver.NewAlwaysAllowAuthorizer(),
 		AdmissionControl:   admit.NewAlwaysAdmit(),

--- a/test/integration/master_test.go
+++ b/test/integration/master_test.go
@@ -29,7 +29,7 @@ func TestExperimentalPrefix(t *testing.T) {
 	_, s := framework.RunAMaster(t)
 	defer s.Close()
 
-	resp, err := http.Get(s.URL + "/experimental/")
+	resp, err := http.Get(s.URL + "/apis/experimental/")
 	if err != nil {
 		t.Fatalf("unexpected error getting experimental prefix: %v", err)
 	}


### PR DESCRIPTION
register experimental apis as /apis/experimental/..
mark --api-version as deprecated

@lavalamp 
