### PR TITLE
let apiserver support api discovery

### DIFF
--- a/api/swagger-spec/resourceListing.json
+++ b/api/swagger-spec/resourceListing.json
@@ -10,6 +10,10 @@
     "description": "get available API versions"
    },
    {
+    "path": "/apis",
+    "description": "get available API versions"
+   },
+   {
     "path": "/version",
     "description": "git code version from which this is built"
    }

--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -10950,6 +10950,25 @@
       ]
      }
     ]
+   },
+   {
+    "path": "/api/v1",
+    "description": "API at /api/v1 version v1",
+    "operations": [
+     {
+      "type": "void",
+      "method": "GET",
+      "summary": "get available resources",
+      "nickname": "getAPIResources",
+      "parameters": [],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "application/json"
+      ]
+     }
+    ]
    }
   ],
   "models": {

--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -132,11 +132,14 @@ func startComponents(firstManifestURL, secondManifestURL string) (string, string
 	// We will fix this by supporting multiple group versions in Config
 	cl.ExperimentalClient = client.NewExperimentalOrDie(&client.Config{Host: apiServer.URL, Version: testapi.Experimental.Version()})
 
+	storageVersions := make(map[string]string)
 	etcdStorage, err := master.NewEtcdStorage(etcdClient, latest.GroupOrDie("").InterfacesFor, testapi.Default.Version(), etcdtest.PathPrefix())
+	storageVersions[""] = testapi.Default.Version()
 	if err != nil {
 		glog.Fatalf("Unable to get etcd storage: %v", err)
 	}
 	expEtcdStorage, err := master.NewEtcdStorage(etcdClient, latest.GroupOrDie("experimental").InterfacesFor, testapi.Experimental.Version(), etcdtest.PathPrefix())
+	storageVersions["experimental"] = testapi.Experimental.Version()
 	if err != nil {
 		glog.Fatalf("Unable to get etcd storage for experimental: %v", err)
 	}
@@ -171,6 +174,7 @@ func startComponents(firstManifestURL, secondManifestURL string) (string, string
 		ReadWritePort:         portNumber,
 		PublicAddress:         publicAddress,
 		CacheTimeout:          2 * time.Second,
+		StorageVersions:       storageVersions,
 	})
 	handler.delegate = m.Handler
 

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -21,6 +21,7 @@ package app
 
 import (
 	"crypto/tls"
+	"fmt"
 	"net"
 	"net/http"
 	"os"
@@ -245,7 +246,10 @@ func (s *APIServer) verifyClusterIPFlags() {
 	}
 }
 
-func newEtcd(etcdConfigFile string, etcdServerList []string, interfacesFunc meta.VersionInterfacesFunc, defaultVersion, storageVersion, pathPrefix string) (etcdStorage storage.Interface, err error) {
+func newEtcd(etcdConfigFile string, etcdServerList []string, interfacesFunc meta.VersionInterfacesFunc, storageVersion, pathPrefix string) (etcdStorage storage.Interface, err error) {
+	if storageVersion == "" {
+		return etcdStorage, fmt.Errorf("storageVersion is required to create a etcd storage")
+	}
 	var client tools.EtcdClient
 	if etcdConfigFile != "" {
 		client, err = etcd.NewClientFromFile(etcdConfigFile)
@@ -264,11 +268,8 @@ func newEtcd(etcdConfigFile string, etcdServerList []string, interfacesFunc meta
 		etcdClient.SetTransport(transport)
 		client = etcdClient
 	}
-
-	if storageVersion == "" {
-		storageVersion = defaultVersion
-	}
-	return master.NewEtcdStorage(client, interfacesFunc, storageVersion, pathPrefix)
+	etcdStorage, err = master.NewEtcdStorage(client, interfacesFunc, storageVersion, pathPrefix)
+	return etcdStorage, err
 }
 
 // Run runs the specified APIServer.  This should never exit.
@@ -340,7 +341,16 @@ func (s *APIServer) Run(_ []string) error {
 		glog.Fatalf("Invalid server address: %v", err)
 	}
 
-	etcdStorage, err := newEtcd(s.EtcdConfigFile, s.EtcdServerList, latest.GroupOrDie("").InterfacesFor, latest.GroupOrDie("").Version, s.StorageVersion, s.EtcdPathPrefix)
+	g, err := latest.Group("")
+	if err != nil {
+		return err
+	}
+	storageVersions := make(map[string]string)
+	if s.StorageVersion == "" {
+		s.StorageVersion = g.Version
+	}
+	etcdStorage, err := newEtcd(s.EtcdConfigFile, s.EtcdServerList, g.InterfacesFor, s.StorageVersion, s.EtcdPathPrefix)
+	storageVersions[""] = s.StorageVersion
 	if err != nil {
 		glog.Fatalf("Invalid storage version or misconfigured etcd: %v", err)
 	}
@@ -351,10 +361,14 @@ func (s *APIServer) Run(_ []string) error {
 		if err != nil {
 			glog.Fatalf("experimental API is enabled in runtime config, but not enabled in the environment variable KUBE_API_VERSIONS. Error: %v", err)
 		}
-		expEtcdStorage, err = newEtcd(s.EtcdConfigFile, s.EtcdServerList, g.InterfacesFor, g.Version, s.ExpStorageVersion, s.EtcdPathPrefix)
+		if s.ExpStorageVersion == "" {
+			s.ExpStorageVersion = g.Version
+		}
+		expEtcdStorage, err = newEtcd(s.EtcdConfigFile, s.EtcdServerList, g.InterfacesFor, s.ExpStorageVersion, s.EtcdPathPrefix)
 		if err != nil {
 			glog.Fatalf("Invalid experimental storage version or misconfigured etcd: %v", err)
 		}
+		storageVersions["experimental"] = s.StorageVersion
 	}
 
 	n := s.ServiceClusterIPRange
@@ -426,6 +440,7 @@ func (s *APIServer) Run(_ []string) error {
 	config := &master.Config{
 		DatabaseStorage:    etcdStorage,
 		ExpDatabaseStorage: expEtcdStorage,
+		StorageVersions:    storageVersions,
 
 		EventTTL:               s.EventTTL,
 		KubeletClient:          kubeletClient,

--- a/pkg/api/unversioned.go
+++ b/pkg/api/unversioned.go
@@ -22,16 +22,64 @@ import (
 
 // This file contains API types that are unversioned.
 
-// APIVersions lists the api versions that are available, to allow
-// version negotiation. APIVersions isn't just an unnamed array of
-// strings in order to allow for future evolution, though unversioned
+// APIVersions lists the versions that are available, to allow clients to
+// discover the API at /api, which is the root path of the legacy v1 API.
 type APIVersions struct {
+	// versions are the api versions that are available.
 	Versions []string `json:"versions"`
 }
 
+// APIGroupList is a list of APIGroup, to allow clients to discover the API at
+// /apis.
+type APIGroupList struct {
+	// groups is a list of APIGroup.
+	Groups []APIGroup `json:"groups"`
+}
+
+// APIGroup contains the name, the supported versions, and the preferred version
+// of a group.
+type APIGroup struct {
+	// name is the name of the group.
+	Name string `json:"name"`
+	// versions are the versions supported in this group.
+	Versions []GroupVersion `json:"versions"`
+	// preferredVersion is the version preferred by the API server, which
+	// probably is the storage version.
+	PreferredVersion GroupVersion `json:"preferredVersion,omitempty"`
+}
+
+// GroupVersion contains the "group/version" and "version" string of a version.
+// It is made a struct to keep extensiblity.
+type GroupVersion struct {
+	// groupVersion specifies the API group and version in the form "group/version"
+	GroupVersion string `json:"groupVersion"`
+	// version specifies the version in the form of "version". This is to save
+	// the clients the trouble of splitting the GroupVersion.
+	Version string `json:"version"`
+}
+
+// APIResource specifies the name of a resource and whether it is namespaced.
+type APIResource struct {
+	// name is the name of the resource.
+	Name string `json:"name"`
+	// namespaced indicates if a resource is namespaced or not.
+	Namespaced bool `json:"namespaced"`
+}
+
+// APIResourceList is a list of APIResource, it is used to expose the name of the
+// resources supported in a specific group and version, and if the resource
+// is namespaced.
+type APIResourceList struct {
+	// groupVersion is the group and version this APIResourceList is for.
+	GroupVersion string `json:"groupVersion"`
+	// resources contains the name of the resources and if they are namespaced.
+	APIResources []APIResource `json:"resources"`
+}
+
 // RootPaths lists the paths available at root.
-// For example: "/healthz", "/api".
+// For example: "/healthz", "/apis".
 type RootPaths struct {
+	// paths are the paths available at root.
 	Paths []string `json:"paths"`
 }
 

--- a/pkg/apis/experimental/types.go
+++ b/pkg/apis/experimental/types.go
@@ -168,6 +168,7 @@ type ThirdPartyResourceList struct {
 }
 
 // An APIVersion represents a single concrete version of an object model.
+// TODO: we should consider merge this struct with GroupVersion in unversioned.go
 type APIVersion struct {
 	// Name of this version (e.g. 'v1').
 	Name string `json:"name,omitempty"`

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -59,9 +59,12 @@ func setUp(t *testing.T) (Master, Config, *assert.Assertions) {
 	config := Config{}
 	fakeClient := tools.NewFakeEtcdClient(t)
 	fakeClient.Machines = []string{"http://machine1:4001", "http://machine2", "http://machine3:4003"}
+	storageVersions := make(map[string]string)
 	config.DatabaseStorage = etcdstorage.NewEtcdStorage(fakeClient, testapi.Default.Codec(), etcdtest.PathPrefix())
+	storageVersions[""] = testapi.Default.Version()
 	config.ExpDatabaseStorage = etcdstorage.NewEtcdStorage(fakeClient, testapi.Experimental.Codec(), etcdtest.PathPrefix())
-
+	storageVersions["experimental"] = testapi.Experimental.Version()
+	config.StorageVersions = storageVersions
 	master.nodeRegistry = registrytest.NewNodeRegistry([]string{"node1", "node2"}, api.NodeResources{})
 
 	return master, config, assert.New(t)

--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -406,6 +406,7 @@ func TestAuthModeAlwaysAllow(t *testing.T) {
 		APIPrefix:             "/api",
 		Authorizer:            apiserver.NewAlwaysAllowAuthorizer(),
 		AdmissionControl:      admit.NewAlwaysAdmit(),
+		StorageVersions:       map[string]string{"": testapi.Default.Version()},
 	})
 
 	transport := http.DefaultTransport
@@ -522,6 +523,7 @@ func TestAuthModeAlwaysDeny(t *testing.T) {
 		APIPrefix:             "/api",
 		Authorizer:            apiserver.NewAlwaysDenyAuthorizer(),
 		AdmissionControl:      admit.NewAlwaysAdmit(),
+		StorageVersions:       map[string]string{"": testapi.Default.Version()},
 	})
 
 	transport := http.DefaultTransport
@@ -590,6 +592,7 @@ func TestAliceNotForbiddenOrUnauthorized(t *testing.T) {
 		Authenticator:         getTestTokenAuth(),
 		Authorizer:            allowAliceAuthorizer{},
 		AdmissionControl:      admit.NewAlwaysAdmit(),
+		StorageVersions:       map[string]string{"": testapi.Default.Version()},
 	})
 
 	previousResourceVersion := make(map[string]float64)
@@ -677,6 +680,7 @@ func TestBobIsForbidden(t *testing.T) {
 		Authenticator:         getTestTokenAuth(),
 		Authorizer:            allowAliceAuthorizer{},
 		AdmissionControl:      admit.NewAlwaysAdmit(),
+		StorageVersions:       map[string]string{"": testapi.Default.Version()},
 	})
 
 	transport := http.DefaultTransport
@@ -738,6 +742,7 @@ func TestUnknownUserIsUnauthorized(t *testing.T) {
 		Authenticator:         getTestTokenAuth(),
 		Authorizer:            allowAliceAuthorizer{},
 		AdmissionControl:      admit.NewAlwaysAdmit(),
+		StorageVersions:       map[string]string{"": testapi.Default.Version()},
 	})
 
 	transport := http.DefaultTransport
@@ -818,6 +823,7 @@ func TestNamespaceAuthorization(t *testing.T) {
 		Authenticator:         getTestTokenAuth(),
 		Authorizer:            a,
 		AdmissionControl:      admit.NewAlwaysAdmit(),
+		StorageVersions:       map[string]string{"": testapi.Default.Version()},
 	})
 
 	previousResourceVersion := make(map[string]float64)
@@ -933,6 +939,7 @@ func TestKindAuthorization(t *testing.T) {
 		Authenticator:         getTestTokenAuth(),
 		Authorizer:            a,
 		AdmissionControl:      admit.NewAlwaysAdmit(),
+		StorageVersions:       map[string]string{"": testapi.Default.Version()},
 	})
 
 	previousResourceVersion := make(map[string]float64)
@@ -1035,6 +1042,7 @@ func TestReadOnlyAuthorization(t *testing.T) {
 		Authenticator:         getTestTokenAuth(),
 		Authorizer:            a,
 		AdmissionControl:      admit.NewAlwaysAdmit(),
+		StorageVersions:       map[string]string{"": testapi.Default.Version()},
 	})
 
 	transport := http.DefaultTransport

