### PR TITLE
Allow deployment to update pod labels

### DIFF
--- a/pkg/apis/experimental/validation/validation.go
+++ b/pkg/apis/experimental/validation/validation.go
@@ -240,7 +240,7 @@ func ValidateDeploymentSpec(spec *experimental.DeploymentSpec) errs.ValidationEr
 	allErrs := errs.ValidationErrorList{}
 	allErrs = append(allErrs, apivalidation.ValidateNonEmptySelector(spec.Selector, "selector")...)
 	allErrs = append(allErrs, apivalidation.ValidatePositiveField(int64(spec.Replicas), "replicas")...)
-	allErrs = append(allErrs, apivalidation.ValidatePodTemplateSpecForRC(spec.Template, spec.Selector, spec.Replicas, "template")...)
+	allErrs = append(allErrs, apivalidation.ValidatePodTemplateSpecForRC(spec.Template, nil, spec.Replicas, "template")...)
 	allErrs = append(allErrs, ValidateDeploymentStrategy(&spec.Strategy, "strategy")...)
 	allErrs = append(allErrs, apivalidation.ValidateLabelName(spec.UniqueLabelKey, "uniqueLabel")...)
 	return allErrs

--- a/pkg/apis/experimental/validation/validation_test.go
+++ b/pkg/apis/experimental/validation/validation_test.go
@@ -593,12 +593,6 @@ func TestValidateDeployment(t *testing.T) {
 			Namespace: api.NamespaceDefault,
 		},
 	}
-	// selector should match the labels in pod template.
-	invalidSelectorDeployment := validDeployment()
-	invalidSelectorDeployment.Spec.Selector = map[string]string{
-		"name": "def",
-	}
-	errorCases["selector does not match labels"] = invalidSelectorDeployment
 
 	// RestartPolicy should be always.
 	invalidRestartPolicyDeployment := validDeployment()


### PR DESCRIPTION
Ref #1743

Right now, we enforce that PodTemplateSpec.Labels match with Deployment.Spec.Selector, ie the new pods should have same labels as the old pods that deployment selects.
This PR remove this restriction.
