### PR TITLE
[WIP] Introduce the 'new' Command

### DIFF
--- a/.generated_docs
+++ b/.generated_docs
@@ -25,6 +25,7 @@ docs/man/man1/kubectl-get.1
 docs/man/man1/kubectl-label.1
 docs/man/man1/kubectl-logs.1
 docs/man/man1/kubectl-namespace.1
+docs/man/man1/kubectl-new.1
 docs/man/man1/kubectl-patch.1
 docs/man/man1/kubectl-port-forward.1
 docs/man/man1/kubectl-proxy.1
@@ -61,6 +62,7 @@ docs/user-guide/kubectl/kubectl_get.md
 docs/user-guide/kubectl/kubectl_label.md
 docs/user-guide/kubectl/kubectl_logs.md
 docs/user-guide/kubectl/kubectl_namespace.md
+docs/user-guide/kubectl/kubectl_new.md
 docs/user-guide/kubectl/kubectl_patch.md
 docs/user-guide/kubectl/kubectl_port-forward.md
 docs/user-guide/kubectl/kubectl_proxy.md

--- a/contrib/completions/bash/kubectl
+++ b/contrib/completions/bash/kubectl
@@ -531,6 +531,29 @@ _kubectl_apply()
     must_have_one_noun=()
 }
 
