### PR TITLE
add a Version() function to runtime.Encoder

### DIFF
--- a/pkg/api/meta/restmapper_test.go
+++ b/pkg/api/meta/restmapper_test.go
@@ -25,6 +25,10 @@ import (
 
 type fakeCodec struct{}
 
+func (fakeCodec) Version() string {
+	return ""
+}
+
 func (fakeCodec) Encode(runtime.Object) ([]byte, error) {
 	return []byte{}, nil
 }

--- a/pkg/registry/thirdpartyresourcedata/codec.go
+++ b/pkg/registry/thirdpartyresourcedata/codec.go
@@ -220,6 +220,9 @@ func encodeToJSON(obj *experimental.ThirdPartyResourceData) ([]byte, error) {
 	return json.Marshal(objMap)
 }
 
+func (t *thirdPartyResourceDataCodec) Version() string {
+	return "ThirdpartyResourceDataCodec does not have a version"
+}
 func (t *thirdPartyResourceDataCodec) Encode(obj runtime.Object) (data []byte, err error) {
 	switch obj := obj.(type) {
 	case *experimental.ThirdPartyResourceData:

--- a/pkg/runtime/codec.go
+++ b/pkg/runtime/codec.go
@@ -78,6 +78,11 @@ func (c *codecWrapper) Encode(obj Object) ([]byte, error) {
 	return c.EncodeToVersion(obj, c.version)
 }
 
+// Version implements Encoder
+func (c *codecWrapper) Version() string {
+	return c.version
+}
+
 // TODO: Make this behaviour default when we move everyone away from
 // the unversioned types.
 //

--- a/pkg/runtime/interfaces.go
+++ b/pkg/runtime/interfaces.go
@@ -45,6 +45,9 @@ type Decoder interface {
 // Encoder defines methods for serializing API objects into bytes
 type Encoder interface {
 	Encode(obj Object) (data []byte, err error)
+	// Version returns the group and version the encoder will encode an object
+	// to, in the form of "group/version".
+	Version() (version string)
 }
 
 // Codec defines methods for serializing and deserializing API objects.


### PR DESCRIPTION
Ref https://github.com/caesarxuchao/kubernetes/commit/9c5ace530b4389e9ba47f3d2f93081b023191fd2#commitcomment-13145842

The Version() function shall return the version the encoder will encode object to.

@lavalamp @smarterclayton
