### PR TITLE
Fix documentation in clientcmd/doc.go.

### DIFF
--- a/pkg/client/unversioned/clientcmd/doc.go
+++ b/pkg/client/unversioned/clientcmd/doc.go
@@ -19,13 +19,19 @@ Package clientcmd provides one stop shopping for building a working client from 
 from a .kubeconfig file, from command line flags, or from any merged combination.
 
 Sample usage from merged .kubeconfig files (local directory, home directory)
-	loadingRules := clientcmd.NewKubeConfigLoadingRules()
+
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	// if you want to change the loading rules (which files in which order), you can do so here
 
 	configOverrides := &clientcmd.ConfigOverrides{}
 	// if you want to change override values or bind them to flags, there are methods to help you
 
-	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingKubeConfig(loadingRules, configOverrides)
-	kubeConfig.Client()
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
+	config, err := kubeConfig.ClientConfig()
+	if err != nil {
+		// Do something
+	}
+	client, err := unversioned.New(config)
+	// ...
 */
 package clientcmd

--- a/pkg/client/unversioned/doc.go
+++ b/pkg/client/unversioned/doc.go
@@ -15,14 +15,14 @@ limitations under the License.
 */
 
 /*
-Package client contains the implementation of the client side communication with the
+Package unversioned contains the implementation of the client side communication with the
 Kubernetes master. The Client class provides methods for reading, creating, updating,
 and deleting pods, replication controllers, daemons, services, and nodes.
 
 Most consumers should use the Config object to create a Client:
 
     import (
-      "k8s.io/kubernetes/pkg/client"
+      client "k8s.io/kubernetes/pkg/client/unversioned"
       "k8s.io/kubernetes/pkg/api"
       "k8s.io/kubernetes/pkg/fields"
       "k8s.io/kubernetes/pkg/labels"


### PR DESCRIPTION
The package documentation in `clientcmd` seems to reflect an older API. This updates the documentation to use the current API.
