### PR TITLE
kubelet: add a docker pod lifecycle event generator

### DIFF
--- a/pkg/kubelet/container/fake_runtime.go
+++ b/pkg/kubelet/container/fake_runtime.go
@@ -33,6 +33,7 @@ type FakeRuntime struct {
 	sync.Mutex
 	CalledFunctions   []string
 	PodList           []*Pod
+	AllPodList        []*Pod
 	ContainerList     []*Container
 	ImageList         []Image
 	PodStatus         api.PodStatus
@@ -88,6 +89,7 @@ func (f *FakeRuntime) ClearCalls() {
 
 	f.CalledFunctions = []string{}
 	f.PodList = []*Pod{}
+	f.AllPodList = []*Pod{}
 	f.ContainerList = []*Container{}
 	f.PodStatus = api.PodStatus{}
 	f.StartedPods = []string{}
@@ -149,6 +151,9 @@ func (f *FakeRuntime) GetPods(all bool) ([]*Pod, error) {
 	defer f.Unlock()
 
 	f.CalledFunctions = append(f.CalledFunctions, "GetPods")
+	if all {
+		return f.AllPodList, f.Err
+	}
 	return f.PodList, f.Err
 }
 

--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -84,6 +84,8 @@ type DockerInterface interface {
 	StartExec(string, docker.StartExecOptions) error
 	InspectExec(id string) (*docker.ExecInspect, error)
 	AttachToContainer(opts docker.AttachToContainerOptions) error
+	AddEventListener(listener chan<- *docker.APIEvents) error
+	RemoveEventListener(listener chan *docker.APIEvents) error
 }
 
 // KubeletContainerName encapsulates a pod name and a Kubernetes container name.

--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -55,6 +55,16 @@ const (
 	quotaPeriod = 100000
 )
 
+// Docker's remote API provides the option of filtering containers based on
+// status (created|restarting|running|paused|exited).
+const (
+	DockerExited     = "exited"
+	DockerCreated    = "created"
+	DockerRestarting = "restarting"
+	DockerPaused     = "paused"
+	DockerRunning    = "running"
+)
+
 // DockerInterface is an abstract interface for testability.  It abstracts the interface of docker.Client.
 type DockerInterface interface {
 	ListContainers(options docker.ListContainersOptions) ([]docker.APIContainers, error)
@@ -348,13 +358,40 @@ func milliCPUToShares(milliCPU int64) int64 {
 
 // GetKubeletDockerContainers lists all container or just the running ones.
 // Returns a map of docker containers that we manage, keyed by container ID.
-// TODO: Move this function with dockerCache to DockerManager.
+// TODO: Replace this function with GetKubeletManagedContainers directly.
 func GetKubeletDockerContainers(client DockerInterface, allContainers bool) (DockerContainers, error) {
-	result := make(DockerContainers)
-	containers, err := client.ListContainers(docker.ListContainersOptions{All: allContainers})
-	if err != nil {
-		return nil, err
+	if allContainers {
+		return GetKubeletManagedContainers(client, listAll)
+	} else {
+		return GetKubeletManagedContainers(client, listRunning)
 	}
+}
+
+type listContainersType string
+
+const (
+	listAll     listContainersType = "all"
+	listRunning listContainersType = "running"
+	listExited  listContainersType = "exited"
+)
+
+func getContainers(client DockerInterface, ctype listContainersType) ([]docker.APIContainers, error) {
+	switch ctype {
+	case listAll:
+		return client.ListContainers(docker.ListContainersOptions{All: true})
+	case listRunning:
+		return client.ListContainers(docker.ListContainersOptions{All: false})
+	case listExited:
+		return client.ListContainers(docker.ListContainersOptions{
+			All:     true,
+			Filters: map[string][]string{"status": {DockerExited}}})
+	default:
+		return nil, fmt.Errorf("unknown container type: %q", ctype)
+	}
+}
+
+func filterKubeletContainers(containers []docker.APIContainers) DockerContainers {
+	result := make(DockerContainers)
 	for i := range containers {
 		container := &containers[i]
 		if len(container.Names) == 0 {
@@ -370,5 +407,15 @@ func GetKubeletDockerContainers(client DockerInterface, allContainers bool) (Doc
 		}
 		result[kubeletTypes.DockerID(container.ID)] = container
 	}
-	return result, nil
+	return result
+}
+
+// GetKubeletManagedContainers returns a map of all docker containers that we
+// manage, keyed by container ID.
+func GetKubeletManagedContainers(client DockerInterface, status listContainersType) (DockerContainers, error) {
+	containers, err := getContainers(client, status)
+	if err != nil {
+		return nil, err
+	}
+	return filterKubeletContainers(containers), nil
 }

--- a/pkg/kubelet/dockertools/fake_docker_client.go
+++ b/pkg/kubelet/dockertools/fake_docker_client.go
@@ -322,6 +322,14 @@ func (f *FakeDockerClient) RemoveImage(image string) error {
 	return err
 }
 
+func (f *FakeDockerClient) AddEventListener(listener chan<- *docker.APIEvents) error {
+	return nil
+}
+
+func (f *FakeDockerClient) RemoveEventListener(listener chan *docker.APIEvents) error {
+	return nil
+}
+
 // FakeDockerPuller is a stub implementation of DockerPuller.
 type FakeDockerPuller struct {
 	sync.Mutex

--- a/pkg/kubelet/dockertools/instrumented_docker.go
+++ b/pkg/kubelet/dockertools/instrumented_docker.go
@@ -198,3 +198,21 @@ func (in instrumentedDockerInterface) AttachToContainer(opts docker.AttachToCont
 	recordError(operation, err)
 	return err
 }
+
+func (in instrumentedDockerInterface) AddEventListener(listener chan<- *docker.APIEvents) error {
+	const operation = "add_event_listener"
+	defer recordOperation(operation, time.Now())
+
+	err := in.client.AddEventListener(listener)
+	recordError(operation, err)
+	return err
+}
+
+func (in instrumentedDockerInterface) RemoveEventListener(listener chan *docker.APIEvents) error {
+	const operation = "remove_event_listener"
+	defer recordOperation(operation, time.Now())
+
+	err := in.client.RemoveEventListener(listener)
+	recordError(operation, err)
+	return err
+}

--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -1919,3 +1919,32 @@ func getPidMode(pod *api.Pod) string {
 	}
 	return pidMode
 }
+
+func (dm *DockerManager) getContainers(listType listContainersType) ([]*kubecontainer.Container, error) {
+	containers, err := GetKubeletManagedContainers(dm.client, listType)
+	if err != nil {
+		return nil, err
+	}
+	runtimeContainers := []*kubecontainer.Container{}
+	for _, c := range containers {
+		converted, err := toRuntimeContainer(c)
+		if err != nil {
+			glog.Errorf("Error examining the container: %v", err)
+			continue
+		}
+		runtimeContainers = append(runtimeContainers, converted)
+	}
+	return runtimeContainers, nil
+}
+
+func (dm *DockerManager) GetRunningContainers() ([]*kubecontainer.Container, error) {
+	return dm.getContainers(listRunning)
+}
+
+func (dm *DockerManager) GetTerminatedContainers() ([]*kubecontainer.Container, error) {
+	return dm.getContainers(listExited)
+}
+
+func (dm *DockerManager) GetAllContainers() ([]*kubecontainer.Container, error) {
+	return dm.getContainers(listAll)
+}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1788,8 +1788,10 @@ func (kl *Kubelet) syncLoopIteration(updates <-chan PodUpdate, handler SyncHandl
 		}
 	case e := <-plegCh:
 		pod, ok := kl.podManager.GetPodByUID(e.ID)
-		if !ok {
+		if !ok || e.Type == pleg.ContainerStarted || e.Type == pleg.NetworkSetupCompleted {
 			// If the pod no longer exists, ignore the event.
+			// Also ignore "succeeded" events for now until pod workers can
+			// properly filter out their expectations.
 			glog.V(4).Infof("SyncLoop (PLEG): ignore irrelevant event: %#v", e)
 			break
 		}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/golang/glog"
 	cadvisorApi "github.com/google/cadvisor/info/v1"
+
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/api/validation"
@@ -100,7 +101,8 @@ const (
 	// Relisting is used to discover missing container events.
 	// Use a shorter period because generic PLEG relies on relisting for
 	// container events.
-	plegRelistPeriod = time.Second * 3
+	plegRelistPeriod       = time.Second * 3
+	dockerPlegRelistPeriod = time.Second * 30
 )
 
 var (
@@ -315,7 +317,8 @@ func NewMainKubelet(
 			procFs,
 			klet.cpuCFSQuota)
 		klet.containerRuntimeName = "docker"
-		klet.pleg = pleg.NewGenericPLEG(klet.containerRuntime, plegChannelCapacity, plegRelistPeriod)
+		klet.pleg = pleg.NewDockerPLEG(pleg.NewDockerEventWatcher(dockerClient), klet.containerRuntime.(*dockertools.DockerManager),
+			plegChannelCapacity, dockerPlegRelistPeriod)
 	case "rkt":
 		conf := &rkt.Config{
 			Path:               rktPath,

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/container"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/network"
+	"k8s.io/kubernetes/pkg/kubelet/pleg"
 	"k8s.io/kubernetes/pkg/kubelet/status"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util"
@@ -135,6 +136,7 @@ func newTestKubelet(t *testing.T) *TestKubelet {
 	kubelet.backOff = util.NewBackOff(time.Second, time.Minute)
 	kubelet.backOff.Clock = fakeClock
 	kubelet.podKillingCh = make(chan *kubecontainer.Pod, 20)
+	kubelet.pleg = pleg.NewGenericPLEG(fakeRuntime, 100, time.Hour)
 	return &TestKubelet{kubelet, fakeRuntime, mockCadvisor, fakeKubeClient, fakeMirrorClient, fakeNodeManager}
 }
 
@@ -317,12 +319,12 @@ func TestSyncLoopTimeUpdate(t *testing.T) {
 		t.Errorf("Unexpected sync loop time: %s, expected 0", loopTime1)
 	}
 
-	kubelet.syncLoopIteration(make(chan PodUpdate), kubelet)
+	kubelet.syncLoopIteration(make(chan PodUpdate), kubelet, make(chan *pleg.PodLifecycleEvent))
 	loopTime2 := kubelet.LatestLoopEntryTime()
 	if loopTime2.IsZero() {
 		t.Errorf("Unexpected sync loop time: 0, expected non-zero value.")
 	}
-	kubelet.syncLoopIteration(make(chan PodUpdate), kubelet)
+	kubelet.syncLoopIteration(make(chan PodUpdate), kubelet, make(chan *pleg.PodLifecycleEvent))
 	loopTime3 := kubelet.LatestLoopEntryTime()
 	if !loopTime3.After(loopTime1) {
 		t.Errorf("Sync Loop Time was not updated correctly. Second update timestamp should be greater than first update timestamp")
@@ -340,7 +342,7 @@ func TestSyncLoopAbort(t *testing.T) {
 	close(ch)
 
 	// sanity check (also prevent this test from hanging in the next step)
-	ok := kubelet.syncLoopIteration(ch, kubelet)
+	ok := kubelet.syncLoopIteration(ch, kubelet, make(chan *pleg.PodLifecycleEvent, 1))
 	if ok {
 		t.Fatalf("expected syncLoopIteration to return !ok since update chan was closed")
 	}

--- a/pkg/kubelet/pleg/common_utils.go
+++ b/pkg/kubelet/pleg/common_utils.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pleg
+
+import (
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/types"
+	"k8s.io/kubernetes/pkg/util/sets"
+)
+
+// buildIDMap returns a container ID to pod ID map.
+func buildIDMap(pods []*kubecontainer.Pod) map[string]types.UID {
+	cmap := make(map[string]types.UID)
+	for _, p := range pods {
+		for _, c := range p.Containers {
+			cmap[string(c.ID)] = p.ID
+		}
+	}
+	return cmap
+}
+
+// buildContainerSet returns set of container IDs.
+func buildContainerSet(pods []*kubecontainer.Pod) sets.String {
+	cset := sets.NewString()
+	for _, p := range pods {
+		for _, c := range p.Containers {
+			cset.Insert(string(c.ID))
+		}
+	}
+	return cset
+}

--- a/pkg/kubelet/pleg/container_event_watcher.go
+++ b/pkg/kubelet/pleg/container_event_watcher.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pleg
+
+import (
+	"time"
+)
+
+type ContainerEvent struct {
+	ID        string
+	Timestamp time.Time
+	Type      ContainerEventType
+}
+
+type ContainerEventType string
+
+const (
+	ContainerEventStarted = "STARTED"
+	ContainerEventStopped = "STOPPED"
+)
+
+type ContainerEventWatcher interface {
+	Watch() (<-chan *ContainerEvent, error)
+	Stop()
+}

--- a/pkg/kubelet/pleg/docker.go
+++ b/pkg/kubelet/pleg/docker.go
@@ -1,0 +1,284 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pleg
+
+import (
+	"time"
+
+	"github.com/golang/glog"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/kubelet/dockertools"
+	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
+)
+
+// For testability.
+type DockerContainerGetter interface {
+	GetRunningContainers() ([]*kubecontainer.Container, error)
+	GetTerminatedContainers() ([]*kubecontainer.Container, error)
+	GetAllContainers() ([]*kubecontainer.Container, error)
+	ExamineContainer(dockerID string) (*dockertools.ContainerExaminationResult, error)
+}
+
+// DockerPLEG implements PodLifecycleEventGenerator for the Docker container
+// runtime. When receiving an upstream container event, it inspects the
+// container and generate a corresponding pod event. The inspection is
+// necessary for retrieving information such as pod ID, which may not be
+// provided by the upstream.
+//
+// DockerPLEG may miss a container event if *both* of the following
+// requirements are met:
+//   1. The container event stream misses an event.
+//   2. The specific container was removed (i.e., garbage collected) before
+//      next relisting.
+// Genernally, (2) should not happen with kubelet's GC policy, unless user
+// employs an external garbage collector. In the case where DockerPLEG is unable
+// to inspect a container, the event'd would be skipped until the next relist.
+//
+// After being restarted, DockerPLEG may report outdated container events
+// from the first relisting, due to the loss of internal states. Subscribers
+// are expected to handle these irrelevant events.
+type DockerPLEG struct {
+	// The period for relisting.
+	relistPeriod time.Duration
+	// The timestamp of the last relist.
+	relistTimestamp time.Time
+	// The upstream container event watcher.
+	upstreamWatcher ContainerEventWatcher
+	upstreamCh      <-chan *ContainerEvent
+	// The channel for the subscriber to receive.
+	// TODO: Support multiple subscribers.
+	eventChannel chan *PodLifecycleEvent
+	// The underlying container runtime.
+	// TODO(yujuhong): Replace this with kubecontainer.Runtime, or define a new
+	// interface.
+	runtime DockerContainerGetter
+	// The set of containers (IDs) that we know are alive.
+	aliveContainers sets.String
+	// The set of containers (IDs) that we know are dead.
+	deadContainers sets.String
+}
+
+var _ PodLifecycleEventGenerator = &DockerPLEG{}
+
+func NewDockerPLEG(upstreamWatcher ContainerEventWatcher, runtime DockerContainerGetter, channelCapacity int,
+	relistPeriod time.Duration) *DockerPLEG {
+	return &DockerPLEG{
+		relistPeriod:    relistPeriod,
+		upstreamWatcher: upstreamWatcher,
+		runtime:         runtime,
+		eventChannel:    make(chan *PodLifecycleEvent, channelCapacity),
+		aliveContainers: sets.NewString(),
+		deadContainers:  sets.NewString(),
+	}
+}
+
+const (
+	// Time between retries if the container event stream channel has been
+	// closed.
+	retryInterval = time.Second * 3
+)
+
+// Returns a channel from which the subscriber can recieve PodLifecycleEvent
+// events.
+func (d *DockerPLEG) Watch() chan *PodLifecycleEvent {
+	return d.eventChannel
+}
+
+// Instruct DockerPLEG to start watch upstrem for changes (and generate pod
+// lifcycle events to the downstream channel).
+func (d *DockerPLEG) Start() {
+	go util.Until(d.doWork, retryInterval, util.NeverStop)
+	glog.V(3).Infof("DockerPLEG: Started.")
+}
+
+// startWatchingUpstream starts watching upstream for container changes, and
+// sets the upstreamCh channel.
+func (d *DockerPLEG) startWatchingUpstream() error {
+	// TODO(yujuhong): Make sure there is enough channel capacity to buffer
+	// the events, or we should buffer it internally.
+	ch, err := d.upstreamWatcher.Watch()
+	if err != nil {
+		return err
+	}
+	d.upstreamCh = ch
+	return nil
+}
+
+func (d *DockerPLEG) doWork() {
+	// We need to start watching the upstream before relisting to ensure
+	// that we don't miss any event. Duplicated events will be filtered out and
+	// ignored.
+	if err := d.startWatchingUpstream(); err != nil {
+		glog.Errorf("Unable to watch upstream %v: %v", d.upstreamWatcher, err)
+	}
+
+	d.relist()
+	for {
+		select {
+		case e, ok := <-d.upstreamCh:
+			if !ok {
+				glog.Errorf("DockerPLEG: Upstream channel closed")
+				return
+			}
+			glog.V(3).Infof("DockerPLEG: Received an event from upstream: %+v", e)
+			if e.Timestamp.Before(d.relistTimestamp) {
+				// Any event that is older than the last relist timestamp
+				// is considered outdated, and should be discarded
+				glog.V(3).Infof("DockerPLEG: Discarding outdated event %+v", e)
+				break
+			}
+			d.processEvent(e)
+		case <-time.After(d.relistPeriod):
+			glog.V(3).Infof("DockerPLEG: Relisting")
+			d.relist()
+		}
+	}
+}
+
+func (d *DockerPLEG) processEvent(e *ContainerEvent) {
+	switch e.Type {
+	case ContainerEventStarted:
+		d.handleContainerStarted(e)
+	case ContainerEventStopped:
+		d.handleContainerStopped(e)
+	default:
+		glog.Errorf("DockerPLEG: Unknown event: %+v", e)
+	}
+}
+
+// relist scans the docker containers to discover missing container events.
+func (d *DockerPLEG) relist() {
+	oldAlive := d.aliveContainers
+	oldDead := d.deadContainers
+	// Set the relist timestamp.
+	d.relistTimestamp = time.Now()
+	alive, dead, err := d.getAliveAndDeadConainerSets()
+	if err != nil {
+		glog.Errorf("DockerPLEG: Unable to get pods from the container runtime: %v", err)
+		return
+	}
+	// A set of dead containers whose existence we weren't aware of prior to
+	// relist. This means that we may have missed both the creation and deletion
+	// events of a container. We'd send out both creation and deletion events for
+	// them.
+	missed := dead.Difference(oldDead).Difference(oldAlive)
+
+	// Generate corresponding container events, which will be treated the same
+	// way as the events from upstream. Note that the internal alive/dead
+	// container sets will be modified accordingly when processing the events.
+	started := alive.Difference(oldAlive)
+	stopped := oldAlive.Difference(alive)
+	if started.Len() != 0 || stopped.Len() != 0 || missed.Len() != 0 {
+		glog.V(2).Infof("DockerPLEG: Discovered missing events; started: %v, stopped: %v, missed: %v",
+			started.List(), stopped.List(), missed.List())
+	}
+	for _, c := range started.Union(missed).List() {
+		d.processEvent(&ContainerEvent{
+			ID:        c,
+			Timestamp: d.relistTimestamp,
+			Type:      ContainerEventStarted,
+		})
+	}
+	for _, c := range stopped.Union(missed).List() {
+		d.processEvent(&ContainerEvent{
+			ID:        c,
+			Timestamp: d.relistTimestamp,
+			Type:      ContainerEventStopped,
+		})
+	}
+}
+
+func (d *DockerPLEG) getAliveAndDeadConainerSets() (sets.String, sets.String, error) {
+	running, err := d.runtime.GetRunningContainers()
+	if err != nil {
+		return nil, nil, err
+	}
+	dead, err := d.runtime.GetTerminatedContainers()
+	if err != nil {
+		return nil, nil, err
+	}
+	return containerListToSet(running), containerListToSet(dead), nil
+}
+
+func (d *DockerPLEG) handleContainerStarted(e *ContainerEvent) {
+	if d.aliveContainers.Has(e.ID) && !d.deadContainers.Has(e.ID) {
+		// TODO(yujuhong): Why would we see duplicated events?
+		glog.Warningf("DockerPLEG: Received duplicated event: %#v", e)
+		return
+	}
+	// We need to derive some information from the container ID: pod ID,
+	// whether the container is a network container.
+	result, err := d.runtime.ExamineContainer(e.ID)
+	if err != nil {
+		// We haven't updated the internal container sets yet. If this
+		// container is observed in the next relisting, we'd try inspecting
+		// again.
+		glog.Errorf("DockerPLEG: Unable to examine container %q: %v", e.ID, err)
+		return
+	}
+	// Update internal storage.
+	d.aliveContainers.Insert(e.ID)
+	d.deadContainers.Insert(e.ID)
+
+	pod := result.Pod
+	container := result.Pod.Containers[0]
+	if result.IsInfraContainer {
+		d.eventChannel <- &PodLifecycleEvent{ID: pod.ID, Type: NetworkSetupCompleted}
+	} else {
+		d.eventChannel <- &PodLifecycleEvent{ID: pod.ID, Type: ContainerStarted, Data: container.Name}
+	}
+}
+
+func (d *DockerPLEG) handleContainerStopped(e *ContainerEvent) {
+	if !d.aliveContainers.Has(e.ID) && d.deadContainers.Has(e.ID) {
+		// TODO(yjhong): Why would we see duplicated events?
+		glog.V(4).Infof("DockerPLEG: Received duplicated event: %#v", e)
+		return
+	}
+	// We need to derive some information from the container ID: pod ID,
+	// whether the container is a network container.
+	result, err := d.runtime.ExamineContainer(e.ID)
+	if err != nil {
+		// We haven't updated the internal container sets yet. If this
+		// container is observed in the next relisting, we'd try inspecting
+		// again.
+		glog.Errorf("DockerPLEG: Unable to examine container %q: %v", e.ID, err)
+		return
+	}
+	// Update internal storage.
+	d.aliveContainers.Delete(e.ID)
+	d.deadContainers.Insert(e.ID)
+
+	pod := result.Pod
+	container := result.Pod.Containers[0]
+	if result.IsInfraContainer {
+		d.eventChannel <- &PodLifecycleEvent{ID: pod.ID, Type: NetworkFailed}
+	} else {
+		d.eventChannel <- &PodLifecycleEvent{ID: pod.ID, Type: ContainerStopped, Data: container.Name}
+	}
+}
+
+// containerListToSet converts a list of containers to a set of container IDs
+// in strings.
+func containerListToSet(containers []*kubecontainer.Container) sets.String {
+	cset := sets.NewString()
+	for _, c := range containers {
+		cset.Insert(string(c.ID))
+	}
+	return cset
+}

--- a/pkg/kubelet/pleg/docker.go
+++ b/pkg/kubelet/pleg/docker.go
@@ -30,7 +30,6 @@ import (
 type DockerContainerGetter interface {
 	GetRunningContainers() ([]*kubecontainer.Container, error)
 	GetTerminatedContainers() ([]*kubecontainer.Container, error)
-	GetAllContainers() ([]*kubecontainer.Container, error)
 	ExamineContainer(dockerID string) (*dockertools.ContainerExaminationResult, error)
 }
 
@@ -179,7 +178,7 @@ func (d *DockerPLEG) relist() {
 	missed := dead.Difference(oldDead).Difference(oldAlive)
 
 	// Generate corresponding container events, which will be treated the same
-	// way as the events from upstream. Note that the internal alive/dead
+	// way as the events from upstream. Note that the internal running/dead
 	// container sets will be modified accordingly when processing the events.
 	started := alive.Difference(oldAlive)
 	stopped := oldAlive.Difference(alive)

--- a/pkg/kubelet/pleg/docker_event_watcher.go
+++ b/pkg/kubelet/pleg/docker_event_watcher.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pleg
+
+import (
+	"time"
+
+	docker "github.com/fsouza/go-dockerclient"
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/kubelet/dockertools"
+	"k8s.io/kubernetes/pkg/util"
+)
+
+// dockerEventWatcher watches event stream from docker, and translates the
+// events into ContainerEvent events.
+type dockerEventWatcher struct {
+	client dockertools.DockerInterface
+	source chan *docker.APIEvents
+	sink   chan *ContainerEvent
+}
+
+var _ ContainerEventWatcher = &dockerEventWatcher{}
+
+const (
+	dockerContainerStartStatus = "start"
+	dockerContainerDieStatus   = "die"
+	// Pick an arbitrary number that is considered large enough.
+	dockerSourceChannelCapacity = 1000
+	dockerSinkChannelCapacity   = 1000
+)
+
+func NewDockerEventWatcher(client dockertools.DockerInterface) *dockerEventWatcher {
+	return &dockerEventWatcher{client: client}
+}
+
+func (d *dockerEventWatcher) doWork() {
+	d.source = make(chan *docker.APIEvents, dockerSourceChannelCapacity)
+	defer close(d.source)
+	if err := d.client.AddEventListener(d.source); err != nil {
+		glog.Errorf("dockerEventWatcher: Unable to watch docker events: %v", err)
+		return
+	}
+	for event := range d.source {
+		glog.Infof("dockerEventWatcher: Receiving event %#v", event)
+		switch event.Status {
+		case dockerContainerStartStatus:
+			d.sink <- &ContainerEvent{
+				ID:        event.ID,
+				Timestamp: time.Unix(event.Time, 0),
+				Type:      ContainerEventStarted,
+			}
+		case dockerContainerDieStatus:
+			d.sink <- &ContainerEvent{
+				ID:        event.ID,
+				Timestamp: time.Unix(event.Time, 0),
+				Type:      ContainerEventStopped,
+			}
+		default:
+			break
+		}
+	}
+}
+
+func (d *dockerEventWatcher) Watch() (<-chan *ContainerEvent, error) {
+	d.sink = make(chan *ContainerEvent, dockerSinkChannelCapacity)
+	// Launch a goroutine to adapt the events from the upstream docker
+	// channel to ContainerEvent events.
+	go util.Until(d.doWork, 0, util.NeverStop)
+	return d.sink, nil
+}
+
+func (d *dockerEventWatcher) Stop() {
+	d.client.RemoveEventListener(d.source)
+	close(d.source)
+	close(d.sink)
+}

--- a/pkg/kubelet/pleg/docker_test.go
+++ b/pkg/kubelet/pleg/docker_test.go
@@ -1,0 +1,226 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pleg
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/kubelet/dockertools"
+	"k8s.io/kubernetes/pkg/types"
+)
+
+const (
+	testWaitForEventsTimeout = time.Minute * 1
+)
+
+type fakeContainerGetter struct {
+	lock     sync.RWMutex
+	running  []*kubecontainer.Container
+	dead     []*kubecontainer.Container
+	cResults map[string]*dockertools.ContainerExaminationResult
+}
+
+func newFakeContainerGetter() *fakeContainerGetter {
+	return &fakeContainerGetter{cResults: make(map[string]*dockertools.ContainerExaminationResult)}
+}
+
+func (f *fakeContainerGetter) GetRunningContainers() ([]*kubecontainer.Container, error) {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+	return f.running, nil
+}
+
+func (f *fakeContainerGetter) GetTerminatedContainers() ([]*kubecontainer.Container, error) {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+	return f.dead, nil
+}
+
+func (f *fakeContainerGetter) ExamineContainer(dockerID string) (*dockertools.ContainerExaminationResult, error) {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+	if c, ok := f.cResults[dockerID]; ok {
+		return c, nil
+	}
+	return nil, fmt.Errorf("cannot examine container %q", dockerID)
+}
+
+func (f *fakeContainerGetter) SetContainers(running, dead []*kubecontainer.Pod) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	f.running = []*kubecontainer.Container{}
+	f.dead = []*kubecontainer.Container{}
+	for _, p := range running {
+		for _, c := range p.Containers {
+			f.running = append(f.running, c)
+			f.cResults[string(c.ID)] = &dockertools.ContainerExaminationResult{Pod: p}
+		}
+	}
+	for _, p := range dead {
+		for _, c := range p.Containers {
+			f.dead = append(f.dead, c)
+			f.cResults[string(c.ID)] = &dockertools.ContainerExaminationResult{Pod: p}
+		}
+	}
+}
+
+func (f *fakeContainerGetter) SetContainerResults(pods []*kubecontainer.Pod) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	for _, p := range pods {
+		for _, c := range p.Containers {
+			f.cResults[string(c.ID)] = &dockertools.ContainerExaminationResult{Pod: p}
+		}
+	}
+}
+
+type TestDockerPLEG struct {
+	pleg                  *DockerPLEG
+	containerGetter       *fakeContainerGetter
+	containerEventWatcher *fakeContainerEventWatcher
+}
+
+func newTestDockerPLEG(relistPeriod time.Duration) *TestDockerPLEG {
+	containerGetter := newFakeContainerGetter()
+	containerEventWatcher := &fakeContainerEventWatcher{}
+	// The channel capacity should be large enough to hold all events in a
+	// single test.
+	pleg := NewDockerPLEG(containerEventWatcher, containerGetter, 100, relistPeriod)
+	return &TestDockerPLEG{pleg: pleg, containerGetter: containerGetter, containerEventWatcher: containerEventWatcher}
+}
+
+func TestRelisting(t *testing.T) {
+	// Set a high relist period because we want to manually trigger relisting.
+	testPleg := newTestDockerPLEG(time.Hour)
+	pleg, containerGetter := testPleg.pleg, testPleg.containerGetter
+	ch := pleg.Watch()
+
+	// Report containers that are newly running.
+	running := []*kubecontainer.Pod{
+		{
+			ID: "1234",
+			Containers: []*kubecontainer.Container{
+				{ID: types.UID("c1"), Name: "foo"},
+			},
+		},
+		{
+			ID: "7890",
+			Containers: []*kubecontainer.Container{
+				{ID: types.UID("c2"), Name: "bar"},
+			},
+		},
+	}
+	containerGetter.SetContainers(running, []*kubecontainer.Pod{})
+	pleg.relist()
+	expected := []*PodLifecycleEvent{
+		{ID: "1234", Type: ContainerStarted, Data: "foo"},
+		{ID: "7890", Type: ContainerStarted, Data: "bar"},
+	}
+	actual := getEventsFromChannel(ch)
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("Expected: %#v, got: %#v", expected, actual)
+	}
+
+	// Report containers that are newly dead.
+	containerGetter.SetContainers([]*kubecontainer.Pod{}, []*kubecontainer.Pod{})
+	pleg.relist()
+	expected = []*PodLifecycleEvent{
+		{ID: "1234", Type: ContainerStopped, Data: "foo"},
+		{ID: "7890", Type: ContainerStopped, Data: "bar"},
+	}
+	actual = getEventsFromChannel(ch)
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("Expected: %#v, got: %#v", expected, actual)
+	}
+
+	// If a new dead container has not been seen in running/dead container set,
+	// send both creation and deletion event for it.
+	dead := []*kubecontainer.Pod{
+		{
+			ID: "4567",
+			Containers: []*kubecontainer.Container{
+				{ID: types.UID("c3"), Name: "tar"},
+			},
+		},
+	}
+	containerGetter.SetContainers([]*kubecontainer.Pod{}, dead)
+	pleg.relist()
+	expected = []*PodLifecycleEvent{
+		{ID: "4567", Type: ContainerStarted, Data: "tar"},
+		{ID: "4567", Type: ContainerStopped, Data: "tar"},
+	}
+	actual = getEventsFromChannel(ch)
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("Expected: %#v, got: %#v", expected, actual)
+	}
+}
+
+func getNumEventsFromChannel(ch <-chan *PodLifecycleEvent, numEvents int, timeout time.Duration) []*PodLifecycleEvent {
+	events := []*PodLifecycleEvent{}
+	start := time.Now()
+	for len(events) < numEvents && time.Now().Before(start.Add(timeout)) {
+		events = append(events, getEventsFromChannel(ch)...)
+		time.Sleep(time.Second)
+	}
+	return events
+}
+
+func TestProcessContainerEvents(t *testing.T) {
+	// Set a high relist period because we don't want to test relisting here.
+	testPleg := newTestDockerPLEG(time.Hour)
+	pleg, containerGetter, containerEventWatcher := testPleg.pleg, testPleg.containerGetter, testPleg.containerEventWatcher
+	ch := pleg.Watch()
+
+	pods := []*kubecontainer.Pod{
+		{
+			ID: "9999",
+			Containers: []*kubecontainer.Container{
+				{ID: types.UID("c1"), Name: "foo"},
+			},
+		},
+		{
+			ID: "7890",
+			Containers: []*kubecontainer.Container{
+				{ID: types.UID("c2"), Name: "bar"},
+			},
+		},
+	}
+	// This makes sure that pleg can inspect the container for pod ID, etc.
+	containerGetter.SetContainerResults(pods)
+	// Start a goroutine to watch container events.
+	pleg.Start()
+	// Send the container events. The timestamps are set slightly ahead of time
+	// so that they are guaranteed to be greater than the last relist
+	// timestamp. This ensures that they are not treated as outdated events.
+	containerEventWatcher.SetEvents([]*ContainerEvent{
+		{ID: "c1", Timestamp: time.Now().Add(time.Hour), Type: ContainerEventStarted},
+		{ID: "c2", Timestamp: time.Now().Add(time.Hour), Type: ContainerEventStopped},
+	})
+	expected := []*PodLifecycleEvent{
+		{ID: "9999", Type: ContainerStarted, Data: "foo"},
+		{ID: "7890", Type: ContainerStopped, Data: "bar"},
+	}
+	actual := getNumEventsFromChannel(ch, len(expected), testWaitForEventsTimeout)
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("Expected: %#v, got: %#v", expected, actual)
+	}
+}

--- a/pkg/kubelet/pleg/fake_container_event_watcher.go
+++ b/pkg/kubelet/pleg/fake_container_event_watcher.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pleg
+
+type fakeContainerEventWatcher struct {
+	ch chan *ContainerEvent
+}
+
+var _ ContainerEventWatcher = &fakeContainerEventWatcher{}
+
+func (f *fakeContainerEventWatcher) SetEvents(events []*ContainerEvent) {
+	f.createChannelIfEmpty()
+	for _, e := range events {
+		f.ch <- e
+	}
+}
+
+func (f *fakeContainerEventWatcher) Watch() (<-chan *ContainerEvent, error) {
+	f.createChannelIfEmpty()
+	return f.ch, nil
+}
+
+func (f *fakeContainerEventWatcher) Stop() {
+	close(f.ch)
+}
+
+func (f *fakeContainerEventWatcher) createChannelIfEmpty() {
+	if f.ch == nil {
+		f.ch = make(chan *ContainerEvent, 1000)
+	}
+}

--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pleg
+
+import (
+	"time"
+
+	"github.com/golang/glog"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/types"
+	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
+)
+
+// GenericPLEG is an extremely simple generic PLEG that relies solely on
+// periodic listing to discover container changes. It should be be used
+// as temporary replacement or container runtimes do not support a proper
+// event generator yet.
+//
+// Note that Generic PLEG assumes that a container would not be created and
+// garbage collected within one relist period. If this is not true, it might
+// miss the container completely. Relisting failure would also lead to a longer
+// window where a container could be missing. It is recommended to set the
+// relist period short and have an auxiliary, longer periodic sync in kubelet
+// the safety net.
+type GenericPLEG struct {
+	// The period for relisting.
+	relistPeriod time.Duration
+	runtime      kubecontainer.Runtime
+	eventChannel chan *PodLifecycleEvent
+	// IDs of all visible containers.
+	containers sets.String
+	// IDs of all running containers
+	runningContainers sets.String
+	// Map container ID to pod ID.
+	idMap map[string]types.UID
+}
+
+var _ PodLifecycleEventGenerator = &GenericPLEG{}
+
+func NewGenericPLEG(runtime kubecontainer.Runtime, channelCapacity int,
+	relistPeriod time.Duration) *GenericPLEG {
+	return &GenericPLEG{
+		relistPeriod:      relistPeriod,
+		runtime:           runtime,
+		eventChannel:      make(chan *PodLifecycleEvent, channelCapacity),
+		idMap:             make(map[string]types.UID),
+		containers:        sets.NewString(),
+		runningContainers: sets.NewString(),
+	}
+}
+
+// Returns a channel from which the subscriber can recieve PodLifecycleEvent
+// events.
+func (g *GenericPLEG) Watch() chan *PodLifecycleEvent {
+	return g.eventChannel
+}
+
+func (g *GenericPLEG) doWork() {
+	select {
+	case <-time.After(g.relistPeriod):
+		glog.V(3).Infof("GenericPLEG: Relisting")
+		g.relist()
+	}
+}
+
+// Start spawns a goroutine to relist periodically.
+func (g *GenericPLEG) Start() {
+	g.relist()
+	go util.Until(g.doWork, 0, util.NeverStop)
+}
+
+func buildPodIDSet(containerIDs []string, idMap map[string]types.UID) sets.String {
+	pids := sets.NewString()
+	for _, cid := range containerIDs {
+		if pid, ok := idMap[cid]; ok {
+			pids.Insert(string(pid))
+		}
+	}
+	return pids
+}
+
+// relist relists and sends out PodSync events for pods that have changed.
+// Changes may include container start/deletion, etc.
+func (g *GenericPLEG) relist() {
+	// We ask the runtime twice in order to distinguish between running and
+	// non-running containers. We may want to augment the runtime interface to
+	// make this easier.
+	runningPods, err := g.runtime.GetPods(false)
+	if err != nil {
+		glog.Errorf("GenericPLEG: Unable to retrieve pods: %v", err)
+		return
+	}
+	pods, err := g.runtime.GetPods(true)
+	if err != nil {
+		glog.Errorf("GenericPLEG: Unable to retrieve pods: %v", err)
+		return
+	}
+
+	runningContainers := buildContainerSet(runningPods)
+	containers := buildContainerSet(pods)
+	idMap := buildIDMap(append(pods, runningPods...))
+	toSync := sets.NewString()
+
+	// Newly observed running containers.
+	c := runningContainers.Difference(g.runningContainers).List()
+	toSync = toSync.Union(buildPodIDSet(c, idMap))
+	if len(c) != 0 {
+		glog.V(4).Infof("GenericPLEG: Discovered new running containers: %v", c)
+	}
+	// Containers that were running before, but are no longer running, i.e.,
+	// containers that recently died.
+	c = g.runningContainers.Difference(runningContainers).List()
+	toSync = toSync.Union(buildPodIDSet(c, g.idMap))
+	if len(c) != 0 {
+		glog.V(4).Infof("GenericPLEG: Discovered containers that became non-running: %v", c)
+	}
+	// Newly observed non-running containers. This may include recently died
+	// containers, and newly created (but not yet running) containers, etc.
+	// What we really want is to capture containers that were created and died
+	// (but not yet removed) after the last relist.
+	c = containers.Difference(g.containers).List()
+	toSync = toSync.Union(buildPodIDSet(c, idMap))
+	if len(c) != 0 {
+		glog.V(4).Infof("GenericPLEG: Discovered new non-running containers: %v", c)
+	}
+
+	// Update the internal storage.
+	g.runningContainers = runningContainers
+	g.containers = containers
+	g.idMap = idMap
+	// Send out sync events.
+	for _, pid := range toSync.List() {
+		g.eventChannel <- &PodLifecycleEvent{ID: types.UID(pid), Type: PodSync}
+	}
+}

--- a/pkg/kubelet/pleg/generic_test.go
+++ b/pkg/kubelet/pleg/generic_test.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pleg
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/types"
+)
+
+type TestGenericPLEG struct {
+	pleg    *GenericPLEG
+	runtime *kubecontainer.FakeRuntime
+}
+
+func newTestGenericPLEG() *TestGenericPLEG {
+	fakeRuntime := &kubecontainer.FakeRuntime{}
+	// The channel capacity should be large enough to hold all events in a
+	// single test.
+	pleg := NewGenericPLEG(fakeRuntime, 100, time.Hour)
+	return &TestGenericPLEG{pleg: pleg, runtime: fakeRuntime}
+}
+
+func getEventsFromChannel(ch <-chan *PodLifecycleEvent) []*PodLifecycleEvent {
+	events := []*PodLifecycleEvent{}
+	for len(ch) > 0 {
+		e := <-ch
+		events = append(events, e)
+	}
+	return events
+}
+
+func TestRelistNewRunningContainers(t *testing.T) {
+	testPleg := newTestGenericPLEG()
+	pleg, runtime := testPleg.pleg, testPleg.runtime
+	ch := pleg.Watch()
+
+	// The first relist should send a PodSync event to each pod.
+	runtime.PodList = []*kubecontainer.Pod{
+		{
+			ID: "1234",
+			Containers: []*kubecontainer.Container{
+				{ID: types.UID("c1")},
+			},
+		},
+		{
+			ID: "4567",
+			Containers: []*kubecontainer.Container{
+				{ID: types.UID("c2")},
+			},
+		},
+	}
+	pleg.relist()
+	expected := []*PodLifecycleEvent{
+		{ID: "1234", Type: PodSync},
+		{ID: "4567", Type: PodSync},
+	}
+	actual := getEventsFromChannel(ch)
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("Expected: %#v, got: %#v", expected, actual)
+	}
+
+	// The second relist should not send out any event because the pod list has
+	// not changed.
+	pleg.relist()
+	if len(ch) != 0 {
+		t.Fatalf("Expected 0 event in the channel, got %d", len(ch))
+	}
+
+	// Add a new pod and relist to get the new event.
+	runtime.PodList = append(runtime.PodList, &kubecontainer.Pod{
+		ID:        "7890",
+		Name:      "bar",
+		Namespace: "ns",
+		Containers: []*kubecontainer.Container{
+			{ID: types.UID("c3")},
+		},
+	})
+	pleg.relist()
+	expected = []*PodLifecycleEvent{{ID: "7890", Type: PodSync}}
+	actual = getEventsFromChannel(ch)
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("Expected: %#v, got: %#v", expected, actual)
+	}
+}
+
+func TestRelistContainerNoLongerRunning(t *testing.T) {
+	testPleg := newTestGenericPLEG()
+	pleg, runtime := testPleg.pleg, testPleg.runtime
+	ch := pleg.Watch()
+
+	runtime.PodList = []*kubecontainer.Pod{
+		{
+			ID: "1234",
+			Containers: []*kubecontainer.Container{
+				{ID: types.UID("s1")},
+				{ID: types.UID("s2")},
+			},
+		},
+	}
+	pleg.relist()
+	// Drain events from channel
+	getEventsFromChannel(ch)
+
+	// Remove a container.
+	runtime.PodList = []*kubecontainer.Pod{
+		{
+			ID: "1234",
+			Containers: []*kubecontainer.Container{
+				{ID: types.UID("s1")},
+			},
+		},
+	}
+	pleg.relist()
+	expected := []*PodLifecycleEvent{{ID: "1234", Type: PodSync}}
+	actual := getEventsFromChannel(ch)
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected: %#v, got: %#v", expected, actual)
+	}
+
+	// Remove the entire pod.
+	runtime.PodList = []*kubecontainer.Pod{}
+	pleg.relist()
+	expected = []*PodLifecycleEvent{{ID: "1234", Type: PodSync}}
+	actual = getEventsFromChannel(ch)
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected: %#v, got: %#v", expected, actual)
+	}
+
+}
+
+func TestRelisstNewNonRunningContainer(t *testing.T) {
+	testPleg := newTestGenericPLEG()
+	pleg, runtime := testPleg.pleg, testPleg.runtime
+	ch := pleg.Watch()
+
+	runtime.AllPodList = []*kubecontainer.Pod{
+		{
+			ID: "1234",
+			Containers: []*kubecontainer.Container{
+				{ID: types.UID("x1")},
+			},
+		},
+	}
+	pleg.relist()
+	expected := []*PodLifecycleEvent{{ID: "1234", Type: PodSync}}
+	actual := getEventsFromChannel(ch)
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected: %#v, got: %#v", expected, actual)
+	}
+}

