### PR TITLE
update createExternalLoadBalancer to createLoadBalancer

### DIFF
--- a/pkg/controller/service/servicecontroller.go
+++ b/pkg/controller/service/servicecontroller.go
@@ -320,9 +320,9 @@ func (s *ServiceController) createLoadBalancerIfNeeded(namespacedName types.Name
 
 		// The load balancer doesn't exist yet, so create it.
 		s.eventRecorder.Event(service, "CreatingLoadBalancer", "Creating load balancer")
-		err := s.createExternalLoadBalancer(service)
+		err := s.createLoadBalancer(service)
 		if err != nil {
-			return fmt.Errorf("failed to create external load balancer for service %s: %v", namespacedName, err), retryable
+			return fmt.Errorf("Failed to create load balancer for service %s: %v", namespacedName, err), retryable
 		}
 		s.eventRecorder.Event(service, "CreatedLoadBalancer", "Created load balancer")
 	}
@@ -368,7 +368,7 @@ func (s *ServiceController) persistUpdate(service *api.Service) error {
 	return err
 }
 
-func (s *ServiceController) createExternalLoadBalancer(service *api.Service) error {
+func (s *ServiceController) createLoadBalancer(service *api.Service) error {
 	ports, err := getPortsForLB(service)
 	if err != nil {
 		return err


### PR DESCRIPTION
as the api.md said:
The service.spec.createExternalLoadBalancer property is removed. Specify service.spec.type: "LoadBalancer" to create an external load balancer instead.

so i think it better to use createLoadBalancer here, please check :)
