### PR TITLE
kubelet rejects pods from apiserver if node is unschedulable

### DIFF
--- a/pkg/kubelet/fake_node_manager.go
+++ b/pkg/kubelet/fake_node_manager.go
@@ -44,3 +44,7 @@ func (f *fakeNodeManager) GetHostIP() (net.IP, error) {
 func (f *fakeNodeManager) GetPodCIDR() string {
 	return f.podCIDR
 }
+
+func (f *fakeNodeManager) NodeIsSchedulable() bool {
+	return !f.node.Spec.Unschedulable
+}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1672,6 +1672,9 @@ func (kl *Kubelet) rejectPod(pod *api.Pod, reason, message string) {
 // can be admitted, a brief single-word reason and a message explaining why
 // the pod cannot be admitted.
 func (kl *Kubelet) canAdmitPod(pods []*api.Pod, pod *api.Pod) (bool, string, string) {
+	if !kl.nodeManager.NodeIsSchedulable() && !isStaticPod(pod) {
+		return false, "NodeUnschedulable", "cannot start the pod because node is not schedulable"
+	}
 	if hasHostPortConflicts(pods) {
 		return false, "HostPortConflict", "cannot start the pod due to host port conflict."
 	}

--- a/pkg/kubelet/node_manager.go
+++ b/pkg/kubelet/node_manager.go
@@ -59,6 +59,7 @@ type nodeManager interface {
 	GetNode() (*api.Node, error)
 	GetPodCIDR() string
 	GetHostIP() (net.IP, error)
+	NodeIsSchedulable() bool
 }
 
 type realNodeManager struct {
@@ -156,6 +157,15 @@ func (nm *realNodeManager) GetNode() (*api.Node, error) {
 		return nil, errors.New("unable to get node entry because apiserver client is nil")
 	}
 	return nm.nodeLister.GetNodeInfo(nm.nodeName)
+}
+
+func (nm *realNodeManager) NodeIsSchedulable() bool {
+	node, err := nm.GetNode()
+	if err != nil {
+		// If we cannot get the Node spec, assume the node is not schedulable.
+		return false
+	}
+	return !node.Spec.Unschedulable
 }
 
 // Returns host IP or nil in case of error.

--- a/pkg/kubelet/runonce_test.go
+++ b/pkg/kubelet/runonce_test.go
@@ -87,7 +87,7 @@ func TestRunOnce(t *testing.T) {
 		containerRefManager: kubecontainer.NewRefManager(),
 		readinessManager:    kubecontainer.NewReadinessManager(),
 		podManager:          podManager,
-		nodeManager:         &fakeNodeManager{},
+		nodeManager:         &fakeNodeManager{node: &api.Node{}},
 		os:                  kubecontainer.FakeOS{},
 		volumeManager:       newVolumeManager(),
 		diskSpaceManager:    diskSpaceManager,


### PR DESCRIPTION
When a node becomes unschedulable, kubelet should reject any new pods from the
apiserver. Note that if kubelet restarts, it will not be able to tell new pods
from existing pods, hence it would reject existing pods.

This PR fixes #14140
