### PR TITLE
Fix to detect unformatted volumes in CoreOS

### DIFF
--- a/pkg/util/mount/mount.go
+++ b/pkg/util/mount/mount.go
@@ -98,9 +98,10 @@ func (mounter *SafeFormatAndMount) formatAndMount(source string, target string, 
 
 // diskLooksUnformatted uses 'file' to see if the given disk is unformated
 func (mounter *SafeFormatAndMount) diskLooksUnformatted(disk string) (bool, error) {
-	args := []string{"-L", "--special-files", disk}
-	cmd := mounter.Runner.Command("file", args...)
+	args := []string{"-nd", "-o", "FSTYPE", disk}
+	cmd := mounter.Runner.Command("lsblk", args...)
 	dataOut, err := cmd.CombinedOutput()
+	output := strings.TrimSpace(string(dataOut))
 
 	// TODO (#13212): check if this disk has partitions and return false, and
 	// an error if so.
@@ -109,7 +110,7 @@ func (mounter *SafeFormatAndMount) diskLooksUnformatted(disk string) (bool, erro
 		return false, err
 	}
 
-	return !strings.Contains(string(dataOut), "filesystem"), nil
+	return output == "", nil
 }
 
 // New returns a mount.Interface for the current system.

--- a/pkg/util/mount/safe_format_and_mount_test.go
+++ b/pkg/util/mount/safe_format_and_mount_test.go
@@ -65,7 +65,7 @@ func TestSafeFormatAndMount(t *testing.T) {
 			fstype:    "ext4",
 			mountErrs: []error{fmt.Errorf("unknown filesystem type '(null)'")},
 			execScripts: []ExecArgs{
-				{"file", []string{"-L", "--special-files", "/dev/foo"}, "ext4 filesystem", nil},
+				{"lsblk", []string{"-nd", "-o", "FSTYPE", "/dev/foo"}, "ext4", nil},
 			},
 			expectedError: fmt.Errorf("unknown filesystem type '(null)'"),
 		},
@@ -73,7 +73,7 @@ func TestSafeFormatAndMount(t *testing.T) {
 			fstype:    "ext4",
 			mountErrs: []error{fmt.Errorf("unknown filesystem type '(null)'")},
 			execScripts: []ExecArgs{
-				{"file", []string{"-L", "--special-files", "/dev/foo"}, "data", nil},
+				{"lsblk", []string{"-nd", "-o", "FSTYPE", "/dev/foo"}, "", nil},
 				{"mkfs.ext4", []string{"-E", "lazy_itable_init=0,lazy_journal_init=0", "-F", "/dev/foo"}, "", fmt.Errorf("formatting failed")},
 			},
 			expectedError: fmt.Errorf("formatting failed"),
@@ -82,7 +82,7 @@ func TestSafeFormatAndMount(t *testing.T) {
 			fstype:    "ext4",
 			mountErrs: []error{fmt.Errorf("unknown filesystem type '(null)'"), fmt.Errorf("Still cannot mount")},
 			execScripts: []ExecArgs{
-				{"file", []string{"-L", "--special-files", "/dev/foo"}, "data", nil},
+				{"lsblk", []string{"-nd", "-o", "FSTYPE", "/dev/foo"}, "", nil},
 				{"mkfs.ext4", []string{"-E", "lazy_itable_init=0,lazy_journal_init=0", "-F", "/dev/foo"}, "", nil},
 			},
 			expectedError: fmt.Errorf("Still cannot mount"),
@@ -91,7 +91,7 @@ func TestSafeFormatAndMount(t *testing.T) {
 			fstype:    "ext4",
 			mountErrs: []error{fmt.Errorf("unknown filesystem type '(null)'"), nil},
 			execScripts: []ExecArgs{
-				{"file", []string{"-L", "--special-files", "/dev/foo"}, "data", nil},
+				{"lsblk", []string{"-nd", "-o", "FSTYPE", "/dev/foo"}, "", nil},
 				{"mkfs.ext4", []string{"-E", "lazy_itable_init=0,lazy_journal_init=0", "-F", "/dev/foo"}, "", nil},
 			},
 			expectedError: nil,
@@ -100,7 +100,7 @@ func TestSafeFormatAndMount(t *testing.T) {
 			fstype:    "ext3",
 			mountErrs: []error{fmt.Errorf("unknown filesystem type '(null)'"), nil},
 			execScripts: []ExecArgs{
-				{"file", []string{"-L", "--special-files", "/dev/foo"}, "data", nil},
+				{"lsblk", []string{"-nd", "-o", "FSTYPE", "/dev/foo"}, "", nil},
 				{"mkfs.ext3", []string{"-E", "lazy_itable_init=0,lazy_journal_init=0", "-F", "/dev/foo"}, "", nil},
 			},
 			expectedError: nil,


### PR DESCRIPTION
The `file` command used here to check whether a device is formatted is not available in CoreOS. The effect is that the mounter skips the formatting step and tries to mount an unformatted volume which fails. This makes it quite tedious to use persistent volumes in CoreOS.

This patch replaces the `file` command with `lsblk` which is available in CoreOS. I checked that it's also available on Fedora, CentOS, RHEL, Debian, Ubuntu and SLES. 

Additionally, I checked the most recent version of the above OS that `lsblk` actually behaves the same. The output is literally consistent for the following tests:
1. Check for unknown device
2. Check new unformatted device
3. Format device
4. Check formatted device

Here is the console log of my tests:

CoreOS 766.3.0 Stable

```
$ source /etc/os-release; echo $PRETTY_NAME
CoreOS 766.3.0+2015-09-16-1354
$ lsblk -nd -o FSTYPE /dev/foo
lsblk: /dev/foo: not a block device
$ lsblk -nd -o FSTYPE /dev/sdf

$ mkfs.ext4 /dev/sdf
$ lsblk -nd -o FSTYPE /dev/sdf
ext4
```

RedHat Enterprise Linux 7

```
$ source /etc/os-release; echo $PRETTY_NAME
Red Hat Enterprise Linux Server 7.1 (Maipo)
$ lsblk -nd -o FSTYPE /dev/foo
lsblk: /dev/foo: not a block device
$ lsblk -nd -o FSTYPE /dev/sdf

$ mkfs.ext4 /dev/sdf
$ lsblk -nd -o FSTYPE /dev/sdf
ext4
```

Ubuntu 14.04

```
$ source /etc/os-release; echo $PRETTY_NAME
Ubuntu 14.04.2 LTS
$ lsblk -nd -o FSTYPE /dev/foo
lsblk: /dev/foo: not a block device
$ lsblk -nd -o FSTYPE /dev/sdf

$ mkfs.ext4 /dev/sdf
$ lsblk -nd -o FSTYPE /dev/sdf
ext4
```

Ubuntu 12.04

```
$ source /etc/os-release; echo $PRETTY_NAME
Ubuntu precise (12.04.5 LTS)
$ lsblk -nd -o FSTYPE /dev/foo
lsblk: /dev/foo: not a block device
$ lsblk -nd -o FSTYPE /dev/sdf

$ mkfs.ext4 /dev/sdf
$ lsblk -nd -o FSTYPE /dev/sdf
ext4
```

Debian 7

```
$ source /etc/os-release; echo $PRETTY_NAME
Debian GNU/Linux 7 (wheezy)
$ lsblk -nd -o FSTYPE /dev/foo
lsblk: /dev/foo: not a block device
$ lsblk -nd -o FSTYPE /dev/sdf

$ mkfs.ext4 /dev/sdf
$ lsblk -nd -o FSTYPE /dev/sdf
ext4
```
