### PR TITLE
If an isolator's request is nil, populate it with the limit and vice versa

### DIFF
--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -214,10 +214,10 @@ func rawValue(value string) *json.RawMessage {
 // rawValue converts the request, limit to *json.RawMessage
 func rawRequestLimit(request, limit string) *json.RawMessage {
 	if request == "" {
-		return rawValue(fmt.Sprintf(`{"limit":%q}`, limit))
+		request = limit
 	}
 	if limit == "" {
-		return rawValue(fmt.Sprintf(`{"request":%q}`, request))
+		limit = request
 	}
 	return rawValue(fmt.Sprintf(`{"request":%q,"limit":%q}`, request, limit))
 }


### PR DESCRIPTION
The appc spec isn't currently clear about if both fields are required (https://github.com/appc/spec/issues/484), and before rkt v0.8.1 if either field was nil it would result in a crash.  Currently rkt will ignore isolators that don't have both fields set, so I think this is a reasonable approach to making sure isolators are actually used.  Presumably this will be irrelevant once there are constructors for isolators (https://github.com/appc/spec/issues/268).
