### PR TITLE
MESOS: Fix escaping in mesos-slave command line

### DIFF
--- a/cluster/mesos/docker/docker-compose.yml
+++ b/cluster/mesos/docker/docker-compose.yml
@@ -34,12 +34,12 @@ mesosslave:
   - bash
   - -xc
   - >
-    NAME=$(cut -f2 -d/ <<<$MESOSMASTER1_NAME) &&
+    NAME=$(cut -f2 -d/ <<<${MESOSMASTER1_NAME}) &&
     N=${NAME##*_} &&
-    DOCKER_NETWORK_OFFSET=0.0.$N.0
+    DOCKER_NETWORK_OFFSET=0.0.${N}.0
     exec wrapdocker mesos-slave
-    --work_dir="/var/tmp/mesos/$N"
-    --attributes=rack:$N\\;gen:201$N
+    --work_dir="/var/tmp/mesos/${N}"
+    --attributes="rack:${N};gen:201${N}"
     --hostname=$(getent hosts mesosslave | cut -d' ' -f1 | sort -u | tail -1)
   command: ~
   environment:


### PR DESCRIPTION
The `\\;` made the command line of the mesos-slave end, leaving out the `--hostname` argument. The result was that in the mesos-ui you could not click on sandbox links anymore.
