### PR TITLE
Explicitly log how long each step of e2e setup/test/teardown takes.

### DIFF
--- a/hack/e2e.go
+++ b/hack/e2e.go
@@ -31,6 +31,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 )
 
 var (
@@ -84,6 +85,7 @@ type TestResult struct {
 type ResultsByTest map[string]TestResult
 
 func main() {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
 	flag.Parse()
 
 	if *isup {
@@ -297,6 +299,10 @@ func finishRunning(stepName string, cmd *exec.Cmd) bool {
 		cmd.Stderr = os.Stderr
 	}
 	log.Printf("Running: %v", stepName)
+	defer func(start time.Time) {
+		log.Printf("Step '%s' finished in %s", stepName, time.Since(start))
+	}(time.Now())
+
 	if err := cmd.Run(); err != nil {
 		log.Printf("Error running %v: %v", stepName, err)
 		return false


### PR DESCRIPTION
A lot of Jenkins runs are taking longer than they used to, and I think this is due to spending more time in setup or teardown, but it's pretty hard to pull that information out.

Explicitly logging the duration of each of these steps should help debug what's happening.

@kubernetes/goog-testing 
