### PR TITLE
Disable influxdb sink for heapster, except for testing

### DIFF
--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -29,7 +29,6 @@ spec:
           command:
             - /heapster
             - --source=kubernetes:''
-            - --sink=gcm
             - --sink=gcmautoscaling
             - --sink=gcl
             - --sink_frequency=2m

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -29,7 +29,6 @@ spec:
           command:
             - /heapster
             - --source=kubernetes:''
-            - --sink=gcl
             - --sink=gcmautoscaling
             - --sink=influxdb:http://monitoring-influxdb:8086
             - --sink_frequency=2m

--- a/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
@@ -36,11 +36,16 @@ spec:
             mountPath: /data
         - image: grafana/grafana:2.1.0
           name: grafana
+          volumeMounts:
+            - name: grafana-persistent-storage
+              mountPath: /var/lib/grafana
           resources:
             limits:
               cpu: 100m
               memory: 100Mi
       volumes:
       - name: influxdb-persistent-storage
+        emptyDir: {}
+      - name: grafana-persistent-storage
         emptyDir: {}
 

--- a/cluster/aws/config-default.sh
+++ b/cluster/aws/config-default.sh
@@ -60,9 +60,10 @@ MASTER_IP_RANGE="${MASTER_IP_RANGE:-10.246.0.0/24}"
 MASTER_RESERVED_IP="${MASTER_RESERVED_IP:-}"
 
 # Optional: Cluster monitoring to setup as part of the cluster bring up:
-#   none     - No cluster monitoring setup
-#   influxdb - Heapster, InfluxDB, and Grafana
-ENABLE_CLUSTER_MONITORING="${KUBE_ENABLE_CLUSTER_MONITORING:-influxdb}"
+#   none       - No cluster monitoring setup
+#   influxdb   - Heapster, InfluxDB, and Grafana
+#   standalone - Heapster.
+ENABLE_CLUSTER_MONITORING="${KUBE_ENABLE_CLUSTER_MONITORING:-standalone}"
 
 # Optional: Enable node logging.
 ENABLE_NODE_LOGGING="${KUBE_ENABLE_NODE_LOGGING:-true}"

--- a/cluster/aws/config-test.sh
+++ b/cluster/aws/config-test.sh
@@ -58,7 +58,8 @@ MASTER_RESERVED_IP="${MASTER_RESERVED_IP:-}"
 # Optional: Cluster monitoring to setup as part of the cluster bring up:
 #   none     - No cluster monitoring setup
 #   influxdb - Heapster, InfluxDB, and Grafana
-ENABLE_CLUSTER_MONITORING="${KUBE_ENABLE_CLUSTER_MONITORING:-none}"
+#   standalone - Heapster only.
+ENABLE_CLUSTER_MONITORING="${KUBE_ENABLE_CLUSTER_MONITORING:-standalone}"
 
 # Optional: Enable node logging.
 ENABLE_NODE_LOGGING="${KUBE_ENABLE_NODE_LOGGING:-true}"

--- a/cluster/azure/config-default.sh
+++ b/cluster/azure/config-default.sh
@@ -48,8 +48,8 @@ ELASTICSEARCH_LOGGING_REPLICAS=1
 # Optional: Cluster monitoring to setup as part of the cluster bring up:
 #   none     - No cluster monitoring setup 
 #   influxdb - Heapster, InfluxDB, and Grafana 
-#   google   - Heapster, Google Cloud Monitoring, and Google Cloud Logging
-ENABLE_CLUSTER_MONITORING="${KUBE_ENABLE_CLUSTER_MONITORING:-influxdb}"
+#   standalone - Heapster.
+ENABLE_CLUSTER_MONITORING="${KUBE_ENABLE_CLUSTER_MONITORING:-standalone}"
 
 # Optional: Install Kubernetes UI
 ENABLE_CLUSTER_UI="${KUBE_ENABLE_CLUSTER_UI:-true}"

--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -55,10 +55,10 @@ ALLOCATE_NODE_CIDRS=true
 # Optional: Cluster monitoring to setup as part of the cluster bring up:
 #   none           - No cluster monitoring setup
 #   influxdb       - Heapster, InfluxDB, and Grafana
