### PR TITLE
docs: revamp CoreOS getting started guides

### DIFF
--- a/docs/getting-started-guides/coreos.md
+++ b/docs/getting-started-guides/coreos.md
@@ -95,7 +95,7 @@ Guide to running an HA etcd cluster with a single master on Azure. Uses the Azur
 
 <hr/>
 
-[**Multi-node cluster using cloud-config, coreos and VMware ESXi**](https://github.com/xavierbaude/VMware-coreos-multi-nodes-Kubernetes)
+[**Multi-node cluster using cloud-config, CoreOS and VMware ESXi**](https://github.com/xavierbaude/VMware-coreos-multi-nodes-Kubernetes)
 
 Configure a single master, single worker cluster on VMware ESXi.
 

--- a/docs/getting-started-guides/coreos.md
+++ b/docs/getting-started-guides/coreos.md
@@ -31,17 +31,73 @@ Documentation for other releases can be found at
 
 <!-- END MUNGE: UNVERSIONED_WARNING -->
 
-## Getting started on [CoreOS](http://coreos.com)
+## Getting Started on [CoreOS](https://coreos.com)
 
-There are multiple guides on running Kubernetes with [CoreOS](http://coreos.com):
+There are multiple guides on running Kubernetes with [CoreOS](https://coreos.com/kubernetes/docs/latest/):
 
-* [Multi-node Cluster](coreos/coreos_multinode_cluster.md)
-* [Setup Multi-node Cluster on Google Compute Engine in an easy way](https://github.com/rimusz/coreos-multi-node-k8s-gce/blob/master/README.md)
-* [Multi-node cluster using cloud-config and Weave on Vagrant](https://github.com/errordeveloper/weave-demos/blob/master/poseidon/README.md)
-* [Multi-node cluster using cloud-config and Vagrant (supports VirtualBox, Parallels and VMware)](https://github.com/pires/kubernetes-vagrant-coreos-cluster/blob/master/README.md)
-* [Multi-node cluster with Vagrant and fleet units using a small OS X App](https://github.com/rimusz/coreos-osx-gui-kubernetes-cluster/blob/master/README.md)
-* [Resizable multi-node cluster on Azure with Weave](coreos/azure/README.md)
-* [Multi-node cluster using cloud-config, coreos and VMware ESXi](https://github.com/xavierbaude/VMware-coreos-multi-nodes-Kubernetes)
+### Official CoreOS Guides
+
+These guides are maintained by CoreOS and deploy Kubernetes the "CoreOS Way" with full TLS, the DNS add-on, and more. These guides pass Kubernetes conformance testing and we encourage you to [test this yourself](https://coreos.com/kubernetes/docs/latest/conformance-tests.html).
+
+[**Vagrant Multi-Node**](https://coreos.com/kubernetes/docs/latest/kubernetes-on-vagrant.html)
+
+Guide to setting up a multi-node cluster on Vagrant. The deployer can independently configure the number of etcd nodes, master nodes, and worker nodes to bring up a fully HA control plane.
+
+<hr/>
+
+[**Vagrant Single-Node**](https://coreos.com/kubernetes/docs/latest/kubernetes-on-vagrant-single.html)
+
+Quickest way to set up a Kubernetes development environment locally. As easy as `git clone`, `vagrant up` and configuring `kubectl`.
+
+<hr/>
+
+[**Full Step by Step Guide**](https://coreos.com/kubernetes/docs/latest/getting-started.html)
+
+A generic guide to setting up an HA cluster on any cloud or bare metal, with full TLS. Repeat the master or worker steps to configure more machines of that role.
+
+### Community Guides
+
+These guides are maintained by community members and cover specific platforms, use-cases and experiment with different ways of configuring Kubernetes on CoreOS.
+
+[**Multi-node Cluster**](coreos/coreos_multinode_cluster.md)
+
+Set up a single master, multi-worker cluster on your choice of platform: AWS, GCE, or VMware Fusion.
+
+<hr/>
+
+[**Easy Multi-node Cluster on Google Compute Engine**](https://github.com/rimusz/coreos-multi-node-k8s-gce/blob/master/README.md)
+
+Scripted installation of a single master, multi-worker cluster on GCE. Kubernetes components are managed by [fleet](https://github.com/coreos/fleet).
+
+<hr/>
+
+[**Multi-node cluster using cloud-config and Weave on Vagrant**](https://github.com/errordeveloper/weave-demos/blob/master/poseidon/README.md)
+
+Configure a Vagrant-based cluster of 3 machines with networking provided by Weave.
+
+<hr/>
+
+[**Multi-node cluster using cloud-config and Vagrant**](https://github.com/pires/kubernetes-vagrant-coreos-cluster/blob/master/README.md)
+
+Configure a single-master, multi-worker cluster locally, running on your choice of hypervisor: VirtualBox, Parallels, or VMware
+
+<hr/>
+
+[**Multi-node cluster with Vagrant and fleet units using a small OS X App**](https://github.com/rimusz/coreos-osx-gui-kubernetes-cluster/blob/master/README.md)
+
+Guide to running a single master, multi-worker cluster controlled by an OS X menubar application. Uses Vagrant under the hood.
+
+<hr/>
+
+[**Resizable multi-node cluster on Azure with Weave**](coreos/azure/README.md)
+
+Guide to running an HA etcd cluster with a single master on Azure. Uses the Azure node.js CLI to resize the cluster.
+
+<hr/>
+
+[**Multi-node cluster using cloud-config, coreos and VMware ESXi**](https://github.com/xavierbaude/VMware-coreos-multi-nodes-Kubernetes)
+
+Configure a singe master, single worker cluster on VMware EXSi.
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->
 [![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/getting-started-guides/coreos.md?pixel)]()

--- a/docs/getting-started-guides/coreos.md
+++ b/docs/getting-started-guides/coreos.md
@@ -47,7 +47,7 @@ Guide to setting up a multi-node cluster on Vagrant. The deployer can independen
 
 [**Vagrant Single-Node**](https://coreos.com/kubernetes/docs/latest/kubernetes-on-vagrant-single.html)
 
-Quickest way to set up a Kubernetes development environment locally. As easy as `git clone`, `vagrant up` and configuring `kubectl`.
+The quickest way to set up a Kubernetes development environment locally. As easy as `git clone`, `vagrant up` and configuring `kubectl`.
 
 <hr/>
 
@@ -57,7 +57,7 @@ A generic guide to setting up an HA cluster on any cloud or bare metal, with ful
 
 ### Community Guides
 
-These guides are maintained by community members and cover specific platforms, use-cases and experiment with different ways of configuring Kubernetes on CoreOS.
+These guides are maintained by community members, cover specific platforms and use cases, and experiment with different ways of configuring Kubernetes on CoreOS.
 
 [**Multi-node Cluster**](coreos/coreos_multinode_cluster.md)
 
@@ -79,7 +79,7 @@ Configure a Vagrant-based cluster of 3 machines with networking provided by Weav
 
 [**Multi-node cluster using cloud-config and Vagrant**](https://github.com/pires/kubernetes-vagrant-coreos-cluster/blob/master/README.md)
 
-Configure a single-master, multi-worker cluster locally, running on your choice of hypervisor: VirtualBox, Parallels, or VMware
+Configure a single master, multi-worker cluster locally, running on your choice of hypervisor: VirtualBox, Parallels, or VMware
 
 <hr/>
 
@@ -97,7 +97,7 @@ Guide to running an HA etcd cluster with a single master on Azure. Uses the Azur
 
 [**Multi-node cluster using cloud-config, coreos and VMware ESXi**](https://github.com/xavierbaude/VMware-coreos-multi-nodes-Kubernetes)
 
-Configure a singe master, single worker cluster on VMware EXSi.
+Configure a single master, single worker cluster on VMware ESXi.
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->
 [![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/getting-started-guides/coreos.md?pixel)]()


### PR DESCRIPTION
- Split the guides into two sections: official and community
- Added descriptions to more clearly articulate the differences between them

Fixes https://github.com/kubernetes/kubernetes/issues/14205, https://github.com/kubernetes/kubernetes/issues/9178, and https://github.com/kubernetes/kubernetes/issues/14032

CLA should be pre-signed by CoreOS, Inc.
