### PR TITLE
Remove type validation in resource.Quantity.Add

### DIFF
--- a/pkg/api/resource/quantity.go
+++ b/pkg/api/resource/quantity.go
@@ -323,9 +323,6 @@ func (q *Quantity) Cmp(y Quantity) int {
 }
 
 func (q *Quantity) Add(y Quantity) error {
-	if q.Format != y.Format {
-		return fmt.Errorf("format mismatch: %v vs. %v", q.Format, y.Format)
-	}
 	q.Amount.Add(q.Amount, y.Amount)
 	return nil
 }

--- a/plugin/pkg/admission/resourcequota/admission_test.go
+++ b/plugin/pkg/admission/resourcequota/admission_test.go
@@ -128,6 +128,14 @@ func TestIncrementUsagePodResources(t *testing.T) {
 			expectedError: true,
 		},
 		{
+			testName:      "memory-not-allowed-with-different-format",
+			existing:      validPod("a", 1, getResourceRequirements(getResourceList("", "100M"), getResourceList("", ""))),
+			input:         validPod("b", 1, getResourceRequirements(getResourceList("", "450Mi"), getResourceList("", ""))),
+			resourceName:  api.ResourceMemory,
+			hard:          resource.MustParse("500Mi"),
+			expectedError: true,
+		},
+		{
 			testName:      "memory-no-request",
 			existing:      validPod("a", 1, getResourceRequirements(getResourceList("", "100Mi"), getResourceList("", ""))),
 			input:         validPod("b", 1, getResourceRequirements(getResourceList("", ""), getResourceList("", ""))),


### PR DESCRIPTION
Fixes: #14021

The type validation is unnecessary for add and will cause problem.
Type will always keep unchanged after new amount is added.
