### PR TITLE
Remove unnecessary GinkgoRecover() calls

### DIFF
--- a/test/e2e/networking.go
+++ b/test/e2e/networking.go
@@ -129,7 +129,6 @@ var _ = Describe("Networking", func() {
 
 		// Clean up service
 		defer func() {
-			defer GinkgoRecover()
 			By("Cleaning up the service")
 			if err = f.Client.Services(f.Namespace.Name).Delete(svc.Name); err != nil {
 				Failf("unable to delete svc %v: %v", svc.Name, err)
@@ -166,7 +165,6 @@ var _ = Describe("Networking", func() {
 
 		// Clean up the pods
 		defer func() {
-			defer GinkgoRecover()
 			By("Cleaning up the webserver pods")
 			for _, podName := range podNames {
 				if err = f.Client.Pods(f.Namespace.Name).Delete(podName, nil); err != nil {


### PR DESCRIPTION
@quinton-hoole pointed out to me that these are not needed here, since these aren't in a goroutine; they're probably a leftover from when I  had this test using the (broken) Ginkgo timeout feature.

There are others in the code that should be examined, too.
