### PR TITLE
[libvirt-coreos cluster] Get rid of the etcd discovery mechanism in favor of static configuration

### DIFF
--- a/cluster/libvirt-coreos/user_data.yml
+++ b/cluster/libvirt-coreos/user_data.yml
@@ -15,11 +15,12 @@ write_files:
 
 coreos:
   etcd2:
-    discovery: ${discovery}
     advertise-client-urls: http://${public_ip}:2379
     initial-advertise-peer-urls: http://${public_ip}:2380
     listen-client-urls: http://0.0.0.0:2379
     listen-peer-urls: http://${public_ip}:2380
+    initial-cluster-state: new
+    initial-cluster: ${etcd2_initial_cluster}
   units:
     - name: static.network
       command: start
@@ -70,6 +71,11 @@ coreos:
         Type=oneshot
     - name: etcd2.service
       command: start
+      drop-ins:
+        - name: 10-override-name.conf
+          content: |
+            [Service]
+            Environment=ETCD_NAME=%H
     - name: docker.service
       command: start
       drop-ins:

--- a/cluster/libvirt-coreos/util.sh
+++ b/cluster/libvirt-coreos/util.sh
@@ -189,11 +189,18 @@ function kube-up {
 
   readonly ssh_keys="$(cat ~/.ssh/id_*.pub | sed 's/^/  - /')"
   readonly kubernetes_dir="$POOL_PATH/kubernetes"
-  readonly discovery=$(curl -s https://discovery.etcd.io/new?size=$(($NUM_MINIONS+1)))
-
-  readonly machines=$(join , "${KUBE_MINION_IP_ADDRESSES[@]}")
 
   local i
+  for (( i = 0 ; i <= $NUM_MINIONS ; i++ )); do
+    if [[ $i -eq $NUM_MINIONS ]]; then
+        etcd2_initial_cluster[$i]="${MASTER_NAME}=http://${MASTER_IP}:2380"
+    else
+        etcd2_initial_cluster[$i]="${MINION_NAMES[$i]}=http://${MINION_IPS[$i]}:2380"
+    fi
+  done
+  etcd2_initial_cluster=$(join , "${etcd2_initial_cluster[@]}")
+  readonly machines=$(join , "${KUBE_MINION_IP_ADDRESSES[@]}")
+
   for (( i = 0 ; i <= $NUM_MINIONS ; i++ )); do
     if [[ $i -eq $NUM_MINIONS ]]; then
         type=master

--- a/docs/getting-started-guides/libvirt-coreos.md
+++ b/docs/getting-started-guides/libvirt-coreos.md
@@ -227,12 +227,6 @@ Bring up a libvirt-CoreOS cluster of 5 nodes
 NUM_MINIONS=5 cluster/kube-up.sh
 ```
 
-Bring up a libvirt-CoreOS cluster with a local etcd discovery
-
-```sh
-DISCOVERY=local-etcd cluster/kube-up.sh
-```
-
 Destroy the libvirt-CoreOS cluster
 
 ```sh


### PR DESCRIPTION
In order to make the etcd instances of the VMs join into a single cluster, we used to use the discovery mechanism.

This made the cluster bootstrap dependent on an external etcd cluster instance.

74601ea replaced the dependency on `discovery.etcd.io` by a local etcd cluster.

This change completely gets rid of the dynamic discovery mechanism in favor of the static configuration method.

This should be both safe and light since it completely removes the need of having a pre-existing external etcd cluster running somewhere (either `discovery.etcd.io`, or locally).
