### PR TITLE
Add a method for encoding directly to a io.Writer and use it for HTTP

### DIFF
--- a/hack/benchmark-integration.sh
+++ b/hack/benchmark-integration.sh
@@ -28,16 +28,18 @@ cleanup() {
   kube::log::status "Benchmark cleanup complete"
 }
 
+ARGS="-bench-pods 3000 -bench-tasks 100 -bench-tasks 10"
+
 runTests() {
   kube::etcd::start
   kube::log::status "Running benchmarks"
-  KUBE_GOFLAGS="-tags 'benchmark no-docker' -bench . -benchtime 1s -cpu 4" \
+  KUBE_GOFLAGS="-tags 'benchmark no-docker' -bench . -benchmem -benchtime 1s -cpu 4" \
     KUBE_RACE="-race" \
     KUBE_TEST_API_VERSIONS="v1" \
     KUBE_TIMEOUT="-timeout 10m" \
     KUBE_TEST_ETCD_PREFIXES="registry"\
     ETCD_CUSTOM_PREFIX="None" \
-    KUBE_TEST_ARGS="-bench-quiet 0 -bench-pods 30 -bench-tasks 1"\
+    KUBE_TEST_ARGS="${ARGS}" \
     "${KUBE_ROOT}/hack/test-go.sh" test/integration
   cleanup
 }

