### PR TITLE
Update static Pod annotations with contents of mirror pod.

### DIFF
--- a/pkg/kubelet/config/config.go
+++ b/pkg/kubelet/config/config.go
@@ -338,61 +338,6 @@ func filterInvalidPods(pods []*api.Pod, source string, recorder record.EventReco
 	return
 }
 
-// Annotations that the kubelet adds to the pod.
-var localAnnotations = []string{
-	kubelet.ConfigSourceAnnotationKey,
-	kubelet.ConfigMirrorAnnotationKey,
-	kubelet.ConfigFirstSeenAnnotationKey,
-}
-
-func isLocalAnnotationKey(key string) bool {
-	for _, localKey := range localAnnotations {
-		if key == localKey {
-			return true
-		}
-	}
-	return false
-}
-
-// isAnnotationMapEqual returns true if the existing annotation Map is equal to candidate except
-// for local annotations.
-func isAnnotationMapEqual(existingMap, candidateMap map[string]string) bool {
-	if candidateMap == nil {
-		return true
-	}
-	for k, v := range candidateMap {
-		if existingValue, ok := existingMap[k]; ok && existingValue == v {
-			continue
-		}
-		return false
-	}
-	for k := range existingMap {
-		if isLocalAnnotationKey(k) {
-			continue
-		}
-		// stale entry in existing map.
-		if _, exists := candidateMap[k]; !exists {
-			return false
-		}
-	}
-	return true
-}
-
-// updateAnnotations returns an Annotation map containing the api annotation map plus
-// locally managed annotations
-func updateAnnotations(existing, ref *api.Pod) {
-	annotations := make(map[string]string, len(ref.Annotations)+len(localAnnotations))
-	for k, v := range ref.Annotations {
-		annotations[k] = v
-	}
-	for _, k := range localAnnotations {
-		if v, ok := existing.Annotations[k]; ok {
-			annotations[k] = v
-		}
-	}
-	existing.Annotations = annotations
-}
-
 // checkAndUpdatePod updates existing if ref makes a meaningful change and returns true, or
 // returns false if there was no update.
 func checkAndUpdatePod(existing, ref *api.Pod) bool {
@@ -401,14 +346,14 @@ func checkAndUpdatePod(existing, ref *api.Pod) bool {
 	if reflect.DeepEqual(existing.Spec, ref.Spec) &&
 		reflect.DeepEqual(existing.DeletionTimestamp, ref.DeletionTimestamp) &&
 		reflect.DeepEqual(existing.DeletionGracePeriodSeconds, ref.DeletionGracePeriodSeconds) &&
-		isAnnotationMapEqual(existing.Annotations, ref.Annotations) {
+		kubelet.IsPodRemoteAnnotationMapEqual(existing.Annotations, ref.Annotations) {
 		return false
 	}
 	// this is an update
 	existing.Spec = ref.Spec
 	existing.DeletionTimestamp = ref.DeletionTimestamp
 	existing.DeletionGracePeriodSeconds = ref.DeletionGracePeriodSeconds
-	updateAnnotations(existing, ref)
+	kubelet.UpdatePodRemoteAnnotations(existing, ref)
 	return true
 }
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1349,12 +1349,17 @@ func (kl *Kubelet) syncPod(pod *api.Pod, mirrorPod *api.Pod, runningPod kubecont
 	}
 
 	if isStaticPod(pod) {
-		if mirrorPod != nil && !kl.podManager.IsMirrorPodOf(mirrorPod, pod) {
-			// The mirror pod is semantically different from the static pod. Remove
-			// it. The mirror pod will get recreated later.
-			glog.Errorf("Deleting mirror pod %q because it is outdated", podFullName)
-			if err := kl.podManager.DeleteMirrorPod(podFullName); err != nil {
-				glog.Errorf("Failed deleting mirror pod %q: %v", podFullName, err)
+		if mirrorPod != nil {
+			if !kl.podManager.IsMirrorPodOf(mirrorPod, pod) {
+				// The mirror pod is semantically different from the static pod. Remove
+				// it. The mirror pod will get recreated later.
+				glog.Errorf("Deleting mirror pod %q because it is outdated", podFullName)
+				if err := kl.podManager.DeleteMirrorPod(podFullName); err != nil {
+					glog.Errorf("Failed deleting mirror pod %q: %v", podFullName, err)
+				}
+			} else {
+				// Merge in the annotations from the mirror pod.
+				UpdatePodRemoteAnnotations(pod, mirrorPod)
 			}
 		}
 		if mirrorPod == nil {


### PR DESCRIPTION
Support pod Annotations for static pods (dynamic pod support has been covered by pr #13334). This allows the master to add capabilities to the static pod. For instance, an optional network manager component can move a pod to a segregated network.
