### PR TITLE
Fix doc generation on Macs

### DIFF
--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -175,7 +175,7 @@ kube::util::gen-docs() {
   # create the list of generated files
   pushd "${dest}" > /dev/null
   touch .generated_docs
-  find -type f | cut -sd / -f 2- | LC_ALL=C sort > .generated_docs
+  find . -type f | cut -sd / -f 2- | LC_ALL=C sort > .generated_docs
   popd > /dev/null
 
   while read file; do


### PR DESCRIPTION
The find util on macs require a path. Linux does not. So give it the
path to work on both.