--- a/pkg/api/meta/restmapper_test.go
+++ b/pkg/api/meta/restmapper_test.go
@@ -18,6 +18,7 @@ package meta
 
 import (
 	"errors"
+	"io"
 	"testing"
 
 	"k8s.io/kubernetes/pkg/runtime"
@@ -27,6 +28,10 @@ type fakeCodec struct{}
 
 func (fakeCodec) Encode(runtime.Object) ([]byte, error) {
 	return []byte{}, nil
+}
+
+func (fakeCodec) EncodeToStream(runtime.Object, io.Writer) error {
+	return nil
 }
 
 func (fakeCodec) Decode([]byte) (runtime.Object, error) {

--- a/pkg/conversion/encode.go
+++ b/pkg/conversion/encode.go
@@ -17,8 +17,10 @@ limitations under the License.
 package conversion
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"path"
 )
 
@@ -51,6 +53,14 @@ import (
 // config files.
 //
 func (s *Scheme) EncodeToVersion(obj interface{}, destVersion string) (data []byte, err error) {
+	buff := &bytes.Buffer{}
+	if err := s.EncodeToVersionStream(obj, destVersion, buff); err != nil {
+		return nil, err
+	}
+	return buff.Bytes(), nil
+}
+
+func (s *Scheme) EncodeToVersionStream(obj interface{}, destVersion string, stream io.Writer) error {
 	obj = maybeCopy(obj)
 	v, _ := EnforcePtr(obj) // maybeCopy guarantees a pointer
 
@@ -58,28 +68,34 @@ func (s *Scheme) EncodeToVersion(obj interface{}, destVersion string) (data []by
 	// destVersion is v1, encode it to v1 for backward compatibility.
 	pkg := path.Base(v.Type().PkgPath())
 	if pkg == "unversioned" && destVersion != "v1" {
-		return s.encodeUnversionedObject(obj)
+		// TODO: convert this to streaming too
+		data, err := s.encodeUnversionedObject(obj)
+		if err != nil {
+			return err
+		}
+		_, err = stream.Write(data)
+		return err
 	}
 
 	if _, registered := s.typeToVersion[v.Type()]; !registered {
-		return nil, fmt.Errorf("type %v is not registered for %q and it will be impossible to Decode it, therefore Encode will refuse to encode it.", v.Type(), destVersion)
+		return fmt.Errorf("type %v is not registered for %q and it will be impossible to Decode it, therefore Encode will refuse to encode it.", v.Type(), destVersion)
 	}
 
 	objVersion, objKind, err := s.ObjectVersionAndKind(obj)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// Perform a conversion if necessary.
 	if objVersion != destVersion {
 		objOut, err := s.NewObject(destVersion, objKind)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		flags, meta := s.generateConvertMeta(objVersion, destVersion, obj)
 		err = s.converter.Convert(obj, objOut, flags, meta)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		obj = objOut
 	}
@@ -87,29 +103,29 @@ func (s *Scheme) EncodeToVersion(obj interface{}, destVersion string) (data []by
 	// ensure the output object name comes from the destination type
 	_, objKind, err = s.ObjectVersionAndKind(obj)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// Version and Kind should be set on the wire.
 	err = s.SetVersionAndKind(destVersion, objKind, obj)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// To add metadata, do some simple surgery on the JSON.
-	data, err = json.Marshal(obj)
-	if err != nil {
-		return nil, err
+	encoder := json.NewEncoder(stream)
+	if err := encoder.Encode(obj); err != nil {
+		return err
 	}
 
 	// Version and Kind should be blank in memory. Reset them, since it's
 	// possible that we modified a user object and not a copy above.
 	err = s.SetVersionAndKind("", "", obj)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return data, nil
+	return nil
 }
 
 func (s *Scheme) encodeUnversionedObject(obj interface{}) (data []byte, err error) {

--- a/pkg/runtime/codec.go
+++ b/pkg/runtime/codec.go
@@ -17,6 +17,8 @@ limitations under the License.
 package runtime
 
 import (
+	"io"
+
 	"k8s.io/kubernetes/pkg/util/yaml"
 )
 
@@ -76,6 +78,10 @@ type codecWrapper struct {
 // Encode implements Codec
 func (c *codecWrapper) Encode(obj Object) ([]byte, error) {
 	return c.EncodeToVersion(obj, c.version)
+}
+
+func (c *codecWrapper) EncodeToStream(obj Object, stream io.Writer) error {
+	return c.EncodeToVersionStream(obj, c.version, stream)
 }
 
 // TODO: Make this behaviour default when we move everyone away from

--- a/pkg/runtime/interfaces.go
+++ b/pkg/runtime/interfaces.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package runtime
 
+import (
+	"io"
+)
+
 // ObjectScheme represents common conversions between formal external API versions
 // and the internal Go structs. ObjectScheme is typically used with ObjectCodec to
 // transform internal Go structs into serialized versions. There may be many valid
@@ -45,6 +49,7 @@ type Decoder interface {
 // Encoder defines methods for serializing API objects into bytes
 type Encoder interface {
 	Encode(obj Object) (data []byte, err error)
+	EncodeToStream(obj Object, stream io.Writer) error
 }
 
 // Codec defines methods for serializing and deserializing API objects.
@@ -67,6 +72,7 @@ type ObjectEncoder interface {
 	// to a specified output version. An error is returned if the object
 	// cannot be converted for any reason.
 	EncodeToVersion(obj Object, outVersion string) ([]byte, error)
+	EncodeToVersionStream(obj Object, outVersion string, stream io.Writer) error
 }
 
 // ObjectConvertor converts an object to a different version.

--- a/pkg/runtime/scheme.go
+++ b/pkg/runtime/scheme.go
@@ -19,6 +19,7 @@ package runtime
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/url"
 	"reflect"
 
@@ -432,6 +433,10 @@ func (s *Scheme) ConvertToVersion(in Object, outVersion string) (Object, error) 
 // config files.
 func (s *Scheme) EncodeToVersion(obj Object, destVersion string) (data []byte, err error) {
 	return s.raw.EncodeToVersion(obj, destVersion)
+}
+
+func (s *Scheme) EncodeToVersionStream(obj Object, destVersion string, stream io.Writer) error {
+	return s.raw.EncodeToVersionStream(obj, destVersion, stream)
 }
 
 // Decode converts a YAML or JSON string back into a pointer to an api object.

--- a/pkg/runtime/scheme_test.go
+++ b/pkg/runtime/scheme_test.go
@@ -246,13 +246,16 @@ func TestExtensionMapping(t *testing.T) {
 	}{
 		{
 			&InternalExtensionType{Extension: runtime.EmbeddedObject{Object: &ExtensionA{TestString: "foo"}}},
-			`{"kind":"ExtensionType","apiVersion":"testExternal","extension":{"kind":"A","testString":"foo"}}`,
+			`{"kind":"ExtensionType","apiVersion":"testExternal","extension":{"kind":"A","testString":"foo"}}
+`,
 		}, {
 			&InternalExtensionType{Extension: runtime.EmbeddedObject{Object: &ExtensionB{TestString: "bar"}}},
-			`{"kind":"ExtensionType","apiVersion":"testExternal","extension":{"kind":"B","testString":"bar"}}`,
+			`{"kind":"ExtensionType","apiVersion":"testExternal","extension":{"kind":"B","testString":"bar"}}
+`,
 		}, {
 			&InternalExtensionType{Extension: runtime.EmbeddedObject{Object: nil}},
-			`{"kind":"ExtensionType","apiVersion":"testExternal","extension":null}`,
+			`{"kind":"ExtensionType","apiVersion":"testExternal","extension":null}
+`,
 		},
 	}
 
@@ -261,7 +264,7 @@ func TestExtensionMapping(t *testing.T) {
 		if err != nil {
 			t.Errorf("unexpected error '%v' (%#v)", err, item.obj)
 		} else if e, a := item.encoded, string(gotEncoded); e != a {
-			t.Errorf("expected %v, got %v", e, a)
+			t.Errorf("expected\n%#v\ngot\n%#v\n", e, a)
 		}
 
 		gotDecoded, err := scheme.Decode([]byte(item.encoded))


### PR DESCRIPTION
@lavalamp @davidopp @wojtek-t @gmarek 

This eliminates an allocation on every API call.

Next up is doing the same thing on the decode side.