--- a/pkg/kubelet/pleg/pleg.go
+++ b/pkg/kubelet/pleg/pleg.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pleg
+
+import (
+	"k8s.io/kubernetes/pkg/types"
+)
+
+type PodLifeCycleEventType string
+
+const (
+	ContainerStarted      PodLifeCycleEventType = "ContainerStarted"
+	ContainerStopped      PodLifeCycleEventType = "ContainerStopped"
+	NetworkSetupCompleted PodLifeCycleEventType = "NetworkSetupCompleted"
+	NetworkFailed         PodLifeCycleEventType = "NetworkFailed"
+	// PodSync is used to trigger syncing of a pod when the observed change of
+	// the state of the pod cannot be captured by any single event above. E.g.,
+	// during the bootstrapping phase, sending a PodSync event to each pod
+	// ensures that all pods are sync'd once.
+	PodSync PodLifeCycleEventType = "PodSync"
+)
+
+// PodLifecycleEvent is an event reflects the change of the pod state.
+type PodLifecycleEvent struct {
+	// The pod ID.
+	ID types.UID
+	// The type of the event.
+	Type PodLifeCycleEventType
+	// The accompanied data which varies based on the event type.
+	//   - ContainerStarted/ContainerStopped: the container name (string).
+	//   - All other event types: unused.
+	Data interface{}
+}
+
+type PodLifecycleEventGenerator interface {
+	Start()
+	Watch() chan *PodLifecycleEvent
+}

