### PR TITLE
Move scheduler from devel to admin

### DIFF
--- a/docs/admin/scheduler.md
+++ b/docs/admin/scheduler.md
@@ -20,7 +20,7 @@ refer to the docs that go with that version.
 
 <strong>
 The latest 1.0.x release of this document can be found
-[here](http://releases.k8s.io/release-1.0/docs/devel/scheduler.md).
+[here](http://releases.k8s.io/release-1.0/docs/admin/scheduler.md).
 
 Documentation for other releases can be found at
 [releases.k8s.io](http://releases.k8s.io).
@@ -79,6 +79,8 @@ If you want to get a global picture of how the scheduler works, you can start in
 [plugin/cmd/kube-scheduler/app/server.go](http://releases.k8s.io/HEAD/plugin/cmd/kube-scheduler/app/server.go)
 
 
+
+
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/devel/scheduler.md?pixel)]()
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/admin/scheduler.md?pixel)]()
 <!-- END MUNGE: GENERATED_ANALYTICS -->

--- a/docs/admin/scheduler_algorithm.md
+++ b/docs/admin/scheduler_algorithm.md
@@ -20,7 +20,7 @@ refer to the docs that go with that version.
 
 <strong>
 The latest 1.0.x release of this document can be found
-[here](http://releases.k8s.io/release-1.0/docs/devel/scheduler_algorithm.md).
+[here](http://releases.k8s.io/release-1.0/docs/admin/scheduler_algorithm.md).
 
 Documentation for other releases can be found at
 [releases.k8s.io](http://releases.k8s.io).
@@ -67,6 +67,8 @@ Currently, Kubernetes scheduler provides some practical priority functions, incl
 The details of the above priority functions can be found in [plugin/pkg/scheduler/algorithm/priorities](http://releases.k8s.io/HEAD/plugin/pkg/scheduler/algorithm/priorities/). Kubernetes uses some, but not all, of these priority functions by default. You can see which ones are used by default in [plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go](http://releases.k8s.io/HEAD/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go). Similar as predicates, you can combine the above priority functions and assign weight factors (positive number) to them as you want (check [scheduler.md](scheduler.md) for how to customize).
 
 
+
+
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/devel/scheduler_algorithm.md?pixel)]()
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/admin/scheduler_algorithm.md?pixel)]()
 <!-- END MUNGE: GENERATED_ANALYTICS -->


### PR DESCRIPTION
**Modifications:**

Scheduler as one of the master components, I do not find a good reason it should resident in `docs/devel`, so I moved them to `docs/admin` by using the `git mv` command.

Meanwhile I removed its executable permissions.

Affected files:
- `scheduler.md`
- `scheduler_algorithm.md`

**Legacy problems:**

After that I ran a `hack/update-generated-docs.sh` command, it automatically updated the doc links from `docs/devel/scheduler.md` to `docs/admin/scheduler.md`, but made the links below unavailable:
- `http://releases.k8s.io/release-1.0/docs/admin/scheduler.md`
- `http://releases.k8s.io/release-1.0/docs/admin/scheduler_algorithm.md`

**Please:**
1. Review if the moving of scheduler from `docs/devel` to `docs/admin` is necessary and acceptable. If you think it is unnecessary and gives me a good reason I will close this PR.
2. How to handle the unavailable links?  
