### PR TITLE
temporary fix of kube_version_change

### DIFF
--- a/cmd/kube-version-change/version.go
+++ b/cmd/kube-version-change/version.go
@@ -28,7 +28,7 @@ import (
 	"runtime"
 
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/latest"
+	"k8s.io/kubernetes/pkg/api/registered"
 	"k8s.io/kubernetes/pkg/util"
 
 	"github.com/ghodss/yaml"
@@ -39,7 +39,7 @@ var (
 	inputSource   = flag.StringP("input", "i", "-", "Input source; '-' means stdin")
 	outputDest    = flag.StringP("output", "o", "-", "Output destination; '-' means stdout")
 	rewrite       = flag.StringP("rewrite", "r", "", "If nonempty, use this as both input and output.")
-	outputVersion = flag.StringP("out-version", "v", latest.GroupOrDie("").Version, "Version to convert input to")
+	outputVersion = flag.StringP("out-version", "v", registered.RegisteredVersions[0], "Version to convert input to")
 )
 
 // isYAML determines whether data is JSON or YAML formatted by seeing


### PR DESCRIPTION
Can't get latest version by latest package now, use first of
registeredVersions instead.

fixs:https://github.com/kubernetes/kubernetes/pull/13833#commitcomment-13323822
