### PR TITLE
Extended defaults for jobs.

### DIFF
--- a/pkg/apis/experimental/v1/defaults.go
+++ b/pkg/apis/experimental/v1/defaults.go
@@ -76,6 +76,19 @@ func addDefaultingFuncs() {
 			}
 		},
 		func(obj *Job) {
+			var labels map[string]string
+			if obj.Spec.Template != nil {
+				labels = obj.Spec.Template.Labels
+			}
+			// TODO: support templates defined elsewhere when we support them in the API
+			if labels != nil {
+				if len(obj.Spec.Selector) == 0 {
+					obj.Spec.Selector = labels
+				}
+				if len(obj.Labels) == 0 {
+					obj.Labels = labels
+				}
+			}
 			if obj.Spec.Completions == nil {
 				completions := 1
 				obj.Spec.Completions = &completions

--- a/pkg/apis/experimental/v1/defaults_test.go
+++ b/pkg/apis/experimental/v1/defaults_test.go
@@ -192,20 +192,48 @@ func TestSetDefaultDeployment(t *testing.T) {
 func TestSetDefaultJob(t *testing.T) {
 	expected := &Job{
 		Spec: JobSpec{
+			Selector:    map[string]string{"job": "selector"},
 			Completions: newInt(1),
 			Parallelism: newInt(2),
 		},
 	}
 	tests := []*Job{
-		{},
+		// selector set explicitly, completions and parallelism - default
+		{
+			Spec: JobSpec{
+				Selector: map[string]string{"job": "selector"},
+			},
+		},
+		// selector from template labels, completions and parallelism - default
+		{
+			Spec: JobSpec{
+				Template: &v1.PodTemplateSpec{
+					ObjectMeta: v1.ObjectMeta{
+						Labels: map[string]string{"job": "selector"},
+					},
+				},
+			},
+		},
+		// selector from template labels, completions set explicitly, parallelism - default
 		{
 			Spec: JobSpec{
 				Completions: newInt(1),
+				Template: &v1.PodTemplateSpec{
+					ObjectMeta: v1.ObjectMeta{
+						Labels: map[string]string{"job": "selector"},
+					},
+				},
 			},
 		},
+		// selector from template labels, completions - default, parallelism set explicitly
 		{
 			Spec: JobSpec{
 				Parallelism: newInt(2),
+				Template: &v1.PodTemplateSpec{
+					ObjectMeta: v1.ObjectMeta{
+						Labels: map[string]string{"job": "selector"},
+					},
+				},
 			},
 		},
 	}
@@ -222,6 +250,9 @@ func TestSetDefaultJob(t *testing.T) {
 		}
 		if *got.Spec.Parallelism != *expected.Spec.Parallelism {
 			t.Errorf("got different parallelism than expected: %d %d", *got.Spec.Parallelism, *expected.Spec.Parallelism)
+		}
+		if !reflect.DeepEqual(got.Spec.Selector, expected.Spec.Selector) {
+			t.Errorf("got different selectors %#v %#v", got.Spec.Selector, expected.Spec.Selector)
 		}
 	}
 }

--- a/pkg/apis/experimental/v1/types.go
+++ b/pkg/apis/experimental/v1/types.go
@@ -407,7 +407,7 @@ type JobSpec struct {
 	Completions *int `json:"completions,omitempty"`
 
 	// Selector is a label query over pods that should match the pod count.
-	Selector map[string]string `json:"selector"`
+	Selector map[string]string `json:"selector,omitempty"`
 
 	// Template is the object that describes the pod that will be created when
 	// executing a job.


### PR DESCRIPTION
Currently jobs will only default completions and parallelism. This adds
copying labels map for pod's template as selectors, similarly how it's done
in replication controller.

@erictune ptal
