### PR TITLE
MESOS: pass node capacity values to kubelet

### DIFF
--- a/cluster/mesos/docker/docker-compose.yml
+++ b/cluster/mesos/docker/docker-compose.yml
@@ -145,6 +145,7 @@ scheduler:
     --mesos-master=mesosmaster1:5050
     --cluster-dns=10.10.10.10
     --cluster-domain=cluster.local
+    --mesos-executor-cpus=1.0
     --v=4
   environment:
   - MESOS_DOCKER_ETCD_TIMEOUT

--- a/cluster/mesos/docker/docker-compose.yml
+++ b/cluster/mesos/docker/docker-compose.yml
@@ -50,6 +50,7 @@ mesosslave:
   - MESOS_RESOURCES=cpus:4;mem:1280;disk:25600;ports:[8000-21099]
   - MESOS_SWITCH_USER=0
   - MESOS_CONTAINERIZERS=docker,mesos
+  - MESOS_ISOLATION=cgroups/cpu,cgroups/mem
   - DOCKER_DAEMON_ARGS
   links:
   - etcd

--- a/contrib/mesos/pkg/executor/executor.go
+++ b/contrib/mesos/pkg/executor/executor.go
@@ -92,6 +92,11 @@ type kuberTask struct {
 
 type podStatusFunc func() (*api.PodStatus, error)
 
+type NodeInfo struct {
+	Cores int
+	Mem   int64 // in bytes
+}
+
 // KubernetesExecutor is an mesos executor that runs pods
 // in a minion machine.
 type KubernetesExecutor struct {
@@ -113,6 +118,7 @@ type KubernetesExecutor struct {
 	staticPodsConfigPath string
 	podController        *framework.Controller
 	launchGracePeriod    time.Duration
+	nodeInfos            chan<- NodeInfo
 }
 
 type Config struct {
@@ -127,6 +133,7 @@ type Config struct {
 	StaticPodsConfigPath string
 	PodLW                cache.ListerWatcher // mandatory, otherwise initialiation will panic
 	LaunchGracePeriod    time.Duration
+	NodeInfos            chan<- NodeInfo
 }
 
 func (k *KubernetesExecutor) isConnected() bool {
@@ -152,6 +159,7 @@ func New(config Config) *KubernetesExecutor {
 		podStatusFunc:        config.PodStatusFunc,
 		staticPodsConfigPath: config.StaticPodsConfigPath,
 		launchGracePeriod:    config.LaunchGracePeriod,
+		nodeInfos:            config.NodeInfos,
 	}
 
 	// watch pods from the given pod ListWatch
@@ -236,6 +244,10 @@ func (k *KubernetesExecutor) Registered(driver bindings.ExecutorDriver,
 		Pods: []*api.Pod{},
 		Op:   kubetypes.SET,
 	})
+
+	if slaveInfo != nil && k.nodeInfos != nil {
+		k.nodeInfos <- nodeInfo(slaveInfo, executorInfo) // leave it behind the upper lock to avoid panics
+	}
 }
 
 // Reregistered is called when the executor is successfully re-registered with the slave.
@@ -254,6 +266,16 @@ func (k *KubernetesExecutor) Reregistered(driver bindings.ExecutorDriver, slaveI
 		if err != nil {
 			log.Errorf("cannot update node labels: %v", err)
 		}
+	}
+
+	if slaveInfo != nil && k.nodeInfos != nil {
+		// make sure nodeInfos is not nil and send new NodeInfo
+		k.lock.Lock()
+		defer k.lock.Unlock()
+		if k.isDone() {
+			return
+		}
+		k.nodeInfos <- nodeInfo(slaveInfo, nil)
 	}
 }
 
@@ -796,6 +818,7 @@ func (k *KubernetesExecutor) doShutdown(driver bindings.ExecutorDriver) {
 	// signal to all listeners that this KubeletExecutor is done!
 	close(k.terminate)
 	close(k.updateChan)
+	close(k.nodeInfos)
 
 	if k.shutdownAlert != nil {
 		func() {
@@ -925,4 +948,41 @@ func differentTime(a, b *unversionedapi.Time) bool {
 
 func differentPeriod(a, b *int64) bool {
 	return (a == nil) != (b == nil) || (a != nil && b != nil && *a != *b)
+}
+
+func nodeInfo(si *mesos.SlaveInfo, ei *mesos.ExecutorInfo) NodeInfo {
+	var executorCPU, executorMem float64
+
+	// get executor resources
+	if ei != nil {
+		for _, r := range ei.GetResources() {
+			if r == nil || r.GetType() != mesos.Value_SCALAR {
+				continue
+			}
+			switch r.GetName() {
+			case "cpus":
+				executorCPU = r.GetScalar().GetValue()
+			case "mem":
+				executorMem = r.GetScalar().GetValue()
+			}
+		}
+	}
+
+	// get resource capacity of the node
+	ni := NodeInfo{}
+	for _, r := range si.GetResources() {
+		if r == nil || r.GetType() != mesos.Value_SCALAR {
+			continue
+		}
+
+		switch r.GetName() {
+		case "cpus":
+			// We intentionally take the floor of executorCPU because cores are integers
+			// and we would loose a complete cpu here if the value is <1.
+			ni.Cores = int(r.GetScalar().GetValue() - float64(int(executorCPU)))
+		case "mem":
+			ni.Mem = int64(r.GetScalar().GetValue()-executorMem) * 1024 * 1024
+		}
+	}
+	return ni
 }

--- a/contrib/mesos/pkg/executor/executor.go
+++ b/contrib/mesos/pkg/executor/executor.go
@@ -979,6 +979,7 @@ func nodeInfo(si *mesos.SlaveInfo, ei *mesos.ExecutorInfo) NodeInfo {
 		case "cpus":
 			// We intentionally take the floor of executorCPU because cores are integers
 			// and we would loose a complete cpu here if the value is <1.
+			// TODO(sttts): switch to float64 when "Machine Allocables" are implemented
 			ni.Cores = int(r.GetScalar().GetValue() - float64(int(executorCPU)))
 		case "mem":
 			ni.Mem = int64(r.GetScalar().GetValue()-executorMem) * 1024 * 1024

--- a/contrib/mesos/pkg/executor/executor_test.go
+++ b/contrib/mesos/pkg/executor/executor_test.go
@@ -135,8 +135,9 @@ func TestExecutorLaunchAndKillTask(t *testing.T) {
 	mockDriver := &MockExecutorDriver{}
 	updates := make(chan kubetypes.PodUpdate, 1024)
 	config := Config{
-		Docker:  dockertools.ConnectToDockerOrDie("fake://"),
-		Updates: updates,
+		Docker:    dockertools.ConnectToDockerOrDie("fake://"),
+		Updates:   updates,
+		NodeInfos: make(chan NodeInfo, 1),
 		APIClient: client.NewOrDie(&client.Config{
 			Host:    testApiServer.server.URL,
 			Version: testapi.Default.Version(),
@@ -297,8 +298,9 @@ func TestExecutorStaticPods(t *testing.T) {
 
 	mockDriver := &MockExecutorDriver{}
 	config := Config{
-		Docker:  dockertools.ConnectToDockerOrDie("fake://"),
-		Updates: make(chan kubetypes.PodUpdate, 1), // allow kube-executor source to proceed past init
+		Docker:    dockertools.ConnectToDockerOrDie("fake://"),
+		Updates:   make(chan kubetypes.PodUpdate, 1), // allow kube-executor source to proceed past init
+		NodeInfos: make(chan NodeInfo, 1),
 		APIClient: client.NewOrDie(&client.Config{
 			Host:    testApiServer.server.URL,
 			Version: testapi.Default.Version(),
@@ -379,8 +381,9 @@ func TestExecutorFrameworkMessage(t *testing.T) {
 	mockDriver := &MockExecutorDriver{}
 	kubeletFinished := make(chan struct{})
 	config := Config{
-		Docker:  dockertools.ConnectToDockerOrDie("fake://"),
-		Updates: make(chan kubetypes.PodUpdate, 1024),
+		Docker:    dockertools.ConnectToDockerOrDie("fake://"),
+		Updates:   make(chan kubetypes.PodUpdate, 1024),
+		NodeInfos: make(chan NodeInfo, 1),
 		APIClient: client.NewOrDie(&client.Config{
 			Host:    testApiServer.server.URL,
 			Version: testapi.Default.Version(),
@@ -558,8 +561,9 @@ func TestExecutorShutdown(t *testing.T) {
 	var exitCalled int32 = 0
 	updates := make(chan kubetypes.PodUpdate, 1024)
 	config := Config{
-		Docker:  dockertools.ConnectToDockerOrDie("fake://"),
-		Updates: updates,
+		Docker:    dockertools.ConnectToDockerOrDie("fake://"),
+		Updates:   updates,
+		NodeInfos: make(chan NodeInfo, 1),
 		ShutdownAlert: func() {
 			close(kubeletFinished)
 		},

--- a/contrib/mesos/pkg/executor/service/cadvisor.go
+++ b/contrib/mesos/pkg/executor/service/cadvisor.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"k8s.io/kubernetes/pkg/kubelet/cadvisor"
+
+	cadvisorApi "github.com/google/cadvisor/info/v1"
+)
+
+type MesosCadvisor struct {
+	cadvisor.Interface
+	cores int
+	mem   int64
+}
+
+func NewMesosCadvisor(cores int, mem int64, port uint) (*MesosCadvisor, error) {
+	c, err := cadvisor.New(port)
+	if err != nil {
+		return nil, err
+	}
+	return &MesosCadvisor{c, cores, mem}, nil
+}
+
+func (mc *MesosCadvisor) MachineInfo() (*cadvisorApi.MachineInfo, error) {
+	mi, err := mc.Interface.MachineInfo()
+	if err != nil {
+		return nil, err
+	}
+
+	// set Mesos provided values
+	mesosMi := *mi
+	mesosMi.NumCores = mc.cores
+	mesosMi.MemoryCapacity = mc.mem
+
+	return &mesosMi, nil
+}


### PR DESCRIPTION
The node capacity is derived from the Mesos slave resources and passed to the kubelet via our modified cAdvisor.

This patch is based on https://github.com/kubernetes/kubernetes/pull/13036. Only the last few commits are relevant for this PR.

This is only a work-around until https://github.com/kubernetes/kubernetes/issues/13984 hits master.
