### PR TITLE
Deployment API: Updating MaxSurge and MaxUnavailable to be on desired replicas

### DIFF
--- a/pkg/apis/experimental/v1/types.go
+++ b/pkg/apis/experimental/v1/types.go
@@ -243,27 +243,28 @@ const (
 // Spec to control the desired behavior of rolling update.
 type RollingUpdateDeployment struct {
 	// The maximum number of pods that can be unavailable during the update.
-	// Value can be an absolute number (ex: 5) or a percentage of total pods at the start of update (ex: 10%).
+	// Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
 	// Absolute number is calculated from percentage by rounding up.
 	// This can not be 0 if MaxSurge is 0.
 	// By default, a fixed value of 1 is used.
-	// Example: when this is set to 30%, the old RC can be scaled down by 30%
+	// Example: when this is set to 30%, the old RC can be scaled down to 70% of desired pods
 	// immediately when the rolling update starts. Once new pods are ready, old RC
 	// can be scaled down further, followed by scaling up the new RC, ensuring
-	// that at least 70% of original number of pods are available at all times
-	// during the update.
+	// that the total number of pods available at all times during the update is at
+	// least 70% of desired pods.
 	MaxUnavailable *util.IntOrString `json:"maxUnavailable,omitempty"`
 
-	// The maximum number of pods that can be scheduled above the original number of
+	// The maximum number of pods that can be scheduled above the desired number of
 	// pods.
-	// Value can be an absolute number (ex: 5) or a percentage of total pods at
-	// the start of the update (ex: 10%). This can not be 0 if MaxUnavailable is 0.
+	// Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+	// This can not be 0 if MaxUnavailable is 0.
 	// Absolute number is calculated from percentage by rounding up.
 	// By default, a value of 1 is used.
-	// Example: when this is set to 30%, the new RC can be scaled up by 30%
-	// immediately when the rolling update starts. Once old pods have been killed,
+	// Example: when this is set to 30%, the new RC can be scaled up immediately when
+	// the rolling update starts, such that the total number of old and new pods do not exceed
+	// 130% of desired pods. Once old pods have been killed,
 	// new RC can be scaled up further, ensuring that total number of pods running
-	// at any time during the update is atmost 130% of original pods.
+	// at any time during the update is atmost 130% of desired pods.
 	MaxSurge *util.IntOrString `json:"maxSurge,omitempty"`
 
 	// Minimum number of seconds for which a newly created pod should be ready


### PR DESCRIPTION
Based on discussion at https://github.com/kubernetes/kubernetes/issues/14008

cc @bgrant0607 @ghodss @ironcladlou 
