### PR TITLE
Cleanups in HorizontalPodAutoscaler API.

### DIFF
--- a/docs/proposals/horizontal-pod-autoscaler.md
+++ b/docs/proposals/horizontal-pod-autoscaler.md
@@ -134,11 +134,11 @@ type HorizontalPodAutoscalerSpec struct {
 	// ScaleRef is a reference to Scale subresource. HorizontalPodAutoscaler will learn the current
 	// resource consumption from its status, and will set the desired number of pods by modifying its spec.
 	ScaleRef *SubresourceReference
-	// MinCount is the lower limit for the number of pods that can be set by the autoscaler.
-	MinCount int
-	// MaxCount is the upper limit for the number of pods that can be set by the autoscaler.
-	// It cannot be smaller than MinCount.
-	MaxCount int
+	// MinReplicas is the lower limit for the number of pods that can be set by the autoscaler.
+	MinReplicas int
+	// MaxReplicas is the upper limit for the number of pods that can be set by the autoscaler.
+	// It cannot be smaller than MinReplicas.
+	MaxReplicas int
 	// Target is the target average consumption of the given resource that the autoscaler will try
 	// to maintain by adjusting the desired number of pods.
 	// Currently this can be either "cpu" or "memory".
@@ -173,7 +173,7 @@ type ResourceConsumption struct {
 ```
 
 ```Scale``` will be a reference to the Scale subresource.
-```MinCount```, ```MaxCount``` and ```Target``` will define autoscaler configuration.
+```MinReplicas```, ```MaxReplicas``` and ```Target``` will define autoscaler configuration.
 We will also introduce HorizontalPodAutoscalerList object to enable listing all autoscalers in the cluster:
 
 ```go
@@ -194,8 +194,8 @@ and check their average CPU or memory usage from the last 1 minute
 (there will be API on master for this purpose, see
 [#11951](https://github.com/kubernetes/kubernetes/issues/11951).
 Then, it will compare the current CPU or memory consumption with the Target,
-and adjust the count of the Scale if needed to match the target
-(preserving condition: MinCount <= Count <= MaxCount).
+and adjust the replicas of the Scale if needed to match the target
+(preserving condition: MinReplicas <= Replicas <= MaxReplicas).
 
 The target number of pods will be calculated from the following formula:
 

--- a/pkg/apis/experimental/deep_copy_generated.go
+++ b/pkg/apis/experimental/deep_copy_generated.go
@@ -957,8 +957,8 @@ func deepCopy_experimental_HorizontalPodAutoscalerSpec(in HorizontalPodAutoscale
 	} else {
 		out.ScaleRef = nil
 	}
-	out.MinCount = in.MinCount
-	out.MaxCount = in.MaxCount
+	out.MinReplicas = in.MinReplicas
+	out.MaxReplicas = in.MaxReplicas
 	if err := deepCopy_experimental_ResourceConsumption(in.Target, &out.Target, c); err != nil {
 		return err
 	}

--- a/pkg/apis/experimental/types.go
+++ b/pkg/apis/experimental/types.go
@@ -92,10 +92,10 @@ type HorizontalPodAutoscalerSpec struct {
 	// ScaleRef is a reference to Scale subresource. HorizontalPodAutoscaler will learn the current resource consumption from its status,
 	// and will set the desired number of pods by modyfying its spec.
 	ScaleRef *SubresourceReference `json:"scaleRef"`
-	// MinCount is the lower limit for the number of pods that can be set by the autoscaler.
-	MinCount int `json:"minCount"`
-	// MaxCount is the upper limit for the number of pods that can be set by the autoscaler. It cannot be smaller than MinCount.
-	MaxCount int `json:"maxCount"`
+	// MinReplicas is the lower limit for the number of pods that can be set by the autoscaler.
+	MinReplicas int `json:"minReplicas"`
+	// MaxReplicas is the upper limit for the number of pods that can be set by the autoscaler. It cannot be smaller than MinReplicas.
+	MaxReplicas int `json:"maxReplicas"`
 	// Target is the target average consumption of the given resource that the autoscaler will try to maintain by adjusting the desired number of pods.
 	// Currently two types of resources are supported: "cpu" and "memory".
 	Target ResourceConsumption `json:"target"`

--- a/pkg/apis/experimental/v1/conversion_generated.go
+++ b/pkg/apis/experimental/v1/conversion_generated.go
@@ -1756,8 +1756,8 @@ func convert_experimental_HorizontalPodAutoscalerSpec_To_v1_HorizontalPodAutosca
 	} else {
 		out.ScaleRef = nil
 	}
-	out.MinCount = in.MinCount
-	out.MaxCount = in.MaxCount
+	out.MinReplicas = in.MinReplicas
+	out.MaxReplicas = in.MaxReplicas
 	if err := convert_experimental_ResourceConsumption_To_v1_ResourceConsumption(&in.Target, &out.Target, s); err != nil {
 		return err
 	}
@@ -2272,8 +2272,8 @@ func convert_v1_HorizontalPodAutoscalerSpec_To_experimental_HorizontalPodAutosca
 	} else {
 		out.ScaleRef = nil
 	}
-	out.MinCount = in.MinCount
-	out.MaxCount = in.MaxCount
+	out.MinReplicas = in.MinReplicas
+	out.MaxReplicas = in.MaxReplicas
 	if err := convert_v1_ResourceConsumption_To_experimental_ResourceConsumption(&in.Target, &out.Target, s); err != nil {
 		return err
 	}

--- a/pkg/apis/experimental/v1/deep_copy_generated.go
+++ b/pkg/apis/experimental/v1/deep_copy_generated.go
@@ -969,8 +969,8 @@ func deepCopy_v1_HorizontalPodAutoscalerSpec(in HorizontalPodAutoscalerSpec, out
 	} else {
 		out.ScaleRef = nil
 	}
-	out.MinCount = in.MinCount
-	out.MaxCount = in.MaxCount
+	out.MinReplicas = in.MinReplicas
+	out.MaxReplicas = in.MaxReplicas
 	if err := deepCopy_v1_ResourceConsumption(in.Target, &out.Target, c); err != nil {
 		return err
 	}

--- a/pkg/apis/experimental/v1/types.go
+++ b/pkg/apis/experimental/v1/types.go
@@ -82,10 +82,10 @@ type HorizontalPodAutoscalerSpec struct {
 	// ScaleRef is a reference to Scale subresource. HorizontalPodAutoscaler will learn the current resource consumption from its status,
 	// and will set the desired number of pods by modyfying its spec.
 	ScaleRef *SubresourceReference `json:"scaleRef"`
-	// MinCount is the lower limit for the number of pods that can be set by the autoscaler.
-	MinCount int `json:"minCount"`
-	// MaxCount is the upper limit for the number of pods that can be set by the autoscaler. It cannot be smaller than MinCount.
-	MaxCount int `json:"maxCount"`
+	// MinReplicas is the lower limit for the number of pods that can be set by the autoscaler.
+	MinReplicas int `json:"minReplicas"`
+	// MaxReplicas is the upper limit for the number of pods that can be set by the autoscaler. It cannot be smaller than MinReplicas.
+	MaxReplicas int `json:"maxReplicas"`
 	// Target is the target average consumption of the given resource that the autoscaler will try to maintain by adjusting the desired number of pods.
 	// Currently two types of resources are supported: "cpu" and "memory".
 	Target ResourceConsumption `json:"target"`

--- a/pkg/apis/experimental/v1/types_swagger_doc_generated.go
+++ b/pkg/apis/experimental/v1/types_swagger_doc_generated.go
@@ -155,11 +155,11 @@ func (HorizontalPodAutoscalerList) SwaggerDoc() map[string]string {
 }
 
 var map_HorizontalPodAutoscalerSpec = map[string]string{
-	"":         "HorizontalPodAutoscalerSpec is the specification of a horizontal pod autoscaler.",
-	"scaleRef": "ScaleRef is a reference to Scale subresource. HorizontalPodAutoscaler will learn the current resource consumption from its status, and will set the desired number of pods by modyfying its spec.",
-	"minCount": "MinCount is the lower limit for the number of pods that can be set by the autoscaler.",
-	"maxCount": "MaxCount is the upper limit for the number of pods that can be set by the autoscaler. It cannot be smaller than MinCount.",
-	"target":   "Target is the target average consumption of the given resource that the autoscaler will try to maintain by adjusting the desired number of pods. Currently two types of resources are supported: \"cpu\" and \"memory\".",
+	"":            "HorizontalPodAutoscalerSpec is the specification of a horizontal pod autoscaler.",
+	"scaleRef":    "ScaleRef is a reference to Scale subresource. HorizontalPodAutoscaler will learn the current resource consumption from its status, and will set the desired number of pods by modyfying its spec.",
+	"minReplicas": "MinReplicas is the lower limit for the number of pods that can be set by the autoscaler.",
+	"maxReplicas": "MaxReplicas is the upper limit for the number of pods that can be set by the autoscaler. It cannot be smaller than MinReplicas.",
+	"target":      "Target is the target average consumption of the given resource that the autoscaler will try to maintain by adjusting the desired number of pods. Currently two types of resources are supported: \"cpu\" and \"memory\".",
 }
 
 func (HorizontalPodAutoscalerSpec) SwaggerDoc() map[string]string {

--- a/pkg/apis/experimental/validation/validation.go
+++ b/pkg/apis/experimental/validation/validation.go
@@ -40,11 +40,11 @@ func ValidateHorizontalPodAutoscalerName(name string, prefix bool) (bool, string
 
 func validateHorizontalPodAutoscalerSpec(autoscaler experimental.HorizontalPodAutoscalerSpec) errs.ValidationErrorList {
 	allErrs := errs.ValidationErrorList{}
-	if autoscaler.MinCount < 0 {
-		allErrs = append(allErrs, errs.NewFieldInvalid("minCount", autoscaler.MinCount, `must be non-negative`))
+	if autoscaler.MinReplicas < 0 {
+		allErrs = append(allErrs, errs.NewFieldInvalid("minReplicas", autoscaler.MinReplicas, `must be non-negative`))
 	}
-	if autoscaler.MaxCount < autoscaler.MinCount {
-		allErrs = append(allErrs, errs.NewFieldInvalid("maxCount", autoscaler.MaxCount, `must be bigger or equal to minCount`))
+	if autoscaler.MaxReplicas < autoscaler.MinReplicas {
+		allErrs = append(allErrs, errs.NewFieldInvalid("maxReplicas", autoscaler.MaxReplicas, `must be bigger or equal to minReplicas`))
 	}
 	if autoscaler.ScaleRef == nil {
 		allErrs = append(allErrs, errs.NewFieldRequired("scaleRef"))

--- a/pkg/apis/experimental/validation/validation_test.go
+++ b/pkg/apis/experimental/validation/validation_test.go
@@ -38,9 +38,9 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ScaleRef: &experimental.SubresourceReference{
 					Subresource: "scale",
 				},
-				MinCount: 1,
-				MaxCount: 5,
-				Target:   experimental.ResourceConsumption{Resource: api.ResourceCPU, Quantity: resource.MustParse("0.8")},
+				MinReplicas: 1,
+				MaxReplicas: 5,
+				Target:      experimental.ResourceConsumption{Resource: api.ResourceCPU, Quantity: resource.MustParse("0.8")},
 			},
 		},
 	}
@@ -60,12 +60,12 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ScaleRef: &experimental.SubresourceReference{
 					Subresource: "scale",
 				},
-				MinCount: -1,
-				MaxCount: 5,
-				Target:   experimental.ResourceConsumption{Resource: api.ResourceCPU, Quantity: resource.MustParse("0.8")},
+				MinReplicas: -1,
+				MaxReplicas: 5,
+				Target:      experimental.ResourceConsumption{Resource: api.ResourceCPU, Quantity: resource.MustParse("0.8")},
 			},
 		},
-		"must be bigger or equal to minCount": {
+		"must be bigger or equal to minReplicas": {
 			ObjectMeta: api.ObjectMeta{
 				Name:      "myautoscaler",
 				Namespace: api.NamespaceDefault,
@@ -74,9 +74,9 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ScaleRef: &experimental.SubresourceReference{
 					Subresource: "scale",
 				},
-				MinCount: 7,
-				MaxCount: 5,
-				Target:   experimental.ResourceConsumption{Resource: api.ResourceCPU, Quantity: resource.MustParse("0.8")},
+				MinReplicas: 7,
+				MaxReplicas: 5,
+				Target:      experimental.ResourceConsumption{Resource: api.ResourceCPU, Quantity: resource.MustParse("0.8")},
 			},
 		},
 		"invalid value": {
@@ -88,9 +88,9 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ScaleRef: &experimental.SubresourceReference{
 					Subresource: "scale",
 				},
-				MinCount: 1,
-				MaxCount: 5,
-				Target:   experimental.ResourceConsumption{Resource: api.ResourceCPU, Quantity: resource.MustParse("-0.8")},
+				MinReplicas: 1,
+				MaxReplicas: 5,
+				Target:      experimental.ResourceConsumption{Resource: api.ResourceCPU, Quantity: resource.MustParse("-0.8")},
 			},
 		},
 		"resource not supported": {
@@ -102,9 +102,9 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				ScaleRef: &experimental.SubresourceReference{
 					Subresource: "scale",
 				},
-				MinCount: 1,
-				MaxCount: 5,
-				Target:   experimental.ResourceConsumption{Resource: api.ResourceName("NotSupportedResource"), Quantity: resource.MustParse("0.8")},
+				MinReplicas: 1,
+				MaxReplicas: 5,
+				Target:      experimental.ResourceConsumption{Resource: api.ResourceName("NotSupportedResource"), Quantity: resource.MustParse("0.8")},
 			},
 		},
 		"required value": {
@@ -113,9 +113,9 @@ func TestValidateHorizontalPodAutoscaler(t *testing.T) {
 				Namespace: api.NamespaceDefault,
 			},
 			Spec: experimental.HorizontalPodAutoscalerSpec{
-				MinCount: 1,
-				MaxCount: 5,
-				Target:   experimental.ResourceConsumption{Resource: api.ResourceCPU, Quantity: resource.MustParse("0.8")},
+				MinReplicas: 1,
+				MaxReplicas: 5,
+				Target:      experimental.ResourceConsumption{Resource: api.ResourceCPU, Quantity: resource.MustParse("0.8")},
 			},
 		},
 	}

--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -92,8 +92,8 @@ func (a *HorizontalController) reconcileAutoscaler(hpa experimental.HorizontalPo
 	usageRatio := float64(currentConsumption.Quantity.MilliValue()) / float64(hpa.Spec.Target.Quantity.MilliValue())
 	desiredReplicas := int(math.Ceil(usageRatio * float64(currentReplicas)))
 
-	if desiredReplicas < hpa.Spec.MinCount {
-		desiredReplicas = hpa.Spec.MinCount
+	if desiredReplicas < hpa.Spec.MinReplicas {
+		desiredReplicas = hpa.Spec.MinReplicas
 	}
 
 	// TODO: remove when pod ideling is done.
@@ -101,8 +101,8 @@ func (a *HorizontalController) reconcileAutoscaler(hpa experimental.HorizontalPo
 		desiredReplicas = 1
 	}
 
-	if desiredReplicas > hpa.Spec.MaxCount {
-		desiredReplicas = hpa.Spec.MaxCount
+	if desiredReplicas > hpa.Spec.MaxReplicas {
+		desiredReplicas = hpa.Spec.MaxReplicas
 	}
 	now := time.Now()
 	rescale := false

--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -54,8 +54,8 @@ type fakeResponseWrapper struct {
 }
 
 type testCase struct {
-	minCount        int
-	maxCount        int
+	minReplicas     int
+	maxReplicas     int
 	initialReplicas int
 	desiredReplicas int
 	targetResource  api.ResourceName
@@ -92,9 +92,9 @@ func (tc *testCase) prepareTestClient(t *testing.T) *testclient.Fake {
 							Namespace:   namespace,
 							Subresource: "scale",
 						},
-						MinCount: tc.minCount,
-						MaxCount: tc.maxCount,
-						Target:   experimental.ResourceConsumption{Resource: tc.targetResource, Quantity: tc.targetLevel},
+						MinReplicas: tc.minReplicas,
+						MaxReplicas: tc.maxReplicas,
+						Target:      experimental.ResourceConsumption{Resource: tc.targetResource, Quantity: tc.targetLevel},
 					},
 				},
 			},
@@ -204,8 +204,8 @@ func (tc *testCase) runTest(t *testing.T) {
 
 func TestCPU(t *testing.T) {
 	tc := testCase{
-		minCount:        1,
-		maxCount:        5,
+		minReplicas:     1,
+		maxReplicas:     5,
 		initialReplicas: 1,
 		desiredReplicas: 2,
 		targetResource:  api.ResourceCPU,
@@ -217,8 +217,8 @@ func TestCPU(t *testing.T) {
 
 func TestMemory(t *testing.T) {
 	tc := testCase{
-		minCount:        1,
-		maxCount:        5,
+		minReplicas:     1,
+		maxReplicas:     5,
 		initialReplicas: 1,
 		desiredReplicas: 2,
 		targetResource:  api.ResourceMemory,
@@ -230,8 +230,8 @@ func TestMemory(t *testing.T) {
 
 func TestScaleUp(t *testing.T) {
 	tc := testCase{
-		minCount:        2,
-		maxCount:        6,
+		minReplicas:     2,
+		maxReplicas:     6,
 		initialReplicas: 3,
 		desiredReplicas: 5,
 		targetResource:  api.ResourceMemory,
@@ -243,8 +243,8 @@ func TestScaleUp(t *testing.T) {
 
 func TestScaleDown(t *testing.T) {
 	tc := testCase{
-		minCount:        2,
-		maxCount:        6,
+		minReplicas:     2,
+		maxReplicas:     6,
 		initialReplicas: 5,
 		desiredReplicas: 3,
 		targetResource:  api.ResourceCPU,
@@ -256,8 +256,8 @@ func TestScaleDown(t *testing.T) {
 
 func TestTolerance(t *testing.T) {
 	tc := testCase{
-		minCount:        1,
-		maxCount:        5,
+		minReplicas:     1,
+		maxReplicas:     5,
 		initialReplicas: 3,
 		desiredReplicas: 3,
 		targetResource:  api.ResourceMemory,
@@ -267,10 +267,10 @@ func TestTolerance(t *testing.T) {
 	tc.runTest(t)
 }
 
-func TestMinCount(t *testing.T) {
+func TestMinReplicas(t *testing.T) {
 	tc := testCase{
-		minCount:        2,
-		maxCount:        5,
+		minReplicas:     2,
+		maxReplicas:     5,
 		initialReplicas: 3,
 		desiredReplicas: 2,
 		targetResource:  api.ResourceMemory,
@@ -280,10 +280,10 @@ func TestMinCount(t *testing.T) {
 	tc.runTest(t)
 }
 
-func TestMaxCount(t *testing.T) {
+func TestMaxReplicas(t *testing.T) {
 	tc := testCase{
-		minCount:        2,
-		maxCount:        5,
+		minReplicas:     2,
+		maxReplicas:     5,
 		initialReplicas: 3,
 		desiredReplicas: 5,
 		targetResource:  api.ResourceMemory,
@@ -295,8 +295,8 @@ func TestMaxCount(t *testing.T) {
 
 func TestSuperfluousMetrics(t *testing.T) {
 	tc := testCase{
-		minCount:        2,
-		maxCount:        6,
+		minReplicas:     2,
+		maxReplicas:     6,
 		initialReplicas: 4,
 		desiredReplicas: 4,
 		targetResource:  api.ResourceMemory,
@@ -308,8 +308,8 @@ func TestSuperfluousMetrics(t *testing.T) {
 
 func TestMissingMetrics(t *testing.T) {
 	tc := testCase{
-		minCount:        2,
-		maxCount:        6,
+		minReplicas:     2,
+		maxReplicas:     6,
 		initialReplicas: 4,
 		desiredReplicas: 4,
 		targetResource:  api.ResourceMemory,
@@ -321,8 +321,8 @@ func TestMissingMetrics(t *testing.T) {
 
 func TestEmptyMetrics(t *testing.T) {
 	tc := testCase{
-		minCount:        2,
-		maxCount:        6,
+		minReplicas:     2,
+		maxReplicas:     6,
 		initialReplicas: 4,
 		desiredReplicas: 4,
 		targetResource:  api.ResourceMemory,
@@ -334,8 +334,8 @@ func TestEmptyMetrics(t *testing.T) {
 
 func TestEventCreated(t *testing.T) {
 	tc := testCase{
-		minCount:        1,
-		maxCount:        5,
+		minReplicas:     1,
+		maxReplicas:     5,
 		initialReplicas: 1,
 		desiredReplicas: 2,
 		targetResource:  api.ResourceCPU,
@@ -348,8 +348,8 @@ func TestEventCreated(t *testing.T) {
 
 func TestEventNotCreated(t *testing.T) {
 	tc := testCase{
-		minCount:        1,
-		maxCount:        5,
+		minReplicas:     1,
+		maxReplicas:     5,
 		initialReplicas: 2,
 		desiredReplicas: 2,
 		targetResource:  api.ResourceCPU,

--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -1261,8 +1261,8 @@ func (d *HorizontalPodAutoscalerDescriber) Describe(namespace, name string) (str
 		} else {
 			fmt.Fprintf(out, "<not available>\n")
 		}
-		fmt.Fprintf(out, "Min pods:\t%d\n", hpa.Spec.MinCount)
-		fmt.Fprintf(out, "Max pods:\t%d\n", hpa.Spec.MaxCount)
+		fmt.Fprintf(out, "Min pods:\t%d\n", hpa.Spec.MinReplicas)
+		fmt.Fprintf(out, "Max pods:\t%d\n", hpa.Spec.MaxReplicas)
 
 		// TODO: switch to scale subresource once the required code is submitted.
 		if strings.ToLower(hpa.Spec.ScaleRef.Kind) == "replicationcontroller" {

--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -1284,8 +1284,8 @@ func printHorizontalPodAutoscaler(hpa *experimental.HorizontalPodAutoscaler, w i
 	if hpa.Status != nil && hpa.Status.CurrentConsumption != nil {
 		current = fmt.Sprintf("%s %v", hpa.Status.CurrentConsumption.Quantity.String(), hpa.Status.CurrentConsumption.Resource)
 	}
-	minPods := hpa.Spec.MinCount
-	maxPods := hpa.Spec.MaxCount
+	minPods := hpa.Spec.MinReplicas
+	maxPods := hpa.Spec.MaxReplicas
 	if withNamespace {
 		if _, err := fmt.Fprintf(w, "%s\t", namespace); err != nil {
 			return err

--- a/pkg/registry/horizontalpodautoscaler/etcd/etcd_test.go
+++ b/pkg/registry/horizontalpodautoscaler/etcd/etcd_test.go
@@ -46,9 +46,9 @@ func validNewHorizontalPodAutoscaler(name string) *experimental.HorizontalPodAut
 			ScaleRef: &experimental.SubresourceReference{
 				Subresource: "scale",
 			},
-			MinCount: 1,
-			MaxCount: 5,
-			Target:   experimental.ResourceConsumption{Resource: api.ResourceCPU, Quantity: resource.MustParse("0.8")},
+			MinReplicas: 1,
+			MaxReplicas: 5,
+			Target:      experimental.ResourceConsumption{Resource: api.ResourceCPU, Quantity: resource.MustParse("0.8")},
 		},
 	}
 }
@@ -75,7 +75,7 @@ func TestUpdate(t *testing.T) {
 		// updateFunc
 		func(obj runtime.Object) runtime.Object {
 			object := obj.(*experimental.HorizontalPodAutoscaler)
-			object.Spec.MaxCount = object.Spec.MaxCount + 1
+			object.Spec.MaxReplicas = object.Spec.MaxReplicas + 1
 			return object
 		},
 	)

--- a/test/e2e/horizontal_pod_autoscaling.go
+++ b/test/e2e/horizontal_pod_autoscaling.go
@@ -171,9 +171,9 @@ func createCPUHorizontalPodAutoscaler(rc *ResourceConsumer, cpu string) {
 				Namespace:   rc.framework.Namespace.Name,
 				Subresource: subresource,
 			},
-			MinCount: 1,
-			MaxCount: 5,
-			Target:   experimental.ResourceConsumption{Resource: api.ResourceCPU, Quantity: resource.MustParse(cpu)},
+			MinReplicas: 1,
+			MaxReplicas: 5,
+			Target:      experimental.ResourceConsumption{Resource: api.ResourceCPU, Quantity: resource.MustParse(cpu)},
 		},
 	}
 	_, errHPA := rc.framework.Client.Experimental().HorizontalPodAutoscalers(rc.framework.Namespace.Name).Create(hpa)
@@ -194,9 +194,9 @@ func createMemoryHorizontalPodAutoscaler(rc *ResourceConsumer, memory string) {
 				Namespace:   rc.framework.Namespace.Name,
 				Subresource: subresource,
 			},
-			MinCount: 1,
-			MaxCount: 5,
-			Target:   experimental.ResourceConsumption{Resource: api.ResourceMemory, Quantity: resource.MustParse(memory + "M")},
+			MinReplicas: 1,
+			MaxReplicas: 5,
+			Target:      experimental.ResourceConsumption{Resource: api.ResourceMemory, Quantity: resource.MustParse(memory + "M")},
 		},
 	}
 	_, errHPA := rc.framework.Client.Experimental().HorizontalPodAutoscalers(rc.framework.Namespace.Name).Create(hpa)


### PR DESCRIPTION
Cleanups in HorizontalPodAutoscaler API: renamed Min/MaxCount to Min/MaxReplicas as Replicas is the proper name used in other objects.
