### PR TITLE
Remove ExpStorageVersion and add StorageVersions to APIServer struct

### DIFF
--- a/cmd/kube-apiserver/app/server_test.go
+++ b/cmd/kube-apiserver/app/server_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package app
 
 import (
+	"reflect"
 	"regexp"
 	"testing"
 )
@@ -58,6 +59,42 @@ func TestLongRunningRequestRegexp(t *testing.T) {
 	for _, path := range doMatch {
 		if !regexp.MatchString(path) {
 			t.Errorf("path should have match regexp did not: %s", path)
+		}
+	}
+}
+
+func TestGenerateStorageVersionMap(t *testing.T) {
+	testCases := []struct {
+		legacyVersion   string
+		storageVersions string
+		expectedMap     map[string]string
+	}{
+		{
+			legacyVersion:   "v1",
+			storageVersions: "v1,experimental/v1alpha1",
+			expectedMap: map[string]string{
+				"":             "v1",
+				"experimental": "experimental/v1alpha1",
+			},
+		},
+		{
+			legacyVersion:   "",
+			storageVersions: "experimental/v1alpha1,v1",
+			expectedMap: map[string]string{
+				"":             "v1",
+				"experimental": "experimental/v1alpha1",
+			},
+		},
+		{
+			legacyVersion:   "",
+			storageVersions: "",
+			expectedMap:     map[string]string{},
+		},
+	}
+	for _, test := range testCases {
+		output := generateStorageVersionMap(test.legacyVersion, test.storageVersions)
+		if !reflect.DeepEqual(test.expectedMap, output) {
+			t.Errorf("unexpected error. expect: %v, got: %v", test.expectedMap, output)
 		}
 	}
 }

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -268,6 +268,7 @@ ssh-user
 static-pods-config
 stats-port
 storage-version
+storage-versions
 streaming-connection-idle-timeout
 suicide-timeout
 sync-frequency

--- a/pkg/api/latest/latest.go
+++ b/pkg/api/latest/latest.go
@@ -18,6 +18,8 @@ package latest
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/registered"
@@ -32,6 +34,9 @@ var (
 	RegisterGroup = allGroups.RegisterGroup
 	// GroupOrDie is a shortcut to allGroups.GroupOrDie.
 	GroupOrDie = allGroups.GroupOrDie
+	// AllPreferredGroupVersions returns the preferred versions of all
+	// registered groups in the form of "group1/version1,group2/version2,..."
+	AllPreferredGroupVersions = allGroups.AllPreferredGroupVersions
 )
 
 // GroupMetaMap is a map between group names and their metadata.
@@ -74,6 +79,20 @@ func (g GroupMetaMap) GroupOrDie(group string) *GroupMeta {
 		}
 	}
 	return groupMeta
+}
+
+// AllPreferredGroupVersions returns the preferred versions of all registered
+// groups in the form of "group1/version1,group2/version2,..."
+func (g GroupMetaMap) AllPreferredGroupVersions() string {
+	if len(g) == 0 {
+		return ""
+	}
+	var defaults []string
+	for _, groupMeta := range g {
+		defaults = append(defaults, groupMeta.GroupVersion)
+	}
+	sort.Strings(defaults)
+	return strings.Join(defaults, ",")
 }
 
 // GroupMeta stores the metadata of a group, such as the latest supported version.

--- a/pkg/api/latest/latest_test.go
+++ b/pkg/api/latest/latest_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package latest
+
+import "testing"
+
+func TestAllPreferredGroupVersions(t *testing.T) {
+	testCases := []struct {
+		groupMetaMap GroupMetaMap
+		expect       string
+	}{
+		{
+			groupMetaMap: GroupMetaMap{
+				"group1": &GroupMeta{
+					GroupVersion: "group1/v1",
+				},
+				"group2": &GroupMeta{
+					GroupVersion: "group2/v2",
+				},
+				"": &GroupMeta{
+					GroupVersion: "v1",
+				},
+			},
+			expect: "group1/v1,group2/v2,v1",
+		},
+		{
+			groupMetaMap: GroupMetaMap{
+				"": &GroupMeta{
+					GroupVersion: "v1",
+				},
+			},
+			expect: "v1",
+		},
+		{
+			groupMetaMap: GroupMetaMap{},
+			expect:       "",
+		},
+	}
+	for _, testCase := range testCases {
+		output := testCase.groupMetaMap.AllPreferredGroupVersions()
+		if testCase.expect != output {
+			t.Errorf("Error. expect: %s, got: %s", testCase.expect, output)
+		}
+	}
+}


### PR DESCRIPTION
User can specify StorageVersions flag in the form of `group1/version1,group2/version2...`, and the version of the storage of a group would be default to the latest.Group("group").Version if it's not specified in the Storageversions flag.

@lavalamp 
