### PR TITLE
IPC followup

### DIFF
--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -1259,6 +1259,20 @@ func TestValidatePodSpec(t *testing.T) {
 			RestartPolicy: api.RestartPolicyAlways,
 			DNSPolicy:     api.DNSClusterFirst,
 		},
+		{ // Populate HostIPC.
+			HostIPC:       true,
+			Volumes:       []api.Volume{{Name: "vol", VolumeSource: api.VolumeSource{EmptyDir: &api.EmptyDirVolumeSource{}}}},
+			Containers:    []api.Container{{Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent"}},
+			RestartPolicy: api.RestartPolicyAlways,
+			DNSPolicy:     api.DNSClusterFirst,
+		},
+		{ // Populate HostPID.
+			HostPID:       true,
+			Volumes:       []api.Volume{{Name: "vol", VolumeSource: api.VolumeSource{EmptyDir: &api.EmptyDirVolumeSource{}}}},
+			Containers:    []api.Container{{Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent"}},
+			RestartPolicy: api.RestartPolicyAlways,
+			DNSPolicy:     api.DNSClusterFirst,
+		},
 	}
 	for i := range successCases {
 		if errs := ValidatePodSpec(&successCases[i]); len(errs) != 0 {
@@ -1306,7 +1320,6 @@ func TestValidatePodSpec(t *testing.T) {
 				},
 			},
 			HostNetwork:   true,
-			HostIPC:       true,
 			RestartPolicy: api.RestartPolicyAlways,
 			DNSPolicy:     api.DNSClusterFirst,
 		},

--- a/pkg/kubelet/dockertools/manager_test.go
+++ b/pkg/kubelet/dockertools/manager_test.go
@@ -2071,7 +2071,7 @@ func TestGetPidMode(t *testing.T) {
 func TestGetIPCMode(t *testing.T) {
 	// test false
 	pod := &api.Pod{}
-	ipcMode := getIPCMode(pod, "")
+	ipcMode := getIPCMode(pod)
 
 	if ipcMode != "" {
 		t.Errorf("expected empty ipc mode for pod but got %v", ipcMode)
@@ -2079,7 +2079,7 @@ func TestGetIPCMode(t *testing.T) {
 
 	// test true
 	pod.Spec.HostIPC = true
-	ipcMode = getIPCMode(pod, "")
+	ipcMode = getIPCMode(pod)
 	if ipcMode != "host" {
 		t.Errorf("expected host ipc mode for pod but got %v", ipcMode)
 	}


### PR DESCRIPTION
Follow ups for https://github.com/kubernetes/kubernetes/pull/12470#discussion_r39893894 and https://github.com/kubernetes/kubernetes/pull/12470#discussion_r39902214.  Last commit only (https://github.com/kubernetes/kubernetes/pull/12470 is waiting to merge).
1.  Always point to the infra container for ipc mode.
2.  Individual tests (and removal of HostIPC on a test it wasn't valid for)

@liggitt @vishh @pmorie @simon3z

```
pod with HostIPC = false
[pweil@localhost ipctests]$ docker inspect 268 | grep Ipc
        "IpcMode": "container:7ce684cce5258f926ff65e40829d34020289d385798ace9d6c4329b3c4f97615",
[pweil@localhost ipctests]$ docker inspect 7ce68 | grep Ipc
        "IpcMode": "",

pod with HostIPC = true
[pweil@localhost ipctests]$ docker inspect fea | grep Ipc
        "IpcMode": "container:c4973a2498a368c87631add6c9ccda79dcfc80663b7cd89d1976a58afed9d11f",
[pweil@localhost ipctests]$ docker inspect c49 | grep Ipc
        "IpcMode": "host",
```
