### PR TITLE
Fix a flake in the kubelet test.

### DIFF
--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -336,6 +336,9 @@ func TestSyncLoopAbort(t *testing.T) {
 	kubelet := testKubelet.kubelet
 	kubelet.lastTimestampRuntimeUp = time.Now()
 	kubelet.networkConfigured = true
+	// The syncLoop waits on time.After(resyncInterval), set it really big so that we don't race for
+	// the channel close
+	kubelet.resyncInterval = time.Second * 30
 
 	ch := make(chan PodUpdate)
 	close(ch)


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/14309

The race is that sometimes the `<- time.After(...)` [call](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kubelet.go#L1770) can sometimes trigger which returns `true` which causes the test to fail.

@dchen1107 @JanetKuo 
