### PR TITLE
Flag controlled RLIMIT_NOFILE for kubelet.

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -158,6 +158,7 @@ maximum-dead-containers-per-container
 max-log-age
 max-log-backups
 max-log-size
+max-open-files
 max-outgoing-burst
 max-outgoing-qps
 max-pods

--- a/pkg/util/resource_container_linux.go
+++ b/pkg/util/resource_container_linux.go
@@ -20,6 +20,7 @@ package util
 
 import (
 	"os"
+	"syscall"
 
 	"github.com/docker/libcontainer/cgroups/fs"
 	"github.com/docker/libcontainer/configs"
@@ -38,4 +39,8 @@ func RunInResourceContainer(containerName string) error {
 	}
 
 	return manager.Apply(os.Getpid())
+}
+
+func ApplyRLimitForSelf(maxOpenFiles uint64) {
+	syscall.Setrlimit(syscall.RLIMIT_NOFILE, &syscall.Rlimit{Max: maxOpenFiles, Cur: maxOpenFiles})
 }

--- a/pkg/util/resource_container_unsupported.go
+++ b/pkg/util/resource_container_unsupported.go
@@ -25,3 +25,7 @@ import (
 func RunInResourceContainer(containerName string) error {
 	return errors.New("resource-only containers unsupported in this platform")
 }
+
+func ApplyRLimitForSelf(maxOpenFiles uint64) error {
+	return errors.New("SetRLimit unsupported in this platform")
+}


### PR DESCRIPTION
Default: 1000000

During some tests, I observed some error messages logged by cAdvisor:

```
I0917 14:58:50.355545   17206 container.go:369] Failed to update stats for container "/system/system.slice/docker-1d2119f0415897dca023510fb88ba5fc6c894f9f58a0c773c97d15a38f3b9ffb.scope": du command failed on /var/lib/docker/aufs/diff/1d2119f0415897dca023510fb88ba5fc6c894f9f58a0c773c97d15a38f3b9ffb with output  - fork/exec /usr/bin/du: cannot allocate memory, continuing to push stats
```

Above message is actually from golang library, and the message is misleading. The resource having issue here is not memory, instead of NOFILE. 
