### PR TITLE
Added unsupported for non-linux platforms

### DIFF
--- a/pkg/util/bandwidth/linux.go
+++ b/pkg/util/bandwidth/linux.go
@@ -1,3 +1,5 @@
+// +build linux
+
 /*
 Copyright 2015 The Kubernetes Authors All rights reserved.
 

--- a/pkg/util/bandwidth/unsupported.go
+++ b/pkg/util/bandwidth/unsupported.go
@@ -1,0 +1,52 @@
+// +build !linux
+
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bandwidth
+
+import (
+	"errors"
+
+	"k8s.io/kubernetes/pkg/api/resource"
+)
+
+type unsupportedShaper struct {
+}
+
+func NewTCShaper(iface string) BandwidthShaper {
+	return &unsupportedShaper{}
+}
+
+func (f *unsupportedShaper) Limit(cidr string, egress, ingress *resource.Quantity) error {
+	return errors.New("unimplemented")
+}
+
+func (f *unsupportedShaper) Reset(cidr string) error {
+	return nil
+}
+
+func (f *unsupportedShaper) ReconcileInterface() error {
+	return errors.New("unimplemented")
+}
+
+func (f *unsupportedShaper) ReconcileCIDR(cidr string, egress, ingress *resource.Quantity) error {
+	return errors.New("unimplemented")
+}
+
+func (f *unsupportedShaper) GetCIDRs() ([]string, error) {
+	return []string{}, nil
+}


### PR DESCRIPTION
I switched to Go 1.3 on OS X to address another issue but found I could not build the latest due to this compilation error:

```
_output/local/go/src/k8s.io/kubernetes/pkg/kubelet/kubelet.go:2024: undefined: bandwidth.NewTCShaper
```

Adding non-linux platform support to pkg/util/bandwidth fixes this.

@brendandburns added the bandwidth code recently

This compilation error does _not_ happen with Go 1.4 on OS X.