+_kubectl_new()
+{
+    last_command="kubectl_new"
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--dry-run")
+    flags+=("--labels=")
+    flags+=("--name=")
+    flags+=("--output=")
+    two_word_flags+=("-o")
+    flags+=("--output-version=")
+    flags+=("--schema-cache-dir=")
+    flags+=("--validate")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+}
+
 _kubectl_namespace()
 {
     last_command="kubectl_namespace"
@@ -1199,6 +1222,7 @@ _kubectl()
     commands+=("delete")
     commands+=("edit")
     commands+=("apply")
+    commands+=("new")
     commands+=("namespace")
     commands+=("logs")
     commands+=("rolling-update")

--- a/docs/man/man1/kubectl-new.1
+++ b/docs/man/man1/kubectl-new.1
@@ -3,24 +3,71 @@
 
 .SH NAME
 .PP
-kubectl \- kubectl controls the Kubernetes cluster manager
+kubectl new \- Create a new object of the given type by filling in a template
 
 
 .SH SYNOPSIS
 .PP
-\fBkubectl\fP [OPTIONS]
+\fBkubectl new\fP [OPTIONS]
 
 
 .SH DESCRIPTION
 .PP
-kubectl controls the Kubernetes cluster manager.
+Create a new object of the given type using a template.
 
 .PP
-Find more information at 
-\[la]https://github.com/kubernetes/kubernetes\[ra].
+The new command pulls down an example for the given object type, allows
+you to edit the filled in example, and then submits it for creation.  The
+editing functionality functions similarly to the 'edit' command \-\- you
+can control the editor used, as well as the format and version, using
+the same flags and environment variables.
+
+.PP
+By default, before submission your new object will be validated.  If an
+invalid object is encountered, you will be returned to the editor with the
+invalid part indicated with comments.  Use the '\-\-validate=false' in order
+to skip local validation.
+
+.PP
+You can specify namespace, name, and labels (in 'key1=value1,key2=value2' form)
+from the command line using the '\-\-namespace', '\-\-name', and '\-\-labels' flags.
+
+.PP
+You can use the '\-\-dry\-run' flag to just output the example to standard out
+without launching an editor or submitting the object for creation.
 
 
 .SH OPTIONS
+.PP
+\fB\-\-dry\-run\fP=false
+    If true, only print the example object, without editing or creating it.
+
+.PP
+\fB\-\-labels\fP=""
+    A comma\-separated list of labels in key=value form to apply to the created object
+
+.PP
+\fB\-\-name\fP=""
+    The name of the new object
+
+.PP
+\fB\-o\fP, \fB\-\-output\fP="yaml"
+    Output format. One of: 'yaml' or 'json'.
+
+.PP
+\fB\-\-output\-version\fP=""
+    Output the formatted object with the given version (default api\-version).
+
+.PP
+\fB\-\-schema\-cache\-dir\fP="\~/.kube/schema"
+    If non\-empty, load/store cached API schemas in this directory, default is '$HOME/.kube/schema'
+
+.PP
+\fB\-\-validate\fP=true
+    If true, use a schema to validate the input before sending it
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
 .PP
 \fB\-\-alsologtostderr\fP=false
     log to standard error as well as files
@@ -114,9 +161,27 @@ Find more information at
     comma\-separated list of pattern=N settings for file\-filtered logging
 
 
+.SH EXAMPLE
+.PP
+.RS
+
+.nf
+# Create a new pod named 'website':
+  $ kubectl new pod \-\-name website \-\-labels end=front,app=site
+
+  # Don't validate the object before creation
+  $ kubectl new namespace \-\-validate=false \-\-name my\-ns
+
+  # Don't edit or create a new object \-\- just output the example
+  $ kubectl new namespace \-\-name my\-ns \-\-dry\-run
+
+.fi
+.RE
+
+
 .SH SEE ALSO
 .PP
-\fBkubectl\-get(1)\fP, \fBkubectl\-describe(1)\fP, \fBkubectl\-create(1)\fP, \fBkubectl\-replace(1)\fP, \fBkubectl\-patch(1)\fP, \fBkubectl\-delete(1)\fP, \fBkubectl\-edit(1)\fP, \fBkubectl\-apply(1)\fP, \fBkubectl\-new(1)\fP, \fBkubectl\-namespace(1)\fP, \fBkubectl\-logs(1)\fP, \fBkubectl\-rolling\-update(1)\fP, \fBkubectl\-scale(1)\fP, \fBkubectl\-attach(1)\fP, \fBkubectl\-exec(1)\fP, \fBkubectl\-port\-forward(1)\fP, \fBkubectl\-proxy(1)\fP, \fBkubectl\-run(1)\fP, \fBkubectl\-stop(1)\fP, \fBkubectl\-expose(1)\fP, \fBkubectl\-label(1)\fP, \fBkubectl\-annotate(1)\fP, \fBkubectl\-config(1)\fP, \fBkubectl\-cluster\-info(1)\fP, \fBkubectl\-api\-versions(1)\fP, \fBkubectl\-version(1)\fP, \fBkubectl\-explain(1)\fP, \fBkubectl\-convert(1)\fP,
+\fBkubectl(1)\fP,
 
 
 .SH HISTORY

--- a/docs/user-guide/kubectl/kubectl.md
+++ b/docs/user-guide/kubectl/kubectl.md
@@ -94,6 +94,7 @@ kubectl
 * [kubectl label](kubectl_label.md)	 - Update the labels on a resource
 * [kubectl logs](kubectl_logs.md)	 - Print the logs for a container in a pod.
 * [kubectl namespace](kubectl_namespace.md)	 - SUPERSEDED: Set and view the current Kubernetes namespace
+* [kubectl new](kubectl_new.md)	 - Create a new object of the given type by filling in a template
 * [kubectl patch](kubectl_patch.md)	 - Update field(s) of a resource by stdin.
 * [kubectl port-forward](kubectl_port-forward.md)	 - Forward one or more local ports to a pod.
 * [kubectl proxy](kubectl_proxy.md)	 - Run a proxy to the Kubernetes API server

--- a/docs/user-guide/kubectl/kubectl_new.md
+++ b/docs/user-guide/kubectl/kubectl_new.md
@@ -1,0 +1,126 @@
+<!-- BEGIN MUNGE: UNVERSIONED_WARNING -->
+
+<!-- BEGIN STRIP_FOR_RELEASE -->
+
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+<img src="http://kubernetes.io/img/warning.png" alt="WARNING"
+     width="25" height="25">
+
+<h2>PLEASE NOTE: This document applies to the HEAD of the source tree</h2>
+
+If you are using a released version of Kubernetes, you should
+refer to the docs that go with that version.
+
+<strong>
+The latest 1.0.x release of this document can be found
+[here](http://releases.k8s.io/release-1.0/docs/user-guide/kubectl/kubectl_new.md).
+
+Documentation for other releases can be found at
+[releases.k8s.io](http://releases.k8s.io).
+</strong>
+--
+
+<!-- END STRIP_FOR_RELEASE -->
+
+<!-- END MUNGE: UNVERSIONED_WARNING -->
+
+## kubectl new
+
+Create a new object of the given type by filling in a template
+
+### Synopsis
+
+
+Create a new object of the given type using a template.
+
+The new command pulls down an example for the given object type, allows
+you to edit the filled in example, and then submits it for creation.  The
+editing functionality functions similarly to the 'edit' command -- you
+can control the editor used, as well as the format and version, using
+the same flags and environment variables.
+
+By default, before submission your new object will be validated.  If an
+invalid object is encountered, you will be returned to the editor with the
+invalid part indicated with comments.  Use the '--validate=false' in order
+to skip local validation.
+
+You can specify namespace, name, and labels (in 'key1=value1,key2=value2' form)
+from the command line using the '--namespace', '--name', and '--labels' flags.
+
+You can use the '--dry-run' flag to just output the example to standard out
+without launching an editor or submitting the object for creation.
+
+
+```
+kubectl new TYPE [--name NAME] [--labels key1=val,key2=val]
+```
+
+### Examples
+
+```
+# Create a new pod named 'website':
+  $ kubectl new pod --name website --labels end=front,app=site
+
+  # Don't validate the object before creation
+  $ kubectl new namespace --validate=false --name my-ns
+
+  # Don't edit or create a new object -- just output the example
+  $ kubectl new namespace --name my-ns --dry-run
+```
+
+### Options
+
+```
+      --dry-run[=false]: If true, only print the example object, without editing or creating it.
+      --labels="": A comma-separated list of labels in key=value form to apply to the created object
+      --name="": The name of the new object
+  -o, --output="yaml": Output format. One of: 'yaml' or 'json'.
+      --output-version="": Output the formatted object with the given version (default api-version).
+      --schema-cache-dir="~/.kube/schema": If non-empty, load/store cached API schemas in this directory, default is '$HOME/.kube/schema'
+      --validate[=true]: If true, use a schema to validate the input before sending it
+```
+
+### Options inherited from parent commands
+
+```
+      --alsologtostderr[=false]: log to standard error as well as files
+      --api-version="": The API version to use when talking to the server
+      --certificate-authority="": Path to a cert. file for the certificate authority.
+      --client-certificate="": Path to a client key file for TLS.
+      --client-key="": Path to a client key file for TLS.
+      --cluster="": The name of the kubeconfig cluster to use
+      --context="": The name of the kubeconfig context to use
+      --insecure-skip-tls-verify[=false]: If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure.
+      --kubeconfig="": Path to the kubeconfig file to use for CLI requests.
+      --log-backtrace-at=:0: when logging hits line file:N, emit a stack trace
+      --log-dir="": If non-empty, write log files in this directory
+      --log-flush-frequency=5s: Maximum number of seconds between log flushes
+      --logtostderr[=true]: log to standard error instead of files
+      --match-server-version[=false]: Require server version to match client version
+      --namespace="": If present, the namespace scope for this CLI request.
+      --password="": Password for basic authentication to the API server.
+  -s, --server="": The address and port of the Kubernetes API server
+      --stderrthreshold=2: logs at or above this threshold go to stderr
+      --token="": Bearer token for authentication to the API server.
+      --user="": The name of the kubeconfig user to use
+      --username="": Username for basic authentication to the API server.
+      --v=0: log level for V logs
+      --vmodule=: comma-separated list of pattern=N settings for file-filtered logging
+```
+
+### SEE ALSO
+
+* [kubectl](kubectl.md)	 - kubectl controls the Kubernetes cluster manager
+
+###### Auto generated by spf13/cobra at 2015-10-01 17:45:42.444817341 +0000 UTC
+
+<!-- BEGIN MUNGE: GENERATED_ANALYTICS -->
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/user-guide/kubectl/kubectl_new.md?pixel)]()
+<!-- END MUNGE: GENERATED_ANALYTICS -->

--- a/pkg/api/examples/doc.go
+++ b/pkg/api/examples/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package examples provides interfaces and implementations for obtaining
+// examples for different types and versions of API objects
+package examples

--- a/pkg/api/examples/interfaces.go
+++ b/pkg/api/examples/interfaces.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package examples
+
+import "k8s.io/kubernetes/pkg/runtime"
+
+// ExampleBuilder fetches examples and templates for Kubernetes
+// API object kinds.
+type ExampleBuilder interface {
+	// NewExample fetches a new copy of an example object of
+	// the given version and kind, prepopulated with common values.
+	// If no example is found, it should return false for the boolean,
+	// but still return an emtpy object of the correct version and kind.
+	NewExample(version, kind string) (runtime.Object, bool, error)
+}

--- a/pkg/api/examples/static.go
+++ b/pkg/api/examples/static.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package examples
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+type staticExampleBuilder struct {
+	creater   runtime.ObjectCreater
+	convertor runtime.ObjectConvertor
+	examples  map[string]runtime.Object
+}
+
+var _ ExampleBuilder = &staticExampleBuilder{}
+
+func (f *staticExampleBuilder) NewExample(version, kind string) (runtime.Object, bool, error) {
+	if example, ok := f.examples[kind]; ok {
+		versionedExample, err := f.convertor.ConvertToVersion(example, version)
+		if err != nil {
+			return nil, true, err
+		}
+
+		return versionedExample, true, nil
+	}
+
+	example, err := f.creater.New(version, kind)
+	return example, false, err
+}
+
+func NewStaticExampleBuilder(creater runtime.ObjectCreater, convertor runtime.ObjectConvertor) ExampleBuilder {
+	return &staticExampleBuilder{
+		creater:   creater,
+		convertor: convertor,
+		examples: map[string]runtime.Object{
+			"Pod": &api.Pod{
+				Spec: api.PodSpec{
+					Containers: []api.Container{
+						{
+							Name:  "webserver",
+							Image: "nginx",
+							Ports: []api.ContainerPort{
+								{Name: "http", ContainerPort: 80, Protocol: "TCP"},
+							},
+							VolumeMounts: []api.VolumeMount{
+								{Name: "html", ReadOnly: true, MountPath: "/usr/share/nginx/html"},
+							},
+						},
+					},
+					Volumes: []api.Volume{
+						{Name: "html", VolumeSource: api.VolumeSource{EmptyDir: &api.EmptyDirVolumeSource{}}},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -151,6 +151,7 @@ Find more information at https://github.com/kubernetes/kubernetes.`,
 	cmds.AddCommand(NewCmdDelete(f, out))
 	cmds.AddCommand(NewCmdEdit(f, out))
 	cmds.AddCommand(NewCmdApply(f, out))
+	cmds.AddCommand(NewCmdNew(f, out))
 
 	cmds.AddCommand(NewCmdNamespace(out))
 	cmds.AddCommand(NewCmdLog(f, out))

--- a/pkg/kubectl/cmd/new.go
+++ b/pkg/kubectl/cmd/new.go
@@ -22,7 +22,6 @@ import (
 	"github.com/spf13/cobra"
 	"io"
 
-	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/kubectl"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
@@ -91,7 +90,8 @@ func initExample(cmdNamespace string, resource string, f *cmdutil.Factory, cmd *
 		return nil, err
 	}
 
-	obj, err := api.Scheme.New(version, kind)
+	exBuilder := f.ExampleBuilder()
+	obj, _, err := exBuilder.NewExample(version, kind)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubectl/cmd/new.go
+++ b/pkg/kubectl/cmd/new.go
@@ -1,0 +1,224 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/spf13/cobra"
+	"io"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/kubectl"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/kubectl/resource"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+const (
+	new_long = `Create a new object of the given type using a template.
+
+The new command pulls down an example for the given object type, allows
+you to edit the filled in example, and then submits it for creation.  The
+editing functionality functions similarly to the 'edit' command -- you
+can control the editor used, as well as the format and version, using
+the same flags and environment variables.
+
+By default, before submission your new object will be validated.  If an
+invalid object is encountered, you will be returned to the editor with the
+invalid part indicated with comments.  Use the '--validate=false' in order
+to skip local validation.
+
+You can specify namespace, name, and labels (in 'key1=value1,key2=value2' form)
+from the command line using the '--namespace', '--name', and '--labels' flags.
+
+You can use the '--dry-run' flag to just output the example to standard out
+without launching an editor or submitting the object for creation.
+`
+
+	new_example = `# Create a new pod named 'website':
+  $ kubectl new pod --name website --labels end=front,app=site
+
+  # Don't validate the object before creation
+  $ kubectl new namespace --validate=false --name my-ns
+
+  # Don't edit or create a new object -- just output the example
+  $ kubectl new namespace --name my-ns --dry-run`
+)
+
+func NewCmdNew(f *cmdutil.Factory, out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "new TYPE [--name NAME] [--labels key1=val,key2=val]",
+		Short:   "Create a new object of the given type by filling in a template",
+		Long:    new_long,
+		Example: new_example,
+		Run: func(cmd *cobra.Command, args []string) {
+			err := RunNew(f, out, cmd, args)
+			cmdutil.CheckErr(err)
+		},
+	}
+
+	cmd.Flags().StringP("output", "o", "yaml", "Output format. One of: 'yaml' or 'json'.")
+	cmd.Flags().String("output-version", "", "Output the formatted object with the given version (default api-version).")
+	cmd.PersistentFlags().String("name", "", "The name of the new object")
+	cmd.PersistentFlags().String("labels", "", "A comma-separated list of labels in key=value form to apply to the created object")
+	cmd.Flags().Bool("dry-run", false, "If true, only print the example object, without editing or creating it.")
+
+	cmdutil.AddValidateFlags(cmd)
+
+	return cmd
+}
+
+func initExample(cmdNamespace string, resource string, f *cmdutil.Factory, cmd *cobra.Command) (runtime.Object, error) {
+	mapper, _ := f.Object()
+	version, kind, err := mapper.VersionAndKindForResource(resource)
+	if err != nil {
+		return nil, err
+	}
+
+	obj, err := api.Scheme.New(version, kind)
+	if err != nil {
+		return nil, err
+	}
+
+	mapping, err := mapper.RESTMapping(kind, version)
+	if err != nil {
+		return nil, err
+	}
+
+	err = mapping.SetAPIVersion(obj, version)
+	if err != nil {
+		return nil, err
+	}
+	err = mapping.SetKind(obj, kind)
+	if err != nil {
+		return nil, err
+	}
+	err = mapping.SetNamespace(obj, cmdNamespace)
+	if err != nil {
+		return nil, err
+	}
+
+	nameFlag := cmdutil.GetFlagString(cmd, "name")
+	if nameFlag != "" {
+		err = mapping.SetName(obj, nameFlag)
+	} else {
+		err = mapping.SetName(obj, " ")
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	labelsFlag := cmdutil.GetFlagString(cmd, "labels")
+	if labelsFlag != "" {
+		parsedLabels, err := kubectl.ParseLabels(labelsFlag)
+		if err != nil {
+			return nil, err
+		}
+
+		err = mapping.SetLabels(obj, parsedLabels)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return obj, nil
+}
+
+func RunNew(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		fmt.Fprint(out, "You must specify the type of resource to create. ", valid_resources)
+		return cmdutil.UsageError(cmd, "Required resource not specified.")
+	}
+	targetResource := args[0]
+	cmdNamespace, _, err := f.DefaultNamespace()
+	if err != nil {
+		return err
+	}
+	obj, err := initExample(cmdNamespace, targetResource, f, cmd)
+	if err != nil {
+		return err
+	}
+
+	schema, err := f.Validator(cmdutil.GetFlagBool(cmd, "validate"), cmdutil.GetFlagString(cmd, "schema-cache-dir"))
+	if err != nil {
+		return err
+	}
+
+	// if we are using dry run, just output directly
+	if cmdutil.GetFlagBool(cmd, "dry-run") {
+		printer, _, err := getEditPrinter(cmd)
+		if err != nil {
+			return err
+		}
+		return printer.PrintObj(obj, out)
+	}
+
+	addSource := func(b *resource.Builder, enforceNamespace bool, printer kubectl.ResourcePrinter) *resource.Builder {
+		initialOutput := &bytes.Buffer{}
+		printer.PrintObj(obj, initialOutput)
+		b = b.Stream(initialOutput, "[new]")
+
+		if enforceNamespace {
+			b = b.RequireNamespace()
+		}
+
+		return b
+	}
+
+	process := func(visitor resource.Visitor, original, edited []byte, obj runtime.Object, updates *resource.Info, file string, results *editResults, mapper meta.RESTMapper, defaultVersion string) error {
+
+		// validate if we asked for it
+		if err := resource.ValidateSchema(edited, schema); err != nil {
+			// add in our own validation error
+			results.edit = append(results.edit, updates)
+			reason := editReason{
+				head:  fmt.Sprintf("failed to validate the %s %s", updates.Mapping.Kind, updates.Name),
+				other: []string{err.Error()},
+			}
+			results.header.reasons = append(results.header.reasons, reason)
+			fmt.Fprintln(out, "Error: failed to validate the %s %s: %v", updates.Mapping.Kind, updates.Name, err)
+			return nil
+		}
+
+		return visitor.Visit(func(info *resource.Info, err error) error {
+			if err != nil {
+				return err
+			}
+
+			data, err := info.Mapping.Codec.Encode(info.Object)
+			if err != nil {
+				fmt.Fprintln(out, results.addError(err, info))
+				return nil
+				//return cmdutil.AddSourceToErr("creating", info.Source, err)
+			}
+			obj, err := resource.NewHelper(info.Client, info.Mapping).Create(info.Namespace, true, data)
+			if err != nil {
+				//return cmdutil.AddSourceToErr("creating", info.Source, err)
+				fmt.Fprintln(out, results.addError(err, info))
+				return nil
+			}
+			info.Refresh(obj, true)
+			printObjectSpecificMessage(info.Object, out)
+			cmdutil.PrintSuccess(mapper, false, out, info.Mapping.Resource, info.Name, "created")
+			return nil
+		})
+	}
+
+	return doEdit(f, out, cmd, "kubectl-new-", false, addSource, process)
+}

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -32,6 +32,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/examples"
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/registered"
 	"k8s.io/kubernetes/pkg/api/validation"
@@ -90,6 +91,8 @@ type Factory struct {
 	Generator func(name string) (kubectl.Generator, bool)
 	// Check whether the kind of resources could be exposed
 	CanBeExposed func(kind string) error
+	// Returns an interface for obtaining examples for different object types
+	ExampleBuilder func() examples.ExampleBuilder
 }
 
 // NewFactory creates a factory with the default Kubernetes resources defined
@@ -255,6 +258,9 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 				return fmt.Errorf("invalid resource provided: %v, only a replication controller, service or pod is accepted", kind)
 			}
 			return nil
+		},
+		ExampleBuilder: func() examples.ExampleBuilder {
+			return examples.NewStaticExampleBuilder(api.Scheme, api.Scheme)
 		},
 	}
 }


### PR DESCRIPTION
This PR introduces the `new` command, which allows users to create new objects by dumping an 'example' object into an editor, and then letting the user edit the object before creation.  The actually edit functionality was pulled from the new `edit` command.

The original intent was to store examples in Swagger, but unfortunately, go-restful doesn't support the latest version of the Swagger spec, and thus does not support the `example` field on models.  Therefore, this PR presents implementations of two different ways of adding examples in the mean time -- one in which API objects are annotated with the `example` tag (and then reflection is used to generate the example), and another in which examples are "registered" with the API `Scheme`, similarly to how default functions and conversion functions work.

Part of #10495 