-#   google         - Heapster, Google Cloud Monitoring, and Google Cloud Logging
-#   googleinfluxdb - Enable influxdb and google (except GCM)
+#   google         - Heapster, Google Cloud Logging, Google Auto Scaling
+#   googleinfluxdb - Enable influxdb and Google Auto Scaling
 #   standalone     - Heapster only. Metrics available via Heapster REST API.
-ENABLE_CLUSTER_MONITORING="${KUBE_ENABLE_CLUSTER_MONITORING:-googleinfluxdb}"
+ENABLE_CLUSTER_MONITORING="${KUBE_ENABLE_CLUSTER_MONITORING:-google}"
 
 # Optional: Enable node logging.
 ENABLE_NODE_LOGGING="${KUBE_ENABLE_NODE_LOGGING:-true}"

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -55,7 +55,7 @@ SERVICE_CLUSTER_IP_RANGE="10.0.0.0/16"  # formerly PORTAL_NET
 # Optional: Cluster monitoring to setup as part of the cluster bring up:
 #   none     - No cluster monitoring setup
 #   influxdb - Heapster, InfluxDB, and Grafana
-#   google   - Heapster, Google Cloud Monitoring, and Google Cloud Logging
+#   google   - Heapster, Google Auto Scaling, and Google Cloud Logging
 ENABLE_CLUSTER_MONITORING="${KUBE_ENABLE_CLUSTER_MONITORING:-influxdb}"
 
 TEST_CLUSTER_LOG_LEVEL="${TEST_CLUSTER_LOG_LEVEL:---v=4}"

--- a/cluster/rackspace/config-default.sh
+++ b/cluster/rackspace/config-default.sh
@@ -49,8 +49,8 @@ ELASTICSEARCH_LOGGING_REPLICAS=1
 # Optional: Cluster monitoring to setup as part of the cluster bring up:
 #   none     - No cluster monitoring setup 
 #   influxdb - Heapster, InfluxDB, and Grafana 
-#   google   - Heapster, Google Cloud Monitoring, and Google Cloud Logging
-ENABLE_CLUSTER_MONITORING="${KUBE_ENABLE_CLUSTER_MONITORING:-influxdb}"
+#   standalone - Heapster only
+ENABLE_CLUSTER_MONITORING="${KUBE_ENABLE_CLUSTER_MONITORING:-standalone}"
 
 # Optional: Install cluster DNS.
 ENABLE_CLUSTER_DNS="${KUBE_ENABLE_CLUSTER_DNS:-true}"

--- a/cluster/vagrant/config-default.sh
+++ b/cluster/vagrant/config-default.sh
@@ -66,8 +66,8 @@ ELASTICSEARCH_LOGGING_REPLICAS=1
 # Optional: Cluster monitoring to setup as part of the cluster bring up:
 #   none     - No cluster monitoring setup
 #   influxdb - Heapster, InfluxDB, and Grafana
-#   google   - Heapster, Google Cloud Monitoring, and Google Cloud Logging
-ENABLE_CLUSTER_MONITORING="${KUBE_ENABLE_CLUSTER_MONITORING:-influxdb}"
+#   standalone - Heapster only
+ENABLE_CLUSTER_MONITORING="${KUBE_ENABLE_CLUSTER_MONITORING:-standalone}"
 
 # Extra options to set on the Docker command line.  This is useful for setting
 # --insecure-registry for local registries, or globally configuring selinux options

--- a/cluster/vsphere/config-default.sh
+++ b/cluster/vsphere/config-default.sh
@@ -44,8 +44,8 @@ ELASTICSEARCH_LOGGING_REPLICAS=1
 # Optional: Cluster monitoring to setup as part of the cluster bring up:
 #   none     - No cluster monitoring setup 
 #   influxdb - Heapster, InfluxDB, and Grafana 
-#   google   - Heapster, Google Cloud Monitoring, and Google Cloud Logging
-ENABLE_CLUSTER_MONITORING="${KUBE_ENABLE_CLUSTER_MONITORING:-influxdb}"
+#   standalone - Heapster only
+ENABLE_CLUSTER_MONITORING="${KUBE_ENABLE_CLUSTER_MONITORING:-standalone}"
 
 # Optional: Install cluster DNS.
 ENABLE_CLUSTER_DNS="${KUBE_ENABLE_CLUSTER_DNS:-true}"

