### PR TITLE
Fix typos in nodesjs-mongodb example readme

### DIFF
--- a/examples/nodesjs-mongodb/README.md
+++ b/examples/nodesjs-mongodb/README.md
@@ -74,7 +74,7 @@ kubectl create -f examples/nodesjs-mongodb/mongo-service.yaml
 
 ### Creating the MongoDB Controller
 
-Next, create the MongoDB instnace that runs the Database.  Databases also need persistant storage, which will be different for each platform.
+Next, create the MongoDB instance that runs the Database.  Databases also need persistent storage, which will be different for each platform.
 
 ```yaml
 apiVersion: v1
@@ -182,7 +182,7 @@ spec:
 
 This service is called "web," and it uses a [LoadBalancer](../../docs/user-guide/services.md#type-loadbalancer) to distribute traffic on port 80 to port 3000 running on Pods with the "web" tag. Port 80 is the standard HTTP port, and port 3000 is the standard Node.js port.
 
-On Google Container Engine, a [netowrk load balancer](https://cloud.google.com/compute/docs/load-balancing/network/) and [firewall rule](https://cloud.google.com/compute/docs/networking#addingafirewall) to allow traffic are automatically created.
+On Google Container Engine, a [network load balancer](https://cloud.google.com/compute/docs/load-balancing/network/) and [firewall rule](https://cloud.google.com/compute/docs/networking#addingafirewall) to allow traffic are automatically created.
 
 To start the service, run:
 
@@ -196,7 +196,7 @@ You may also need to open appropriate Firewall ports to allow traffic.
 
 ### Creating the Node.js Controller
 
-The final step is deplyoing the Node.js container that will run the application code. This container can easily by replaced by any other web serving frontend, such as Rails, LAMP, Java, Go, etc.
+The final step is deploying the Node.js container that will run the application code. This container can easily by replaced by any other web serving frontend, such as Rails, LAMP, Java, Go, etc.
 
 The most important thing to keep in mind is how to access the MongoDB service.
 
@@ -212,7 +212,7 @@ With this Kubernetes setup, that line of code would become:
 MongoClient.connect('mongodb://mongo:27017/database-name', function(err, db) { console.log(db); });
 ```
 
-The MongoDB Service previously created tells Kubernetes to configure the clutser so 'mongo' points to the MongoDB instance created earlier.
+The MongoDB Service previously created tells Kubernetes to configure the cluster so 'mongo' points to the MongoDB instance created earlier.
 
 #### Custom Container
 
@@ -292,7 +292,7 @@ spec:
 
 [Download file](web-controller-demo.yaml)
 
-This will use the default Node.js container, and will pull and execute code at run time. This is not reccomended; typically, your code should be part of the container.
+This will use the default Node.js container, and will pull and execute code at run time. This is not recommended; typically, your code should be part of the container.
 
 To start the Controller, run:
 


### PR DESCRIPTION
These appear to be outright misspellings or typos of dictionary words in the readme.  I didn't bother with any grammatical errors or potentially contentious changes (e.g. frontend -> front-end).

The contributor guide says to open an issue first to get approval before submitting a patch, and I'm sorry for not doing that, but I figured this was small and obvious enough to just do outright.
