### PR TITLE
Add kubectl expose to GCE_PARALLEL_FLAKY_TESTS

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -160,6 +160,7 @@ GCE_PARALLEL_FLAKY_TESTS=(
     "Services.*endpoint"
     "Services.*up\sand\sdown"
     "Networking\sshould\sfunction\sfor\sintra-pod\scommunication"  # possibly causing Ginkgo to get stuck, issue: #13485
+    "Kubectl\sexpose"
     )
 
 # Tests that should not run on soak cluster.


### PR DESCRIPTION
It's essentially the same as Services.*expose, just using kubectl instead of client lib. Fixed typo and changed to use shared serviceStartTimeout while I'm at it.

Fixes #14078

cc @ixdy