--- a/pkg/kubelet/pod_manager.go
+++ b/pkg/kubelet/pod_manager.go
@@ -44,6 +44,7 @@ type podManager interface {
 	GetPods() []*api.Pod
 	GetPodByFullName(podFullName string) (*api.Pod, bool)
 	GetPodByName(namespace, name string) (*api.Pod, bool)
+	GetPodByUID(uid types.UID) (*api.Pod, bool)
 	GetPodByMirrorPod(*api.Pod) (*api.Pod, bool)
 	GetMirrorPodByPod(*api.Pod) (*api.Pod, bool)
 	GetPodsAndMirrorPods() ([]*api.Pod, []*api.Pod)
@@ -191,6 +192,15 @@ func (pm *basicPodManager) GetPodsAndMirrorPods() ([]*api.Pod, []*api.Pod) {
 // Returns all pods (including mirror pods).
 func (pm *basicPodManager) getAllPods() []*api.Pod {
 	return append(podsMapToPods(pm.podByUID), podsMapToPods(pm.mirrorPodByUID)...)
+}
+
+// GetPodByUID provides the (non-mirror) pod that matches pod UID, as well as
+// whether the pod is found.
+func (pm *basicPodManager) GetPodByUID(uid types.UID) (*api.Pod, bool) {
+	pm.lock.RLock()
+	defer pm.lock.RUnlock()
+	pod, ok := pm.podByUID[uid]
+	return pod, ok
 }
 
 // GetPodByName provides the (non-mirror) pod that matches namespace and name,


### PR DESCRIPTION
This PR adds a pod lifecycle event generator based on the docker event stream.

The PR depends on #13571, and is part of #12802, as listed in https://github.com/kubernetes/kubernetes/pull/13571#issuecomment-137614015
