### PR TITLE
kubelet: disable LastProbeTime in pod condition

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2518,7 +2518,9 @@ func readyPodCondition(isPodReady bool, reason, message string, existingStatus *
 	} else {
 		condition.Status = api.ConditionFalse
 	}
-	condition.LastProbeTime = currentTime
+	// Disable setting LastProbeTime to avoid constantly sending pod status
+	// update to the apiserver. See http://issues.k8s.io/14273
+	// condition.LastProbeTime = currentTime
 	condition.Reason = reason
 	condition.Message = message
 	if existingStatus != nil {


### PR DESCRIPTION
LastProbeTime was introduced recently in the PodCondition. Because
LastProbeTime changes whenever kubelet generates the pod status, it caused
kubelet to send an update to the apiserver on every sync, leading to
performance regression and test failures (#14273). This PR temporariliy
disables setting the field to make the e2e tests green.
