### PR TITLE
Clean the govet errors

### DIFF
--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -11853,10 +11853,10 @@
     "id": "v1.DaemonEndpoint",
     "description": "DaemonEndpoint contains information about a single Daemon endpoint.",
     "required": [
-     "Port"
+     "port"
     ],
     "properties": {
-     "Port": {
+     "port": {
       "type": "integer",
       "format": "int32",
       "description": "Port number of the given endpoint."

--- a/pkg/api/rest/resttest/resttest.go
+++ b/pkg/api/rest/resttest/resttest.go
@@ -568,7 +568,7 @@ func (t *Tester) testDeleteGracefulHasDefault(obj runtime.Object, setFn SetFunc,
 		t.Errorf("unexpected error: %v", err)
 	}
 	if _, err := getFn(ctx, foo); err != nil {
-		t.Fatalf("did not gracefully delete resource", err)
+		t.Fatalf("did not gracefully delete resource: %v", err)
 	}
 
 	object, err := t.storage.(rest.Getter).Get(ctx, objectMeta.Name)
@@ -595,7 +595,7 @@ func (t *Tester) testDeleteGracefulWithValue(obj runtime.Object, setFn SetFunc, 
 		t.Errorf("unexpected error: %v", err)
 	}
 	if _, err := getFn(ctx, foo); err != nil {
-		t.Fatalf("did not gracefully delete resource", err)
+		t.Fatalf("did not gracefully delete resource: %v", err)
 	}
 
 	object, err := t.storage.(rest.Getter).Get(ctx, objectMeta.Name)
@@ -622,7 +622,7 @@ func (t *Tester) testDeleteGracefulExtend(obj runtime.Object, setFn SetFunc, get
 		t.Errorf("unexpected error: %v", err)
 	}
 	if _, err := getFn(ctx, foo); err != nil {
-		t.Fatalf("did not gracefully delete resource", err)
+		t.Fatalf("did not gracefully delete resource: %v", err)
 	}
 
 	// second delete duration is ignored
@@ -654,7 +654,7 @@ func (t *Tester) testDeleteGracefulImmediate(obj runtime.Object, setFn SetFunc, 
 		t.Errorf("unexpected error: %v", err)
 	}
 	if _, err := getFn(ctx, foo); err != nil {
-		t.Fatalf("did not gracefully delete resource", err)
+		t.Fatalf("did not gracefully delete resource: %v", err)
 	}
 
 	// second delete is immediate, resource is deleted
@@ -912,7 +912,7 @@ func (t *Tester) testListNotFound(assignFn AssignFunc, setRVFn SetRVFunc) {
 		t.Errorf("unexpected error: %v", err)
 	}
 	if meta.ResourceVersion != "123" {
-		t.Errorf("unexpected resource version: %d", meta.ResourceVersion)
+		t.Errorf("unexpected resource version: %s", meta.ResourceVersion)
 	}
 }
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1348,7 +1348,7 @@ type NodeSpec struct {
 // DaemonEndpoint contains information about a single Daemon endpoint.
 type DaemonEndpoint struct {
 	// Port number of the given endpoint.
-	Port int `json:port`
+	Port int `json:"port"`
 }
 
 // NodeDaemonEndpoints lists ports opened by daemons running on the Node.

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -1701,7 +1701,7 @@ type NodeSpec struct {
 // DaemonEndpoint contains information about a single Daemon endpoint.
 type DaemonEndpoint struct {
 	// Port number of the given endpoint.
-	Port int `json:port`
+	Port int `json:"port"`
 }
 
 // NodeDaemonEndpoints lists ports opened by daemons running on the Node.

--- a/pkg/api/v1/types_swagger_doc_generated.go
+++ b/pkg/api/v1/types_swagger_doc_generated.go
@@ -226,7 +226,7 @@ func (ContainerStatus) SwaggerDoc() map[string]string {
 
 var map_DaemonEndpoint = map[string]string{
 	"":     "DaemonEndpoint contains information about a single Daemon endpoint.",
-	"Port": "Port number of the given endpoint.",
+	"port": "Port number of the given endpoint.",
 }
 
 func (DaemonEndpoint) SwaggerDoc() map[string]string {

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -458,7 +458,7 @@ func TestValidateVolumes(t *testing.T) {
 		{Name: "secret", VolumeSource: api.VolumeSource{Secret: &api.SecretVolumeSource{SecretName: "my-secret"}}},
 		{Name: "glusterfs", VolumeSource: api.VolumeSource{Glusterfs: &api.GlusterfsVolumeSource{EndpointsName: "host1", Path: "path", ReadOnly: false}}},
 		{Name: "rbd", VolumeSource: api.VolumeSource{RBD: &api.RBDVolumeSource{CephMonitors: []string{"foo"}, RBDImage: "bar", FSType: "ext4"}}},
-		{Name: "cinder", VolumeSource: api.VolumeSource{Cinder: &api.CinderVolumeSource{"29ea5088-4f60-4757-962e-dba678767887", "ext4", false}}},
+		{Name: "cinder", VolumeSource: api.VolumeSource{Cinder: &api.CinderVolumeSource{VolumeID: "29ea5088-4f60-4757-962e-dba678767887", FSType: "ext4", ReadOnly: false}}},
 		{Name: "cephfs", VolumeSource: api.VolumeSource{CephFS: &api.CephFSVolumeSource{Monitors: []string{"foo"}}}},
 		{Name: "downwardapi", VolumeSource: api.VolumeSource{DownwardAPI: &api.DownwardAPIVolumeSource{Items: []api.DownwardAPIVolumeFile{
 			{Path: "labels", FieldRef: api.ObjectFieldSelector{

--- a/pkg/client/unversioned/testclient/fixture.go
+++ b/pkg/client/unversioned/testclient/fixture.go
@@ -90,8 +90,6 @@ func ObjectReaction(o ObjectRetriever, mapper meta.RESTMapper) ReactionFunc {
 		default:
 			return false, nil, fmt.Errorf("no reaction implemented for %s", action)
 		}
-
-		return true, nil, nil
 	}
 }
 

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -1288,7 +1288,7 @@ func (self *AWSCloud) findVPCID() (string, error) {
 	metadata := self.awsServices.Metadata()
 	macsBytes, err := metadata.GetMetaData("network/interfaces/macs/")
 	if err != nil {
-		return "", fmt.Errorf("Could not list interfaces of the instance", err)
+		return "", fmt.Errorf("Could not list interfaces of the instance: %v", err)
 	}
 
 	// loop over interfaces, first vpc id returned wins

--- a/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_test.go
@@ -658,7 +658,7 @@ func TestFindVPCID(t *testing.T) {
 	}
 	vpcID, err := c.findVPCID()
 	if err != nil {
-		t.Errorf("Unexpected error:", err)
+		t.Errorf("Unexpected error: %v", err)
 	}
 	if vpcID != "vpc-mac0" {
 		t.Errorf("Unexpected vpcID: %s", vpcID)

--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -638,7 +638,7 @@ func (gce *GCECloud) CreateTargetHttpProxy(urlMap *compute.UrlMap, name string) 
 
 // SetUrlMapForTargetHttpProxy sets the given UrlMap for the given TargetHttpProxy.
 func (gce *GCECloud) SetUrlMapForTargetHttpProxy(proxy *compute.TargetHttpProxy, urlMap *compute.UrlMap) error {
-	op, err := gce.service.TargetHttpProxies.SetUrlMap(gce.projectID, proxy.Name, &compute.UrlMapReference{urlMap.SelfLink}).Do()
+	op, err := gce.service.TargetHttpProxies.SetUrlMap(gce.projectID, proxy.Name, &compute.UrlMapReference{UrlMap: urlMap.SelfLink}).Do()
 	if err != nil {
 		return err
 	}
@@ -679,7 +679,7 @@ func (gce *GCECloud) CreateGlobalForwardingRule(proxy *compute.TargetHttpProxy, 
 
 // SetProxyForGlobalForwardingRule links the given TargetHttpProxy with the given GlobalForwardingRule.
 func (gce *GCECloud) SetProxyForGlobalForwardingRule(fw *compute.ForwardingRule, proxy *compute.TargetHttpProxy) error {
-	op, err := gce.service.GlobalForwardingRules.SetTarget(gce.projectID, fw.Name, &compute.TargetReference{proxy.SelfLink}).Do()
+	op, err := gce.service.GlobalForwardingRules.SetTarget(gce.projectID, fw.Name, &compute.TargetReference{Target: proxy.SelfLink}).Do()
 	if err != nil {
 		return err
 	}
@@ -785,7 +785,7 @@ func (gce *GCECloud) AddInstancesToInstanceGroup(name string, instanceNames []st
 	// Adding the same instance twice will result in a 4xx error
 	instances := []*compute.InstanceReference{}
 	for _, ins := range instanceNames {
-		instances = append(instances, &compute.InstanceReference{makeHostURL(gce.projectID, gce.zone, ins)})
+		instances = append(instances, &compute.InstanceReference{Instance: makeHostURL(gce.projectID, gce.zone, ins)})
 	}
 	op, err := gce.service.InstanceGroups.AddInstances(
 		gce.projectID, gce.zone, name,
@@ -807,7 +807,7 @@ func (gce *GCECloud) RemoveInstancesFromInstanceGroup(name string, instanceNames
 	instances := []*compute.InstanceReference{}
 	for _, ins := range instanceNames {
 		instanceLink := makeHostURL(gce.projectID, gce.zone, ins)
-		instances = append(instances, &compute.InstanceReference{instanceLink})
+		instances = append(instances, &compute.InstanceReference{Instance: instanceLink})
 	}
 	op, err := gce.service.InstanceGroups.RemoveInstances(
 		gce.projectID, gce.zone, name,
@@ -833,7 +833,7 @@ func (gce *GCECloud) AddPortToInstanceGroup(ig *compute.InstanceGroup, port int6
 		}
 	}
 	glog.Infof("Adding port %v to instance group %v with %d ports", port, ig.Name, len(ig.NamedPorts))
-	namedPort := compute.NamedPort{fmt.Sprintf("port%v", port), port}
+	namedPort := compute.NamedPort{Name: fmt.Sprintf("port%v", port), Port: port}
 	ig.NamedPorts = append(ig.NamedPorts, &namedPort)
 	op, err := gce.service.InstanceGroups.SetNamedPorts(
 		gce.projectID, gce.zone, ig.Name,

--- a/pkg/controller/job/controller_test.go
+++ b/pkg/controller/job/controller_test.go
@@ -232,7 +232,7 @@ func TestControllerSyncJob(t *testing.T) {
 		// run
 		err := manager.syncJob(getKey(job, t))
 		if err != nil {
-			t.Errorf("%s: unexpected error when syncing jobs %v", err)
+			t.Errorf("%s: unexpected error when syncing jobs %v", name, err)
 		}
 
 		// validate created/deleted pods

--- a/pkg/kubectl/cmd/edit.go
+++ b/pkg/kubectl/cmd/edit.go
@@ -279,7 +279,6 @@ func RunEdit(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []strin
 		// loop again and edit the remaining items
 		infos = results.edit
 	}
-	return nil
 }
 
 // print json file (such as patch file) content for debugging

--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -1298,7 +1298,7 @@ func describeNodeResource(pods []*api.Pod, node *api.Node, out io.Writer) error 
 			memoryReq.String(), int64(fractionMemoryReq), memoryLimit.String(), int64(fractionMemoryLimit))
 	}
 
-	fmt.Fprint(out, "Allocated resources:\n  (Total limits may be over 100%, i.e., overcommitted. More info: http://releases.k8s.io/HEAD/docs/user-guide/compute-resources.md)\n  CPU Requests\tCPU Limits\tMemory Requests\tMemory Limits\n")
+	fmt.Fprintf(out, "Allocated resources:\n  (Total limits may be over 100%%, i.e., overcommitted. More info: http://releases.k8s.io/HEAD/docs/user-guide/compute-resources.md)\n  CPU Requests\tCPU Limits\tMemory Requests\tMemory Limits\n")
 	fmt.Fprint(out, "  ────────────\t──────────\t───────────────\t─────────────\n")
 	reqs, limits, err := getPodsTotalRequestsAndLimits(nonTerminatedPods)
 	if err != nil {

--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -1226,7 +1226,7 @@ func printThirdPartyResource(rsrc *experimental.ThirdPartyResource, w io.Writer,
 	versions := make([]string, len(rsrc.Versions))
 	for ix := range rsrc.Versions {
 		version := &rsrc.Versions[ix]
-		versions[ix] = fmt.Sprint("%s/%s", version.APIGroup, version.Name)
+		versions[ix] = fmt.Sprintf("%s/%s", version.APIGroup, version.Name)
 	}
 	versionsString := strings.Join(versions, ",")
 	if _, err := fmt.Fprintf(w, "%s\t%s\t%s", rsrc.Name, rsrc.Description, versionsString); err != nil {

--- a/pkg/kubectl/rolling_updater.go
+++ b/pkg/kubectl/rolling_updater.go
@@ -403,7 +403,7 @@ func (r *RollingUpdater) getOrCreateTargetControllerWithClient(controller *api.R
 			return nil, false, err
 		}
 		if controller.Spec.Replicas <= 0 {
-			return nil, false, fmt.Errorf("Invalid controller spec for %s; required: > 0 replicas, actual: %d\n", controller.Name, controller.Spec)
+			return nil, false, fmt.Errorf("Invalid controller spec for %s; required: > 0 replicas, actual: %d\n", controller.Name, controller.Spec.Replicas)
 		}
 		// The controller wasn't found, so create it.
 		if controller.Annotations == nil {

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -3229,7 +3229,7 @@ func TestCleanupBandwidthLimits(t *testing.T) {
 
 		err := testKube.kubelet.cleanupBandwidthLimits(test.pods)
 		if err != nil {
-			t.Errorf("unexpected error: %v (%s)", test.name)
+			t.Errorf("unexpected error: %v (%s)", err, test.name)
 		}
 		if !reflect.DeepEqual(shaper.ResetCIDRs, test.expectResetCIDRs) {
 			t.Errorf("[%s]\nexpected: %v, saw: %v", test.name, test.expectResetCIDRs, shaper.ResetCIDRs)

--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -1270,7 +1270,7 @@ func (r *runtime) getImageByName(imageName string) (*kubecontainer.Image, error)
 	case 2:
 		break
 	default:
-		return nil, fmt.Errorf("invalid image name: %q, requires 'name[:version]'")
+		return nil, fmt.Errorf("invalid image name: %q, requires 'name[:version]'", imageName)
 	}
 
 	for _, img := range images {

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -54,7 +54,7 @@ import (
 )
 
 // setUp is a convience function for setting up for (most) tests.
-func setUp(t *testing.T) (Master, Config, *assert.Assertions) {
+func setUp(t *testing.T) (*Master, Config, *assert.Assertions) {
 	master := Master{}
 	config := Config{}
 	fakeClient := tools.NewFakeEtcdClient(t)
@@ -64,7 +64,7 @@ func setUp(t *testing.T) (Master, Config, *assert.Assertions) {
 
 	master.nodeRegistry = registrytest.NewNodeRegistry([]string{"node1", "node2"}, api.NodeResources{})
 
-	return master, config, assert.New(t)
+	return &master, config, assert.New(t)
 }
 
 // TestNew verifies that the New function returns a Master
@@ -437,7 +437,7 @@ type FooList struct {
 	unversioned.TypeMeta `json:",inline"`
 	unversioned.ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
-	items []Foo `json:"items"`
+	Items []Foo `json:"items"`
 }
 
 func initThirdParty(t *testing.T, version string) (*tools.FakeEtcdClient, *httptest.Server, *assert.Assertions) {

--- a/pkg/master/thirdparty_controller_test.go
+++ b/pkg/master/thirdparty_controller_test.go
@@ -172,7 +172,7 @@ func TestSyncAPIs(t *testing.T) {
 		cntrl := ThirdPartyController{master: &fake}
 
 		if err := cntrl.syncResourceList(test.list); err != nil {
-			t.Errorf("[%s] unexpected error: %v", test.name)
+			t.Errorf("[%s] unexpected error: %v", test.name, err)
 		}
 		if len(test.expectedInstalled) != len(fake.installed) {
 			t.Errorf("[%s] unexpected installed APIs: %d, expected %d (%#v)", test.name, len(fake.installed), len(test.expectedInstalled), fake.installed[0])

--- a/pkg/registry/thirdpartyresourcedata/codec_test.go
+++ b/pkg/registry/thirdpartyresourcedata/codec_test.go
@@ -39,7 +39,7 @@ type FooList struct {
 	unversioned.TypeMeta `json:",inline"`
 	unversioned.ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"`
 
-	items []Foo `json:"items"`
+	Items []Foo `json:"items"`
 }
 
 func TestCodec(t *testing.T) {
@@ -65,7 +65,7 @@ func TestCodec(t *testing.T) {
 			obj: &Foo{
 				ObjectMeta: api.ObjectMeta{
 					Name:              "bar",
-					CreationTimestamp: unversioned.Time{time.Unix(100, 0)},
+					CreationTimestamp: unversioned.Time{Time: time.Unix(100, 0)},
 				},
 				TypeMeta: unversioned.TypeMeta{Kind: "Foo"},
 			},

--- a/pkg/util/backoff_test.go
+++ b/pkg/util/backoff_test.go
@@ -54,7 +54,6 @@ func TestBackoffReset(t *testing.T) {
 	step := time.Second
 	maxDuration := step * 5
 	b := NewFakeBackOff(step, maxDuration, tc)
-	startTime := tc.Now()
 
 	// get to backoff = maxDuration
 	for i := 0; i <= int(maxDuration/step); i++ {
@@ -70,7 +69,7 @@ func TestBackoffReset(t *testing.T) {
 	lastUpdate := tc.Now()
 	tc.Step(2*maxDuration + step) // time += 11s, 11 > 2*maxDuration
 	if b.IsInBackOffSince(id, lastUpdate) {
-		t.Errorf("now=%s lastUpdate=%s (%s) expected Backoff reset got %s b.lastUpdate=%s", tc.Now(), startTime, tc.Now().Sub(lastUpdate), b.Get(id))
+		t.Errorf("now=%s lastUpdate=%s (%s) expected Backoff reset got %s", tc.Now(), lastUpdate, tc.Now().Sub(lastUpdate), b.Get(id))
 	}
 }
 

--- a/pkg/util/dbus/dbus_test.go
+++ b/pkg/util/dbus/dbus_test.go
@@ -213,7 +213,7 @@ func TestFakeDBus(t *testing.T) {
 			if method == "org.freedesktop.DBus.GetNameOwner" {
 				checkName := args[0].(string)
 				if checkName != ownedName {
-					return nil, godbus.Error{"org.freedesktop.DBus.Error.NameHasNoOwner", nil}
+					return nil, godbus.Error{Name: "org.freedesktop.DBus.Error.NameHasNoOwner", Body: nil}
 				} else {
 					return []interface{}{uniqueName}, nil
 				}

--- a/pkg/util/iptables/iptables_test.go
+++ b/pkg/util/iptables/iptables_test.go
@@ -673,7 +673,7 @@ func TestReload(t *testing.T) {
 			// EnsureChain
 			func() ([]byte, error) { return []byte{}, nil },
 			// EnsureRule abc check
-			func() ([]byte, error) { return []byte{}, &exec.FakeExitError{1} },
+			func() ([]byte, error) { return []byte{}, &exec.FakeExitError{Status: 1} },
 			// EnsureRule abc
 			func() ([]byte, error) { return []byte{}, nil },
 
@@ -681,7 +681,7 @@ func TestReload(t *testing.T) {
 			// EnsureChain
 			func() ([]byte, error) { return []byte{}, nil },
 			// EnsureRule abc check
-			func() ([]byte, error) { return []byte{}, &exec.FakeExitError{1} },
+			func() ([]byte, error) { return []byte{}, &exec.FakeExitError{Status: 1} },
 			// EnsureRule abc
 			func() ([]byte, error) { return []byte{}, nil },
 		},

--- a/pkg/volume/aws_ebs/aws_ebs.go
+++ b/pkg/volume/aws_ebs/aws_ebs.go
@@ -106,7 +106,7 @@ func (plugin *awsElasticBlockStorePlugin) newBuilderInternal(spec *volume.Spec, 
 		fsType:      fsType,
 		partition:   partition,
 		readOnly:    readOnly,
-		diskMounter: &mount.SafeFormatAndMount{plugin.host.GetMounter(), exec.New()}}, nil
+		diskMounter: &mount.SafeFormatAndMount{Interface: plugin.host.GetMounter(), Runner: exec.New()}}, nil
 }
 
 func (plugin *awsElasticBlockStorePlugin) NewCleaner(volName string, podUID types.UID) (volume.Cleaner, error) {

--- a/pkg/volume/cephfs/cephfs_test.go
+++ b/pkg/volume/cephfs/cephfs_test.go
@@ -69,7 +69,7 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("Failed to make a new Builder: %v", err)
 	}
 	if builder == nil {
-		t.Errorf("Got a nil Builder: %v")
+		t.Errorf("Got a nil Builder: %v", builder)
 	}
 	path := builder.GetPath()
 	if path != "/tmp/fake/pods/poduid/volumes/kubernetes.io~cephfs/vol1" {
@@ -90,7 +90,7 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("Failed to make a new Cleaner: %v", err)
 	}
 	if cleaner == nil {
-		t.Errorf("Got a nil Cleaner: %v")
+		t.Errorf("Got a nil Cleaner: %v", cleaner)
 	}
 	if err := cleaner.TearDown(); err != nil {
 		t.Errorf("Expected success, got: %v", err)

--- a/pkg/volume/cinder/cinder_test.go
+++ b/pkg/volume/cinder/cinder_test.go
@@ -88,7 +88,7 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("Failed to make a new Builder: %v", err)
 	}
 	if builder == nil {
-		t.Errorf("Got a nil Builder: %v")
+		t.Errorf("Got a nil Builder: %v", builder)
 	}
 
 	path := builder.GetPath()
@@ -119,7 +119,7 @@ func TestPlugin(t *testing.T) {
 		t.Errorf("Failed to make a new Cleaner: %v", err)
 	}
 	if cleaner == nil {
-		t.Errorf("Got a nil Cleaner: %v")
+		t.Errorf("Got a nil Cleaner: %v", cleaner)
 	}
 
 	if err := cleaner.TearDown(); err != nil {

--- a/pkg/volume/cinder/cinder_util.go
+++ b/pkg/volume/cinder/cinder_util.go
@@ -178,14 +178,12 @@ func isFormatRequired(devicePath string, fstype string, exec *cinderSafeFormatAn
 		glog.Warningf("Failed to get any response from /bin/lsblk")
 		return false, errors.New("Failed to get reponse from /bin/lsblk")
 	}
-	glog.Warningf("Unknown error occured executing /bin/lsblk")
-	return false, errors.New("Unknown error occured executing /bin/lsblk")
 }
 
 func formatVolume(devicePath string, fstype string, exec *cinderSafeFormatAndMount) (bool, error) {
 	if "ext4" != fstype && "ext3" != fstype {
 		glog.Warningf("Unsupported format type: %q\n", fstype)
-		return false, errors.New(fmt.Sprint("Unsupported format type: %q\n", fstype))
+		return false, errors.New(fmt.Sprintf("Unsupported format type: %q\n", fstype))
 	}
 	args := []string{devicePath}
 	cmd := exec.runner.Command(fmt.Sprintf("/sbin/mkfs.%s", fstype), args...)

--- a/pkg/volume/gce_pd/gce_pd.go
+++ b/pkg/volume/gce_pd/gce_pd.go
@@ -104,7 +104,7 @@ func (plugin *gcePersistentDiskPlugin) newBuilderInternal(spec *volume.Spec, pod
 		},
 		fsType:      fsType,
 		readOnly:    readOnly,
-		diskMounter: &mount.SafeFormatAndMount{mounter, exec.New()}}, nil
+		diskMounter: &mount.SafeFormatAndMount{Interface: mounter, Runner: exec.New()}}, nil
 }
 
 func (plugin *gcePersistentDiskPlugin) NewCleaner(volName string, podUID types.UID) (volume.Cleaner, error) {

--- a/pkg/volume/host_path/host_path_test.go
+++ b/pkg/volume/host_path/host_path_test.go
@@ -91,7 +91,7 @@ func TestDeleter(t *testing.T) {
 	defer os.RemoveAll(tempPath)
 	err := os.MkdirAll(tempPath, 0750)
 	if err != nil {
-		t.Fatal("Failed to create tmp directory for deleter: %v", err)
+		t.Fatalf("Failed to create tmp directory for deleter: %v", err)
 	}
 
 	plugMgr := volume.VolumePluginMgr{}

--- a/plugin/pkg/admission/namespace/lifecycle/admission_test.go
+++ b/plugin/pkg/admission/namespace/lifecycle/admission_test.go
@@ -114,16 +114,16 @@ func TestAdmission(t *testing.T) {
 	// verify create/update/delete of object in non-existant namespace throws error
 	err = handler.Admit(admission.NewAttributesRecord(&badPod, "Pod", badPod.Namespace, badPod.Name, "pods", "", admission.Create, nil))
 	if err == nil {
-		t.Errorf("Expected an aerror that objects cannot be created in non-existant namespaces", err)
+		t.Errorf("Expected an aerror that objects cannot be created in non-existant namespaces: %v", err)
 	}
 
 	err = handler.Admit(admission.NewAttributesRecord(&badPod, "Pod", badPod.Namespace, badPod.Name, "pods", "", admission.Update, nil))
 	if err == nil {
-		t.Errorf("Expected an aerror that objects cannot be updated in non-existant namespaces", err)
+		t.Errorf("Expected an aerror that objects cannot be updated in non-existant namespaces: %v", err)
 	}
 
 	err = handler.Admit(admission.NewAttributesRecord(&badPod, "Pod", badPod.Namespace, badPod.Name, "pods", "", admission.Delete, nil))
 	if err == nil {
-		t.Errorf("Expected an aerror that objects cannot be deleted in non-existant namespaces", err)
+		t.Errorf("Expected an aerror that objects cannot be deleted in non-existant namespaces: %v", err)
 	}
 }


### PR DESCRIPTION
After running the static check, errors generated as below. 

<pre>
# make vet
hack/vet-go.sh  
pkg/api/types.go:1348: struct field tag `json:port` not compatible with reflect.StructTag.Get: bad syntax for struct tag value
pkg/api/rest/resttest/resttest.go:571: no formatting directive in Fatalf call
pkg/api/rest/resttest/resttest.go:598: no formatting directive in Fatalf call
pkg/api/rest/resttest/resttest.go:625: no formatting directive in Fatalf call
pkg/api/rest/resttest/resttest.go:657: no formatting directive in Fatalf call
pkg/api/rest/resttest/resttest.go:915: arg meta.ResourceVersion for printf verb %d of wrong type: string
pkg/api/v1/types.go:1697: struct field tag `json:port` not compatible with reflect.StructTag.Get: bad syntax for struct tag value
pkg/api/validation/validation_test.go:461: k8s.io/kubernetes/pkg/api.CinderVolumeSource composite literal uses unkeyed fields
pkg/client/unversioned/testclient/fixture.go:94: unreachable code
pkg/cloudprovider/providers/aws/aws.go:1291: no formatting directive in Errorf call
pkg/cloudprovider/providers/aws/aws_test.go:661: no formatting directive in Errorf call
pkg/cloudprovider/providers/gce/gce.go:641: google.golang.org/api/compute/v1.UrlMapReference composite literal uses unkeyed fields
pkg/cloudprovider/providers/gce/gce.go:682: google.golang.org/api/compute/v1.TargetReference composite literal uses unkeyed fields
pkg/cloudprovider/providers/gce/gce.go:788: google.golang.org/api/compute/v1.InstanceReference composite literal uses unkeyed fields
pkg/cloudprovider/providers/gce/gce.go:810: google.golang.org/api/compute/v1.InstanceReference composite literal uses unkeyed fields
pkg/cloudprovider/providers/gce/gce.go:836: google.golang.org/api/compute/v1.NamedPort composite literal uses unkeyed fields
pkg/controller/job/job_controller_test.go:247: missing argument for Errorf("%v"): format reads arg 2, have only 1 args
pkg/kubectl/describe.go:1301: possible formatting directive in Fprint call
pkg/kubectl/resource_printer.go:1229: possible formatting directive in Sprint call
pkg/kubectl/rolling_updater.go:406: arg controller.Spec for printf verb %d of wrong type: k8s.io/kubernetes/pkg/api.ReplicationControllerSpec
pkg/kubectl/cmd/edit.go:282: unreachable code
pkg/kubectl/cmd/cmd_test.go:359: k8s.io/kubernetes/pkg/api/unversioned.Time composite literal uses unkeyed fields
pkg/kubectl/cmd/cmd_test.go:376: k8s.io/kubernetes/pkg/api/unversioned.Time composite literal uses unkeyed fields
pkg/kubectl/cmd/cmd_test.go:393: k8s.io/kubernetes/pkg/api/unversioned.Time composite literal uses unkeyed fields
pkg/kubectl/cmd/cmd_test.go:410: k8s.io/kubernetes/pkg/api/unversioned.Time composite literal uses unkeyed fields
pkg/kubectl/cmd/cmd_test.go:427: k8s.io/kubernetes/pkg/api/unversioned.Time composite literal uses unkeyed fields
pkg/kubelet/kubelet_test.go:3201: missing argument for Errorf("%s"): format reads arg 2, have only 1 args
pkg/kubelet/rkt/rkt.go:1273: missing argument for Errorf("%q"): format reads arg 1, have only 0 args
pkg/master/master_test.go:57: setUp returns Lock by value: master.Master contains sync.Mutex
pkg/master/master_test.go:440: struct field items has json tag but is not exported
pkg/master/thirdparty_controller_test.go:175: missing argument for Errorf("%v"): format reads arg 2, have only 1 args
pkg/registry/thirdpartyresourcedata/codec_test.go:42: struct field items has json tag but is not exported
pkg/registry/thirdpartyresourcedata/codec_test.go:68: k8s.io/kubernetes/pkg/api/unversioned.Time composite literal uses unkeyed fields
pkg/util/backoff_test.go:73: missing argument for Errorf("%s"): format reads arg 5, have only 4 args
pkg/util/dbus/dbus_test.go:216: github.com/godbus/dbus.Error composite literal uses unkeyed fields
pkg/util/iptables/iptables_test.go:676: k8s.io/kubernetes/pkg/util/exec.FakeExitError composite literal uses unkeyed fields
pkg/util/iptables/iptables_test.go:684: k8s.io/kubernetes/pkg/util/exec.FakeExitError composite literal uses unkeyed fields
pkg/volume/aws_ebs/aws_ebs.go:109: k8s.io/kubernetes/pkg/util/mount.SafeFormatAndMount composite literal uses unkeyed fields
pkg/volume/cephfs/cephfs_test.go:72: missing argument for Errorf("%v"): format reads arg 1, have only 0 args
pkg/volume/cephfs/cephfs_test.go:93: missing argument for Errorf("%v"): format reads arg 1, have only 0 args
pkg/volume/cinder/cinder_util.go:181: unreachable code
pkg/volume/cinder/cinder_util.go:188: possible formatting directive in Sprint call
pkg/volume/cinder/cinder_test.go:91: missing argument for Errorf("%v"): format reads arg 1, have only 0 args
pkg/volume/cinder/cinder_test.go:122: missing argument for Errorf("%v"): format reads arg 1, have only 0 args
pkg/volume/gce_pd/gce_pd.go:107: k8s.io/kubernetes/pkg/util/mount.SafeFormatAndMount composite literal uses unkeyed fields
pkg/volume/host_path/host_path_test.go:94: possible formatting directive in Fatal call
plugin/pkg/admission/namespace/lifecycle/admission_test.go:117: no formatting directive in Errorf call
plugin/pkg/admission/namespace/lifecycle/admission_test.go:122: no formatting directive in Errorf call
plugin/pkg/admission/namespace/lifecycle/admission_test.go:127: no formatting directive in Errorf call
make: *** [vet] Error 1
</pre>
