### PR TITLE
hack/test-go.sh: make kube::test::find_dirs actually work correctly

### DIFF
--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -28,17 +28,16 @@ kube::test::find_dirs() {
     cd ${KUBE_ROOT}
     find . -not \( \
         \( \
-          -wholename './output' \
-          -o -wholename './_output' \
-          -o -wholename './_artifacts/' \
-          -o -wholename './_gopath/' \
-          -o -wholename './release' \
-          -o -wholename './target' \
-          -o -wholename '*/Godeps/*' \
-          -o -wholename './release*' \
-          -o -wholename '*/contrib/podex/*' \
-          -o -wholename '*/test/e2e/*' \
-          -o -wholename '*/test/integration/*' \
+          -path './_artifacts/*' \
+          -o -path './_output/*' \
+          -o -path './_gopath/*' \
+          -o -path './Godeps/*' \
+          -o -path './contrib/podex/*' \
+          -o -path './output/*' \
+          -o -path './release/*' \
+          -o -path './target/*' \
+          -o -path './test/e2e/*' \
+          -o -path './test/integration/*' \
         \) -prune \
       \) -name '*_test.go' -print0 | xargs -0n1 dirname | sed 's|^\./||' | sort -u
   )


### PR DESCRIPTION
A follow-on to #13951, as my changes to `hack/test-go.sh` in that PR were insufficient; _gopath was still being included in the list of directories being tested:

```
+ ./hack/test-go.sh
Running tests for APIVersion: v1,experimental/v1 with etcdPrefix: registry
+++ [0915 23:17:22] Running tests without code coverage
_output/local/go/src/k8s.io/kubernetes/_gopath/src/github.com/jstemmer/go-junit-report/go-junit-report.go:8:2: cannot find package "github.com/jstemmer/go-junit-report/parser" in any of:
        /usr/local/go/src/github.com/jstemmer/go-junit-report/parser (from $GOROOT)
        /jenkins-master-data/jobs/kubernetes-test-go/workspace/_output/local/go/src/github.com/jstemmer/go-junit-report/parser (from $GOPATH)
        /jenkins-master-data/jobs/kubernetes-test-go/workspace/Godeps/_workspace/src/github.com/jstemmer/go-junit-report/parser
+++ [0915 23:17:25] Saved JUnit XML test report to /var/lib/jenkins/jobs/kubernetes-test-go/workspace/_artifacts/junit_v1,experimental-v1_20150915-231722.xml
!!! Error in ./hack/test-go.sh:212
  'return ${rc}' exited with status 1
Call stack:
  1: ./hack/test-go.sh:212 main(...)
Exiting with status 1
```

I've actually tested my fix locally this time. :)

@kubernetes/goog-testing @kubernetes/rh-cluster-infra @timothysc
