### PR TITLE
Fix race in lifecycle admission test

### DIFF
--- a/plugin/pkg/admission/namespace/lifecycle/admission_test.go
+++ b/plugin/pkg/admission/namespace/lifecycle/admission_test.go
@@ -18,6 +18,7 @@ package lifecycle
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 
 	"k8s.io/kubernetes/pkg/admission"
@@ -39,6 +40,7 @@ func TestAdmission(t *testing.T) {
 			Phase: api.NamespaceActive,
 		},
 	}
+	var namespaceLock sync.RWMutex
 
 	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
 	store.Add(namespaceObj)
@@ -46,12 +48,16 @@ func TestAdmission(t *testing.T) {
 	mockClient := &testclient.Fake{}
 	mockClient.AddWatchReactor("*", testclient.DefaultWatchReactor(fakeWatch, nil))
 	mockClient.AddReactor("get", "namespaces", func(action testclient.Action) (bool, runtime.Object, error) {
+		namespaceLock.RLock()
+		defer namespaceLock.RUnlock()
 		if getAction, ok := action.(testclient.GetAction); ok && getAction.GetName() == namespaceObj.Name {
 			return true, namespaceObj, nil
 		}
 		return true, nil, fmt.Errorf("No result for action %v", action)
 	})
 	mockClient.AddReactor("list", "namespaces", func(action testclient.Action) (bool, runtime.Object, error) {
+		namespaceLock.RLock()
+		defer namespaceLock.RUnlock()
 		return true, &api.NamespaceList{Items: []api.Namespace{*namespaceObj}}, nil
 	})
 
@@ -78,7 +84,9 @@ func TestAdmission(t *testing.T) {
 	}
 
 	// change namespace state to terminating
+	namespaceLock.Lock()
 	namespaceObj.Status.Phase = api.NamespaceTerminating
+	namespaceLock.Unlock()
 	store.Add(namespaceObj)
 
 	// verify create operations in the namespace cause an error


### PR DESCRIPTION
.State.Phase is read and written by multiple goroutines as reported by `godep go test -race` on Go 1.5.1. Adding the mutex around the object fixes the issue.

As reported by @mikedanese in #13838. Looks to me like it's clear that the test code is racey, in the sense that it hands over an object and then modifies it without making sure it is okay to modify. But if I'm wrong and it was done like this on purpose, let me know.
