### PR TITLE
Check the condition immediately in util.Wait funcs

### DIFF
--- a/pkg/util/wait/wait_test.go
+++ b/pkg/util/wait/wait_test.go
@@ -38,8 +38,8 @@ DRAIN:
 			t.Errorf("unexpected timeout after poll")
 		}
 	}
-	if count > 3 {
-		t.Errorf("expected up to three values, got %d", count)
+	if count < 2 {
+		t.Errorf("expected at least two values, got %d", count)
 	}
 }
 


### PR DESCRIPTION
Have poller() send to the channel once, immediately, before the ticker
starts. This way, Poll, PollInfinite, and WaitFor will check the
condition immediately, instead of waiting for the poller's interval to
elapse once before doing the initial condition check.
