### PR TITLE
Change 'params' to 'extraParams' to keep align with naming conventions

### DIFF
--- a/docs/devel/api_changes.md
+++ b/docs/devel/api_changes.md
@@ -157,7 +157,7 @@ type Frobber struct {
 	Height int           `json:"height"`
 	Width  int           `json:"width"`
 	Param  string        `json:"param"`  // the first param
-	ExtraParams []string `json:"params"` // additional params
+	ExtraParams []string `json:"extraParams"` // additional params
 }
 ```
 


### PR DESCRIPTION
Change `params` to `extraParams` to keep align with naming conventions.

> Go field names must be CamelCase. JSON field names must be camelCase. Other than capitalization of the initial letter, the two should almost always match. No underscores nor dashes in either

Please refer to [Naming conventions](https://github.com/kubernetes/kubernetes/blob/master/docs/devel/api-conventions.md#naming-conventions).
