### PR TITLE
Vagrant salt-minion should have low oom_score_adj and restart policy

### DIFF
--- a/cluster/vagrant/provision-minion.sh
+++ b/cluster/vagrant/provision-minion.sh
@@ -163,6 +163,29 @@ swapoff -a
 if ! which salt-minion >/dev/null 2>&1; then
   # Install Salt
   curl -sS -L --connect-timeout 20 --retry 6 --retry-delay 10 https://bootstrap.saltstack.com | sh -s
+  
+  # Edit the Salt minion unit file to do restart always
+  # needed because vagrant uses this as basis for registration of nodes in cloud provider
+  # set a oom_score_adj to -999 to prevent our node from being killed with salt-master and then making kubelet NotReady
+  # because its not found in salt cloud provider call
+  cat <<EOF >/usr/lib/systemd/system/salt-minion.service 
+[Unit]
+Description=The Salt Minion
+After=syslog.target network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/salt-minion
+Restart=Always
+OOMScoreAdjust=-999
+
+[Install]
+WantedBy=multi-user.target
+EOF
+  
+  systemctl daemon-reload
+  systemctl restart salt-minion.service
+
 else
   # Sometimes the minion gets wedged when it comes up along with the master.
   # Restarting it here un-wedges it.


### PR DESCRIPTION
I had been testing the Node to determine what happens when a OOM occurs to ensure our QoS tiers work as expected with memory oom_score_adj heuristics.  What I found was that the kernel often saved the kubelet, docker, kube-proxy, but on Vagrant cluster, it would kill my salt-minion.

In a vagrant cluster, this is bad because the salt-minion needs to run to report itself to the salt-master which is queried by the vagrant kube cloud_provider to determine information about itself.  Without the salt-minion running, the Kubelet on the Node in question would never recover.

Change here is to set restart policy, and set salt-minion oom_score_adjust equivalent to kubelet, kube-proxy on the node.  This appears to let user's then use the vagrant cluster to test images that do memhog scenarios to ensure that the node is stable and does the right thing.
