### PR TITLE
Bump Container Inspect to loglevel 4

### DIFF
--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -311,7 +311,7 @@ func (dm *DockerManager) inspectContainer(dockerID, containerName, tPath string,
 		return &result
 	}
 
-	glog.V(3).Infof("Container inspect result: %+v", *inspectResult)
+	glog.V(4).Infof("Container inspect result: %+v", *inspectResult)
 	result.status = api.ContainerStatus{
 		Name:        containerName,
 		Image:       inspectResult.Config.Image,


### PR DESCRIPTION
This dumps a substantial amount of information that seems to be useful only for debugging purposes.
