### PR TITLE
e2e: set default timeout on Client

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -834,6 +834,9 @@ func loadClient() (*client.Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error creating client: %v", err.Error())
 	}
+	if c.Timeout == 0 {
+		c.Timeout = singleCallTimeout
+	}
 	return c, nil
 }
 


### PR DESCRIPTION
This should fix one of the root causes of #13485.

The _Networking should function for intra-pod communication_ test makes several Client API calls without explicitly setting a timeout (https://github.com/kubernetes/kubernetes/blob/master/test/e2e/networking.go#L189-L195, https://github.com/kubernetes/kubernetes/blob/master/test/e2e/networking.go#L199-L205).

There is no default timeout set on the Client, and this has occasionally blocked without returning, particularly in parallel runs. Hopefully by setting a timeout, this can return with an `err`, letting us better investigate what's broken (if anything).

I'm setting the default here rather than in this test itself, since there appear to be other tests which similarly make Client API calls without setting a timeout, and it'd be better just to have a reasonable default in all cases.

@kubernetes/goog-testing 