--- a/docs/admin/cluster-large.md
+++ b/docs/admin/cluster-large.md
@@ -82,7 +82,7 @@ These limits, however, are based on data collected from addons running on 4-node
 
 To avoid running into cluster addon resource issues, when creating a cluster with many nodes, consider the following:
 * Scale memory and CPU limits for each of the following addons, if used, along with the size of cluster (there is one replica of each handling the entire cluster so memory and CPU usage tends to grow proportionally with size/load on cluster):
-  * Heapster ([GCM/GCL backed](http://releases.k8s.io/HEAD/cluster/addons/cluster-monitoring/google/heapster-controller.yaml), [InfluxDB backed](http://releases.k8s.io/HEAD/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml), [InfluxDB/GCL backed](http://releases.k8s.io/HEAD/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml), [standalone](http://releases.k8s.io/HEAD/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml))
+  * Heapster ([Auto Scaling/GCL backed](http://releases.k8s.io/HEAD/cluster/addons/cluster-monitoring/google/heapster-controller.yaml), [InfluxDB backed](http://releases.k8s.io/HEAD/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml), [InfluxDB/Auto Scaling backed](http://releases.k8s.io/HEAD/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml), [standalone](http://releases.k8s.io/HEAD/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml))
   * [InfluxDB and Grafana](http://releases.k8s.io/HEAD/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml)
   * [skydns, kube2sky, and dns etcd](http://releases.k8s.io/HEAD/cluster/addons/dns/skydns-rc.yaml.in)
   * [Kibana](http://releases.k8s.io/HEAD/cluster/addons/fluentd-elasticsearch/kibana-controller.yaml)
@@ -94,6 +94,20 @@ To avoid running into cluster addon resource issues, when creating a cluster wit
 
 For directions on how to detect if addon containers are hitting resource limits, see the [Troubleshooting section of Compute Resources](../user-guide/compute-resources.md#troubleshooting).
 
+### Monitoring
+
+[Heapster](https://github.com/kubernetes/heapster) provides monitoring for Kubernetes cluster.
+Heapster supports multiple timeseries storage backends. Refer to heapster repo for more information.
+On GCE, Heapster is set to run with Google Cloud Logging and auto scaling backends turned on.
+
+On all other deployments, it is recommended to run Heapster in [standalone](http://releases.k8s.io/HEAD/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml) mode.
+
+We maintain an [InfluxDB & Grafana](http://releases.k8s.io/HEAD/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml) backend for Heapster.
+To enable long term storage of cluster compute resource usage metrics, it is recommended to run heapster with the InfluxDB backend (or some other heapster supported backend).
+Before running heapster with InfluxDB backend, update the [influxDB config](http://releases.k8s.io/HEAD/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml) to use [persistent volumes](../user-guide/persistent-volumes.md) instead of `empty directory` in the `volumes` section, and install InfluxDB and Grafana.
+
+[Kubedash](https://github.com/kubernetes/kubedash) provides an easy to use introspection UI that is powered by Heapster.
+Follow the instruction in kubedash repo to install Kubedash after running Heapster.
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->
 [![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/admin/cluster-large.md?pixel)]()

--- a/docs/admin/cluster-management.md
+++ b/docs/admin/cluster-management.md
@@ -141,7 +141,7 @@ gcloud preview autoscaler --zone compute-zone <command>
 
 Note that autoscaling will work properly only if node metrics are accessible in Google Cloud Monitoring.
 To make the metrics accessible, you need to create your cluster with ```KUBE_ENABLE_CLUSTER_MONITORING```
-equal to ```google``` or ```googleinfluxdb``` (```googleinfluxdb``` is the default value).
+equal to ```google``` or ```googleinfluxdb``` (```google``` is the default value).
 
 ## Maintenance on a Node
 


### PR DESCRIPTION
On gce, we run the autoscaling sink and gcl sink. 
On all other deployment, we deploy heapster only.

Heapster now provides a UI via Kubedash. There is no need for deploying InfluxDB by default, since it requires admin intervention.

Added a persistent storage for Grafana container to retain the config information.

cc @piosz @dchen1107 
