### PR TITLE
LimitRanger plugin annotates the pods it modifies

### DIFF
--- a/plugin/pkg/admission/initialresources/admission.go
+++ b/plugin/pkg/admission/initialresources/admission.go
@@ -19,6 +19,7 @@ package initialresources
 import (
 	"flag"
 	"io"
+	"sort"
 	"strings"
 	"time"
 
@@ -123,6 +124,7 @@ func (ir initialResources) estimateAndFillResourcesIfNotSet(pod *api.Pod) {
 			req[api.ResourceMemory] = *mem
 		}
 		if len(setRes) > 0 {
+			sort.Strings(setRes)
 			a := strings.Join(setRes, ", ") + " request for container " + c.Name
 			annotations = append(annotations, a)
 		}


### PR DESCRIPTION
I like the changes proposed in https://github.com/kubernetes/kubernetes/pull/13985 to track what requests were set by that admission plugin.

I wanted to add the same concept to `LimitRanger`.  Since it can set either requests or limits, its separated into two annotations.
