### PR TITLE
Fix Cephfs example typo

### DIFF
--- a/examples/cephfs/cephfs.json
+++ b/examples/cephfs/cephfs.json
@@ -28,7 +28,7 @@
         						"10.16.154.83:6789"
     				 ],
                     "user": "admin",
-                    "scretFile": "/etc/ceph/admin.secret",
+                    "secretFile": "/etc/ceph/admin.secret",
                     "readOnly": true
                 }
             }


### PR DESCRIPTION
Just Fix a typo error while looking at the examples of cephfs.