--- a/test/integration/scheduler_test.go
+++ b/test/integration/scheduler_test.go
@@ -75,6 +75,7 @@ func TestUnschedulableNodes(t *testing.T) {
 		APIPrefix:             "/api",
 		Authorizer:            apiserver.NewAlwaysAllowAuthorizer(),
 		AdmissionControl:      admit.NewAlwaysAdmit(),
+		StorageVersions:       map[string]string{"": testapi.Default.Version()},
 	})
 
 	restClient := client.NewOrDie(&client.Config{Host: s.URL, Version: testapi.Default.Version()})

--- a/test/integration/secret_test.go
+++ b/test/integration/secret_test.go
@@ -68,6 +68,7 @@ func TestSecrets(t *testing.T) {
 		APIPrefix:             "/api",
 		Authorizer:            apiserver.NewAlwaysAllowAuthorizer(),
 		AdmissionControl:      admit.NewAlwaysAdmit(),
+		StorageVersions:       map[string]string{"": testapi.Default.Version()},
 	})
 
 	framework.DeleteAllEtcdKeys()

--- a/test/integration/service_account_test.go
+++ b/test/integration/service_account_test.go
@@ -420,6 +420,7 @@ func startServiceAccountTestServer(t *testing.T) (*client.Client, client.Config,
 		Authenticator:     authenticator,
 		Authorizer:        authorizer,
 		AdmissionControl:  serviceAccountAdmission,
+		StorageVersions:   map[string]string{"": testapi.Default.Version()},
 	})
 
 	// Start the service account and service account token controllers

