### PR TITLE
Fix document link

### DIFF
--- a/examples/simple-nginx.md
+++ b/examples/simple-nginx.md
@@ -67,7 +67,7 @@ kubectl stop rc my-nginx
 
 ### Exposing your pods to the internet.
 
-On some platforms (for example Google Compute Engine) the kubectl command can integrate with your cloud provider to add a [public IP address](../docs/user-guide/services.md#external-services) for the pods,
+On some platforms (for example Google Compute Engine) the kubectl command can integrate with your cloud provider to add a [public IP address](../docs/user-guide/services.md#publishing-services---service-types) for the pods,
 to do this run:
 
 ```bash


### PR DESCRIPTION
Fix a document link in `examples/simple-nginx.md`
