### PR TITLE
Move util.Time to api/unversioned and add Duration

### DIFF
--- a/contrib/mesos/pkg/scheduler/fcfs.go
+++ b/contrib/mesos/pkg/scheduler/fcfs.go
@@ -18,6 +18,7 @@ package scheduler
 
 import (
 	"fmt"
+
 	log "github.com/golang/glog"
 
 	"k8s.io/kubernetes/contrib/mesos/pkg/offers"

--- a/contrib/mesos/pkg/scheduler/plugin_test.go
+++ b/contrib/mesos/pkg/scheduler/plugin_test.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/kubernetes/pkg/client/cache"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
-	kutil "k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/watch"
 
 	log "github.com/golang/glog"
@@ -273,7 +272,7 @@ func (o *EventObserver) Event(object runtime.Object, reason, message string) {
 func (o *EventObserver) Eventf(object runtime.Object, reason, messageFmt string, args ...interface{}) {
 	o.fifo <- Event{Object: object, Reason: reason, Message: fmt.Sprintf(messageFmt, args...)}
 }
-func (o *EventObserver) PastEventf(object runtime.Object, timestamp kutil.Time, reason, messageFmt string, args ...interface{}) {
+func (o *EventObserver) PastEventf(object runtime.Object, timestamp unversioned.Time, reason, messageFmt string, args ...interface{}) {
 	o.fifo <- Event{Object: object, Reason: reason, Message: fmt.Sprintf(messageFmt, args...)}
 }
 

--- a/docs/design/event_compression.md
+++ b/docs/design/event_compression.md
@@ -49,9 +49,9 @@ Event compression should be best effort (not guaranteed). Meaning, in the worst 
 ## Design
 
 Instead of a single Timestamp, each event object [contains](http://releases.k8s.io/HEAD/pkg/api/types.go#L1111) the following fields:
- * `FirstTimestamp util.Time`
+ * `FirstTimestamp unversioned.Time`
    * The date/time of the first occurrence of the event.
- * `LastTimestamp util.Time`
+ * `LastTimestamp unversioned.Time`
    * The date/time of the most recent occurrence of the event.
    * On first occurrence, this is equal to the FirstTimestamp.
  * `Count int`

--- a/docs/design/expansion.md
+++ b/docs/design/expansion.md
@@ -265,7 +265,7 @@ type ObjectEventRecorder interface {
 	Eventf(reason, messageFmt string, args ...interface{})
 
 	// PastEventf is just like Eventf, but with an option to specify the event's 'timestamp' field.
-	PastEventf(timestamp util.Time, reason, messageFmt string, args ...interface{})
+	PastEventf(timestamp unversioned.Time, reason, messageFmt string, args ...interface{})
 }
 ```
 

--- a/docs/devel/api-conventions.md
+++ b/docs/devel/api-conventions.md
@@ -189,8 +189,8 @@ The `FooCondition` type for some resource type `Foo` may include a subset of the
 ```golang
 	Type               FooConditionType  `json:"type" description:"type of Foo condition"`
 	Status             ConditionStatus   `json:"status" description:"status of the condition, one of True, False, Unknown"`
-	LastHeartbeatTime  util.Time         `json:"lastHeartbeatTime,omitempty" description:"last time we got an update on a given condition"`
-	LastTransitionTime util.Time         `json:"lastTransitionTime,omitempty" description:"last time the condition transit from one status to another"`
+	LastHeartbeatTime  unversioned.Time         `json:"lastHeartbeatTime,omitempty" description:"last time we got an update on a given condition"`
+	LastTransitionTime unversioned.Time         `json:"lastTransitionTime,omitempty" description:"last time the condition transit from one status to another"`
 	Reason             string            `json:"reason,omitempty" description:"one-word CamelCase reason for the condition's last transition"`
 	Message            string            `json:"message,omitempty" description:"human-readable message indicating details about last transition"`
 ```

--- a/docs/proposals/compute-resource-metrics-api.md
+++ b/docs/proposals/compute-resource-metrics-api.md
@@ -161,7 +161,7 @@ type MetricsWindows map[time.Duration]DerivedMetrics
 
 type DerivedMetrics struct {
 	// End time of all the time windows in Metrics
-	EndTime util.Time `json:"endtime"`
+	EndTime unversioned.Time `json:"endtime"`
 
 	Mean       ResourceUsage `json:"mean"`
 	Max        ResourceUsage `json:"max"`

--- a/docs/proposals/horizontal-pod-autoscaler.md
+++ b/docs/proposals/horizontal-pod-autoscaler.md
@@ -162,7 +162,7 @@ type HorizontalPodAutoscalerStatus struct {
 
 	// LastScaleTimestamp is the last time the HorizontalPodAutoscaler scaled the number of pods.
 	// This is used by the autoscaler to control how often the number of pods is changed.
-	LastScaleTimestamp *util.Time
+	LastScaleTimestamp *unversioned.Time
 }
 
 // ResourceConsumption is an object for specifying average resource consumption of a particular resource.

--- a/docs/proposals/job.md
+++ b/docs/proposals/job.md
@@ -131,13 +131,13 @@ type JobStatus struct {
     Conditions []JobCondition
 
     // CreationTime represents time when the job was created
-    CreationTime util.Time
+    CreationTime unversioned.Time
 
     // StartTime represents time when the job was started
-    StartTime util.Time
+    StartTime unversioned.Time
 
     // CompletionTime represents time when the job was completed
-    CompletionTime util.Time
+    CompletionTime unversioned.Time
 
     // Active is the number of actively running pods.
     Active int
@@ -162,8 +162,8 @@ const (
 type JobCondition struct {
     Type               JobConditionType
     Status             ConditionStatus
-    LastHeartbeatTime  util.Time
-    LastTransitionTime util.Time
+    LastHeartbeatTime  unversioned.Time
+    LastTransitionTime unversioned.Time
     Reason             string
     Message            string
 }

--- a/examples/https-nginx/make_secret.go
+++ b/examples/https-nginx/make_secret.go
@@ -24,10 +24,11 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"log"
+
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/runtime"
-	"log"
 )
 
 // TODO:

--- a/pkg/api/conversion.go
+++ b/pkg/api/conversion.go
@@ -18,11 +18,11 @@ package api
 
 import (
 	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/conversion"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/util"
 )
 
 // Codec is the identity codec for this package - it can only convert itself
@@ -46,7 +46,7 @@ func init() {
 		},
 	)
 	Scheme.AddConversionFuncs(
-		func(in *util.Time, out *util.Time, s conversion.Scope) error {
+		func(in *unversioned.Time, out *unversioned.Time, s conversion.Scope) error {
 			// Cannot deep copy these, because time.Time has unexported fields.
 			*out = *in
 			return nil

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -280,7 +280,7 @@ func deepCopy_api_ContainerState(in ContainerState, out *ContainerState, c *conv
 }
 
 func deepCopy_api_ContainerStateRunning(in ContainerStateRunning, out *ContainerStateRunning, c *conversion.Cloner) error {
-	if err := deepCopy_util_Time(in.StartedAt, &out.StartedAt, c); err != nil {
+	if err := deepCopy_unversioned_Time(in.StartedAt, &out.StartedAt, c); err != nil {
 		return err
 	}
 	return nil
@@ -291,10 +291,10 @@ func deepCopy_api_ContainerStateTerminated(in ContainerStateTerminated, out *Con
 	out.Signal = in.Signal
 	out.Reason = in.Reason
 	out.Message = in.Message
-	if err := deepCopy_util_Time(in.StartedAt, &out.StartedAt, c); err != nil {
+	if err := deepCopy_unversioned_Time(in.StartedAt, &out.StartedAt, c); err != nil {
 		return err
 	}
-	if err := deepCopy_util_Time(in.FinishedAt, &out.FinishedAt, c); err != nil {
+	if err := deepCopy_unversioned_Time(in.FinishedAt, &out.FinishedAt, c); err != nil {
 		return err
 	}
 	out.ContainerID = in.ContainerID
@@ -503,10 +503,10 @@ func deepCopy_api_Event(in Event, out *Event, c *conversion.Cloner) error {
 	if err := deepCopy_api_EventSource(in.Source, &out.Source, c); err != nil {
 		return err
 	}
-	if err := deepCopy_util_Time(in.FirstTimestamp, &out.FirstTimestamp, c); err != nil {
+	if err := deepCopy_unversioned_Time(in.FirstTimestamp, &out.FirstTimestamp, c); err != nil {
 		return err
 	}
-	if err := deepCopy_util_Time(in.LastTimestamp, &out.LastTimestamp, c); err != nil {
+	if err := deepCopy_unversioned_Time(in.LastTimestamp, &out.LastTimestamp, c); err != nil {
 		return err
 	}
 	out.Count = in.Count
@@ -913,10 +913,10 @@ func deepCopy_api_NodeAddress(in NodeAddress, out *NodeAddress, c *conversion.Cl
 func deepCopy_api_NodeCondition(in NodeCondition, out *NodeCondition, c *conversion.Cloner) error {
 	out.Type = in.Type
 	out.Status = in.Status
-	if err := deepCopy_util_Time(in.LastHeartbeatTime, &out.LastHeartbeatTime, c); err != nil {
+	if err := deepCopy_unversioned_Time(in.LastHeartbeatTime, &out.LastHeartbeatTime, c); err != nil {
 		return err
 	}
-	if err := deepCopy_util_Time(in.LastTransitionTime, &out.LastTransitionTime, c); err != nil {
+	if err := deepCopy_unversioned_Time(in.LastTransitionTime, &out.LastTransitionTime, c); err != nil {
 		return err
 	}
 	out.Reason = in.Reason
@@ -1028,12 +1028,12 @@ func deepCopy_api_ObjectMeta(in ObjectMeta, out *ObjectMeta, c *conversion.Clone
 	out.UID = in.UID
 	out.ResourceVersion = in.ResourceVersion
 	out.Generation = in.Generation
-	if err := deepCopy_util_Time(in.CreationTimestamp, &out.CreationTimestamp, c); err != nil {
+	if err := deepCopy_unversioned_Time(in.CreationTimestamp, &out.CreationTimestamp, c); err != nil {
 		return err
 	}
 	if in.DeletionTimestamp != nil {
-		out.DeletionTimestamp = new(util.Time)
-		if err := deepCopy_util_Time(*in.DeletionTimestamp, out.DeletionTimestamp, c); err != nil {
+		out.DeletionTimestamp = new(unversioned.Time)
+		if err := deepCopy_unversioned_Time(*in.DeletionTimestamp, out.DeletionTimestamp, c); err != nil {
 			return err
 		}
 	} else {
@@ -1482,8 +1482,8 @@ func deepCopy_api_PodStatus(in PodStatus, out *PodStatus, c *conversion.Cloner) 
 	out.HostIP = in.HostIP
 	out.PodIP = in.PodIP
 	if in.StartTime != nil {
-		out.StartTime = new(util.Time)
-		if err := deepCopy_util_Time(*in.StartTime, out.StartTime, c); err != nil {
+		out.StartTime = new(unversioned.Time)
+		if err := deepCopy_unversioned_Time(*in.StartTime, out.StartTime, c); err != nil {
 			return err
 		}
 	} else {
@@ -2180,6 +2180,15 @@ func deepCopy_unversioned_ListMeta(in unversioned.ListMeta, out *unversioned.Lis
 	return nil
 }
 
+func deepCopy_unversioned_Time(in unversioned.Time, out *unversioned.Time, c *conversion.Cloner) error {
+	if newVal, err := c.DeepCopy(in.Time); err != nil {
+		return err
+	} else {
+		out.Time = newVal.(time.Time)
+	}
+	return nil
+}
+
 func deepCopy_unversioned_TypeMeta(in unversioned.TypeMeta, out *unversioned.TypeMeta, c *conversion.Cloner) error {
 	out.Kind = in.Kind
 	out.APIVersion = in.APIVersion
@@ -2190,15 +2199,6 @@ func deepCopy_util_IntOrString(in util.IntOrString, out *util.IntOrString, c *co
 	out.Kind = in.Kind
 	out.IntVal = in.IntVal
 	out.StrVal = in.StrVal
-	return nil
-}
-
-func deepCopy_util_Time(in util.Time, out *util.Time, c *conversion.Cloner) error {
-	if newVal, err := c.DeepCopy(in.Time); err != nil {
-		return err
-	} else {
-		out.Time = newVal.(time.Time)
-	}
 	return nil
 }
 
@@ -2322,9 +2322,9 @@ func init() {
 		deepCopy_api_VolumeSource,
 		deepCopy_resource_Quantity,
 		deepCopy_unversioned_ListMeta,
+		deepCopy_unversioned_Time,
 		deepCopy_unversioned_TypeMeta,
 		deepCopy_util_IntOrString,
-		deepCopy_util_Time,
 	)
 	if err != nil {
 		// if one of the deep copy functions is malformed, detect it immediately.

--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -23,11 +23,11 @@ import (
 	"strings"
 
 	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/conversion"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/sets"
 
 	"github.com/davecgh/go-spew/spew"
@@ -67,7 +67,7 @@ var Semantic = conversion.EqualitiesOrDie(
 		}
 		return a.Amount.Cmp(b.Amount) == 0
 	},
-	func(a, b util.Time) bool {
+	func(a, b unversioned.Time) bool {
 		return a.UTC() == b.UTC()
 	},
 	func(a, b labels.Selector) bool {

--- a/pkg/api/meta.go
+++ b/pkg/api/meta.go
@@ -25,7 +25,7 @@ import (
 
 // FillObjectMetaSystemFields populates fields that are managed by the system on ObjectMeta.
 func FillObjectMetaSystemFields(ctx Context, meta *ObjectMeta) {
-	meta.CreationTimestamp = util.Now()
+	meta.CreationTimestamp = unversioned.Now()
 	meta.UID = util.NewUUID()
 	meta.SelfLink = ""
 }

--- a/pkg/api/meta/meta_test.go
+++ b/pkg/api/meta/meta_test.go
@@ -20,8 +20,8 @@ import (
 	"reflect"
 	"testing"
 
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/util"
 )
 
 func TestGenericTypeMeta(t *testing.T) {
@@ -31,7 +31,7 @@ func TestGenericTypeMeta(t *testing.T) {
 		Name              string            `json:"name,omitempty"`
 		GenerateName      string            `json:"generateName,omitempty"`
 		UID               string            `json:"uid,omitempty"`
-		CreationTimestamp util.Time         `json:"creationTimestamp,omitempty"`
+		CreationTimestamp unversioned.Time  `json:"creationTimestamp,omitempty"`
 		SelfLink          string            `json:"selfLink,omitempty"`
 		ResourceVersion   string            `json:"resourceVersion,omitempty"`
 		APIVersion        string            `json:"apiVersion,omitempty"`
@@ -146,7 +146,7 @@ type InternalTypeMeta struct {
 	Name              string            `json:"name,omitempty"`
 	GenerateName      string            `json:"generateName,omitempty"`
 	UID               string            `json:"uid,omitempty"`
-	CreationTimestamp util.Time         `json:"creationTimestamp,omitempty"`
+	CreationTimestamp unversioned.Time  `json:"creationTimestamp,omitempty"`
 	SelfLink          string            `json:"selfLink,omitempty"`
 	ResourceVersion   string            `json:"resourceVersion,omitempty"`
 	APIVersion        string            `json:"apiVersion,omitempty"`
@@ -321,7 +321,7 @@ func TestGenericObjectMeta(t *testing.T) {
 		Name              string            `json:"name,omitempty"`
 		GenerateName      string            `json:"generateName,omitempty"`
 		UID               string            `json:"uid,omitempty"`
-		CreationTimestamp util.Time         `json:"creationTimestamp,omitempty"`
+		CreationTimestamp unversioned.Time  `json:"creationTimestamp,omitempty"`
 		SelfLink          string            `json:"selfLink,omitempty"`
 		ResourceVersion   string            `json:"resourceVersion,omitempty"`
 		Labels            map[string]string `json:"labels,omitempty"`

--- a/pkg/api/rest/delete.go
+++ b/pkg/api/rest/delete.go
@@ -20,8 +20,8 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/util"
 )
 
 // RESTDeleteStrategy defines deletion behavior on an object that follows Kubernetes
@@ -62,7 +62,7 @@ func BeforeDelete(strategy RESTDeleteStrategy, ctx api.Context, obj runtime.Obje
 			if period > *objectMeta.DeletionGracePeriodSeconds {
 				return false, true, nil
 			}
-			now := util.NewTime(util.Now().Add(time.Second * time.Duration(*options.GracePeriodSeconds)))
+			now := unversioned.NewTime(unversioned.Now().Add(time.Second * time.Duration(*options.GracePeriodSeconds)))
 			objectMeta.DeletionTimestamp = &now
 			objectMeta.DeletionGracePeriodSeconds = &period
 			options.GracePeriodSeconds = &period
@@ -76,7 +76,7 @@ func BeforeDelete(strategy RESTDeleteStrategy, ctx api.Context, obj runtime.Obje
 	if !strategy.CheckGracefulDelete(obj, options) {
 		return false, false, nil
 	}
-	now := util.NewTime(util.Now().Add(time.Second * time.Duration(*options.GracePeriodSeconds)))
+	now := unversioned.NewTime(unversioned.Now().Add(time.Second * time.Duration(*options.GracePeriodSeconds)))
 	objectMeta.DeletionTimestamp = &now
 	objectMeta.DeletionGracePeriodSeconds = options.GracePeriodSeconds
 	return true, false, nil

--- a/pkg/api/rest/resttest/resttest.go
+++ b/pkg/api/rest/resttest/resttest.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/tools"
-	"k8s.io/kubernetes/pkg/util"
 )
 
 type Tester struct {
@@ -370,7 +369,7 @@ func (t *Tester) testCreateRejectsMismatchedNamespace(valid runtime.Object) {
 
 func (t *Tester) testCreateResetsUserData(valid runtime.Object) {
 	objectMeta := t.getObjectMetaOrFail(valid)
-	now := util.Now()
+	now := unversioned.Now()
 	objectMeta.UID = "bad-uid"
 	objectMeta.CreationTimestamp = now
 

--- a/pkg/api/testing/fuzzer.go
+++ b/pkg/api/testing/fuzzer.go
@@ -71,7 +71,7 @@ func FuzzerFor(t *testing.T, version string, src rand.Source) *fuzz.Fuzzer {
 			var sec, nsec int64
 			c.Fuzz(&sec)
 			c.Fuzz(&nsec)
-			j.CreationTimestamp = util.Unix(sec, nsec).Rfc3339Copy()
+			j.CreationTimestamp = unversioned.Unix(sec, nsec).Rfc3339Copy()
 		},
 		func(j *api.ObjectReference, c fuzz.Continue) {
 			// We have to customize the randomization of TypeMetas because their

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -104,7 +104,7 @@ type ObjectMeta struct {
 	// CreationTimestamp is a timestamp representing the server time when this object was
 	// created. It is not guaranteed to be set in happens-before order across separate operations.
 	// Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-	CreationTimestamp util.Time `json:"creationTimestamp,omitempty"`
+	CreationTimestamp unversioned.Time `json:"creationTimestamp,omitempty"`
 
 	// DeletionTimestamp is the time after which this resource will be deleted. This
 	// field is set by the server when a graceful deletion is requested by the user, and is not
@@ -115,7 +115,7 @@ type ObjectMeta struct {
 	// a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination
 	// signal to the containers in the pod. Once the resource is deleted in the API, the Kubelet
 	// will send a hard termination signal to the container.
-	DeletionTimestamp *util.Time `json:"deletionTimestamp,omitempty"`
+	DeletionTimestamp *unversioned.Time `json:"deletionTimestamp,omitempty"`
 
 	// DeletionGracePeriodSeconds records the graceful deletion value set when graceful deletion
 	// was requested. Represents the most recent grace period, and may only be shortened once set.
@@ -814,17 +814,17 @@ type ContainerStateWaiting struct {
 }
 
 type ContainerStateRunning struct {
-	StartedAt util.Time `json:"startedAt,omitempty"`
+	StartedAt unversioned.Time `json:"startedAt,omitempty"`
 }
 
 type ContainerStateTerminated struct {
-	ExitCode    int       `json:"exitCode"`
-	Signal      int       `json:"signal,omitempty"`
-	Reason      string    `json:"reason,omitempty"`
-	Message     string    `json:"message,omitempty"`
-	StartedAt   util.Time `json:"startedAt,omitempty"`
-	FinishedAt  util.Time `json:"finishedAt,omitempty"`
-	ContainerID string    `json:"containerID,omitempty"`
+	ExitCode    int              `json:"exitCode"`
+	Signal      int              `json:"signal,omitempty"`
+	Reason      string           `json:"reason,omitempty"`
+	Message     string           `json:"message,omitempty"`
+	StartedAt   unversioned.Time `json:"startedAt,omitempty"`
+	FinishedAt  unversioned.Time `json:"finishedAt,omitempty"`
+	ContainerID string           `json:"containerID,omitempty"`
 }
 
 // ContainerState holds a possible state of container.
@@ -980,7 +980,7 @@ type PodStatus struct {
 
 	// Date and time at which the object was acknowledged by the Kubelet.
 	// This is before the Kubelet pulled the container image(s) for the pod.
-	StartTime *util.Time `json:"startTime,omitempty"`
+	StartTime *unversioned.Time `json:"startTime,omitempty"`
 
 	// The list has one entry per container in the manifest. Each entry is
 	// currently the output of `docker inspect`. This output format is *not*
@@ -1415,8 +1415,8 @@ const (
 type NodeCondition struct {
 	Type               NodeConditionType `json:"type"`
 	Status             ConditionStatus   `json:"status"`
-	LastHeartbeatTime  util.Time         `json:"lastHeartbeatTime,omitempty"`
-	LastTransitionTime util.Time         `json:"lastTransitionTime,omitempty"`
+	LastHeartbeatTime  unversioned.Time  `json:"lastHeartbeatTime,omitempty"`
+	LastTransitionTime unversioned.Time  `json:"lastTransitionTime,omitempty"`
 	Reason             string            `json:"reason,omitempty"`
 	Message            string            `json:"message,omitempty"`
 }
@@ -1693,10 +1693,10 @@ type Event struct {
 	Source EventSource `json:"source,omitempty"`
 
 	// The time at which the event was first recorded. (Time of server receipt is in TypeMeta.)
-	FirstTimestamp util.Time `json:"firstTimestamp,omitempty"`
+	FirstTimestamp unversioned.Time `json:"firstTimestamp,omitempty"`
 
 	// The time at which the most recent occurrence of this event was recorded.
-	LastTimestamp util.Time `json:"lastTimestamp,omitempty"`
+	LastTimestamp unversioned.Time `json:"lastTimestamp,omitempty"`
 
 	// The number of times this event has occurred.
 	Count int `json:"count,omitempty"`

--- a/pkg/api/unversioned/duration.go
+++ b/pkg/api/unversioned/duration.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// Duration is a wrapper around time.Duration which supports correct
+// marshaling to YAML and JSON. In particular, it marshals into strings, which
+// can be used as map keys in json.
+type Duration struct {
+	time.Duration
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface.
+func (d *Duration) UnmarshalJSON(b []byte) error {
+	var str string
+	json.Unmarshal(b, &str)
+
+	pd, err := time.ParseDuration(str)
+	if err != nil {
+		return err
+	}
+	d.Duration = pd
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.String())
+}

--- a/pkg/api/unversioned/duration_test.go
+++ b/pkg/api/unversioned/duration_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/ghodss/yaml"
+)
+
+type DurationHolder struct {
+	D Duration `json:"d"`
+}
+
+func TestDurationMarshalYAML(t *testing.T) {
+	cases := []struct {
+		input  Duration
+		result string
+	}{
+		{Duration{5 * time.Second}, "d: 5s\n"},
+		{Duration{2 * time.Minute}, "d: 2m0s\n"},
+		{Duration{time.Hour + 3*time.Millisecond}, "d: 1h0m0.003s\n"},
+	}
+
+	for _, c := range cases {
+		input := DurationHolder{c.input}
+		result, err := yaml.Marshal(&input)
+		if err != nil {
+			t.Errorf("Failed to marshal input: %q: %v", input, err)
+		}
+		if string(result) != c.result {
+			t.Errorf("Failed to marshal input: %q: expected %q, got %q", input, c.result, string(result))
+		}
+	}
+}
+
+func TestDurationUnmarshalYAML(t *testing.T) {
+	cases := []struct {
+		input  string
+		result Duration
+	}{
+		{"d: 0s\n", Duration{}},
+		{"d: 5s\n", Duration{5 * time.Second}},
+		{"d: 2m0s\n", Duration{2 * time.Minute}},
+		{"d: 1h0m0.003s\n", Duration{time.Hour + 3*time.Millisecond}},
+
+		// Units with zero values can optionally be dropped
+		{"d: 2m\n", Duration{2 * time.Minute}},
+		{"d: 1h0.003s\n", Duration{time.Hour + 3*time.Millisecond}},
+	}
+
+	for _, c := range cases {
+		var result DurationHolder
+		if err := yaml.Unmarshal([]byte(c.input), &result); err != nil {
+			t.Errorf("Failed to unmarshal input %q: %v", c.input, err)
+		}
+		if result.D != c.result {
+			t.Errorf("Failed to unmarshal input %q: expected %q, got %q", c.input, c.result, result)
+		}
+	}
+}
+
+func TestDurationMarshalJSON(t *testing.T) {
+	cases := []struct {
+		input  Duration
+		result string
+	}{
+		{Duration{5 * time.Second}, `{"d":"5s"}`},
+		{Duration{2 * time.Minute}, `{"d":"2m0s"}`},
+		{Duration{time.Hour + 3*time.Millisecond}, `{"d":"1h0m0.003s"}`},
+	}
+
+	for _, c := range cases {
+		input := DurationHolder{c.input}
+		result, err := json.Marshal(&input)
+		if err != nil {
+			t.Errorf("Failed to marshal input: %q: %v", input, err)
+		}
+		if string(result) != c.result {
+			t.Errorf("Failed to marshal input: %q: expected %q, got %q", input, c.result, string(result))
+		}
+	}
+}
+
+func TestDurationUnmarshalJSON(t *testing.T) {
+	cases := []struct {
+		input  string
+		result Duration
+	}{
+		{`{"d":"0s"}`, Duration{}},
+		{`{"d":"5s"}`, Duration{5 * time.Second}},
+		{`{"d":"2m0s"}`, Duration{2 * time.Minute}},
+		{`{"d":"1h0m0.003s"}`, Duration{time.Hour + 3*time.Millisecond}},
+
+		// Units with zero values can optionally be dropped
+		{`{"d":"2m"}`, Duration{2 * time.Minute}},
+		{`{"d":"1h0.003s"}`, Duration{time.Hour + 3*time.Millisecond}},
+	}
+
+	for _, c := range cases {
+		var result DurationHolder
+		if err := json.Unmarshal([]byte(c.input), &result); err != nil {
+			t.Errorf("Failed to unmarshal input %q: %v", c.input, err)
+		}
+		if result.D != c.result {
+			t.Errorf("Failed to unmarshal input %q: expected %q, got %q", c.input, c.result, result)
+		}
+	}
+}
+
+func TestDurationMarshalJSONUnmarshalYAML(t *testing.T) {
+	cases := []struct {
+		input Duration
+	}{
+		{Duration{}},
+		{Duration{5 * time.Second}},
+		{Duration{2 * time.Minute}},
+		{Duration{time.Hour + 3*time.Millisecond}},
+	}
+
+	for i, c := range cases {
+		input := DurationHolder{c.input}
+		jsonMarshalled, err := json.Marshal(&input)
+		if err != nil {
+			t.Errorf("%d-1: Failed to marshal input: '%v': %v", i, input, err)
+		}
+
+		var result DurationHolder
+		if err := yaml.Unmarshal(jsonMarshalled, &result); err != nil {
+			t.Errorf("%d-2: Failed to unmarshal '%+v': %v", i, string(jsonMarshalled), err)
+		}
+
+		if input.D != result.D {
+			t.Errorf("%d-4: Failed to marshal input '%#v': got %#v", i, input, result)
+		}
+	}
+}

--- a/pkg/api/unversioned/time.go
+++ b/pkg/api/unversioned/time.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package unversioned
 
 import (
 	"encoding/json"

--- a/pkg/api/unversioned/time_test.go
+++ b/pkg/api/unversioned/time_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package unversioned
 
 import (
 	"encoding/json"

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -52,6 +52,15 @@ func deepCopy_unversioned_ListMeta(in unversioned.ListMeta, out *unversioned.Lis
 	return nil
 }
 
+func deepCopy_unversioned_Time(in unversioned.Time, out *unversioned.Time, c *conversion.Cloner) error {
+	if newVal, err := c.DeepCopy(in.Time); err != nil {
+		return err
+	} else {
+		out.Time = newVal.(time.Time)
+	}
+	return nil
+}
+
 func deepCopy_unversioned_TypeMeta(in unversioned.TypeMeta, out *unversioned.TypeMeta, c *conversion.Cloner) error {
 	out.Kind = in.Kind
 	out.APIVersion = in.APIVersion
@@ -307,7 +316,7 @@ func deepCopy_v1_ContainerState(in ContainerState, out *ContainerState, c *conve
 }
 
 func deepCopy_v1_ContainerStateRunning(in ContainerStateRunning, out *ContainerStateRunning, c *conversion.Cloner) error {
-	if err := deepCopy_util_Time(in.StartedAt, &out.StartedAt, c); err != nil {
+	if err := deepCopy_unversioned_Time(in.StartedAt, &out.StartedAt, c); err != nil {
 		return err
 	}
 	return nil
@@ -318,10 +327,10 @@ func deepCopy_v1_ContainerStateTerminated(in ContainerStateTerminated, out *Cont
 	out.Signal = in.Signal
 	out.Reason = in.Reason
 	out.Message = in.Message
-	if err := deepCopy_util_Time(in.StartedAt, &out.StartedAt, c); err != nil {
+	if err := deepCopy_unversioned_Time(in.StartedAt, &out.StartedAt, c); err != nil {
 		return err
 	}
-	if err := deepCopy_util_Time(in.FinishedAt, &out.FinishedAt, c); err != nil {
+	if err := deepCopy_unversioned_Time(in.FinishedAt, &out.FinishedAt, c); err != nil {
 		return err
 	}
 	out.ContainerID = in.ContainerID
@@ -530,10 +539,10 @@ func deepCopy_v1_Event(in Event, out *Event, c *conversion.Cloner) error {
 	if err := deepCopy_v1_EventSource(in.Source, &out.Source, c); err != nil {
 		return err
 	}
-	if err := deepCopy_util_Time(in.FirstTimestamp, &out.FirstTimestamp, c); err != nil {
+	if err := deepCopy_unversioned_Time(in.FirstTimestamp, &out.FirstTimestamp, c); err != nil {
 		return err
 	}
-	if err := deepCopy_util_Time(in.LastTimestamp, &out.LastTimestamp, c); err != nil {
+	if err := deepCopy_unversioned_Time(in.LastTimestamp, &out.LastTimestamp, c); err != nil {
 		return err
 	}
 	out.Count = in.Count
@@ -924,10 +933,10 @@ func deepCopy_v1_NodeAddress(in NodeAddress, out *NodeAddress, c *conversion.Clo
 func deepCopy_v1_NodeCondition(in NodeCondition, out *NodeCondition, c *conversion.Cloner) error {
 	out.Type = in.Type
 	out.Status = in.Status
-	if err := deepCopy_util_Time(in.LastHeartbeatTime, &out.LastHeartbeatTime, c); err != nil {
+	if err := deepCopy_unversioned_Time(in.LastHeartbeatTime, &out.LastHeartbeatTime, c); err != nil {
 		return err
 	}
-	if err := deepCopy_util_Time(in.LastTransitionTime, &out.LastTransitionTime, c); err != nil {
+	if err := deepCopy_unversioned_Time(in.LastTransitionTime, &out.LastTransitionTime, c); err != nil {
 		return err
 	}
 	out.Reason = in.Reason
@@ -1039,12 +1048,12 @@ func deepCopy_v1_ObjectMeta(in ObjectMeta, out *ObjectMeta, c *conversion.Cloner
 	out.UID = in.UID
 	out.ResourceVersion = in.ResourceVersion
 	out.Generation = in.Generation
-	if err := deepCopy_util_Time(in.CreationTimestamp, &out.CreationTimestamp, c); err != nil {
+	if err := deepCopy_unversioned_Time(in.CreationTimestamp, &out.CreationTimestamp, c); err != nil {
 		return err
 	}
 	if in.DeletionTimestamp != nil {
-		out.DeletionTimestamp = new(util.Time)
-		if err := deepCopy_util_Time(*in.DeletionTimestamp, out.DeletionTimestamp, c); err != nil {
+		out.DeletionTimestamp = new(unversioned.Time)
+		if err := deepCopy_unversioned_Time(*in.DeletionTimestamp, out.DeletionTimestamp, c); err != nil {
 			return err
 		}
 	} else {
@@ -1494,8 +1503,8 @@ func deepCopy_v1_PodStatus(in PodStatus, out *PodStatus, c *conversion.Cloner) e
 	out.HostIP = in.HostIP
 	out.PodIP = in.PodIP
 	if in.StartTime != nil {
-		out.StartTime = new(util.Time)
-		if err := deepCopy_util_Time(*in.StartTime, out.StartTime, c); err != nil {
+		out.StartTime = new(unversioned.Time)
+		if err := deepCopy_unversioned_Time(*in.StartTime, out.StartTime, c); err != nil {
 			return err
 		}
 	} else {
@@ -2194,19 +2203,11 @@ func deepCopy_util_IntOrString(in util.IntOrString, out *util.IntOrString, c *co
 	return nil
 }
 
-func deepCopy_util_Time(in util.Time, out *util.Time, c *conversion.Cloner) error {
-	if newVal, err := c.DeepCopy(in.Time); err != nil {
-		return err
-	} else {
-		out.Time = newVal.(time.Time)
-	}
-	return nil
-}
-
 func init() {
 	err := api.Scheme.AddGeneratedDeepCopyFuncs(
 		deepCopy_resource_Quantity,
 		deepCopy_unversioned_ListMeta,
+		deepCopy_unversioned_Time,
 		deepCopy_unversioned_TypeMeta,
 		deepCopy_v1_AWSElasticBlockStoreVolumeSource,
 		deepCopy_v1_Binding,
@@ -2326,7 +2327,6 @@ func init() {
 		deepCopy_v1_VolumeSource,
 		deepCopy_runtime_RawExtension,
 		deepCopy_util_IntOrString,
-		deepCopy_util_Time,
 	)
 	if err != nil {
 		// if one of the deep copy functions is malformed, detect it immediately.

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -141,7 +141,7 @@ type ObjectMeta struct {
 	// Read-only.
 	// Null for lists.
 	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata
-	CreationTimestamp util.Time `json:"creationTimestamp,omitempty"`
+	CreationTimestamp unversioned.Time `json:"creationTimestamp,omitempty"`
 
 	// DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This
 	// field is set by the server when a graceful deletion is requested by the user, and is not
@@ -157,7 +157,7 @@ type ObjectMeta struct {
 	// Populated by the system when a graceful deletion is requested.
 	// Read-only.
 	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata
-	DeletionTimestamp *util.Time `json:"deletionTimestamp,omitempty"`
+	DeletionTimestamp *unversioned.Time `json:"deletionTimestamp,omitempty"`
 
 	// Number of seconds allowed for this object to gracefully terminate before
 	// it will be removed from the system. Only set when deletionTimestamp is also set.
@@ -1008,7 +1008,7 @@ type ContainerStateWaiting struct {
 // ContainerStateRunning is a running state of a container.
 type ContainerStateRunning struct {
 	// Time at which the container was last (re-)started
-	StartedAt util.Time `json:"startedAt,omitempty"`
+	StartedAt unversioned.Time `json:"startedAt,omitempty"`
 }
 
 // ContainerStateTerminated is a terminated state of a container.
@@ -1022,9 +1022,9 @@ type ContainerStateTerminated struct {
 	// Message regarding the last termination of the container
 	Message string `json:"message,omitempty"`
 	// Time at which previous execution of the container started
-	StartedAt util.Time `json:"startedAt,omitempty"`
+	StartedAt unversioned.Time `json:"startedAt,omitempty"`
 	// Time at which the container last terminated
-	FinishedAt util.Time `json:"finishedAt,omitempty"`
+	FinishedAt unversioned.Time `json:"finishedAt,omitempty"`
 	// Container's ID in the format 'docker://<container_id>'
 	ContainerID string `json:"containerID,omitempty"`
 }
@@ -1227,7 +1227,7 @@ type PodStatus struct {
 
 	// RFC 3339 date and time at which the object was acknowledged by the Kubelet.
 	// This is before the Kubelet pulled the container image(s) for the pod.
-	StartTime *util.Time `json:"startTime,omitempty"`
+	StartTime *unversioned.Time `json:"startTime,omitempty"`
 
 	// The list has one entry per container in the manifest. Each entry is currently the output
 	// of `docker inspect`.
@@ -1774,9 +1774,9 @@ type NodeCondition struct {
 	// Status of the condition, one of True, False, Unknown.
 	Status ConditionStatus `json:"status"`
 	// Last time we got an update on a given condition.
-	LastHeartbeatTime util.Time `json:"lastHeartbeatTime,omitempty"`
+	LastHeartbeatTime unversioned.Time `json:"lastHeartbeatTime,omitempty"`
 	// Last time the condition transit from one status to another.
-	LastTransitionTime util.Time `json:"lastTransitionTime,omitempty"`
+	LastTransitionTime unversioned.Time `json:"lastTransitionTime,omitempty"`
 	// (brief) reason for the condition's last transition.
 	Reason string `json:"reason,omitempty"`
 	// Human readable message indicating details about last transition.
@@ -2110,10 +2110,10 @@ type Event struct {
 	Source EventSource `json:"source,omitempty"`
 
 	// The time at which the event was first recorded. (Time of server receipt is in TypeMeta.)
-	FirstTimestamp util.Time `json:"firstTimestamp,omitempty"`
+	FirstTimestamp unversioned.Time `json:"firstTimestamp,omitempty"`
 
 	// The time at which the most recent occurrence of this event was recorded.
-	LastTimestamp util.Time `json:"lastTimestamp,omitempty"`
+	LastTimestamp unversioned.Time `json:"lastTimestamp,omitempty"`
 
 	// The number of times this event has occurred.
 	Count int `json:"count,omitempty"`

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/capabilities"
 	"k8s.io/kubernetes/pkg/util"
 	utilerrors "k8s.io/kubernetes/pkg/util/errors"
@@ -88,19 +89,19 @@ func TestValidateObjectMetaNamespaces(t *testing.T) {
 func TestValidateObjectMetaUpdateIgnoresCreationTimestamp(t *testing.T) {
 	if errs := ValidateObjectMetaUpdate(
 		&api.ObjectMeta{Name: "test", ResourceVersion: "1"},
-		&api.ObjectMeta{Name: "test", ResourceVersion: "1", CreationTimestamp: util.NewTime(time.Unix(10, 0))},
+		&api.ObjectMeta{Name: "test", ResourceVersion: "1", CreationTimestamp: unversioned.NewTime(time.Unix(10, 0))},
 	); len(errs) != 0 {
 		t.Fatalf("unexpected errors: %v", errs)
 	}
 	if errs := ValidateObjectMetaUpdate(
-		&api.ObjectMeta{Name: "test", ResourceVersion: "1", CreationTimestamp: util.NewTime(time.Unix(10, 0))},
+		&api.ObjectMeta{Name: "test", ResourceVersion: "1", CreationTimestamp: unversioned.NewTime(time.Unix(10, 0))},
 		&api.ObjectMeta{Name: "test", ResourceVersion: "1"},
 	); len(errs) != 0 {
 		t.Fatalf("unexpected errors: %v", errs)
 	}
 	if errs := ValidateObjectMetaUpdate(
-		&api.ObjectMeta{Name: "test", ResourceVersion: "1", CreationTimestamp: util.NewTime(time.Unix(10, 0))},
-		&api.ObjectMeta{Name: "test", ResourceVersion: "1", CreationTimestamp: util.NewTime(time.Unix(11, 0))},
+		&api.ObjectMeta{Name: "test", ResourceVersion: "1", CreationTimestamp: unversioned.NewTime(time.Unix(10, 0))},
+		&api.ObjectMeta{Name: "test", ResourceVersion: "1", CreationTimestamp: unversioned.NewTime(time.Unix(11, 0))},
 	); len(errs) != 0 {
 		t.Fatalf("unexpected errors: %v", errs)
 	}
@@ -1401,7 +1402,7 @@ func TestValidatePod(t *testing.T) {
 }
 
 func TestValidatePodUpdate(t *testing.T) {
-	now := util.Now()
+	now := unversioned.Now()
 	grace := int64(30)
 	grace2 := int64(31)
 	tests := []struct {
@@ -3251,7 +3252,7 @@ func TestValidateNamespaceFinalizeUpdate(t *testing.T) {
 }
 
 func TestValidateNamespaceStatusUpdate(t *testing.T) {
-	now := util.Now()
+	now := unversioned.Now()
 
 	tests := []struct {
 		oldNamespace api.Namespace

--- a/pkg/apis/experimental/deep_copy_generated.go
+++ b/pkg/apis/experimental/deep_copy_generated.go
@@ -372,12 +372,12 @@ func deepCopy_api_ObjectMeta(in api.ObjectMeta, out *api.ObjectMeta, c *conversi
 	out.UID = in.UID
 	out.ResourceVersion = in.ResourceVersion
 	out.Generation = in.Generation
-	if err := deepCopy_util_Time(in.CreationTimestamp, &out.CreationTimestamp, c); err != nil {
+	if err := deepCopy_unversioned_Time(in.CreationTimestamp, &out.CreationTimestamp, c); err != nil {
 		return err
 	}
 	if in.DeletionTimestamp != nil {
-		out.DeletionTimestamp = new(util.Time)
-		if err := deepCopy_util_Time(*in.DeletionTimestamp, out.DeletionTimestamp, c); err != nil {
+		out.DeletionTimestamp = new(unversioned.Time)
+		if err := deepCopy_unversioned_Time(*in.DeletionTimestamp, out.DeletionTimestamp, c); err != nil {
 			return err
 		}
 	} else {
@@ -753,6 +753,15 @@ func deepCopy_unversioned_ListMeta(in unversioned.ListMeta, out *unversioned.Lis
 	return nil
 }
 
+func deepCopy_unversioned_Time(in unversioned.Time, out *unversioned.Time, c *conversion.Cloner) error {
+	if newVal, err := c.DeepCopy(in.Time); err != nil {
+		return err
+	} else {
+		out.Time = newVal.(time.Time)
+	}
+	return nil
+}
+
 func deepCopy_unversioned_TypeMeta(in unversioned.TypeMeta, out *unversioned.TypeMeta, c *conversion.Cloner) error {
 	out.Kind = in.Kind
 	out.APIVersion = in.APIVersion
@@ -978,8 +987,8 @@ func deepCopy_experimental_HorizontalPodAutoscalerStatus(in HorizontalPodAutosca
 		out.CurrentConsumption = nil
 	}
 	if in.LastScaleTimestamp != nil {
-		out.LastScaleTimestamp = new(util.Time)
-		if err := deepCopy_util_Time(*in.LastScaleTimestamp, out.LastScaleTimestamp, c); err != nil {
+		out.LastScaleTimestamp = new(unversioned.Time)
+		if err := deepCopy_unversioned_Time(*in.LastScaleTimestamp, out.LastScaleTimestamp, c); err != nil {
 			return err
 		}
 	} else {
@@ -1007,10 +1016,10 @@ func deepCopy_experimental_Job(in Job, out *Job, c *conversion.Cloner) error {
 func deepCopy_experimental_JobCondition(in JobCondition, out *JobCondition, c *conversion.Cloner) error {
 	out.Type = in.Type
 	out.Status = in.Status
-	if err := deepCopy_util_Time(in.LastProbeTime, &out.LastProbeTime, c); err != nil {
+	if err := deepCopy_unversioned_Time(in.LastProbeTime, &out.LastProbeTime, c); err != nil {
 		return err
 	}
-	if err := deepCopy_util_Time(in.LastTransitionTime, &out.LastTransitionTime, c); err != nil {
+	if err := deepCopy_unversioned_Time(in.LastTransitionTime, &out.LastTransitionTime, c); err != nil {
 		return err
 	}
 	out.Reason = in.Reason
@@ -1082,16 +1091,16 @@ func deepCopy_experimental_JobStatus(in JobStatus, out *JobStatus, c *conversion
 		out.Conditions = nil
 	}
 	if in.StartTime != nil {
-		out.StartTime = new(util.Time)
-		if err := deepCopy_util_Time(*in.StartTime, out.StartTime, c); err != nil {
+		out.StartTime = new(unversioned.Time)
+		if err := deepCopy_unversioned_Time(*in.StartTime, out.StartTime, c); err != nil {
 			return err
 		}
 	} else {
 		out.StartTime = nil
 	}
 	if in.CompletionTime != nil {
-		out.CompletionTime = new(util.Time)
-		if err := deepCopy_util_Time(*in.CompletionTime, out.CompletionTime, c); err != nil {
+		out.CompletionTime = new(unversioned.Time)
+		if err := deepCopy_unversioned_Time(*in.CompletionTime, out.CompletionTime, c); err != nil {
 			return err
 		}
 	} else {
@@ -1258,15 +1267,6 @@ func deepCopy_util_IntOrString(in util.IntOrString, out *util.IntOrString, c *co
 	return nil
 }
 
-func deepCopy_util_Time(in util.Time, out *util.Time, c *conversion.Cloner) error {
-	if newVal, err := c.DeepCopy(in.Time); err != nil {
-		return err
-	} else {
-		out.Time = newVal.(time.Time)
-	}
-	return nil
-}
-
 func init() {
 	err := api.Scheme.AddGeneratedDeepCopyFuncs(
 		deepCopy_api_AWSElasticBlockStoreVolumeSource,
@@ -1308,6 +1308,7 @@ func init() {
 		deepCopy_api_VolumeSource,
 		deepCopy_resource_Quantity,
 		deepCopy_unversioned_ListMeta,
+		deepCopy_unversioned_Time,
 		deepCopy_unversioned_TypeMeta,
 		deepCopy_experimental_APIVersion,
 		deepCopy_experimental_DaemonSet,
@@ -1340,7 +1341,6 @@ func init() {
 		deepCopy_experimental_ThirdPartyResourceDataList,
 		deepCopy_experimental_ThirdPartyResourceList,
 		deepCopy_util_IntOrString,
-		deepCopy_util_Time,
 	)
 	if err != nil {
 		// if one of the deep copy functions is malformed, detect it immediately.

--- a/pkg/apis/experimental/types.go
+++ b/pkg/apis/experimental/types.go
@@ -118,7 +118,7 @@ type HorizontalPodAutoscalerStatus struct {
 
 	// LastScaleTimestamp is the last time the HorizontalPodAutoscaler scaled the number of pods.
 	// This is used by the autoscaler to controll how often the number of pods is changed.
-	LastScaleTimestamp *util.Time `json:"lastScaleTimestamp,omitempty"`
+	LastScaleTimestamp *unversioned.Time `json:"lastScaleTimestamp,omitempty"`
 }
 
 // HorizontalPodAutoscaler represents the configuration of a horizontal pod autoscaler.
@@ -421,12 +421,12 @@ type JobStatus struct {
 	// StartTime represents time when the job was acknowledged by the Job Manager.
 	// It is not guaranteed to be set in happens-before order across separate operations.
 	// It is represented in RFC3339 form and is in UTC.
-	StartTime *util.Time `json:"startTime,omitempty"`
+	StartTime *unversioned.Time `json:"startTime,omitempty"`
 
 	// CompletionTime represents time when the job was completed. It is not guaranteed to
 	// be set in happens-before order across separate operations.
 	// It is represented in RFC3339 form and is in UTC.
-	CompletionTime *util.Time `json:"completionTime,omitempty"`
+	CompletionTime *unversioned.Time `json:"completionTime,omitempty"`
 
 	// Active is the number of actively running pods.
 	Active int `json:"active,omitempty"`
@@ -454,9 +454,9 @@ type JobCondition struct {
 	// Status of the condition, one of True, False, Unknown.
 	Status api.ConditionStatus `json:"status"`
 	// Last time the condition was checked.
-	LastProbeTime util.Time `json:"lastProbeTime,omitempty"`
+	LastProbeTime unversioned.Time `json:"lastProbeTime,omitempty"`
 	// Last time the condition transit from one status to another.
-	LastTransitionTime util.Time `json:"lastTransitionTime,omitempty"`
+	LastTransitionTime unversioned.Time `json:"lastTransitionTime,omitempty"`
 	// (brief) reason for the condition's last transition.
 	Reason string `json:"reason,omitempty"`
 	// Human readable message indicating details about last transition.

--- a/pkg/apis/experimental/v1/deep_copy_generated.go
+++ b/pkg/apis/experimental/v1/deep_copy_generated.go
@@ -52,6 +52,15 @@ func deepCopy_unversioned_ListMeta(in unversioned.ListMeta, out *unversioned.Lis
 	return nil
 }
 
+func deepCopy_unversioned_Time(in unversioned.Time, out *unversioned.Time, c *conversion.Cloner) error {
+	if newVal, err := c.DeepCopy(in.Time); err != nil {
+		return err
+	} else {
+		out.Time = newVal.(time.Time)
+	}
+	return nil
+}
+
 func deepCopy_unversioned_TypeMeta(in unversioned.TypeMeta, out *unversioned.TypeMeta, c *conversion.Cloner) error {
 	out.Kind = in.Kind
 	out.APIVersion = in.APIVersion
@@ -401,12 +410,12 @@ func deepCopy_v1_ObjectMeta(in v1.ObjectMeta, out *v1.ObjectMeta, c *conversion.
 	out.UID = in.UID
 	out.ResourceVersion = in.ResourceVersion
 	out.Generation = in.Generation
-	if err := deepCopy_util_Time(in.CreationTimestamp, &out.CreationTimestamp, c); err != nil {
+	if err := deepCopy_unversioned_Time(in.CreationTimestamp, &out.CreationTimestamp, c); err != nil {
 		return err
 	}
 	if in.DeletionTimestamp != nil {
-		out.DeletionTimestamp = new(util.Time)
-		if err := deepCopy_util_Time(*in.DeletionTimestamp, out.DeletionTimestamp, c); err != nil {
+		out.DeletionTimestamp = new(unversioned.Time)
+		if err := deepCopy_unversioned_Time(*in.DeletionTimestamp, out.DeletionTimestamp, c); err != nil {
 			return err
 		}
 	} else {
@@ -990,8 +999,8 @@ func deepCopy_v1_HorizontalPodAutoscalerStatus(in HorizontalPodAutoscalerStatus,
 		out.CurrentConsumption = nil
 	}
 	if in.LastScaleTimestamp != nil {
-		out.LastScaleTimestamp = new(util.Time)
-		if err := deepCopy_util_Time(*in.LastScaleTimestamp, out.LastScaleTimestamp, c); err != nil {
+		out.LastScaleTimestamp = new(unversioned.Time)
+		if err := deepCopy_unversioned_Time(*in.LastScaleTimestamp, out.LastScaleTimestamp, c); err != nil {
 			return err
 		}
 	} else {
@@ -1019,10 +1028,10 @@ func deepCopy_v1_Job(in Job, out *Job, c *conversion.Cloner) error {
 func deepCopy_v1_JobCondition(in JobCondition, out *JobCondition, c *conversion.Cloner) error {
 	out.Type = in.Type
 	out.Status = in.Status
-	if err := deepCopy_util_Time(in.LastProbeTime, &out.LastProbeTime, c); err != nil {
+	if err := deepCopy_unversioned_Time(in.LastProbeTime, &out.LastProbeTime, c); err != nil {
 		return err
 	}
-	if err := deepCopy_util_Time(in.LastTransitionTime, &out.LastTransitionTime, c); err != nil {
+	if err := deepCopy_unversioned_Time(in.LastTransitionTime, &out.LastTransitionTime, c); err != nil {
 		return err
 	}
 	out.Reason = in.Reason
@@ -1094,16 +1103,16 @@ func deepCopy_v1_JobStatus(in JobStatus, out *JobStatus, c *conversion.Cloner) e
 		out.Conditions = nil
 	}
 	if in.StartTime != nil {
-		out.StartTime = new(util.Time)
-		if err := deepCopy_util_Time(*in.StartTime, out.StartTime, c); err != nil {
+		out.StartTime = new(unversioned.Time)
+		if err := deepCopy_unversioned_Time(*in.StartTime, out.StartTime, c); err != nil {
 			return err
 		}
 	} else {
 		out.StartTime = nil
 	}
 	if in.CompletionTime != nil {
-		out.CompletionTime = new(util.Time)
-		if err := deepCopy_util_Time(*in.CompletionTime, out.CompletionTime, c); err != nil {
+		out.CompletionTime = new(unversioned.Time)
+		if err := deepCopy_unversioned_Time(*in.CompletionTime, out.CompletionTime, c); err != nil {
 			return err
 		}
 	} else {
@@ -1280,19 +1289,11 @@ func deepCopy_util_IntOrString(in util.IntOrString, out *util.IntOrString, c *co
 	return nil
 }
 
-func deepCopy_util_Time(in util.Time, out *util.Time, c *conversion.Cloner) error {
-	if newVal, err := c.DeepCopy(in.Time); err != nil {
-		return err
-	} else {
-		out.Time = newVal.(time.Time)
-	}
-	return nil
-}
-
 func init() {
 	err := api.Scheme.AddGeneratedDeepCopyFuncs(
 		deepCopy_resource_Quantity,
 		deepCopy_unversioned_ListMeta,
+		deepCopy_unversioned_Time,
 		deepCopy_unversioned_TypeMeta,
 		deepCopy_v1_AWSElasticBlockStoreVolumeSource,
 		deepCopy_v1_Capabilities,
@@ -1362,7 +1363,6 @@ func init() {
 		deepCopy_v1_ThirdPartyResourceDataList,
 		deepCopy_v1_ThirdPartyResourceList,
 		deepCopy_util_IntOrString,
-		deepCopy_util_Time,
 	)
 	if err != nil {
 		// if one of the deep copy functions is malformed, detect it immediately.

--- a/pkg/apis/experimental/v1/types.go
+++ b/pkg/apis/experimental/v1/types.go
@@ -107,7 +107,7 @@ type HorizontalPodAutoscalerStatus struct {
 
 	// LastScaleTimestamp is the last time the HorizontalPodAutoscaler scaled the number of pods.
 	// This is used by the autoscaler to controll how often the number of pods is changed.
-	LastScaleTimestamp *util.Time `json:"lastScaleTimestamp,omitempty"`
+	LastScaleTimestamp *unversioned.Time `json:"lastScaleTimestamp,omitempty"`
 }
 
 // HorizontalPodAutoscaler represents the configuration of a horizontal pod autoscaler.
@@ -422,12 +422,12 @@ type JobStatus struct {
 	// StartTime represents time when the job was acknowledged by the Job Manager.
 	// It is not guaranteed to be set in happens-before order across separate operations.
 	// It is represented in RFC3339 form and is in UTC.
-	StartTime *util.Time `json:"startTime,omitempty"`
+	StartTime *unversioned.Time `json:"startTime,omitempty"`
 
 	// CompletionTime represents time when the job was completed. It is not guaranteed to
 	// be set in happens-before order across separate operations.
 	// It is represented in RFC3339 form and is in UTC.
-	CompletionTime *util.Time `json:"completionTime,omitempty"`
+	CompletionTime *unversioned.Time `json:"completionTime,omitempty"`
 
 	// Active is the number of actively running pods.
 	Active int `json:"active,omitempty"`
@@ -455,9 +455,9 @@ type JobCondition struct {
 	// Status of the condition, one of True, False, Unknown.
 	Status v1.ConditionStatus `json:"status"`
 	// Last time the condition was checked.
-	LastProbeTime util.Time `json:"lastProbeTime,omitempty"`
+	LastProbeTime unversioned.Time `json:"lastProbeTime,omitempty"`
 	// Last time the condition transit from one status to another.
-	LastTransitionTime util.Time `json:"lastTransitionTime,omitempty"`
+	LastTransitionTime unversioned.Time `json:"lastTransitionTime,omitempty"`
 	// (brief) reason for the condition's last transition.
 	Reason string `json:"reason,omitempty"`
 	// Human readable message indicating details about last transition.

--- a/pkg/apiserver/api_installer.go
+++ b/pkg/apiserver/api_installer.go
@@ -826,7 +826,7 @@ func typeToJSON(typeName string) string {
 		return "string"
 	case "float64", "float32":
 		return "number"
-	case "util.Time":
+	case "unversioned.Time":
 		return "string"
 	default:
 		return typeName

--- a/pkg/apiserver/authz.go
+++ b/pkg/apiserver/authz.go
@@ -19,6 +19,7 @@ package apiserver
 import (
 	"errors"
 	"fmt"
+
 	"k8s.io/kubernetes/pkg/auth/authorizer"
 	"k8s.io/kubernetes/pkg/auth/authorizer/abac"
 	"k8s.io/kubernetes/pkg/auth/authorizer/union"

--- a/pkg/client/cache/expiration_cache.go
+++ b/pkg/client/cache/expiration_cache.go
@@ -17,9 +17,10 @@ limitations under the License.
 package cache
 
 import (
+	"time"
+
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/util"
-	"time"
 )
 
 // ExpirationCache implements the store interface

--- a/pkg/client/record/event.go
+++ b/pkg/client/record/event.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
@@ -64,7 +65,7 @@ type EventRecorder interface {
 	Eventf(object runtime.Object, reason, messageFmt string, args ...interface{})
 
 	// PastEventf is just like Eventf, but with an option to specify the event's 'timestamp' field.
-	PastEventf(object runtime.Object, timestamp util.Time, reason, messageFmt string, args ...interface{})
+	PastEventf(object runtime.Object, timestamp unversioned.Time, reason, messageFmt string, args ...interface{})
 }
 
 // EventBroadcaster knows how to receive events and send them to any EventSink, watcher, or log.
@@ -238,7 +239,7 @@ type recorderImpl struct {
 	*watch.Broadcaster
 }
 
-func (recorder *recorderImpl) generateEvent(object runtime.Object, timestamp util.Time, reason, message string) {
+func (recorder *recorderImpl) generateEvent(object runtime.Object, timestamp unversioned.Time, reason, message string) {
 	ref, err := api.GetReference(object)
 	if err != nil {
 		glog.Errorf("Could not construct reference to: '%#v' due to: '%v'. Will not report event: '%v' '%v'", object, err, reason, message)
@@ -252,19 +253,19 @@ func (recorder *recorderImpl) generateEvent(object runtime.Object, timestamp uti
 }
 
 func (recorder *recorderImpl) Event(object runtime.Object, reason, message string) {
-	recorder.generateEvent(object, util.Now(), reason, message)
+	recorder.generateEvent(object, unversioned.Now(), reason, message)
 }
 
 func (recorder *recorderImpl) Eventf(object runtime.Object, reason, messageFmt string, args ...interface{}) {
 	recorder.Event(object, reason, fmt.Sprintf(messageFmt, args...))
 }
 
-func (recorder *recorderImpl) PastEventf(object runtime.Object, timestamp util.Time, reason, messageFmt string, args ...interface{}) {
+func (recorder *recorderImpl) PastEventf(object runtime.Object, timestamp unversioned.Time, reason, messageFmt string, args ...interface{}) {
 	recorder.generateEvent(object, timestamp, reason, fmt.Sprintf(messageFmt, args...))
 }
 
 func makeEvent(ref *api.ObjectReference, reason, message string) *api.Event {
-	t := util.Now()
+	t := unversioned.Now()
 	namespace := ref.Namespace
 	if namespace == "" {
 		namespace = api.NamespaceDefault

--- a/pkg/client/record/events_cache.go
+++ b/pkg/client/record/events_cache.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/golang/groupcache/lru"
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 )
 
 type history struct {
@@ -29,7 +29,7 @@ type history struct {
 	Count int
 
 	// The time at which the event was first recorded.
-	FirstTimestamp util.Time
+	FirstTimestamp unversioned.Time
 
 	// The unique name of the first occurrence of this event
 	Name string

--- a/pkg/client/record/events_cache_test.go
+++ b/pkg/client/record/events_cache_test.go
@@ -20,12 +20,12 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 )
 
 func TestAddOrUpdateEventNoExisting(t *testing.T) {
 	// Arrange
-	eventTime := util.Now()
+	eventTime := unversioned.Now()
 	event := api.Event{
 		Reason:  "my reasons are many",
 		Message: "my message is love",
@@ -54,8 +54,8 @@ func TestAddOrUpdateEventNoExisting(t *testing.T) {
 
 func TestAddOrUpdateEventExisting(t *testing.T) {
 	// Arrange
-	event1Time := util.Unix(2324, 2342)
-	event2Time := util.Now()
+	event1Time := unversioned.Unix(2324, 2342)
+	event2Time := unversioned.Now()
 	event1 := api.Event{
 		Reason:  "something happened",
 		Message: "can you believe it?",
@@ -139,7 +139,7 @@ func TestGetEventNoExisting(t *testing.T) {
 
 func TestGetEventExisting(t *testing.T) {
 	// Arrange
-	eventTime := util.Now()
+	eventTime := unversioned.Now()
 	event := api.Event{
 		Reason:  "do I exist",
 		Message: "I do, oh my",

--- a/pkg/client/record/fake.go
+++ b/pkg/client/record/fake.go
@@ -19,8 +19,8 @@ package record
 import (
 	"fmt"
 
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/util"
 )
 
 // FakeRecorder is used as a fake during tests.
@@ -36,5 +36,5 @@ func (f *FakeRecorder) Eventf(object runtime.Object, reason, messageFmt string, 
 	f.Events = append(f.Events, fmt.Sprintf(reason+" "+messageFmt, args...))
 }
 
-func (f *FakeRecorder) PastEventf(object runtime.Object, timestamp util.Time, reason, messageFmt string, args ...interface{}) {
+func (f *FakeRecorder) PastEventf(object runtime.Object, timestamp unversioned.Time, reason, messageFmt string, args ...interface{}) {
 }

--- a/pkg/client/unversioned/events_test.go
+++ b/pkg/client/unversioned/events_test.go
@@ -23,9 +23,9 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
-	"k8s.io/kubernetes/pkg/util"
 )
 
 func TestEventSearch(t *testing.T) {
@@ -65,7 +65,7 @@ func TestEventCreate(t *testing.T) {
 		APIVersion:      "apiv1",
 		ResourceVersion: "1",
 	}
-	timeStamp := util.Now()
+	timeStamp := unversioned.Now()
 	event := &api.Event{
 		ObjectMeta: api.ObjectMeta{
 			Namespace: api.NamespaceDefault,
@@ -104,7 +104,7 @@ func TestEventGet(t *testing.T) {
 		APIVersion:      "apiv1",
 		ResourceVersion: "1",
 	}
-	timeStamp := util.Now()
+	timeStamp := unversioned.Now()
 	event := &api.Event{
 		ObjectMeta: api.ObjectMeta{
 			Namespace: "other",
@@ -144,7 +144,7 @@ func TestEventList(t *testing.T) {
 		APIVersion:      "apiv1",
 		ResourceVersion: "1",
 	}
-	timeStamp := util.Now()
+	timeStamp := unversioned.Now()
 	eventList := &api.EventList{
 		Items: []api.Event{
 			{

--- a/pkg/cloudprovider/providers/aws/aws_instancegroups.go
+++ b/pkg/cloudprovider/providers/aws/aws_instancegroups.go
@@ -18,6 +18,7 @@ package aws_cloud
 
 import (
 	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/golang/glog"

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/experimental"
 	"k8s.io/kubernetes/pkg/client/cache"
 	"k8s.io/kubernetes/pkg/client/record"
@@ -351,8 +352,8 @@ func newCondition() experimental.JobCondition {
 	return experimental.JobCondition{
 		Type:               experimental.JobComplete,
 		Status:             api.ConditionTrue,
-		LastProbeTime:      util.Now(),
-		LastTransitionTime: util.Now(),
+		LastProbeTime:      unversioned.Now(),
+		LastTransitionTime: unversioned.Now(),
 	}
 }
 

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -24,6 +24,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/experimental"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
@@ -120,7 +121,7 @@ func newPodList(count int, status api.PodPhase, job *experimental.Job) []api.Pod
 	for i := 0; i < count; i++ {
 		newPod := api.Pod{
 			ObjectMeta: api.ObjectMeta{
-				Name:      fmt.Sprintf("pod-%v", util.Now().UnixNano()),
+				Name:      fmt.Sprintf("pod-%v", unversioned.Now().UnixNano()),
 				Labels:    job.Spec.Selector,
 				Namespace: job.Namespace,
 			},
@@ -493,8 +494,8 @@ func TestWatchJobs(t *testing.T) {
 			Conditions: []experimental.JobCondition{{
 				Type:               experimental.JobComplete,
 				Status:             api.ConditionTrue,
-				LastProbeTime:      util.Now(),
-				LastTransitionTime: util.Now(),
+				LastProbeTime:      unversioned.Now(),
+				LastTransitionTime: unversioned.Now(),
 			}},
 		},
 	}

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/client/cache"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/controller/framework"
@@ -153,7 +154,7 @@ func (e *contentRemainingError) Error() string {
 // deleteAllContent will delete all content known to the system in a namespace. It returns an estimate
 // of the time remaining before the remaining resources are deleted. If estimate > 0 not all resources
 // are guaranteed to be gone.
-func deleteAllContent(kubeClient client.Interface, experimentalMode bool, namespace string, before util.Time) (estimate int64, err error) {
+func deleteAllContent(kubeClient client.Interface, experimentalMode bool, namespace string, before unversioned.Time) (estimate int64, err error) {
 	err = deleteServiceAccounts(kubeClient, namespace)
 	if err != nil {
 		return estimate, err
@@ -334,12 +335,12 @@ func deleteReplicationControllers(kubeClient client.Interface, ns string) error 
 	return nil
 }
 
-func deletePods(kubeClient client.Interface, ns string, before util.Time) (int64, error) {
+func deletePods(kubeClient client.Interface, ns string, before unversioned.Time) (int64, error) {
 	items, err := kubeClient.Pods(ns).List(labels.Everything(), fields.Everything())
 	if err != nil {
 		return 0, err
 	}
-	expired := util.Now().After(before.Time)
+	expired := unversioned.Now().After(before.Time)
 	var deleteOptions *api.DeleteOptions
 	if expired {
 		deleteOptions = api.NewDeleteOptions(0)

--- a/pkg/controller/namespace/namespace_controller_test.go
+++ b/pkg/controller/namespace/namespace_controller_test.go
@@ -22,8 +22,8 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
-	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/sets"
 )
 
@@ -72,7 +72,7 @@ func TestFinalize(t *testing.T) {
 
 func testSyncNamespaceThatIsTerminating(t *testing.T, experimentalMode bool) {
 	mockClient := &testclient.Fake{}
-	now := util.Now()
+	now := unversioned.Now()
 	testNamespace := api.Namespace{
 		ObjectMeta: api.ObjectMeta{
 			Name:              "test",

--- a/pkg/controller/node/nodecontroller.go
+++ b/pkg/controller/node/nodecontroller.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/client/record"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/cloudprovider"
@@ -49,8 +50,8 @@ const (
 )
 
 type nodeStatusData struct {
-	probeTimestamp           util.Time
-	readyTransitionTimestamp util.Time
+	probeTimestamp           unversioned.Time
+	readyTransitionTimestamp unversioned.Time
 	status                   api.NodeStatus
 }
 
@@ -89,7 +90,7 @@ type NodeController struct {
 	// This timestamp is to be used instead of LastProbeTime stored in Condition. We do this
 	// to aviod the problem with time skew across the cluster.
 	nodeStatusMap map[string]nodeStatusData
-	now           func() util.Time
+	now           func() unversioned.Time
 	// Lock to access evictor workers
 	evictorLock *sync.Mutex
 	// workers that evicts pods from unresponsive nodes.
@@ -140,7 +141,7 @@ func NewNodeController(
 		nodeMonitorPeriod:      nodeMonitorPeriod,
 		nodeStartupGracePeriod: nodeStartupGracePeriod,
 		lookupIP:               net.LookupIP,
-		now:                    util.Now,
+		now:                    unversioned.Now,
 		clusterCIDR:            clusterCIDR,
 		allocateNodeCIDRs:      allocateNodeCIDRs,
 	}
@@ -488,7 +489,7 @@ func (nc *NodeController) tryUpdateNodeStatus(node *api.Node) (time.Duration, ap
 		}
 		nc.nodeStatusMap[node.Name] = savedNodeStatus
 	} else if savedCondition != nil && observedCondition != nil && savedCondition.LastHeartbeatTime != observedCondition.LastHeartbeatTime {
-		var transitionTime util.Time
+		var transitionTime unversioned.Time
 		// If ReadyCondition changed since the last time we checked, we update the transition timestamp to "now",
 		// otherwise we leave it as it is.
 		if savedCondition.LastTransitionTime != observedCondition.LastTransitionTime {

--- a/pkg/controller/node/nodecontroller_test.go
+++ b/pkg/controller/node/nodecontroller_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	apierrors "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
 	"k8s.io/kubernetes/pkg/fields"
@@ -141,7 +142,7 @@ func (m *FakeNodeHandler) Watch(label labels.Selector, field fields.Selector, re
 }
 
 func TestMonitorNodeStatusEvictPods(t *testing.T) {
-	fakeNow := util.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC)
+	fakeNow := unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC)
 	evictionTimeout := 10 * time.Minute
 
 	table := []struct {
@@ -176,15 +177,15 @@ func TestMonitorNodeStatusEvictPods(t *testing.T) {
 					{
 						ObjectMeta: api.ObjectMeta{
 							Name:              "node0",
-							CreationTimestamp: util.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+							CreationTimestamp: unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
 						},
 						Status: api.NodeStatus{
 							Conditions: []api.NodeCondition{
 								{
 									Type:               api.NodeReady,
 									Status:             api.ConditionFalse,
-									LastHeartbeatTime:  util.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
-									LastTransitionTime: util.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+									LastHeartbeatTime:  unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+									LastTransitionTime: unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
 								},
 							},
 						},
@@ -199,8 +200,8 @@ func TestMonitorNodeStatusEvictPods(t *testing.T) {
 						Type:   api.NodeReady,
 						Status: api.ConditionFalse,
 						// Node status has just been updated, and is NotReady for 10min.
-						LastHeartbeatTime:  util.Date(2015, 1, 1, 12, 9, 0, 0, time.UTC),
-						LastTransitionTime: util.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+						LastHeartbeatTime:  unversioned.Date(2015, 1, 1, 12, 9, 0, 0, time.UTC),
+						LastTransitionTime: unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
 					},
 				},
 			},
@@ -214,15 +215,15 @@ func TestMonitorNodeStatusEvictPods(t *testing.T) {
 					{
 						ObjectMeta: api.ObjectMeta{
 							Name:              "node0",
-							CreationTimestamp: util.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+							CreationTimestamp: unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
 						},
 						Status: api.NodeStatus{
 							Conditions: []api.NodeCondition{
 								{
 									Type:               api.NodeReady,
 									Status:             api.ConditionFalse,
-									LastHeartbeatTime:  util.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
-									LastTransitionTime: util.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+									LastHeartbeatTime:  unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+									LastTransitionTime: unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
 								},
 							},
 						},
@@ -237,8 +238,8 @@ func TestMonitorNodeStatusEvictPods(t *testing.T) {
 						Type:   api.NodeReady,
 						Status: api.ConditionFalse,
 						// Node status has just been updated, and is NotReady for 1hr.
-						LastHeartbeatTime:  util.Date(2015, 1, 1, 12, 59, 0, 0, time.UTC),
-						LastTransitionTime: util.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+						LastHeartbeatTime:  unversioned.Date(2015, 1, 1, 12, 59, 0, 0, time.UTC),
+						LastTransitionTime: unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
 					},
 				},
 			},
@@ -252,15 +253,15 @@ func TestMonitorNodeStatusEvictPods(t *testing.T) {
 					{
 						ObjectMeta: api.ObjectMeta{
 							Name:              "node0",
-							CreationTimestamp: util.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+							CreationTimestamp: unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
 						},
 						Status: api.NodeStatus{
 							Conditions: []api.NodeCondition{
 								{
 									Type:               api.NodeReady,
 									Status:             api.ConditionUnknown,
-									LastHeartbeatTime:  util.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
-									LastTransitionTime: util.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+									LastHeartbeatTime:  unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+									LastTransitionTime: unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
 								},
 							},
 						},
@@ -275,8 +276,8 @@ func TestMonitorNodeStatusEvictPods(t *testing.T) {
 						Type:   api.NodeReady,
 						Status: api.ConditionUnknown,
 						// Node status was updated by nodecontroller 10min ago
-						LastHeartbeatTime:  util.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
-						LastTransitionTime: util.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+						LastHeartbeatTime:  unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+						LastTransitionTime: unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
 					},
 				},
 			},
@@ -290,15 +291,15 @@ func TestMonitorNodeStatusEvictPods(t *testing.T) {
 					{
 						ObjectMeta: api.ObjectMeta{
 							Name:              "node0",
-							CreationTimestamp: util.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+							CreationTimestamp: unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
 						},
 						Status: api.NodeStatus{
 							Conditions: []api.NodeCondition{
 								{
 									Type:               api.NodeReady,
 									Status:             api.ConditionUnknown,
-									LastHeartbeatTime:  util.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
-									LastTransitionTime: util.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+									LastHeartbeatTime:  unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+									LastTransitionTime: unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
 								},
 							},
 						},
@@ -313,8 +314,8 @@ func TestMonitorNodeStatusEvictPods(t *testing.T) {
 						Type:   api.NodeReady,
 						Status: api.ConditionUnknown,
 						// Node status was updated by nodecontroller 1hr ago
-						LastHeartbeatTime:  util.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
-						LastTransitionTime: util.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+						LastHeartbeatTime:  unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+						LastTransitionTime: unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
 					},
 				},
 			},
@@ -327,12 +328,12 @@ func TestMonitorNodeStatusEvictPods(t *testing.T) {
 		nodeController := NewNodeController(nil, item.fakeNodeHandler,
 			evictionTimeout, util.NewFakeRateLimiter(), testNodeMonitorGracePeriod,
 			testNodeStartupGracePeriod, testNodeMonitorPeriod, nil, false)
-		nodeController.now = func() util.Time { return fakeNow }
+		nodeController.now = func() unversioned.Time { return fakeNow }
 		if err := nodeController.monitorNodeStatus(); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 		if item.timeToPass > 0 {
-			nodeController.now = func() util.Time { return util.Time{Time: fakeNow.Add(item.timeToPass)} }
+			nodeController.now = func() unversioned.Time { return unversioned.Time{Time: fakeNow.Add(item.timeToPass)} }
 			item.fakeNodeHandler.Existing[0].Status = item.newNodeStatus
 		}
 		if err := nodeController.monitorNodeStatus(); err != nil {
@@ -365,7 +366,7 @@ func TestMonitorNodeStatusEvictPods(t *testing.T) {
 }
 
 func TestMonitorNodeStatusUpdateStatus(t *testing.T) {
-	fakeNow := util.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC)
+	fakeNow := unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC)
 	table := []struct {
 		fakeNodeHandler      *FakeNodeHandler
 		timeToPass           time.Duration
@@ -382,7 +383,7 @@ func TestMonitorNodeStatusUpdateStatus(t *testing.T) {
 					{
 						ObjectMeta: api.ObjectMeta{
 							Name:              "node0",
-							CreationTimestamp: util.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+							CreationTimestamp: unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
 						},
 					},
 				},
@@ -393,7 +394,7 @@ func TestMonitorNodeStatusUpdateStatus(t *testing.T) {
 				{
 					ObjectMeta: api.ObjectMeta{
 						Name:              "node0",
-						CreationTimestamp: util.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+						CreationTimestamp: unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
 					},
 					Status: api.NodeStatus{
 						Conditions: []api.NodeCondition{
@@ -402,7 +403,7 @@ func TestMonitorNodeStatusUpdateStatus(t *testing.T) {
 								Status:             api.ConditionUnknown,
 								Reason:             "NodeStatusNeverUpdated",
 								Message:            fmt.Sprintf("Kubelet never posted node status."),
-								LastHeartbeatTime:  util.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+								LastHeartbeatTime:  unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
 								LastTransitionTime: fakeNow,
 							},
 						},
@@ -435,7 +436,7 @@ func TestMonitorNodeStatusUpdateStatus(t *testing.T) {
 					{
 						ObjectMeta: api.ObjectMeta{
 							Name:              "node0",
-							CreationTimestamp: util.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+							CreationTimestamp: unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
 						},
 						Status: api.NodeStatus{
 							Conditions: []api.NodeCondition{
@@ -443,8 +444,8 @@ func TestMonitorNodeStatusUpdateStatus(t *testing.T) {
 									Type:   api.NodeReady,
 									Status: api.ConditionTrue,
 									// Node status hasn't been updated for 1hr.
-									LastHeartbeatTime:  util.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
-									LastTransitionTime: util.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+									LastHeartbeatTime:  unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+									LastTransitionTime: unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
 								},
 							},
 							Capacity: api.ResourceList{
@@ -467,8 +468,8 @@ func TestMonitorNodeStatusUpdateStatus(t *testing.T) {
 						Type:   api.NodeReady,
 						Status: api.ConditionTrue,
 						// Node status hasn't been updated for 1hr.
-						LastHeartbeatTime:  util.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
-						LastTransitionTime: util.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+						LastHeartbeatTime:  unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+						LastTransitionTime: unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
 					},
 				},
 				Capacity: api.ResourceList{
@@ -480,7 +481,7 @@ func TestMonitorNodeStatusUpdateStatus(t *testing.T) {
 				{
 					ObjectMeta: api.ObjectMeta{
 						Name:              "node0",
-						CreationTimestamp: util.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+						CreationTimestamp: unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
 					},
 					Status: api.NodeStatus{
 						Conditions: []api.NodeCondition{
@@ -489,8 +490,8 @@ func TestMonitorNodeStatusUpdateStatus(t *testing.T) {
 								Status:             api.ConditionUnknown,
 								Reason:             "NodeStatusStopUpdated",
 								Message:            fmt.Sprintf("Kubelet stopped posting node status."),
-								LastHeartbeatTime:  util.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
-								LastTransitionTime: util.Time{Time: util.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC).Add(time.Hour)},
+								LastHeartbeatTime:  unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+								LastTransitionTime: unversioned.Time{Time: unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC).Add(time.Hour)},
 							},
 						},
 						Capacity: api.ResourceList{
@@ -512,7 +513,7 @@ func TestMonitorNodeStatusUpdateStatus(t *testing.T) {
 					{
 						ObjectMeta: api.ObjectMeta{
 							Name:              "node0",
-							CreationTimestamp: util.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+							CreationTimestamp: unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
 						},
 						Status: api.NodeStatus{
 							Conditions: []api.NodeCondition{
@@ -544,12 +545,12 @@ func TestMonitorNodeStatusUpdateStatus(t *testing.T) {
 	for _, item := range table {
 		nodeController := NewNodeController(nil, item.fakeNodeHandler, 5*time.Minute, util.NewFakeRateLimiter(),
 			testNodeMonitorGracePeriod, testNodeStartupGracePeriod, testNodeMonitorPeriod, nil, false)
-		nodeController.now = func() util.Time { return fakeNow }
+		nodeController.now = func() unversioned.Time { return fakeNow }
 		if err := nodeController.monitorNodeStatus(); err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 		if item.timeToPass > 0 {
-			nodeController.now = func() util.Time { return util.Time{Time: fakeNow.Add(item.timeToPass)} }
+			nodeController.now = func() unversioned.Time { return unversioned.Time{Time: fakeNow.Add(item.timeToPass)} }
 			item.fakeNodeHandler.Existing[0].Status = item.newNodeStatus
 			if err := nodeController.monitorNodeStatus(); err != nil {
 				t.Errorf("unexpected error: %v", err)
@@ -566,13 +567,13 @@ func TestMonitorNodeStatusUpdateStatus(t *testing.T) {
 }
 
 func TestNodeDeletion(t *testing.T) {
-	fakeNow := util.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC)
+	fakeNow := unversioned.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC)
 	fakeNodeHandler := &FakeNodeHandler{
 		Existing: []*api.Node{
 			{
 				ObjectMeta: api.ObjectMeta{
 					Name:              "node0",
-					CreationTimestamp: util.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+					CreationTimestamp: unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
 				},
 				Status: api.NodeStatus{
 					Conditions: []api.NodeCondition{
@@ -596,7 +597,7 @@ func TestNodeDeletion(t *testing.T) {
 			{
 				ObjectMeta: api.ObjectMeta{
 					Name:              "node1",
-					CreationTimestamp: util.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+					CreationTimestamp: unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
 				},
 				Status: api.NodeStatus{
 					Conditions: []api.NodeCondition{
@@ -623,7 +624,7 @@ func TestNodeDeletion(t *testing.T) {
 
 	nodeController := NewNodeController(nil, fakeNodeHandler, 5*time.Minute, util.NewFakeRateLimiter(),
 		testNodeMonitorGracePeriod, testNodeStartupGracePeriod, testNodeMonitorPeriod, nil, false)
-	nodeController.now = func() util.Time { return fakeNow }
+	nodeController.now = func() unversioned.Time { return fakeNow }
 	if err := nodeController.monitorNodeStatus(); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/experimental"
 	"k8s.io/kubernetes/pkg/client/record"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
@@ -144,7 +145,7 @@ func (a *HorizontalController) reconcileAutoscaler(hpa experimental.HorizontalPo
 	}
 	hpa.Status = &status
 	if rescale {
-		now := util.NewTime(now)
+		now := unversioned.NewTime(now)
 		hpa.Status.LastScaleTimestamp = &now
 	}
 

--- a/pkg/controller/replication/replication_controller_test.go
+++ b/pkg/controller/replication/replication_controller_test.go
@@ -969,7 +969,7 @@ func TestOverlappingRCs(t *testing.T) {
 		var controllers []*api.ReplicationController
 		for j := 1; j < 10; j++ {
 			controllerSpec := newReplicationController(1)
-			controllerSpec.CreationTimestamp = util.Date(2014, time.December, j, 0, 0, 0, 0, time.Local)
+			controllerSpec.CreationTimestamp = unversioned.Date(2014, time.December, j, 0, 0, 0, 0, time.Local)
 			controllerSpec.Name = string(util.NewUUID())
 			controllers = append(controllers, controllerSpec)
 		}

--- a/pkg/kubectl/cmd/cmd_test.go
+++ b/pkg/kubectl/cmd/cmd_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/api/validation"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
@@ -284,7 +285,7 @@ func ExamplePrintReplicationControllerWithNamespace() {
 			Name:              "foo",
 			Namespace:         "beep",
 			Labels:            map[string]string{"foo": "bar"},
-			CreationTimestamp: util.Time{Time: time.Now().AddDate(-10, 0, 0)},
+			CreationTimestamp: unversioned.Time{Time: time.Now().AddDate(-10, 0, 0)},
 		},
 		Spec: api.ReplicationControllerSpec{
 			Replicas: 1,
@@ -325,7 +326,7 @@ func ExamplePrintPodWithWideFormat() {
 	pod := &api.Pod{
 		ObjectMeta: api.ObjectMeta{
 			Name:              "test1",
-			CreationTimestamp: util.Time{Time: time.Now().AddDate(-10, 0, 0)},
+			CreationTimestamp: unversioned.Time{Time: time.Now().AddDate(-10, 0, 0)},
 		},
 		Spec: api.PodSpec{
 			Containers: make([]api.Container, 2),
@@ -355,7 +356,7 @@ func newAllPhasePodList() *api.PodList {
 			{
 				ObjectMeta: api.ObjectMeta{
 					Name:              "test1",
-					CreationTimestamp: util.Time{time.Now().AddDate(-10, 0, 0)},
+					CreationTimestamp: unversioned.Time{time.Now().AddDate(-10, 0, 0)},
 				},
 				Spec: api.PodSpec{
 					Containers: make([]api.Container, 2),
@@ -372,7 +373,7 @@ func newAllPhasePodList() *api.PodList {
 			{
 				ObjectMeta: api.ObjectMeta{
 					Name:              "test2",
-					CreationTimestamp: util.Time{time.Now().AddDate(-10, 0, 0)},
+					CreationTimestamp: unversioned.Time{time.Now().AddDate(-10, 0, 0)},
 				},
 				Spec: api.PodSpec{
 					Containers: make([]api.Container, 2),
@@ -389,7 +390,7 @@ func newAllPhasePodList() *api.PodList {
 			{
 				ObjectMeta: api.ObjectMeta{
 					Name:              "test3",
-					CreationTimestamp: util.Time{time.Now().AddDate(-10, 0, 0)},
+					CreationTimestamp: unversioned.Time{time.Now().AddDate(-10, 0, 0)},
 				},
 				Spec: api.PodSpec{
 					Containers: make([]api.Container, 2),
@@ -406,7 +407,7 @@ func newAllPhasePodList() *api.PodList {
 			{
 				ObjectMeta: api.ObjectMeta{
 					Name:              "test4",
-					CreationTimestamp: util.Time{time.Now().AddDate(-10, 0, 0)},
+					CreationTimestamp: unversioned.Time{time.Now().AddDate(-10, 0, 0)},
 				},
 				Spec: api.PodSpec{
 					Containers: make([]api.Container, 2),
@@ -423,7 +424,7 @@ func newAllPhasePodList() *api.PodList {
 			{
 				ObjectMeta: api.ObjectMeta{
 					Name:              "test5",
-					CreationTimestamp: util.Time{time.Now().AddDate(-10, 0, 0)},
+					CreationTimestamp: unversioned.Time{time.Now().AddDate(-10, 0, 0)},
 				},
 				Spec: api.PodSpec{
 					Containers: make([]api.Container, 2),
@@ -496,7 +497,7 @@ func ExamplePrintServiceWithNamespacesAndLabels() {
 				ObjectMeta: api.ObjectMeta{
 					Name:              "svc1",
 					Namespace:         "ns1",
-					CreationTimestamp: util.Time{Time: time.Now().AddDate(-10, 0, 0)},
+					CreationTimestamp: unversioned.Time{Time: time.Now().AddDate(-10, 0, 0)},
 					Labels: map[string]string{
 						"l1": "value",
 					},
@@ -517,7 +518,7 @@ func ExamplePrintServiceWithNamespacesAndLabels() {
 				ObjectMeta: api.ObjectMeta{
 					Name:              "svc2",
 					Namespace:         "ns2",
-					CreationTimestamp: util.Time{Time: time.Now().AddDate(-10, 0, 0)},
+					CreationTimestamp: unversioned.Time{Time: time.Now().AddDate(-10, 0, 0)},
 					Labels: map[string]string{
 						"l1": "dolla-bill-yall",
 					},

--- a/pkg/kubectl/describe_test.go
+++ b/pkg/kubectl/describe_test.go
@@ -26,9 +26,9 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
-	"k8s.io/kubernetes/pkg/util"
 )
 
 type describeClient struct {
@@ -85,22 +85,22 @@ func TestPodDescribeResultsSorted(t *testing.T) {
 			{
 				Source:         api.EventSource{Component: "kubelet"},
 				Message:        "Item 1",
-				FirstTimestamp: util.NewTime(time.Date(2014, time.January, 15, 0, 0, 0, 0, time.UTC)),
-				LastTimestamp:  util.NewTime(time.Date(2014, time.January, 15, 0, 0, 0, 0, time.UTC)),
+				FirstTimestamp: unversioned.NewTime(time.Date(2014, time.January, 15, 0, 0, 0, 0, time.UTC)),
+				LastTimestamp:  unversioned.NewTime(time.Date(2014, time.January, 15, 0, 0, 0, 0, time.UTC)),
 				Count:          1,
 			},
 			{
 				Source:         api.EventSource{Component: "scheduler"},
 				Message:        "Item 2",
-				FirstTimestamp: util.NewTime(time.Date(1987, time.June, 17, 0, 0, 0, 0, time.UTC)),
-				LastTimestamp:  util.NewTime(time.Date(1987, time.June, 17, 0, 0, 0, 0, time.UTC)),
+				FirstTimestamp: unversioned.NewTime(time.Date(1987, time.June, 17, 0, 0, 0, 0, time.UTC)),
+				LastTimestamp:  unversioned.NewTime(time.Date(1987, time.June, 17, 0, 0, 0, 0, time.UTC)),
 				Count:          1,
 			},
 			{
 				Source:         api.EventSource{Component: "kubelet"},
 				Message:        "Item 3",
-				FirstTimestamp: util.NewTime(time.Date(2002, time.December, 25, 0, 0, 0, 0, time.UTC)),
-				LastTimestamp:  util.NewTime(time.Date(2002, time.December, 25, 0, 0, 0, 0, time.UTC)),
+				FirstTimestamp: unversioned.NewTime(time.Date(2002, time.December, 25, 0, 0, 0, 0, time.UTC)),
+				LastTimestamp:  unversioned.NewTime(time.Date(2002, time.December, 25, 0, 0, 0, 0, time.UTC)),
 				Count:          1,
 			},
 		},
@@ -131,7 +131,7 @@ func TestDescribeContainers(t *testing.T) {
 				Name: "test",
 				State: api.ContainerState{
 					Running: &api.ContainerStateRunning{
-						StartedAt: util.NewTime(time.Now()),
+						StartedAt: unversioned.NewTime(time.Now()),
 					},
 				},
 				Ready:        true,
@@ -161,8 +161,8 @@ func TestDescribeContainers(t *testing.T) {
 				Name: "test",
 				State: api.ContainerState{
 					Terminated: &api.ContainerStateTerminated{
-						StartedAt:  util.NewTime(time.Now()),
-						FinishedAt: util.NewTime(time.Now()),
+						StartedAt:  unversioned.NewTime(time.Now()),
+						FinishedAt: unversioned.NewTime(time.Now()),
 						Reason:     "potato",
 						ExitCode:   2,
 					},
@@ -179,13 +179,13 @@ func TestDescribeContainers(t *testing.T) {
 				Name: "test",
 				State: api.ContainerState{
 					Running: &api.ContainerStateRunning{
-						StartedAt: util.NewTime(time.Now()),
+						StartedAt: unversioned.NewTime(time.Now()),
 					},
 				},
 				LastTerminationState: api.ContainerState{
 					Terminated: &api.ContainerStateTerminated{
-						StartedAt:  util.NewTime(time.Now().Add(time.Second * 3)),
-						FinishedAt: util.NewTime(time.Now()),
+						StartedAt:  unversioned.NewTime(time.Now().Add(time.Second * 3)),
+						FinishedAt: unversioned.NewTime(time.Now()),
 						Reason:     "crashing",
 						ExitCode:   3,
 					},

--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -41,7 +41,6 @@ import (
 	"k8s.io/kubernetes/pkg/conversion"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/jsonpath"
 	"k8s.io/kubernetes/pkg/util/sets"
 )
@@ -518,7 +517,7 @@ func shortHumanDuration(d time.Duration) string {
 
 // translateTimestamp returns the elapsed time since timestamp in
 // human-readable approximation.
-func translateTimestamp(timestamp util.Time) string {
+func translateTimestamp(timestamp unversioned.Time) string {
 	if timestamp.IsZero() {
 		return "<unknown>"
 	}

--- a/pkg/kubectl/resource_printer_test.go
+++ b/pkg/kubectl/resource_printer_test.go
@@ -390,7 +390,7 @@ func TestTemplateStrings(t *testing.T) {
 							Name: "bar",
 							State: api.ContainerState{
 								Running: &api.ContainerStateRunning{
-									StartedAt: util.Time{},
+									StartedAt: unversioned.Time{},
 								},
 							},
 						},
@@ -407,7 +407,7 @@ func TestTemplateStrings(t *testing.T) {
 							Name: "foo",
 							State: api.ContainerState{
 								Running: &api.ContainerStateRunning{
-									StartedAt: util.Time{},
+									StartedAt: unversioned.Time{},
 								},
 							},
 						},
@@ -415,7 +415,7 @@ func TestTemplateStrings(t *testing.T) {
 							Name: "bar",
 							State: api.ContainerState{
 								Running: &api.ContainerStateRunning{
-									StartedAt: util.Time{},
+									StartedAt: unversioned.Time{},
 								},
 							},
 						},
@@ -514,22 +514,22 @@ func TestPrintEventsResultSorted(t *testing.T) {
 			{
 				Source:         api.EventSource{Component: "kubelet"},
 				Message:        "Item 1",
-				FirstTimestamp: util.NewTime(time.Date(2014, time.January, 15, 0, 0, 0, 0, time.UTC)),
-				LastTimestamp:  util.NewTime(time.Date(2014, time.January, 15, 0, 0, 0, 0, time.UTC)),
+				FirstTimestamp: unversioned.NewTime(time.Date(2014, time.January, 15, 0, 0, 0, 0, time.UTC)),
+				LastTimestamp:  unversioned.NewTime(time.Date(2014, time.January, 15, 0, 0, 0, 0, time.UTC)),
 				Count:          1,
 			},
 			{
 				Source:         api.EventSource{Component: "scheduler"},
 				Message:        "Item 2",
-				FirstTimestamp: util.NewTime(time.Date(1987, time.June, 17, 0, 0, 0, 0, time.UTC)),
-				LastTimestamp:  util.NewTime(time.Date(1987, time.June, 17, 0, 0, 0, 0, time.UTC)),
+				FirstTimestamp: unversioned.NewTime(time.Date(1987, time.June, 17, 0, 0, 0, 0, time.UTC)),
+				LastTimestamp:  unversioned.NewTime(time.Date(1987, time.June, 17, 0, 0, 0, 0, time.UTC)),
 				Count:          1,
 			},
 			{
 				Source:         api.EventSource{Component: "kubelet"},
 				Message:        "Item 3",
-				FirstTimestamp: util.NewTime(time.Date(2002, time.December, 25, 0, 0, 0, 0, time.UTC)),
-				LastTimestamp:  util.NewTime(time.Date(2002, time.December, 25, 0, 0, 0, 0, time.UTC)),
+				FirstTimestamp: unversioned.NewTime(time.Date(2002, time.December, 25, 0, 0, 0, 0, time.UTC)),
+				LastTimestamp:  unversioned.NewTime(time.Date(2002, time.December, 25, 0, 0, 0, 0, time.UTC)),
 				Count:          1,
 			},
 		},
@@ -909,8 +909,8 @@ func TestPrintHumanReadableWithNamespace(t *testing.T) {
 				ObjectMeta:     api.ObjectMeta{Name: name, Namespace: namespaceName},
 				Source:         api.EventSource{Component: "kubelet"},
 				Message:        "Item 1",
-				FirstTimestamp: util.NewTime(time.Date(2014, time.January, 15, 0, 0, 0, 0, time.UTC)),
-				LastTimestamp:  util.NewTime(time.Date(2014, time.January, 15, 0, 0, 0, 0, time.UTC)),
+				FirstTimestamp: unversioned.NewTime(time.Date(2014, time.January, 15, 0, 0, 0, 0, time.UTC)),
+				LastTimestamp:  unversioned.NewTime(time.Date(2014, time.January, 15, 0, 0, 0, 0, time.UTC)),
 				Count:          1,
 			},
 			isNamespaced: true,
@@ -1215,16 +1215,16 @@ type stringTestList []struct {
 
 func TestTranslateTimestamp(t *testing.T) {
 	tl := stringTestList{
-		{"a while from now", translateTimestamp(util.Time{Time: time.Now().Add(2.1e9)}), "<invalid>"},
-		{"almost now", translateTimestamp(util.Time{Time: time.Now().Add(1.9e9)}), "0s"},
-		{"now", translateTimestamp(util.Time{Time: time.Now()}), "0s"},
-		{"unknown", translateTimestamp(util.Time{}), "<unknown>"},
-		{"30 seconds ago", translateTimestamp(util.Time{Time: time.Now().Add(-3e10)}), "30s"},
-		{"5 minutes ago", translateTimestamp(util.Time{Time: time.Now().Add(-3e11)}), "5m"},
-		{"an hour ago", translateTimestamp(util.Time{Time: time.Now().Add(-6e12)}), "1h"},
-		{"2 days ago", translateTimestamp(util.Time{Time: time.Now().AddDate(0, 0, -2)}), "2d"},
-		{"months ago", translateTimestamp(util.Time{Time: time.Now().AddDate(0, -3, 0)}), "92d"},
-		{"10 years ago", translateTimestamp(util.Time{Time: time.Now().AddDate(-10, 0, 0)}), "10y"},
+		{"a while from now", translateTimestamp(unversioned.Time{Time: time.Now().Add(2.1e9)}), "<invalid>"},
+		{"almost now", translateTimestamp(unversioned.Time{Time: time.Now().Add(1.9e9)}), "0s"},
+		{"now", translateTimestamp(unversioned.Time{Time: time.Now()}), "0s"},
+		{"unknown", translateTimestamp(unversioned.Time{}), "<unknown>"},
+		{"30 seconds ago", translateTimestamp(unversioned.Time{Time: time.Now().Add(-3e10)}), "30s"},
+		{"5 minutes ago", translateTimestamp(unversioned.Time{Time: time.Now().Add(-3e11)}), "5m"},
+		{"an hour ago", translateTimestamp(unversioned.Time{Time: time.Now().Add(-6e12)}), "1h"},
+		{"2 days ago", translateTimestamp(unversioned.Time{Time: time.Now().AddDate(0, 0, -2)}), "2d"},
+		{"months ago", translateTimestamp(unversioned.Time{Time: time.Now().AddDate(0, -3, 0)}), "92d"},
+		{"10 years ago", translateTimestamp(unversioned.Time{Time: time.Now().AddDate(-10, 0, 0)}), "10y"},
 	}
 	for _, test := range tl {
 		if test.got != test.exp {
@@ -1243,7 +1243,7 @@ func TestPrintDeployment(t *testing.T) {
 			experimental.Deployment{
 				ObjectMeta: api.ObjectMeta{
 					Name:              "test1",
-					CreationTimestamp: util.Time{Time: time.Now().Add(1.9e9)},
+					CreationTimestamp: unversioned.Time{Time: time.Now().Add(1.9e9)},
 				},
 				Spec: experimental.DeploymentSpec{
 					Replicas: 5,

--- a/pkg/kubectl/service.go
+++ b/pkg/kubectl/service.go
@@ -18,10 +18,11 @@ package kubectl
 
 import (
 	"fmt"
+	"strconv"
+
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
-	"strconv"
 )
 
 // The only difference between ServiceGeneratorV1 and V2 is that the service port is named "default" in V1, while it is left unnamed in V2.

--- a/pkg/kubectl/sorted_event_list_test.go
+++ b/pkg/kubectl/sorted_event_list_test.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 )
 
 // VerifyDatesInOrder checks the start of each line for a RFC1123Z date
@@ -57,22 +57,22 @@ func TestSortableEvents(t *testing.T) {
 		{
 			Source:         api.EventSource{Component: "kubelet"},
 			Message:        "Item 1",
-			FirstTimestamp: util.NewTime(time.Date(2014, time.January, 15, 0, 0, 0, 0, time.UTC)),
-			LastTimestamp:  util.NewTime(time.Date(2014, time.January, 15, 0, 0, 0, 0, time.UTC)),
+			FirstTimestamp: unversioned.NewTime(time.Date(2014, time.January, 15, 0, 0, 0, 0, time.UTC)),
+			LastTimestamp:  unversioned.NewTime(time.Date(2014, time.January, 15, 0, 0, 0, 0, time.UTC)),
 			Count:          1,
 		},
 		{
 			Source:         api.EventSource{Component: "scheduler"},
 			Message:        "Item 2",
-			FirstTimestamp: util.NewTime(time.Date(1987, time.June, 17, 0, 0, 0, 0, time.UTC)),
-			LastTimestamp:  util.NewTime(time.Date(1987, time.June, 17, 0, 0, 0, 0, time.UTC)),
+			FirstTimestamp: unversioned.NewTime(time.Date(1987, time.June, 17, 0, 0, 0, 0, time.UTC)),
+			LastTimestamp:  unversioned.NewTime(time.Date(1987, time.June, 17, 0, 0, 0, 0, time.UTC)),
 			Count:          1,
 		},
 		{
 			Source:         api.EventSource{Component: "kubelet"},
 			Message:        "Item 3",
-			FirstTimestamp: util.NewTime(time.Date(2002, time.December, 25, 0, 0, 0, 0, time.UTC)),
-			LastTimestamp:  util.NewTime(time.Date(2002, time.December, 25, 0, 0, 0, 0, time.UTC)),
+			FirstTimestamp: unversioned.NewTime(time.Date(2002, time.December, 25, 0, 0, 0, 0, time.UTC)),
+			LastTimestamp:  unversioned.NewTime(time.Date(2002, time.December, 25, 0, 0, 0, 0, time.UTC)),
 			Count:          1,
 		},
 	})

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -37,6 +37,7 @@ import (
 	cadvisorApi "github.com/google/cadvisor/info/v1"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/api/validation"
 	"k8s.io/kubernetes/pkg/client/cache"
 	"k8s.io/kubernetes/pkg/client/record"
@@ -1145,7 +1146,7 @@ func (kl *Kubelet) syncPod(pod *api.Pod, mirrorPod *api.Pod, runningPod kubecont
 		}
 
 		podStatus = pod.Status
-		podStatus.StartTime = &util.Time{Time: start}
+		podStatus.StartTime = &unversioned.Time{Time: start}
 		kl.statusManager.SetPodStatus(pod, podStatus)
 		glog.V(3).Infof("Not generating pod status for new pod %q", podFullName)
 	} else {
@@ -1380,7 +1381,7 @@ func (kl *Kubelet) cleanupTerminatedPods(pods []*api.Pod, runningPods []*kubecon
 // pastActiveDeadline returns true if the pod has been active for more than
 // ActiveDeadlineSeconds.
 func (kl *Kubelet) pastActiveDeadline(pod *api.Pod) bool {
-	now := util.Now()
+	now := unversioned.Now()
 	if pod.Spec.ActiveDeadlineSeconds != nil {
 		podStatus, ok := kl.statusManager.GetPodStatus(pod.UID)
 		if !ok {

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/capabilities"
 	"k8s.io/kubernetes/pkg/client/record"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
@@ -2103,8 +2104,8 @@ func TestHandlePortConflicts(t *testing.T) {
 		},
 	}
 	// Make sure the Pods are in the reverse order of creation time.
-	pods[1].CreationTimestamp = util.NewTime(time.Now())
-	pods[0].CreationTimestamp = util.NewTime(time.Now().Add(1 * time.Second))
+	pods[1].CreationTimestamp = unversioned.NewTime(time.Now())
+	pods[0].CreationTimestamp = unversioned.NewTime(time.Now().Add(1 * time.Second))
 	// The newer pod should be rejected.
 	conflictedPod := pods[0]
 
@@ -2193,8 +2194,8 @@ func TestHandleMemExceeded(t *testing.T) {
 		},
 	}
 	// Make sure the Pods are in the reverse order of creation time.
-	pods[1].CreationTimestamp = util.NewTime(time.Now())
-	pods[0].CreationTimestamp = util.NewTime(time.Now().Add(1 * time.Second))
+	pods[1].CreationTimestamp = unversioned.NewTime(time.Now())
+	pods[0].CreationTimestamp = unversioned.NewTime(time.Now().Add(1 * time.Second))
 	// The newer pod should be rejected.
 	notfittingPod := pods[0]
 
@@ -2792,8 +2793,8 @@ func TestIsPodPastActiveDeadline(t *testing.T) {
 
 	exceededActiveDeadlineSeconds := int64(30)
 	notYetActiveDeadlineSeconds := int64(120)
-	now := util.Now()
-	startTime := util.NewTime(now.Time.Add(-1 * time.Minute))
+	now := unversioned.Now()
+	startTime := unversioned.NewTime(now.Time.Add(-1 * time.Minute))
 	pods[0].Status.StartTime = &startTime
 	pods[0].Spec.ActiveDeadlineSeconds = &exceededActiveDeadlineSeconds
 	pods[1].Status.StartTime = &startTime
@@ -2818,8 +2819,8 @@ func TestSyncPodsSetStatusToFailedForPodsThatRunTooLong(t *testing.T) {
 	testKubelet.fakeCadvisor.On("MachineInfo").Return(&cadvisorApi.MachineInfo{}, nil)
 	kubelet := testKubelet.kubelet
 
-	now := util.Now()
-	startTime := util.NewTime(now.Time.Add(-1 * time.Minute))
+	now := unversioned.Now()
+	startTime := unversioned.NewTime(now.Time.Add(-1 * time.Minute))
 	exceededActiveDeadlineSeconds := int64(30)
 
 	pods := []*api.Pod{
@@ -2869,8 +2870,8 @@ func TestSyncPodsDoesNotSetPodsThatDidNotRunTooLongToFailed(t *testing.T) {
 	testKubelet.fakeCadvisor.On("MachineInfo").Return(&cadvisorApi.MachineInfo{}, nil)
 	kubelet := testKubelet.kubelet
 
-	now := util.Now()
-	startTime := util.NewTime(now.Time.Add(-1 * time.Minute))
+	now := unversioned.Now()
+	startTime := unversioned.NewTime(now.Time.Add(-1 * time.Minute))
 	exceededActiveDeadlineSeconds := int64(300)
 
 	pods := []*api.Pod{

--- a/pkg/kubelet/node_manager.go
+++ b/pkg/kubelet/node_manager.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	apierrors "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/client/cache"
 	"k8s.io/kubernetes/pkg/client/record"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
@@ -406,7 +407,7 @@ func (nm *realNodeManager) setNodeStatus(node *api.Node) error {
 	// Check whether network is configured properly
 	networkConfigured := nm.infoGetter.NetworkConfigured()
 
-	currentTime := util.Now()
+	currentTime := unversioned.Now()
 	var newNodeReadyCondition api.NodeCondition
 	var oldNodeReadyConditionStatus api.ConditionStatus
 	if containerRuntimeUp && networkConfigured {

--- a/pkg/kubelet/node_manager_test.go
+++ b/pkg/kubelet/node_manager_test.go
@@ -127,8 +127,8 @@ func TestUpdateNewNodeStatus(t *testing.T) {
 					Status:             api.ConditionTrue,
 					Reason:             "KubeletReady",
 					Message:            fmt.Sprintf("kubelet is posting ready status"),
-					LastHeartbeatTime:  util.Time{},
-					LastTransitionTime: util.Time{},
+					LastHeartbeatTime:  unversioned.Time{},
+					LastTransitionTime: unversioned.Time{},
 				},
 			},
 			NodeInfo: api.NodeSystemInfo{
@@ -175,8 +175,8 @@ func TestUpdateNewNodeStatus(t *testing.T) {
 	if updatedNode.Status.Conditions[0].LastTransitionTime.IsZero() {
 		t.Errorf("unexpected zero last transition timestamp")
 	}
-	updatedNode.Status.Conditions[0].LastHeartbeatTime = util.Time{}
-	updatedNode.Status.Conditions[0].LastTransitionTime = util.Time{}
+	updatedNode.Status.Conditions[0].LastHeartbeatTime = unversioned.Time{}
+	updatedNode.Status.Conditions[0].LastTransitionTime = unversioned.Time{}
 	if !reflect.DeepEqual(expectedNode, updatedNode) {
 		t.Errorf("unexpected objects: %s", util.ObjectDiff(expectedNode, updatedNode))
 	}
@@ -199,8 +199,8 @@ func TestUpdateExistingNodeStatus(t *testing.T) {
 						Status:             api.ConditionTrue,
 						Reason:             "KubeletReady",
 						Message:            fmt.Sprintf("kubelet is posting ready status"),
-						LastHeartbeatTime:  util.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
-						LastTransitionTime: util.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+						LastHeartbeatTime:  unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+						LastTransitionTime: unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
 					},
 				},
 				Capacity: api.ResourceList{
@@ -234,8 +234,8 @@ func TestUpdateExistingNodeStatus(t *testing.T) {
 					Status:             api.ConditionTrue,
 					Reason:             "KubeletReady",
 					Message:            fmt.Sprintf("kubelet is posting ready status"),
-					LastHeartbeatTime:  util.Time{}, // placeholder
-					LastTransitionTime: util.Time{}, // placeholder
+					LastHeartbeatTime:  unversioned.Time{}, // placeholder
+					LastTransitionTime: unversioned.Time{}, // placeholder
 				},
 			},
 			NodeInfo: api.NodeSystemInfo{
@@ -278,15 +278,15 @@ func TestUpdateExistingNodeStatus(t *testing.T) {
 		t.Errorf("unexpected object type")
 	}
 	// Expect LastProbeTime to be updated to Now, while LastTransitionTime to be the same.
-	if reflect.DeepEqual(updatedNode.Status.Conditions[0].LastHeartbeatTime.Rfc3339Copy().UTC(), util.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC).Time) {
-		t.Errorf("expected \n%v\n, got \n%v", util.Now(), util.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC))
+	if reflect.DeepEqual(updatedNode.Status.Conditions[0].LastHeartbeatTime.Rfc3339Copy().UTC(), unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC).Time) {
+		t.Errorf("expected \n%v\n, got \n%v", unversioned.Now(), unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC))
 	}
-	if !reflect.DeepEqual(updatedNode.Status.Conditions[0].LastTransitionTime.Rfc3339Copy().UTC(), util.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC).Time) {
+	if !reflect.DeepEqual(updatedNode.Status.Conditions[0].LastTransitionTime.Rfc3339Copy().UTC(), unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC).Time) {
 		t.Errorf("expected \n%#v\n, got \n%#v", updatedNode.Status.Conditions[0].LastTransitionTime.Rfc3339Copy(),
-			util.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC))
+			unversioned.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC))
 	}
-	updatedNode.Status.Conditions[0].LastHeartbeatTime = util.Time{}
-	updatedNode.Status.Conditions[0].LastTransitionTime = util.Time{}
+	updatedNode.Status.Conditions[0].LastHeartbeatTime = unversioned.Time{}
+	updatedNode.Status.Conditions[0].LastTransitionTime = unversioned.Time{}
 	if !reflect.DeepEqual(expectedNode, updatedNode) {
 		t.Errorf("expected \n%v\n, got \n%v", expectedNode, updatedNode)
 	}
@@ -325,8 +325,8 @@ func TestUpdateNodeStatusWithoutContainerRuntime(t *testing.T) {
 					Status:             api.ConditionFalse,
 					Reason:             "KubeletNotReady",
 					Message:            fmt.Sprintf("container runtime is down"),
-					LastHeartbeatTime:  util.Time{},
-					LastTransitionTime: util.Time{},
+					LastHeartbeatTime:  unversioned.Time{},
+					LastTransitionTime: unversioned.Time{},
 				},
 			},
 			NodeInfo: api.NodeSystemInfo{
@@ -375,8 +375,8 @@ func TestUpdateNodeStatusWithoutContainerRuntime(t *testing.T) {
 	if updatedNode.Status.Conditions[0].LastTransitionTime.IsZero() {
 		t.Errorf("unexpected zero last transition timestamp")
 	}
-	updatedNode.Status.Conditions[0].LastHeartbeatTime = util.Time{}
-	updatedNode.Status.Conditions[0].LastTransitionTime = util.Time{}
+	updatedNode.Status.Conditions[0].LastHeartbeatTime = unversioned.Time{}
+	updatedNode.Status.Conditions[0].LastTransitionTime = unversioned.Time{}
 	if !reflect.DeepEqual(expectedNode, updatedNode) {
 		t.Errorf("unexpected objects: %s", util.ObjectDiff(expectedNode, updatedNode))
 	}

--- a/pkg/kubelet/oom_watcher.go
+++ b/pkg/kubelet/oom_watcher.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/cadvisor/events"
 	cadvisorApi "github.com/google/cadvisor/info/v1"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/client/record"
 	"k8s.io/kubernetes/pkg/kubelet/cadvisor"
 	"k8s.io/kubernetes/pkg/util"
@@ -63,7 +64,7 @@ func (ow *realOOMWatcher) Start(ref *api.ObjectReference) error {
 
 		for event := range eventChannel.GetChannel() {
 			glog.V(2).Infof("Got sys oom event from cadvisor: %v", event)
-			ow.recorder.PastEventf(ref, util.Time{Time: event.Timestamp}, systemOOMEvent, "System OOM encountered")
+			ow.recorder.PastEventf(ref, unversioned.Time{Time: event.Timestamp}, systemOOMEvent, "System OOM encountered")
 		}
 		glog.Errorf("Unexpectedly stopped receiving OOM notifications from cAdvisor")
 	}()

--- a/pkg/kubelet/oom_watcher_test.go
+++ b/pkg/kubelet/oom_watcher_test.go
@@ -21,14 +21,14 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/kubelet/cadvisor"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/util"
 )
 
 type fakeEvent struct {
 	object    runtime.Object
-	timestamp util.Time
+	timestamp unversioned.Time
 	reason    string
 	message   string
 }
@@ -38,14 +38,14 @@ type fakeRecorder struct {
 }
 
 func (f fakeRecorder) Event(object runtime.Object, reason, message string) {
-	f.events = append(f.events, fakeEvent{object, util.Now(), reason, message})
+	f.events = append(f.events, fakeEvent{object, unversioned.Now(), reason, message})
 }
 
 func (f fakeRecorder) Eventf(object runtime.Object, reason, messageFmt string, args ...interface{}) {
-	f.events = append(f.events, fakeEvent{object, util.Now(), reason, fmt.Sprintf(messageFmt, args...)})
+	f.events = append(f.events, fakeEvent{object, unversioned.Now(), reason, fmt.Sprintf(messageFmt, args...)})
 }
 
-func (f fakeRecorder) PastEventf(object runtime.Object, timestamp util.Time, reason, messageFmt string, args ...interface{}) {
+func (f fakeRecorder) PastEventf(object runtime.Object, timestamp unversioned.Time, reason, messageFmt string, args ...interface{}) {
 	f.events = append(f.events, fakeEvent{object, timestamp, reason, fmt.Sprintf(messageFmt, args...)})
 }
 

--- a/pkg/kubelet/rkt/pod_info.go
+++ b/pkg/kubelet/rkt/pod_info.go
@@ -24,8 +24,8 @@ import (
 
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
-	"k8s.io/kubernetes/pkg/util"
 )
 
 // rkt pod state.
@@ -151,7 +151,7 @@ func makeContainerStatus(container *kubecontainer.Container, podInfo *podInfo) a
 		// TODO(yifan): Get StartedAt.
 		status.State = api.ContainerState{
 			Running: &api.ContainerStateRunning{
-				StartedAt: util.Unix(container.Created, 0),
+				StartedAt: unversioned.Unix(container.Created, 0),
 			},
 		}
 	case Embryo, Preparing, Prepared:
@@ -166,7 +166,7 @@ func makeContainerStatus(container *kubecontainer.Container, podInfo *podInfo) a
 		status.State = api.ContainerState{
 			Terminated: &api.ContainerStateTerminated{
 				ExitCode:  exitCode,
-				StartedAt: util.Unix(container.Created, 0),
+				StartedAt: unversioned.Unix(container.Created, 0),
 			},
 		}
 	default:

--- a/pkg/kubelet/status/manager.go
+++ b/pkg/kubelet/status/manager.go
@@ -25,6 +25,7 @@ import (
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	kubeletTypes "k8s.io/kubernetes/pkg/kubelet/types"
 	kubeletUtil "k8s.io/kubernetes/pkg/kubelet/util"
@@ -133,7 +134,7 @@ func (m *manager) SetPodStatus(pod *api.Pod, status api.PodStatus) {
 	if status.StartTime.IsZero() {
 		if pod.Status.StartTime.IsZero() {
 			// the pod did not have a previously recorded value so set to now
-			now := util.Now()
+			now := unversioned.Now()
 			status.StartTime = &now
 		} else {
 			// the pod had a recorded value, but the kubelet restarted so we need to rebuild cache

--- a/pkg/kubelet/status/manager_test.go
+++ b/pkg/kubelet/status/manager_test.go
@@ -24,9 +24,9 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
-	"k8s.io/kubernetes/pkg/util"
 )
 
 var testPod *api.Pod = &api.Pod{
@@ -109,8 +109,8 @@ func TestNewStatusPreservesPodStartTime(t *testing.T) {
 		},
 		Status: api.PodStatus{},
 	}
-	now := util.Now()
-	startTime := util.NewTime(now.Time.Add(-1 * time.Minute))
+	now := unversioned.Now()
+	startTime := unversioned.NewTime(now.Time.Add(-1 * time.Minute))
 	pod.Status.StartTime = &startTime
 	syncer.SetPodStatus(pod, getRandomPodStatus())
 
@@ -129,7 +129,7 @@ func TestChangedStatus(t *testing.T) {
 
 func TestChangedStatusKeepsStartTime(t *testing.T) {
 	syncer := newTestManager()
-	now := util.Now()
+	now := unversioned.Now()
 	firstStatus := getRandomPodStatus()
 	firstStatus.StartTime = &now
 	syncer.SetPodStatus(testPod, firstStatus)

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package iptables
 
 import (
-	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
 	"testing"
+
+	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
 )
 
 func checkAllLines(t *testing.T, table utiliptables.Table, save []byte, expectedLines map[utiliptables.Chain]string) {

--- a/pkg/registry/namespace/etcd/etcd.go
+++ b/pkg/registry/namespace/etcd/etcd.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	apierrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/registry/generic"
@@ -29,7 +30,6 @@ import (
 	"k8s.io/kubernetes/pkg/registry/namespace"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/storage"
-	"k8s.io/kubernetes/pkg/util"
 )
 
 // rest implements a RESTStorage for namespaces against etcd
@@ -95,7 +95,7 @@ func (r *REST) Delete(ctx api.Context, name string, options *api.DeleteOptions) 
 
 	// upon first request to delete, we switch the phase to start namespace termination
 	if namespace.DeletionTimestamp.IsZero() {
-		now := util.Now()
+		now := unversioned.Now()
 		namespace.DeletionTimestamp = &now
 		namespace.Status.Phase = api.NamespaceTerminating
 		result, _, err := r.status.Update(ctx, namespace)

--- a/pkg/registry/namespace/etcd/etcd_test.go
+++ b/pkg/registry/namespace/etcd/etcd_test.go
@@ -21,13 +21,13 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/tools"
 	"k8s.io/kubernetes/pkg/tools/etcdtest"
-	"k8s.io/kubernetes/pkg/util"
 )
 
 func newStorage(t *testing.T) (*REST, *tools.FakeEtcdClient) {
@@ -129,7 +129,7 @@ func TestDeleteNamespaceWithIncompleteFinalizers(t *testing.T) {
 	storage, fakeClient := newStorage(t)
 	key := etcdtest.AddPrefix("namespaces/foo")
 	ctx := api.NewContext()
-	now := util.Now()
+	now := unversioned.Now()
 	namespace := &api.Namespace{
 		ObjectMeta: api.ObjectMeta{
 			Name:              "foo",
@@ -152,7 +152,7 @@ func TestDeleteNamespaceWithCompleteFinalizers(t *testing.T) {
 	storage, fakeClient := newStorage(t)
 	key := etcdtest.AddPrefix("namespaces/foo")
 	ctx := api.NewContext()
-	now := util.Now()
+	now := unversioned.Now()
 	namespace := &api.Namespace{
 		ObjectMeta: api.ObjectMeta{
 			Name:              "foo",

--- a/pkg/registry/namespace/strategy_test.go
+++ b/pkg/registry/namespace/strategy_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 )
 
 func TestNamespaceStrategy(t *testing.T) {
@@ -71,7 +71,7 @@ func TestNamespaceStatusStrategy(t *testing.T) {
 	if StatusStrategy.AllowCreateOnUpdate() {
 		t.Errorf("Namespaces should not allow create on update")
 	}
-	now := util.Now()
+	now := unversioned.Now()
 	oldNamespace := &api.Namespace{
 		ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "10"},
 		Spec:       api.NamespaceSpec{Finalizers: []api.FinalizerName{"kubernetes"}},

--- a/pkg/registry/service/ipallocator/allocator.go
+++ b/pkg/registry/service/ipallocator/allocator.go
@@ -19,10 +19,11 @@ package ipallocator
 import (
 	"errors"
 	"fmt"
-	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/registry/service/allocator"
 	"math/big"
 	"net"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/registry/service/allocator"
 )
 
 // Interface manages the allocation of IP addresses out of a range. Interface

--- a/pkg/registry/service/portallocator/allocator.go
+++ b/pkg/registry/service/portallocator/allocator.go
@@ -19,6 +19,7 @@ package portallocator
 import (
 	"errors"
 	"fmt"
+
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/registry/service/allocator"
 	"k8s.io/kubernetes/pkg/util"

--- a/pkg/registry/thirdpartyresourcedata/codec_test.go
+++ b/pkg/registry/thirdpartyresourcedata/codec_test.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/experimental"
-	"k8s.io/kubernetes/pkg/util"
 )
 
 type Foo struct {
@@ -66,7 +65,7 @@ func TestCodec(t *testing.T) {
 			obj: &Foo{
 				ObjectMeta: api.ObjectMeta{
 					Name:              "bar",
-					CreationTimestamp: util.Time{time.Unix(100, 0)},
+					CreationTimestamp: unversioned.Time{time.Unix(100, 0)},
 				},
 				TypeMeta: unversioned.TypeMeta{Kind: "Foo"},
 			},

--- a/pkg/storage/cacher_test.go
+++ b/pkg/storage/cacher_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/storage"
@@ -171,7 +172,7 @@ func TestListFromMemory(t *testing.T) {
 	for _, item := range result.Items {
 		// unset fields that are set by the infrastructure
 		item.ObjectMeta.ResourceVersion = ""
-		item.ObjectMeta.CreationTimestamp = util.Time{}
+		item.ObjectMeta.CreationTimestamp = unversioned.Time{}
 
 		var expected *api.Pod
 		switch item.ObjectMeta.Name {
@@ -268,7 +269,7 @@ func TestWatch(t *testing.T) {
 			// unset fields that are set by the infrastructure
 			obj := event.Object.(*api.Pod)
 			obj.ObjectMeta.ResourceVersion = ""
-			obj.ObjectMeta.CreationTimestamp = util.Time{}
+			obj.ObjectMeta.CreationTimestamp = unversioned.Time{}
 			if e, a := test.object, obj; !reflect.DeepEqual(e, a) {
 				t.Errorf("expected: %#v, got: %#v", e, a)
 			}
@@ -295,7 +296,7 @@ func TestWatch(t *testing.T) {
 			// unset fields that are set by the infrastructure
 			obj := event.Object.(*api.Pod)
 			obj.ObjectMeta.ResourceVersion = ""
-			obj.ObjectMeta.CreationTimestamp = util.Time{}
+			obj.ObjectMeta.CreationTimestamp = unversioned.Time{}
 			if e, a := test.object, obj; !reflect.DeepEqual(e, a) {
 				t.Errorf("expected: %#v, got: %#v", e, a)
 			}
@@ -468,7 +469,7 @@ func TestFiltering(t *testing.T) {
 			// unset fields that are set by the infrastructure
 			obj := event.Object.(*api.Pod)
 			obj.ObjectMeta.ResourceVersion = ""
-			obj.ObjectMeta.CreationTimestamp = util.Time{}
+			obj.ObjectMeta.CreationTimestamp = unversioned.Time{}
 			if e, a := test.object, obj; !reflect.DeepEqual(e, a) {
 				t.Errorf("expected: %#v, got: %#v", e, a)
 			}

--- a/pkg/storage/etcd/api_object_versioner.go
+++ b/pkg/storage/etcd/api_object_versioner.go
@@ -21,9 +21,9 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/storage"
-	"k8s.io/kubernetes/pkg/util"
 )
 
 // APIObjectVersioner implements versioning and extracting etcd node information
@@ -37,7 +37,7 @@ func (a APIObjectVersioner) UpdateObject(obj runtime.Object, expiration *time.Ti
 		return err
 	}
 	if expiration != nil {
-		objectMeta.DeletionTimestamp = &util.Time{Time: *expiration}
+		objectMeta.DeletionTimestamp = &unversioned.Time{Time: *expiration}
 	}
 	versionString := ""
 	if resourceVersion != 0 {

--- a/pkg/storage/etcd/api_object_versioner_test.go
+++ b/pkg/storage/etcd/api_object_versioner_test.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 )
 
 func TestObjectVersioner(t *testing.T) {
@@ -39,7 +39,7 @@ func TestObjectVersioner(t *testing.T) {
 	if obj.ResourceVersion != "5" || obj.DeletionTimestamp != nil {
 		t.Errorf("unexpected resource version: %#v", obj)
 	}
-	now := util.Time{Time: time.Now()}
+	now := unversioned.Time{Time: time.Now()}
 	obj = &TestResource{ObjectMeta: api.ObjectMeta{ResourceVersion: "a"}}
 	if err := v.UpdateObject(obj, &now.Time, 5); err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/pkg/util/io/io_test.go
+++ b/pkg/util/io/io_test.go
@@ -18,13 +18,14 @@ package io_test
 
 import (
 	"fmt"
+	"os"
+	"testing"
+
 	"github.com/pborman/uuid"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/util/io"
 	"k8s.io/kubernetes/pkg/volume"
-	"os"
-	"testing"
 )
 
 func TestSavePodToFile(t *testing.T) {

--- a/pkg/util/slice/slice.go
+++ b/pkg/util/slice/slice.go
@@ -18,8 +18,9 @@ limitations under the License.
 package slice
 
 import (
-	utilrand "k8s.io/kubernetes/pkg/util/rand"
 	"sort"
+
+	utilrand "k8s.io/kubernetes/pkg/util/rand"
 )
 
 // CopyStrings copies the contents of the specified string slice

--- a/pkg/util/ssh_test.go
+++ b/pkg/util/ssh_test.go
@@ -18,15 +18,15 @@ package util
 
 import (
 	"fmt"
+	"io"
 	"net"
+	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/golang/glog"
 	"golang.org/x/crypto/ssh"
-	"io"
-	"os"
-	"strings"
 )
 
 type testSSHServer struct {

--- a/pkg/volume/util_test.go
+++ b/pkg/volume/util_test.go
@@ -18,11 +18,11 @@ package volume
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
-	"strings"
 )
 
 func TestRecyclerSuccess(t *testing.T) {

--- a/test/e2e/density.go
+++ b/test/e2e/density.go
@@ -254,11 +254,11 @@ var _ = Describe("Density", func() {
 			if itArg.runLatencyTest {
 				Logf("Schedling additional Pods to measure startup latencies")
 
-				createTimes := make(map[string]util.Time, 0)
+				createTimes := make(map[string]unversioned.Time, 0)
 				nodes := make(map[string]string, 0)
-				scheduleTimes := make(map[string]util.Time, 0)
-				runTimes := make(map[string]util.Time, 0)
-				watchTimes := make(map[string]util.Time, 0)
+				scheduleTimes := make(map[string]unversioned.Time, 0)
+				runTimes := make(map[string]unversioned.Time, 0)
+				watchTimes := make(map[string]unversioned.Time, 0)
 
 				var mutex sync.Mutex
 				checkPod := func(p *api.Pod) {
@@ -268,10 +268,10 @@ var _ = Describe("Density", func() {
 
 					if p.Status.Phase == api.PodRunning {
 						if _, found := watchTimes[p.Name]; !found {
-							watchTimes[p.Name] = util.Now()
+							watchTimes[p.Name] = unversioned.Now()
 							createTimes[p.Name] = p.CreationTimestamp
 							nodes[p.Name] = p.Spec.NodeName
-							var startTime util.Time
+							var startTime unversioned.Time
 							for _, cs := range p.Status.ContainerStatuses {
 								if cs.State.Running != nil {
 									if startTime.Before(cs.State.Running.StartedAt) {
@@ -279,7 +279,7 @@ var _ = Describe("Density", func() {
 									}
 								}
 							}
-							if startTime != util.NewTime(time.Time{}) {
+							if startTime != unversioned.NewTime(time.Time{}) {
 								runTimes[p.Name] = startTime
 							} else {
 								Failf("Pod %v is reported to be running, but none of its containers is", p.Name)

--- a/test/e2e/google_compute.go
+++ b/test/e2e/google_compute.go
@@ -18,10 +18,11 @@ package e2e
 
 import (
 	"fmt"
-	"github.com/golang/glog"
 	"os/exec"
 	"regexp"
 	"strings"
+
+	"github.com/golang/glog"
 )
 
 func createGCEStaticIP(name string) (string, error) {

--- a/test/e2e/prompush.go
+++ b/test/e2e/prompush.go
@@ -19,6 +19,7 @@ package e2e
 
 import (
 	"fmt"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/test/integration/scheduler_test.go
+++ b/test/integration/scheduler_test.go
@@ -31,12 +31,12 @@ import (
 	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apiserver"
 	"k8s.io/kubernetes/pkg/client/cache"
 	"k8s.io/kubernetes/pkg/client/record"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/master"
-	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/plugin/pkg/admission/admit"
 	"k8s.io/kubernetes/plugin/pkg/scheduler"
@@ -127,13 +127,13 @@ func DoTestUnschedulableNodes(t *testing.T, restClient *client.Client, nodeStore
 		Type:              api.NodeReady,
 		Status:            api.ConditionTrue,
 		Reason:            fmt.Sprintf("schedulable condition"),
-		LastHeartbeatTime: util.Time{time.Now()},
+		LastHeartbeatTime: unversioned.Time{time.Now()},
 	}
 	badCondition := api.NodeCondition{
 		Type:              api.NodeReady,
 		Status:            api.ConditionUnknown,
 		Reason:            fmt.Sprintf("unschedulable condition"),
-		LastHeartbeatTime: util.Time{time.Now()},
+		LastHeartbeatTime: unversioned.Time{time.Now()},
 	}
 	// Create a new schedulable node, since we're first going to apply
 	// the unschedulable condition and verify that pods aren't scheduled.

--- a/third_party/golang/template/exec.go
+++ b/third_party/golang/template/exec.go
@@ -2,9 +2,10 @@
 //The original private functions indirect and printableValue
 //are exported as public functions.
 package template
+
 import (
-	"reflect"
 	"fmt"
+	"reflect"
 )
 
 var Indirect = indirect
@@ -14,7 +15,6 @@ var (
 	errorType       = reflect.TypeOf((*error)(nil)).Elem()
 	fmtStringerType = reflect.TypeOf((*fmt.Stringer)(nil)).Elem()
 )
-
 
 // indirect returns the item at the end of indirection, and a bool to indicate if it's nil.
 // We indirect through pointers and empty interfaces (only) because


### PR DESCRIPTION
I'll need this for #12952, which tries to use durations as map keys. `time.Duration` marshals into int (its value in nanoseconds), which cannot be used as a map key in json as only strings are allowed.

As discussed with @vishh and @bgrant0607 

CC @kubernetes/goog-csi
