### PR TITLE
NodePort option: Allowing for apiservers behind load-balanced endpoint.

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -17,6 +17,7 @@ api-servers
 api-server-port
 api-token
 api-version
+kubernetes-service-node-port
 authorization-mode
 authorization-policy-file
 auth-path

--- a/pkg/master/controller_test.go
+++ b/pkg/master/controller_test.go
@@ -259,7 +259,7 @@ func TestSetEndpoints(t *testing.T) {
 		}
 		if test.expectUpdate != nil {
 			if len(registry.Updates) != 1 {
-				t.Errorf("case %q: unexpected updates: %v", test.testName, registry.Updates)
+				t.Errorf("case %q: unexpected updates: (%v).  Expected exactly 1 change. ", test.testName, registry.Updates)
 			} else if e, a := test.expectUpdate, &registry.Updates[0]; !reflect.DeepEqual(e, a) {
 				t.Errorf("case %q: expected update:\n%#v\ngot:\n%#v\n", test.testName, e, a)
 			}

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -244,6 +244,8 @@ type Config struct {
 	SSHUser       string
 	SSHKeyfile    string
 	InstallSSHKey InstallSSHKey
+
+	KubernetesServiceNodePort int
 }
 
 type InstallSSHKey func(user string, data []byte) error
@@ -317,7 +319,8 @@ type Master struct {
 	// map from api path to storage for those objects
 	thirdPartyResources map[string]*thirdpartyresourcedataetcd.REST
 	// protects the map
-	thirdPartyResourcesLock sync.RWMutex
+	thirdPartyResourcesLock   sync.RWMutex
+	KubernetesServiceNodePort int
 }
 
 // NewEtcdStorage returns a storage.Interface for the provided arguments or an error if the version
@@ -450,7 +453,8 @@ func New(c *Config) *Master {
 		// TODO: serviceReadWritePort should be passed in as an argument, it may not always be 443
 		serviceReadWritePort: 443,
 
-		installSSHKey: c.InstallSSHKey,
+		installSSHKey:             c.InstallSSHKey,
+		KubernetesServiceNodePort: c.KubernetesServiceNodePort,
 	}
 
 	var handlerContainer *restful.Container
@@ -781,9 +785,10 @@ func (m *Master) NewBootstrapController() *Controller {
 
 		PublicIP: m.clusterIP,
 
-		ServiceIP:         m.serviceReadWriteIP,
-		ServicePort:       m.serviceReadWritePort,
-		PublicServicePort: m.publicReadWritePort,
+		ServiceIP:                 m.serviceReadWriteIP,
+		ServicePort:               m.serviceReadWritePort,
+		PublicServicePort:         m.publicReadWritePort,
+		KubernetesServiceNodePort: m.KubernetesServiceNodePort,
 	}
 }
 


### PR DESCRIPTION
This is a place holder for the WIP example for hiding apiservers behind the service endpoint ( issue #13152 ) 
- I'm rebasing it and so on now.
- Also, I'll generalize it w/ cmd line args rather than hardcoded port.
