### PR TITLE
add patch verb to APIRequestInfo

### DIFF
--- a/pkg/apiserver/handlers.go
+++ b/pkg/apiserver/handlers.go
@@ -495,6 +495,8 @@ func (r *APIRequestInfoResolver) GetAPIRequestInfo(req *http.Request) (APIReques
 			requestInfo.Verb = "get"
 		case "PUT":
 			requestInfo.Verb = "update"
+		case "PATCH":
+			requestInfo.Verb = "patch"
 		case "DELETE":
 			requestInfo.Verb = "delete"
 		}

--- a/pkg/apiserver/handlers_test.go
+++ b/pkg/apiserver/handlers_test.go
@@ -243,6 +243,10 @@ func TestGetAPIRequestInfo(t *testing.T) {
 		// subresource identification
 		{"GET", "/namespaces/other/pods/foo/status", "get", "", "other", "pods", "status", "Pod", "foo", []string{"pods", "foo", "status"}},
 		{"PUT", "/namespaces/other/finalize", "update", "", "other", "finalize", "", "", "", []string{"finalize"}},
+
+		// verb identification
+		{"PATCH", "/namespaces/other/pods/foo", "patch", "", "other", "pods", "", "Pod", "foo", []string{"pods", "foo"}},
+		{"DELETE", "/namespaces/other/pods/foo", "delete", "", "other", "pods", "", "Pod", "foo", []string{"pods", "foo"}},
 	}
 
 	apiRequestInfoResolver := &APIRequestInfoResolver{sets.NewString("api"), testapi.Default.RESTMapper()}


### PR DESCRIPTION
The `APIRequestInfo` doesn't properly handle the `PATCH` verb.  The kube authorizer didn't hit this because it only worried about read versus mutate operation, but this is needed for verb based authorizers.

"patch" is different than "update" because the level of power could be controlled differently.  A given authorizer could choose to collapse these if they wished, but we should return discrete verbs.

@kubernetes/kube-iam 
