### PR TITLE
Rename Deployment API structs

### DIFF
--- a/docs/proposals/deployment.md
+++ b/docs/proposals/deployment.md
@@ -69,7 +69,9 @@ type DeploymentSpec struct {
   Replicas *int
 
   // Label selector for pods. Existing ReplicationControllers whose pods are
-  // selected by this will be scaled down.
+  // selected by this will be scaled down. New ReplicationControllers will be
+  // created with this selector, with a unique label as defined by UniqueLabelKey.
+  // If Selector is empty, it is defaulted to the labels present on the Pod template.
   Selector map[string]string
 
   // Describes the pods that will be created.
@@ -90,27 +92,27 @@ type DeploymentSpec struct {
 
 type DeploymentStrategy struct {
   // Type of deployment. Can be "Recreate" or "RollingUpdate".
-  Type DeploymentType
+  Type DeploymentStrategyType
 
   // TODO: Update this to follow our convention for oneOf, whatever we decide it
   // to be.
-  // Rolling update config params. Present only if DeploymentType =
+  // Rolling update config params. Present only if DeploymentStrategyType =
   // RollingUpdate.
-  RollingUpdate *RollingUpdateDeploymentSpec
+  RollingUpdate *RollingUpdateDeploymentStrategy
 }
 
-type DeploymentType string
+type DeploymentStrategyType string
 
 const (
   // Kill all existing pods before creating new ones.
-  DeploymentRecreate DeploymentType = "Recreate"
+  RecreateDeploymentStrategyType DeploymentStrategyType = "Recreate"
 
   // Replace the old RCs by new one using rolling update i.e gradually scale down the old RCs and scale up the new one.
-  DeploymentRollingUpdate DeploymentType = "RollingUpdate"
+  RollingUpdateDeploymentStrategyType DeploymentStrategyType = "RollingUpdate"
 )
 
 // Spec to control the desired behavior of rolling update.
-type RollingUpdateDeploymentSpec struct {
+type RollingUpdateDeploymentStrategy struct {
   // The maximum number of pods that can be unavailable during the update.
   // Value can be an absolute number (ex: 5) or a percentage of total pods at the start of update (ex: 10%).
   // Absolute number is calculated from percentage by rounding up.
@@ -246,7 +248,7 @@ To begin with, we will support 2 types of deployment:
   This results in a slower deployment, but there is no downtime. At all times
   during the deployment, there are a few pods available (old or new). The number
   of available pods and when is a pod considered "available" can be configured
-  using RollingUpdateDeploymentSpec.
+  using RollingUpdateDeploymentStrategy.
 
 In future, we want to support more deployment types.
 
@@ -254,7 +256,7 @@ In future, we want to support more deployment types.
 
 Apart from the above, we want to add support for the following:
 * Running the deployment process in a pod: In future, we can run the deployment process in a pod. Then users can define their own custom deployments and we can run it using the image name.
-* More DeploymentTypes: https://github.com/openshift/origin/blob/master/examples/deployment/README.md#deployment-types lists most commonly used ones.
+* More DeploymentStrategyTypes: https://github.com/openshift/origin/blob/master/examples/deployment/README.md#deployment-types lists most commonly used ones.
 * Triggers: Deployment will have a trigger field to identify what triggered the deployment. Options are: Manual/UserTriggered, Autoscaler, NewImage.
 * Automatic rollback on error: We want to support automatic rollback on error or timeout.
 

--- a/pkg/api/testing/fuzzer.go
+++ b/pkg/api/testing/fuzzer.go
@@ -124,9 +124,9 @@ func FuzzerFor(t *testing.T, version string, src rand.Source) *fuzz.Fuzzer {
 		func(j *experimental.DeploymentStrategy, c fuzz.Continue) {
 			c.FuzzNoCustom(j) // fuzz self without calling this function again
 			// Ensure that strategyType is one of valid values.
-			strategyTypes := []experimental.DeploymentType{experimental.DeploymentRecreate, experimental.DeploymentRollingUpdate}
+			strategyTypes := []experimental.DeploymentStrategyType{experimental.RecreateDeploymentStrategyType, experimental.RollingUpdateDeploymentStrategyType}
 			j.Type = strategyTypes[c.Rand.Intn(len(strategyTypes))]
-			if j.Type != experimental.DeploymentRollingUpdate {
+			if j.Type != experimental.RollingUpdateDeploymentStrategyType {
 				j.RollingUpdate = nil
 			} else {
 				rollingUpdate := experimental.RollingUpdateDeployment{}

--- a/pkg/apis/experimental/types.go
+++ b/pkg/apis/experimental/types.go
@@ -224,9 +224,9 @@ type DeploymentSpec struct {
 
 type DeploymentStrategy struct {
 	// Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
-	Type DeploymentType `json:"type,omitempty"`
+	Type DeploymentStrategyType `json:"type,omitempty"`
 
-	// Rolling update config params. Present only if DeploymentType =
+	// Rolling update config params. Present only if DeploymentStrategyType =
 	// RollingUpdate.
 	//---
 	// TODO: Update this to follow our convention for oneOf, whatever we decide it
@@ -234,14 +234,14 @@ type DeploymentStrategy struct {
 	RollingUpdate *RollingUpdateDeployment `json:"rollingUpdate,omitempty"`
 }
 
-type DeploymentType string
+type DeploymentStrategyType string
 
 const (
 	// Kill all existing pods before creating new ones.
-	DeploymentRecreate DeploymentType = "Recreate"
+	RecreateDeploymentStrategyType DeploymentStrategyType = "Recreate"
 
 	// Replace the old RCs by new one using rolling update i.e gradually scale down the old RCs and scale up the new one.
-	DeploymentRollingUpdate DeploymentType = "RollingUpdate"
+	RollingUpdateDeploymentStrategyType DeploymentStrategyType = "RollingUpdate"
 )
 
 // Spec to control the desired behavior of rolling update.

--- a/pkg/apis/experimental/v1/conversion.go
+++ b/pkg/apis/experimental/v1/conversion.go
@@ -244,7 +244,7 @@ func convert_experimental_DeploymentStrategy_To_v1_DeploymentStrategy(in *experi
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*experimental.DeploymentStrategy))(in)
 	}
-	out.Type = DeploymentType(in.Type)
+	out.Type = DeploymentStrategyType(in.Type)
 	if in.RollingUpdate != nil {
 		out.RollingUpdate = new(RollingUpdateDeployment)
 		if err := convert_experimental_RollingUpdateDeployment_To_v1_RollingUpdateDeployment(in.RollingUpdate, out.RollingUpdate, s); err != nil {
@@ -260,7 +260,7 @@ func convert_v1_DeploymentStrategy_To_experimental_DeploymentStrategy(in *Deploy
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*DeploymentStrategy))(in)
 	}
-	out.Type = experimental.DeploymentType(in.Type)
+	out.Type = experimental.DeploymentStrategyType(in.Type)
 	if in.RollingUpdate != nil {
 		out.RollingUpdate = new(experimental.RollingUpdateDeployment)
 		if err := convert_v1_RollingUpdateDeployment_To_experimental_RollingUpdateDeployment(in.RollingUpdate, out.RollingUpdate, s); err != nil {

--- a/pkg/apis/experimental/v1/defaults.go
+++ b/pkg/apis/experimental/v1/defaults.go
@@ -50,11 +50,11 @@ func addDefaultingFuncs() {
 				*obj.Spec.Replicas = 1
 			}
 			strategy := &obj.Spec.Strategy
-			// Set default DeploymentType as RollingUpdate.
+			// Set default DeploymentStrategyType as RollingUpdate.
 			if strategy.Type == "" {
-				strategy.Type = DeploymentRollingUpdate
+				strategy.Type = RollingUpdateDeploymentStrategyType
 			}
-			if strategy.Type == DeploymentRollingUpdate {
+			if strategy.Type == RollingUpdateDeploymentStrategyType {
 				if strategy.RollingUpdate == nil {
 					rollingUpdate := RollingUpdateDeployment{}
 					strategy.RollingUpdate = &rollingUpdate

--- a/pkg/apis/experimental/v1/defaults_test.go
+++ b/pkg/apis/experimental/v1/defaults_test.go
@@ -98,7 +98,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 				Spec: DeploymentSpec{
 					Replicas: newInt(1),
 					Strategy: DeploymentStrategy{
-						Type: DeploymentRollingUpdate,
+						Type: RollingUpdateDeploymentStrategyType,
 						RollingUpdate: &RollingUpdateDeployment{
 							MaxSurge:       &defaultIntOrString,
 							MaxUnavailable: &defaultIntOrString,
@@ -123,7 +123,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 				Spec: DeploymentSpec{
 					Replicas: newInt(5),
 					Strategy: DeploymentStrategy{
-						Type: DeploymentRollingUpdate,
+						Type: RollingUpdateDeploymentStrategyType,
 						RollingUpdate: &RollingUpdateDeployment{
 							MaxSurge:       &differentIntOrString,
 							MaxUnavailable: &defaultIntOrString,
@@ -138,7 +138,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 				Spec: DeploymentSpec{
 					Replicas: newInt(5),
 					Strategy: DeploymentStrategy{
-						Type: DeploymentRecreate,
+						Type: RecreateDeploymentStrategyType,
 					},
 				},
 			},
@@ -146,7 +146,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 				Spec: DeploymentSpec{
 					Replicas: newInt(5),
 					Strategy: DeploymentStrategy{
-						Type: DeploymentRecreate,
+						Type: RecreateDeploymentStrategyType,
 					},
 					UniqueLabelKey: newString(deploymentLabelKey),
 				},
@@ -157,7 +157,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 				Spec: DeploymentSpec{
 					Replicas: newInt(5),
 					Strategy: DeploymentStrategy{
-						Type: DeploymentRecreate,
+						Type: RecreateDeploymentStrategyType,
 					},
 					UniqueLabelKey: newString("customDeploymentKey"),
 				},
@@ -166,7 +166,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 				Spec: DeploymentSpec{
 					Replicas: newInt(5),
 					Strategy: DeploymentStrategy{
-						Type: DeploymentRecreate,
+						Type: RecreateDeploymentStrategyType,
 					},
 					UniqueLabelKey: newString("customDeploymentKey"),
 				},

--- a/pkg/apis/experimental/v1/types.go
+++ b/pkg/apis/experimental/v1/types.go
@@ -220,9 +220,9 @@ type DeploymentSpec struct {
 // DeploymentStrategy describes how to replace existing pods with new ones.
 type DeploymentStrategy struct {
 	// Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
-	Type DeploymentType `json:"type,omitempty"`
+	Type DeploymentStrategyType `json:"type,omitempty"`
 
-	// Rolling update config params. Present only if DeploymentType =
+	// Rolling update config params. Present only if DeploymentStrategyType =
 	// RollingUpdate.
 	//---
 	// TODO: Update this to follow our convention for oneOf, whatever we decide it
@@ -230,14 +230,14 @@ type DeploymentStrategy struct {
 	RollingUpdate *RollingUpdateDeployment `json:"rollingUpdate,omitempty"`
 }
 
-type DeploymentType string
+type DeploymentStrategyType string
 
 const (
 	// Kill all existing pods before creating new ones.
-	DeploymentRecreate DeploymentType = "Recreate"
+	RecreateDeploymentStrategyType DeploymentStrategyType = "Recreate"
 
 	// Replace the old RCs by new one using rolling update i.e gradually scale down the old RCs and scale up the new one.
-	DeploymentRollingUpdate DeploymentType = "RollingUpdate"
+	RollingUpdateDeploymentStrategyType DeploymentStrategyType = "RollingUpdate"
 )
 
 // Spec to control the desired behavior of rolling update.

--- a/pkg/apis/experimental/v1/types_swagger_doc_generated.go
+++ b/pkg/apis/experimental/v1/types_swagger_doc_generated.go
@@ -126,7 +126,7 @@ func (DeploymentStatus) SwaggerDoc() map[string]string {
 var map_DeploymentStrategy = map[string]string{
 	"":              "DeploymentStrategy describes how to replace existing pods with new ones.",
 	"type":          "Type of deployment. Can be \"Recreate\" or \"RollingUpdate\". Default is RollingUpdate.",
-	"rollingUpdate": "Rolling update config params. Present only if DeploymentType = RollingUpdate.",
+	"rollingUpdate": "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate.",
 }
 
 func (DeploymentStrategy) SwaggerDoc() map[string]string {

--- a/pkg/apis/experimental/validation/validation.go
+++ b/pkg/apis/experimental/validation/validation.go
@@ -227,9 +227,9 @@ func ValidateDeploymentStrategy(strategy *experimental.DeploymentStrategy, field
 		return allErrs
 	}
 	switch strategy.Type {
-	case experimental.DeploymentRecreate:
-		allErrs = append(allErrs, errs.NewFieldForbidden("rollingUpdate", "rollingUpdate should be nil when strategy type is "+experimental.DeploymentRecreate))
-	case experimental.DeploymentRollingUpdate:
+	case experimental.RecreateDeploymentStrategyType:
+		allErrs = append(allErrs, errs.NewFieldForbidden("rollingUpdate", "rollingUpdate should be nil when strategy type is "+experimental.RecreateDeploymentStrategyType))
+	case experimental.RollingUpdateDeploymentStrategyType:
 		allErrs = append(allErrs, ValidateRollingUpdateDeployment(strategy.RollingUpdate, "rollingUpdate")...)
 	}
 	return allErrs

--- a/pkg/apis/experimental/validation/validation_test.go
+++ b/pkg/apis/experimental/validation/validation_test.go
@@ -613,7 +613,7 @@ func TestValidateDeployment(t *testing.T) {
 	// rollingUpdate should be nil for recreate.
 	invalidRecreateDeployment := validDeployment()
 	invalidRecreateDeployment.Spec.Strategy = experimental.DeploymentStrategy{
-		Type:          experimental.DeploymentRecreate,
+		Type:          experimental.RecreateDeploymentStrategyType,
 		RollingUpdate: &experimental.RollingUpdateDeployment{},
 	}
 	errorCases["rollingUpdate should be nil when strategy type is Recreate"] = invalidRecreateDeployment
@@ -621,7 +621,7 @@ func TestValidateDeployment(t *testing.T) {
 	// MaxSurge should be in the form of 20%.
 	invalidMaxSurgeDeployment := validDeployment()
 	invalidMaxSurgeDeployment.Spec.Strategy = experimental.DeploymentStrategy{
-		Type: experimental.DeploymentRollingUpdate,
+		Type: experimental.RollingUpdateDeploymentStrategyType,
 		RollingUpdate: &experimental.RollingUpdateDeployment{
 			MaxSurge: util.NewIntOrStringFromString("20Percent"),
 		},
@@ -631,7 +631,7 @@ func TestValidateDeployment(t *testing.T) {
 	// MaxSurge and MaxUnavailable cannot both be zero.
 	invalidRollingUpdateDeployment := validDeployment()
 	invalidRollingUpdateDeployment.Spec.Strategy = experimental.DeploymentStrategy{
-		Type: experimental.DeploymentRollingUpdate,
+		Type: experimental.RollingUpdateDeploymentStrategyType,
 		RollingUpdate: &experimental.RollingUpdateDeployment{
 			MaxSurge:       util.NewIntOrStringFromString("0%"),
 			MaxUnavailable: util.NewIntOrStringFromInt(0),
@@ -642,7 +642,7 @@ func TestValidateDeployment(t *testing.T) {
 	// MaxUnavailable should not be more than 100%.
 	invalidMaxUnavailableDeployment := validDeployment()
 	invalidMaxUnavailableDeployment.Spec.Strategy = experimental.DeploymentStrategy{
-		Type: experimental.DeploymentRollingUpdate,
+		Type: experimental.RollingUpdateDeploymentStrategyType,
 		RollingUpdate: &experimental.RollingUpdateDeployment{
 			MaxUnavailable: util.NewIntOrStringFromString("110%"),
 		},


### PR DESCRIPTION
As per conversation with @nikhiljindal, tweak the names of some of the Deployment API structs.
