### PR TITLE
Fix secret generation code in nginx example.

### DIFF
--- a/examples/https-nginx/README.md
+++ b/examples/https-nginx/README.md
@@ -38,7 +38,7 @@ It uses an [nginx server block](http://wiki.nginx.org/ServerBlockExample) to ser
 
 ### Generate certificates
 
-First generate a self signed rsa key and certificate that the server can use for TLS.
+First generate a self signed rsa key and certificate that the server can use for TLS. This step invokes the make_secret.go script in the same directory, which uses the kubernetes api to generate a secret json config in /tmp/secret.json.
 
 ```sh
 $ make keys secret KEY=/tmp/nginx.key CERT=/tmp/nginx.crt SECRET=/tmp/secret.json

--- a/examples/https-nginx/make_secret.go
+++ b/examples/https-nginx/make_secret.go
@@ -27,7 +27,7 @@ import (
 	"log"
 
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/latest"
+	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
@@ -63,5 +63,5 @@ func main() {
 			"nginx.key": nginxKey,
 		},
 	}
-	fmt.Printf(runtime.EncodeOrDie(latest.GroupOrDie("").Codec, secret))
+	fmt.Printf(runtime.EncodeOrDie(testapi.Default.Codec(), secret))
 }


### PR DESCRIPTION
GroupOrDie changed in some way that broke the make_secret script, so this pr swaps it with the testapi codec. Also adds a line of documentation for https://github.com/kubernetes/kubernetes/issues/14017. I'm guessing Chao knows how GroupOrDie changed, if not please re-assign. 
