### PR TITLE
Node controller produces events with invalid names

### DIFF
--- a/pkg/controller/node/nodecontroller.go
+++ b/pkg/controller/node/nodecontroller.go
@@ -380,13 +380,13 @@ func (nc *NodeController) reconcileNodeCIDRs(nodes *api.NodeList) {
 		if node.Spec.PodCIDR == "" {
 			podCIDR, found := availableCIDRs.PopAny()
 			if !found {
-				nc.recordNodeStatusChange(&node, "No available CIDR")
+				nc.recordNodeStatusChange(&node, "CIDRNotAvailable")
 				continue
 			}
 			glog.V(4).Infof("Assigning node %s CIDR %s", node.Name, podCIDR)
 			node.Spec.PodCIDR = podCIDR
 			if _, err := nc.kubeClient.Nodes().Update(&node); err != nil {
-				nc.recordNodeStatusChange(&node, "CIDR assignment failed")
+				nc.recordNodeStatusChange(&node, "CIDRAssignmentFailed")
 			}
 		}
 	}


### PR DESCRIPTION
The NodeController produces Event names that go against our API conventions.

See: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/api-conventions.md#events

Updated to use CamelCase descriptive names.