--- a/test/integration/utils.go
+++ b/test/integration/utils.go
@@ -81,6 +81,7 @@ func runAMaster(t *testing.T) (*master.Master, *httptest.Server) {
 		APIPrefix:             "/api",
 		Authorizer:            apiserver.NewAlwaysAllowAuthorizer(),
 		AdmissionControl:      admit.NewAlwaysAdmit(),
+		StorageVersions:       map[string]string{"": testapi.Default.Version()},
 	})
 
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
The related proposal is here: https://github.com/kubernetes/kubernetes/blob/master/docs/proposals/api-group.md#server-side-implementation

at apis/ (or api/), all supported groups and their versions are returned, in the form of "group/version", encoded in api.APIVersions;
![image](https://cloud.githubusercontent.com/assets/2823529/9867593/545efd34-5b24-11e5-8c1c-c116b2a726d0.png)

at apis/group (currently it's "experimental/", #13945 will make it "apis/experiemental"), all supported versions are returned, in the form of "group/version", encoded in api.APIVersions;
![image](https://cloud.githubusercontent.com/assets/2823529/9867595/563f028e-5b24-11e5-92e8-67d73235f7ae.png)

at apis/group/version, names of supported resources and whether the resource is namespaced is returned, encoded in api.APIResourceList;
![image](https://cloud.githubusercontent.com/assets/2823529/9867711/b522d5fe-5b25-11e5-86ac-8b31c0bc90bd.png)

@bgrant0607 as I added types in unversioned.go
@lavalamp @nikhiljindal 
