### PR TITLE
dereference pointer before printing in the describer

### DIFF
--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -884,8 +884,8 @@ func describeJob(job *experimental.Job, events *api.EventList) (string, error) {
 			fmt.Fprintf(out, "Image(s):\t%s\n", "<no template>")
 		}
 		fmt.Fprintf(out, "Selector:\t%s\n", labels.FormatLabels(job.Spec.Selector))
-		fmt.Fprintf(out, "Parallelism:\t%d\n", job.Spec.Parallelism)
-		fmt.Fprintf(out, "Completions:\t%d\n", job.Spec.Completions)
+		fmt.Fprintf(out, "Parallelism:\t%d\n", *job.Spec.Parallelism)
+		fmt.Fprintf(out, "Completions:\t%d\n", *job.Spec.Completions)
 		fmt.Fprintf(out, "Labels:\t%s\n", labels.FormatLabels(job.Labels))
 		fmt.Fprintf(out, "Pods Statuses:\t%d Running / %d Succeeded / %d Failed\n", job.Status.Active, job.Status.Successful, job.Status.Unsuccessful)
 		if job.Spec.Template != nil {


### PR DESCRIPTION
Fixes #14301

no nil check because they can't be nil by the time we get here. They will have been defaulted.

https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/experimental/v1/defaults.go#L92-L99
