### PR TITLE
MESOS: Send graceful termination update from executor to kubelet

### DIFF
--- a/contrib/mesos/pkg/executor/service/service.go
+++ b/contrib/mesos/pkg/executor/service/service.go
@@ -36,8 +36,10 @@ import (
 	"k8s.io/kubernetes/contrib/mesos/pkg/hyperkube"
 	"k8s.io/kubernetes/contrib/mesos/pkg/redirfd"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/cache"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/credentialprovider"
+	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/healthz"
 	"k8s.io/kubernetes/pkg/kubelet"
 	"k8s.io/kubernetes/pkg/kubelet/cadvisor"
@@ -372,6 +374,7 @@ func (ks *KubeletExecutorServer) createAndInitKubelet(
 			return klet.GetRuntime().GetPodStatus(pod)
 		},
 		StaticPodsConfigPath: staticPodsConfigPath,
+		PodLW:                cache.NewListWatchFromClient(kc.KubeClient, "pods", api.NamespaceAll, fields.OneTermEqualSelector(client.PodHost, kc.NodeName)),
 	})
 
 	go exec.InitializeStaticPodsSource(func() {

--- a/contrib/mesos/pkg/scheduler/pod.go
+++ b/contrib/mesos/pkg/scheduler/pod.go
@@ -78,3 +78,8 @@ func (p *Pod) String() string {
 	}
 	return fmt.Sprintf("{pod:%v, deadline:%v, delay:%v}", p.Pod.Name, displayDeadline, p.GetDelay())
 }
+
+func (p *Pod) InGracefulTermination() bool {
+	return p.Pod.DeletionTimestamp != nil &&
+		p.Pod.DeletionGracePeriodSeconds != nil && *p.Pod.DeletionGracePeriodSeconds > 0
+}


### PR DESCRIPTION
The kubelet gets pod updates from the executor. The executor only passed ADD and REMOVE updates, it did not notice a graceful termination. Hence, terminating pods stayed terminating forever.

With this PR the executor watches the pods which have a binding to the node. When a pod is updated with `pod.DeletionTimestamp != nil` the executor compares it with the pod object it sent to the kubelet. If this differs, the kubelet is notified with a pod update for this node.

Fixes https://github.com/mesosphere/kubernetes-mesos/issues/495
