### PR TITLE
update APIRequestInfo for APIGroup

### DIFF
--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/version"
 	"k8s.io/kubernetes/pkg/watch"
 	"k8s.io/kubernetes/plugin/pkg/admission/admit"
@@ -190,11 +191,16 @@ func handleLinker(storage map[string]rest.Storage, selfLinker runtime.SelfLinker
 	return handleInternal(true, storage, admissionControl, selfLinker)
 }
 
+func newTestAPIRequestInfoResolver() *APIRequestInfoResolver {
+	return &APIRequestInfoResolver{sets.NewString("api", "apis"), sets.NewString("api")}
+}
+
 func handleInternal(legacy bool, storage map[string]rest.Storage, admissionControl admission.Interface, selfLinker runtime.SelfLinker) http.Handler {
 	group := &APIGroupVersion{
 		Storage: storage,
 
 		Root: "/api",
+		APIRequestInfoResolver: newTestAPIRequestInfoResolver(),
 
 		Creater:   api.Scheme,
 		Convertor: api.Scheme,
@@ -2014,12 +2020,13 @@ func TestCreateChecksDecode(t *testing.T) {
 func TestUpdateREST(t *testing.T) {
 	makeGroup := func(storage map[string]rest.Storage) *APIGroupVersion {
 		return &APIGroupVersion{
-			Storage:   storage,
-			Root:      "/api",
-			Creater:   api.Scheme,
-			Convertor: api.Scheme,
-			Typer:     api.Scheme,
-			Linker:    selfLinker,
+			Storage: storage,
+			Root:    "/api",
+			APIRequestInfoResolver: newTestAPIRequestInfoResolver(),
+			Creater:                api.Scheme,
+			Convertor:              api.Scheme,
+			Typer:                  api.Scheme,
+			Linker:                 selfLinker,
 
 			Admit:   admissionControl,
 			Context: requestContextMapper,
@@ -2096,11 +2103,12 @@ func TestParentResourceIsRequired(t *testing.T) {
 		Storage: map[string]rest.Storage{
 			"simple/sub": storage,
 		},
-		Root:      "/api",
-		Creater:   api.Scheme,
-		Convertor: api.Scheme,
-		Typer:     api.Scheme,
-		Linker:    selfLinker,
+		Root: "/api",
+		APIRequestInfoResolver: newTestAPIRequestInfoResolver(),
+		Creater:                api.Scheme,
+		Convertor:              api.Scheme,
+		Typer:                  api.Scheme,
+		Linker:                 selfLinker,
 
 		Admit:   admissionControl,
 		Context: requestContextMapper,
@@ -2124,11 +2132,12 @@ func TestParentResourceIsRequired(t *testing.T) {
 			"simple":     &SimpleRESTStorage{},
 			"simple/sub": storage,
 		},
-		Root:      "/api",
-		Creater:   api.Scheme,
-		Convertor: api.Scheme,
-		Typer:     api.Scheme,
-		Linker:    selfLinker,
+		Root: "/api",
+		APIRequestInfoResolver: newTestAPIRequestInfoResolver(),
+		Creater:                api.Scheme,
+		Convertor:              api.Scheme,
+		Typer:                  api.Scheme,
+		Linker:                 selfLinker,
 
 		Admit:   admissionControl,
 		Context: requestContextMapper,

--- a/pkg/apiserver/errors.go
+++ b/pkg/apiserver/errors.go
@@ -86,3 +86,22 @@ func forbidden(w http.ResponseWriter, req *http.Request) {
 	w.WriteHeader(http.StatusForbidden)
 	fmt.Fprintf(w, "Forbidden: %#v", req.RequestURI)
 }
+
+// errAPIPrefixNotFound indicates that a APIRequestInfo resolution failed because the request isn't under
+// any known API prefixes
+type errAPIPrefixNotFound struct {
+	SpecifiedPrefix string
+}
+
+func (e *errAPIPrefixNotFound) Error() string {
+	return fmt.Sprintf("no valid API prefix found matching %v", e.SpecifiedPrefix)
+}
+
+func IsAPIPrefixNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	_, ok := err.(*errAPIPrefixNotFound)
+	return ok
+}

--- a/pkg/apiserver/handlers.go
+++ b/pkg/apiserver/handlers.go
@@ -367,6 +367,8 @@ func (r *requestAttributeGetter) GetAttribs(req *http.Request) authorizer.Attrib
 
 	apiRequestInfo, _ := r.apiRequestInfoResolver.GetAPIRequestInfo(req)
 
+	attribs.APIGroup = apiRequestInfo.APIGroup
+
 	// If a path follows the conventions of the REST object store, then
 	// we can extract the resource.  Otherwise, not.
 	attribs.Resource = apiRequestInfo.Resource

--- a/pkg/apiserver/handlers.go
+++ b/pkg/apiserver/handlers.go
@@ -348,8 +348,8 @@ type requestAttributeGetter struct {
 }
 
 // NewAttributeGetter returns an object which implements the RequestAttributeGetter interface.
-func NewRequestAttributeGetter(requestContextMapper api.RequestContextMapper, restMapper meta.RESTMapper, apiRoots ...string) RequestAttributeGetter {
-	return &requestAttributeGetter{requestContextMapper, &APIRequestInfoResolver{sets.NewString(apiRoots...), restMapper}}
+func NewRequestAttributeGetter(requestContextMapper api.RequestContextMapper, restMapper meta.RESTMapper, apiRoots []string, grouplessAPIRoots []string) RequestAttributeGetter {
+	return &requestAttributeGetter{requestContextMapper, &APIRequestInfoResolver{sets.NewString(apiRoots...), sets.NewString(grouplessAPIRoots...), restMapper}}
 }
 
 func (r *requestAttributeGetter) GetAttribs(req *http.Request) authorizer.Attributes {
@@ -395,6 +395,8 @@ func WithAuthorizationCheck(handler http.Handler, getAttribs RequestAttributeGet
 type APIRequestInfo struct {
 	// Verb is the kube verb associated with the request, not the http verb.  This includes things like list and watch.
 	Verb       string
+	APIPrefix  string
+	APIGroup   string
 	APIVersion string
 	Namespace  string
 	// Resource is the name of the resource being requested.  This is not the kind.  For example: pods
@@ -415,66 +417,68 @@ type APIRequestInfo struct {
 }
 
 type APIRequestInfoResolver struct {
-	APIPrefixes sets.String
-	RestMapper  meta.RESTMapper
+	APIPrefixes          sets.String
+	GrouplessAPIPrefixes sets.String
+	RestMapper           meta.RESTMapper
 }
 
 // TODO write an integration test against the swagger doc to test the APIRequestInfo and match up behavior to responses
 // GetAPIRequestInfo returns the information from the http request.  If error is not nil, APIRequestInfo holds the information as best it is known before the failure
 // Valid Inputs:
 // Storage paths
-// /namespaces
-// /namespaces/{namespace}
-// /namespaces/{namespace}/{resource}
-// /namespaces/{namespace}/{resource}/{resourceName}
-// /{resource}
-// /{resource}/{resourceName}
+// /apis/{api-group}/{version}/namespaces
+// /api/{version}/namespaces
+// /api/{version}/namespaces/{namespace}
+// /api/{version}/namespaces/{namespace}/{resource}
+// /api/{version}/namespaces/{namespace}/{resource}/{resourceName}
+// /api/{version}/{resource}
+// /api/{version}/{resource}/{resourceName}
 //
 // Special verbs:
-// /proxy/{resource}/{resourceName}
-// /proxy/namespaces/{namespace}/{resource}/{resourceName}
-// /redirect/namespaces/{namespace}/{resource}/{resourceName}
-// /redirect/{resource}/{resourceName}
-// /watch/{resource}
-// /watch/namespaces/{namespace}/{resource}
-//
-// Fully qualified paths for above:
-// /api/{version}/*
-// /api/{version}/*
+// /api/{version}/proxy/{resource}/{resourceName}
+// /api/{version}/proxy/namespaces/{namespace}/{resource}/{resourceName}
+// /api/{version}/redirect/namespaces/{namespace}/{resource}/{resourceName}
+// /api/{version}/redirect/{resource}/{resourceName}
+// /api/{version}/watch/{resource}
+// /api/{version}/watch/namespaces/{namespace}/{resource}
 func (r *APIRequestInfoResolver) GetAPIRequestInfo(req *http.Request) (APIRequestInfo, error) {
 	requestInfo := APIRequestInfo{
 		Raw: splitPath(req.URL.Path),
 	}
 
 	currentParts := requestInfo.Raw
-	if len(currentParts) < 1 {
-		return requestInfo, fmt.Errorf("Unable to determine kind and namespace from an empty URL path")
+	if len(currentParts) < 3 {
+		return requestInfo, fmt.Errorf("a resource request must have a url with at least three parts, not %v", req.URL)
 	}
 
-	for _, currPrefix := range r.APIPrefixes.List() {
-		// handle input of form /api/{version}/* by adjusting special paths
-		if currentParts[0] == currPrefix {
-			if len(currentParts) > 1 {
-				requestInfo.APIVersion = currentParts[1]
-			}
+	if !r.APIPrefixes.Has(currentParts[0]) {
+		return requestInfo, &errAPIPrefixNotFound{currentParts[0]}
+	}
+	requestInfo.APIPrefix = currentParts[0]
+	currentParts = currentParts[1:]
 
-			if len(currentParts) > 2 {
-				currentParts = currentParts[2:]
-			} else {
-				return requestInfo, fmt.Errorf("Unable to determine kind and namespace from url, %v", req.URL)
-			}
+	if !r.GrouplessAPIPrefixes.Has(requestInfo.APIPrefix) {
+		// one part (APIPrefix) has already been consumed, so this is actually "do we have four parts?"
+		if len(currentParts) < 3 {
+			return requestInfo, fmt.Errorf("a resource request with an API group must have a url with at least four parts, not %v", req.URL)
 		}
+
+		requestInfo.APIGroup = currentParts[0]
+		currentParts = currentParts[1:]
 	}
+
+	requestInfo.APIVersion = currentParts[0]
+	currentParts = currentParts[1:]
 
 	// handle input of form /{specialVerb}/*
 	if _, ok := specialVerbs[currentParts[0]]; ok {
-		requestInfo.Verb = currentParts[0]
-
-		if len(currentParts) > 1 {
-			currentParts = currentParts[1:]
-		} else {
-			return requestInfo, fmt.Errorf("Unable to determine kind and namespace from url, %v", req.URL)
+		if len(currentParts) < 2 {
+			return requestInfo, fmt.Errorf("unable to determine kind and namespace from url, %v", req.URL)
 		}
+
+		requestInfo.Verb = currentParts[0]
+		currentParts = currentParts[1:]
+
 	} else {
 		switch req.Method {
 		case "POST":

--- a/pkg/apiserver/handlers_test.go
+++ b/pkg/apiserver/handlers_test.go
@@ -199,6 +199,8 @@ func TestGetAPIRequestInfo(t *testing.T) {
 		method              string
 		url                 string
 		expectedVerb        string
+		expectedAPIPrefix   string
+		expectedAPIGroup    string
 		expectedAPIVersion  string
 		expectedNamespace   string
 		expectedResource    string
@@ -209,42 +211,38 @@ func TestGetAPIRequestInfo(t *testing.T) {
 	}{
 
 		// resource paths
-		{"GET", "/namespaces", "list", "", "", "namespaces", "", "Namespace", "", []string{"namespaces"}},
-		{"GET", "/namespaces/other", "get", "", "other", "namespaces", "", "Namespace", "other", []string{"namespaces", "other"}},
+		{"GET", "/api/v1/namespaces", "list", "api", "", "v1", "", "namespaces", "", "Namespace", "", []string{"namespaces"}},
+		{"GET", "/api/v1/namespaces/other", "get", "api", "", "v1", "other", "namespaces", "", "Namespace", "other", []string{"namespaces", "other"}},
 
-		{"GET", "/namespaces/other/pods", "list", "", "other", "pods", "", "Pod", "", []string{"pods"}},
-		{"GET", "/namespaces/other/pods/foo", "get", "", "other", "pods", "", "Pod", "foo", []string{"pods", "foo"}},
-		{"GET", "/pods", "list", "", api.NamespaceAll, "pods", "", "Pod", "", []string{"pods"}},
-		{"GET", "/namespaces/other/pods/foo", "get", "", "other", "pods", "", "Pod", "foo", []string{"pods", "foo"}},
-		{"GET", "/namespaces/other/pods", "list", "", "other", "pods", "", "Pod", "", []string{"pods"}},
+		{"GET", "/api/v1/namespaces/other/pods", "list", "api", "", "v1", "other", "pods", "", "Pod", "", []string{"pods"}},
+		{"GET", "/api/v1/namespaces/other/pods/foo", "get", "api", "", "v1", "other", "pods", "", "Pod", "foo", []string{"pods", "foo"}},
+		{"GET", "/api/v1/pods", "list", "api", "", "v1", api.NamespaceAll, "pods", "", "Pod", "", []string{"pods"}},
+		{"GET", "/api/v1/namespaces/other/pods/foo", "get", "api", "", "v1", "other", "pods", "", "Pod", "foo", []string{"pods", "foo"}},
+		{"GET", "/api/v1/namespaces/other/pods", "list", "api", "", "v1", "other", "pods", "", "Pod", "", []string{"pods"}},
 
 		// special verbs
-		{"GET", "/proxy/namespaces/other/pods/foo", "proxy", "", "other", "pods", "", "Pod", "foo", []string{"pods", "foo"}},
-		{"GET", "/redirect/namespaces/other/pods/foo", "redirect", "", "other", "pods", "", "Pod", "foo", []string{"pods", "foo"}},
-		{"GET", "/watch/pods", "watch", "", api.NamespaceAll, "pods", "", "Pod", "", []string{"pods"}},
-		{"GET", "/watch/namespaces/other/pods", "watch", "", "other", "pods", "", "Pod", "", []string{"pods"}},
-
-		// fully-qualified paths
-		{"GET", getPath("pods", "other", ""), "list", testapi.Default.Version(), "other", "pods", "", "Pod", "", []string{"pods"}},
-		{"GET", getPath("pods", "other", "foo"), "get", testapi.Default.Version(), "other", "pods", "", "Pod", "foo", []string{"pods", "foo"}},
-		{"GET", getPath("pods", "", ""), "list", testapi.Default.Version(), api.NamespaceAll, "pods", "", "Pod", "", []string{"pods"}},
-		{"POST", getPath("pods", "", ""), "create", testapi.Default.Version(), api.NamespaceAll, "pods", "", "Pod", "", []string{"pods"}},
-		{"GET", getPath("pods", "", "foo"), "get", testapi.Default.Version(), api.NamespaceAll, "pods", "", "Pod", "foo", []string{"pods", "foo"}},
-		{"GET", pathWithPrefix("proxy", "pods", "", "foo"), "proxy", testapi.Default.Version(), api.NamespaceAll, "pods", "", "Pod", "foo", []string{"pods", "foo"}},
-		{"GET", pathWithPrefix("watch", "pods", "", ""), "watch", testapi.Default.Version(), api.NamespaceAll, "pods", "", "Pod", "", []string{"pods"}},
-		{"GET", pathWithPrefix("redirect", "pods", "", ""), "redirect", testapi.Default.Version(), api.NamespaceAll, "pods", "", "Pod", "", []string{"pods"}},
-		{"GET", pathWithPrefix("watch", "pods", "other", ""), "watch", testapi.Default.Version(), "other", "pods", "", "Pod", "", []string{"pods"}},
+		{"GET", "/api/v1/proxy/namespaces/other/pods/foo", "proxy", "api", "", "v1", "other", "pods", "", "Pod", "foo", []string{"pods", "foo"}},
+		{"GET", "/api/v1/redirect/namespaces/other/pods/foo", "redirect", "api", "", "v1", "other", "pods", "", "Pod", "foo", []string{"pods", "foo"}},
+		{"GET", "/api/v1/watch/pods", "watch", "api", "", "v1", api.NamespaceAll, "pods", "", "Pod", "", []string{"pods"}},
+		{"GET", "/api/v1/watch/namespaces/other/pods", "watch", "api", "", "v1", "other", "pods", "", "Pod", "", []string{"pods"}},
 
 		// subresource identification
-		{"GET", "/namespaces/other/pods/foo/status", "get", "", "other", "pods", "status", "Pod", "foo", []string{"pods", "foo", "status"}},
-		{"PUT", "/namespaces/other/finalize", "update", "", "other", "finalize", "", "", "", []string{"finalize"}},
+		{"GET", "/api/v1/namespaces/other/pods/foo/status", "get", "api", "", "v1", "other", "pods", "status", "Pod", "foo", []string{"pods", "foo", "status"}},
+		{"PUT", "/api/v1/namespaces/other/finalize", "update", "api", "", "v1", "other", "finalize", "", "", "", []string{"finalize"}},
 
 		// verb identification
-		{"PATCH", "/namespaces/other/pods/foo", "patch", "", "other", "pods", "", "Pod", "foo", []string{"pods", "foo"}},
-		{"DELETE", "/namespaces/other/pods/foo", "delete", "", "other", "pods", "", "Pod", "foo", []string{"pods", "foo"}},
+		{"PATCH", "/api/v1/namespaces/other/pods/foo", "patch", "api", "", "v1", "other", "pods", "", "Pod", "foo", []string{"pods", "foo"}},
+		{"DELETE", "/api/v1/namespaces/other/pods/foo", "delete", "api", "", "v1", "other", "pods", "", "Pod", "foo", []string{"pods", "foo"}},
+		{"POST", "/api/v1/namespaces/other/pods", "create", "api", "", "v1", "other", "pods", "", "Pod", "", []string{"pods"}},
+
+		// api group identification
+		{"POST", "/apis/experimental/v1/namespaces/other/pods", "create", "api", "experimental", "v1", "other", "pods", "", "Pod", "", []string{"pods"}},
+
+		// api version identification
+		{"POST", "/apis/experimental/v1beta3/namespaces/other/pods", "create", "api", "experimental", "v1beta3", "other", "pods", "", "Pod", "", []string{"pods"}},
 	}
 
-	apiRequestInfoResolver := &APIRequestInfoResolver{sets.NewString("api"), testapi.Default.RESTMapper()}
+	apiRequestInfoResolver := &APIRequestInfoResolver{sets.NewString("api", "apis"), sets.NewString("api"), testapi.Default.RESTMapper()}
 
 	for _, successCase := range successCases {
 		req, _ := http.NewRequest(successCase.method, successCase.url, nil)
@@ -282,7 +280,10 @@ func TestGetAPIRequestInfo(t *testing.T) {
 	errorCases := map[string]string{
 		"no resource path":            "/",
 		"just apiversion":             "/api/version/",
+		"just prefix, group, version": "/apis/group/version/",
 		"apiversion with no resource": "/api/version/",
+		"bad prefix":                  "/badprefix/version/resource",
+		"missing api group":           "/apis/version/resource",
 	}
 	for k, v := range errorCases {
 		req, err := http.NewRequest("GET", v, nil)

--- a/pkg/auth/authorizer/interfaces.go
+++ b/pkg/auth/authorizer/interfaces.go
@@ -41,6 +41,9 @@ type Attributes interface {
 
 	// The kind of object, if a request is for a REST object.
 	GetResource() string
+
+	// The group of the resource, if a request is for a REST object.
+	GetAPIGroup() string
 }
 
 // Authorizer makes an authorization decision based on information gained by making
@@ -61,6 +64,7 @@ type AttributesRecord struct {
 	User      user.Info
 	ReadOnly  bool
 	Namespace string
+	APIGroup  string
 	Resource  string
 }
 
@@ -82,4 +86,8 @@ func (a AttributesRecord) GetNamespace() string {
 
 func (a AttributesRecord) GetResource() string {
 	return a.Resource
+}
+
+func (a AttributesRecord) GetAPIGroup() string {
+	return a.APIGroup
 }

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -572,9 +572,7 @@ func (m *Master) init(c *Config) {
 
 	apiserver.InstallSupport(m.muxHelper, m.rootWebService, c.EnableProfiling, healthzChecks...)
 	apiserver.AddApiWebService(m.handlerContainer, c.APIPrefix, apiVersions)
-	defaultVersion := m.defaultAPIGroupVersion()
-	requestInfoResolver := defaultVersion.GetAPIRequestInfoResolver()
-	apiserver.InstallServiceErrorHandler(m.handlerContainer, requestInfoResolver, apiVersions)
+	apiserver.InstallServiceErrorHandler(m.handlerContainer, m.newAPIRequestInfoResolver(), apiVersions)
 
 	// allGroups records all supported groups at /apis
 	allGroups := []api.APIGroup{}
@@ -608,8 +606,7 @@ func (m *Master) init(c *Config) {
 		}
 		apiserver.AddGroupWebService(m.handlerContainer, c.APIGroupPrefix+"/"+latest.GroupOrDie("experimental").Group+"/", group)
 		allGroups = append(allGroups, group)
-		expRequestInfoResolver := expVersion.GetAPIRequestInfoResolver()
-		apiserver.InstallServiceErrorHandler(m.handlerContainer, expRequestInfoResolver, []string{expVersion.Version})
+		apiserver.InstallServiceErrorHandler(m.handlerContainer, m.newAPIRequestInfoResolver(), []string{expVersion.Version})
 	}
 
 	// This should be done after all groups are registered
@@ -652,10 +649,7 @@ func (m *Master) init(c *Config) {
 
 	m.InsecureHandler = handler
 
-	attributeGetter := apiserver.NewRequestAttributeGetter(m.requestContextMapper, latest.GroupOrDie("").RESTMapper,
-		[]string{strings.Trim(c.APIPrefix, "/"), strings.Trim(thirdpartyprefix, "/")}, // all possible API prefixes
-		[]string{strings.Trim(c.APIPrefix, "/")},                                      // APIPrefixes that won't have groups (legacy)
-	)
+	attributeGetter := apiserver.NewRequestAttributeGetter(m.requestContextMapper, m.newAPIRequestInfoResolver())
 	handler = apiserver.WithAuthorizationCheck(handler, attributeGetter, m.authorizer)
 
 	// Install Authenticator
@@ -781,9 +775,17 @@ func (m *Master) getServersToValidate(c *Config) map[string]apiserver.Server {
 	return serversToValidate
 }
 
+func (m *Master) newAPIRequestInfoResolver() *apiserver.APIRequestInfoResolver {
+	return &apiserver.APIRequestInfoResolver{
+		sets.NewString(strings.Trim(m.apiPrefix, "/"), strings.Trim(thirdpartyprefix, "/")), // all possible API prefixes
+		sets.NewString(strings.Trim(m.apiPrefix, "/")),                                      // APIPrefixes that won't have groups (legacy)
+	}
+}
+
 func (m *Master) defaultAPIGroupVersion() *apiserver.APIGroupVersion {
 	return &apiserver.APIGroupVersion{
 		Root: m.apiPrefix,
+		APIRequestInfoResolver: m.newAPIRequestInfoResolver(),
 
 		Mapper: latest.GroupOrDie("").RESTMapper,
 
@@ -921,8 +923,7 @@ func (m *Master) InstallThirdPartyResource(rsrc *expapi.ThirdPartyResource) erro
 	}
 	apiserver.AddGroupWebService(m.handlerContainer, path, apiGroup)
 	m.addThirdPartyResourceStorage(path, thirdparty.Storage[strings.ToLower(kind)+"s"].(*thirdpartyresourcedataetcd.REST))
-	thirdPartyRequestInfoResolver := &apiserver.APIRequestInfoResolver{APIPrefixes: sets.NewString(strings.Trim(thirdpartyprefix, "/")), RestMapper: thirdparty.Mapper}
-	apiserver.InstallServiceErrorHandler(m.handlerContainer, thirdPartyRequestInfoResolver, []string{thirdparty.Version})
+	apiserver.InstallServiceErrorHandler(m.handlerContainer, m.newAPIRequestInfoResolver(), []string{thirdparty.Version})
 	return nil
 }
 
@@ -936,7 +937,9 @@ func (m *Master) thirdpartyapi(group, kind, version string) *apiserver.APIGroupV
 	}
 
 	return &apiserver.APIGroupVersion{
-		Root: apiRoot,
+		Root:                   apiRoot,
+		Version:                version,
+		APIRequestInfoResolver: m.newAPIRequestInfoResolver(),
 
 		Creater:   thirdpartyresourcedata.NewObjectCreator(version, api.Scheme),
 		Convertor: api.Scheme,
@@ -946,7 +949,6 @@ func (m *Master) thirdpartyapi(group, kind, version string) *apiserver.APIGroupV
 		Codec:         thirdpartyresourcedata.NewCodec(latest.GroupOrDie("experimental").Codec, kind),
 		Linker:        latest.GroupOrDie("experimental").SelfLinker,
 		Storage:       storage,
-		Version:       version,
 		ServerVersion: latest.GroupOrDie("").GroupVersion,
 
 		Context: m.requestContextMapper,
@@ -993,6 +995,7 @@ func (m *Master) experimental(c *Config) *apiserver.APIGroupVersion {
 
 	return &apiserver.APIGroupVersion{
 		Root: m.apiGroupPrefix,
+		APIRequestInfoResolver: m.newAPIRequestInfoResolver(),
 
 		Creater:   api.Scheme,
 		Convertor: api.Scheme,


### PR DESCRIPTION
Update the `APIRequestInfo` and resolver to handle `APIGroup`.  This is needed before the authorizer can be updated to correctly handle groups.

There were a couple bugs with how the existing experimental group and third party groups were wired in, so I've adjusted those too.

@kubernetes/kube-iam 
