### PR TITLE
fix thirdPartyResourceDataCreator.New

### DIFF
--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -939,11 +939,12 @@ func (m *Master) thirdpartyapi(group, kind, version string) *apiserver.APIGroupV
 		Convertor: api.Scheme,
 		Typer:     api.Scheme,
 
-		Mapper:  thirdpartyresourcedata.NewMapper(latest.GroupOrDie("experimental").RESTMapper, kind, version, group),
-		Codec:   thirdpartyresourcedata.NewCodec(latest.GroupOrDie("experimental").Codec, kind),
-		Linker:  latest.GroupOrDie("experimental").SelfLinker,
-		Storage: storage,
-		Version: version,
+		Mapper:        thirdpartyresourcedata.NewMapper(latest.GroupOrDie("experimental").RESTMapper, kind, version, group),
+		Codec:         thirdpartyresourcedata.NewCodec(latest.GroupOrDie("experimental").Codec, kind),
+		Linker:        latest.GroupOrDie("experimental").SelfLinker,
+		Storage:       storage,
+		Version:       version,
+		ServerVersion: latest.GroupOrDie("").GroupVersion,
 
 		Context: m.requestContextMapper,
 

--- a/pkg/registry/thirdpartyresourcedata/codec.go
+++ b/pkg/registry/thirdpartyresourcedata/codec.go
@@ -266,15 +266,18 @@ type thirdPartyResourceDataCreator struct {
 }
 
 func (t *thirdPartyResourceDataCreator) New(version, kind string) (out runtime.Object, err error) {
-	if t.version != version {
-		return nil, fmt.Errorf("unknown version %s for kind %s", version, kind)
-	}
 	switch kind {
 	case "ThirdPartyResourceData":
+		if t.version != version {
+			return nil, fmt.Errorf("unknown version %s for kind %s", version, kind)
+		}
 		return &experimental.ThirdPartyResourceData{}, nil
 	case "ThirdPartyResourceDataList":
+		if t.version != version {
+			return nil, fmt.Errorf("unknown version %s for kind %s", version, kind)
+		}
 		return &experimental.ThirdPartyResourceDataList{}, nil
 	default:
-		return t.delegate.New(latest.GroupOrDie("experimental").Version, kind)
+		return t.delegate.New(version, kind)
 	}
 }


### PR DESCRIPTION
Currently in default case, the thirdPartyResourceDataCreator try to create the object in experimental version, https://github.com/kubernetes/kubernetes/blob/master/pkg/registry/thirdpartyresourcedata/codec.go#L266

```
default:
    return t.delegate.New(latest.GroupOrDie("experimental").Version, kind)
```

but the object may be a v1 object, e.g.,
https://github.com/kubernetes/kubernetes/blob/master/pkg/apiserver/api_installer.go#L186

```
versionedListOptions, err := a.group.Creater.New(serverVersion, "ListOptions")
```

So the thirdPartyResourceDataCreator should try all groups, rather than assume the object exists in v1.

This hasn't caused any problem yet because experimental register its objects to "v1":
https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/experimental/v1/register.go#L34

@brendandburns @lavalamp 

(this is commit "fix thirdPartyResourceDataCreator.New" in #14156)
