### PR TITLE
Filter test output when running unit tests in verbose mode

### DIFF
--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -111,10 +111,15 @@ shift $((OPTIND - 1))
 eval "goflags=(${KUBE_GOFLAGS:-})"
 eval "testargs=(${KUBE_TEST_ARGS:-})"
 
+# Used to filter verbose test output.
+go_test_grep_pattern=".*"
+
 # The go-junit-report tool needs full test case information to produce a
 # meaningful report.
 if [[ -n "${KUBE_JUNIT_REPORT_DIR}" ]] ; then
   goflags+=(-v)
+  # Show only summary lines by matching lines like "status package/test"
+  go_test_grep_pattern="^[^[:space:]]\+[[:space:]]\+[^[:space:]]\+/[^[[:space:]]\+"
 fi
 
 # Filter out arguments that start with "-" and move them to goflags.
@@ -206,7 +211,8 @@ runTests() {
     go test "${goflags[@]:+${goflags[@]}}" \
       ${KUBE_RACE} ${KUBE_TIMEOUT} "${@+${@/#/${KUBE_GO_PACKAGE}/}}" \
      "${testargs[@]:+${testargs[@]}}" \
-     | tee ${junit_filename_prefix:+"${junit_filename_prefix}.stdout"} && rc=$? || rc=$?
+     | tee ${junit_filename_prefix:+"${junit_filename_prefix}.stdout"} \
+     | grep "${go_test_grep_pattern}" && rc=$? || rc=$?
     produceJUnitXMLReport "${junit_filename_prefix}"
     return ${rc}
   fi
@@ -235,7 +241,8 @@ runTests() {
           -coverprofile=\"${cover_report_dir}/\${_pkg}/${cover_profile}\" \
           \"${KUBE_GO_PACKAGE}/\${_pkg}\" \
           ${testargs[@]:+${testargs[@]}} \
-        | tee ${junit_filename_prefix:+\"${junit_filename_prefix}-\$_pkg_out.stdout\"}" \
+        | tee ${junit_filename_prefix:+\"${junit_filename_prefix}-\$_pkg_out.stdout\"} \
+        | grep \"${go_test_grep_pattern}\"" \
       && test_result=$? || test_result=$?
 
   produceJUnitXMLReport "${junit_filename_prefix}"


### PR DESCRIPTION
This should make test output in Shippable and Jenkins readable again (to help find test build errors), while still supporting generating the JUnit XML test reports.

@zmerlynn do you have time to take a look at this?
also cc @kubernetes/goog-testing 
