### PR TITLE
Preparation for Mesos kubelet code-deduplication

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -238,7 +238,7 @@ func startComponents(firstManifestURL, secondManifestURL string) (string, string
 		10*time.Second, /* SyncFrequency */
 		40 /* MaxPods */)
 
-	kubeletapp.RunKubelet(kcfg, nil)
+	kubeletapp.RunKubelet(kcfg)
 	// Kubelet (machine)
 	// Create a second kubelet so that the guestbook example's two redis slaves both
 	// have a place they can schedule.
@@ -270,7 +270,7 @@ func startComponents(firstManifestURL, secondManifestURL string) (string, string
 
 		40 /* MaxPods */)
 
-	kubeletapp.RunKubelet(kcfg, nil)
+	kubeletapp.RunKubelet(kcfg)
 	return apiServer.URL, configFilePath
 }
 

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -714,7 +714,7 @@ func RunKubelet(kcfg *KubeletConfig) error {
 
 	builder := kcfg.Builder
 	if builder == nil {
-		builder = createAndInitKubelet
+		builder = CreateAndInitKubelet
 	}
 	if kcfg.OSInterface == nil {
 		kcfg.OSInterface = kubecontainer.RealOS{}
@@ -848,7 +848,7 @@ type KubeletConfig struct {
 	VolumePlugins                  []volume.VolumePlugin
 }
 
-func createAndInitKubelet(kc *KubeletConfig) (k KubeletBootstrap, pc *config.PodConfig, err error) {
+func CreateAndInitKubelet(kc *KubeletConfig) (k KubeletBootstrap, pc *config.PodConfig, err error) {
 	// TODO: block until all sources have delivered at least one update to the channel, or break the sync loop
 	// up into "per source" synchronizations
 	// TODO: KubeletConfig.KubeClient should be a client interface, but client interface misses certain methods

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -455,7 +455,7 @@ func (s *KubeletServer) Run(kcfg *KubeletConfig) error {
 		glog.Warning(err)
 	}
 
-	if err := RunKubelet(kcfg, nil); err != nil {
+	if err := RunKubelet(kcfg); err != nil {
 		return err
 	}
 
@@ -663,7 +663,7 @@ func SimpleKubelet(client *client.Client,
 //   2 Kubelet binary
 //   3 Standalone 'kubernetes' binary
 // Eventually, #2 will be replaced with instances of #3
-func RunKubelet(kcfg *KubeletConfig, builder KubeletBuilder) error {
+func RunKubelet(kcfg *KubeletConfig) error {
 	kcfg.Hostname = nodeutil.GetHostname(kcfg.HostnameOverride)
 
 	if len(kcfg.NodeName) == 0 {
@@ -712,6 +712,7 @@ func RunKubelet(kcfg *KubeletConfig, builder KubeletBuilder) error {
 
 	credentialprovider.SetPreferredDockercfgPath(kcfg.RootDirectory)
 
+	builder := kcfg.Builder
 	if builder == nil {
 		builder = createAndInitKubelet
 	}
@@ -782,6 +783,7 @@ func makePodSourceConfig(kc *KubeletConfig) *config.PodConfig {
 type KubeletConfig struct {
 	Address                        net.IP
 	AllowPrivileged                bool
+	Builder                        KubeletBuilder
 	CAdvisorInterface              cadvisor.Interface
 	CgroupRoot                     string
 	Cloud                          cloudprovider.Interface

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -826,6 +826,7 @@ type KubeletConfig struct {
 	OOMAdjuster                    *oom.OOMAdjuster
 	OSInterface                    kubecontainer.OSInterface
 	PodCIDR                        string
+	PodConfig                      *config.PodConfig
 	PodInfraContainerImage         string
 	Port                           uint
 	ReadOnlyPort                   uint
@@ -869,7 +870,10 @@ func CreateAndInitKubelet(kc *KubeletConfig) (k KubeletBootstrap, pc *config.Pod
 		KubeletEndpoint: api.DaemonEndpoint{Port: int(kc.Port)},
 	}
 
-	pc = makePodSourceConfig(kc)
+	pc = kc.PodConfig
+	if pc == nil {
+		pc = makePodSourceConfig(kc)
+	}
 	k, err = kubelet.NewMainKubelet(
 		kc.Hostname,
 		kc.NodeName,

--- a/cmd/kubemark/hollow-node.go
+++ b/cmd/kubemark/hollow-node.go
@@ -130,7 +130,7 @@ func main() {
 		10*time.Second,         /* SyncFrequency */
 		40,                     /* MaxPods */
 	)
-	kubeletapp.RunKubelet(kcfg, nil)
+	kubeletapp.RunKubelet(kcfg)
 
 	select {}
 }

--- a/contrib/mesos/pkg/executor/service/service.go
+++ b/contrib/mesos/pkg/executor/service/service.go
@@ -215,9 +215,11 @@ func (s *KubeletExecutorServer) Run(hks hyperkube.Interface, _ []string) error {
 
 	kcfg.NodeName = kcfg.Hostname
 
-	err = app.RunKubelet(&kcfg, app.KubeletBuilder(func(kc *app.KubeletConfig) (app.KubeletBootstrap, *kconfig.PodConfig, error) {
+	kcfg.Builder = app.KubeletBuilder(func(kc *app.KubeletConfig) (app.KubeletBootstrap, *kconfig.PodConfig, error) {
 		return s.createAndInitKubelet(kc, hks, clientConfig)
-	}))
+	})
+
+	err = app.RunKubelet(&kcfg)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The Mesos executor duplicates several hundred lines of kubelet initialization code to apply a handful of small customizations. This PR prepares the kubelet such that in https://github.com/kubernetes/kubernetes/pull/13036 most of the duplication can be removed:
- add PodConfig to KubeletConfig to be optionally overridden
- add KubeletBuilder  to KubeletConfig to be optionally overridden
- make CreateAndInitKubelet public to be re-used by any KubeletBuilder extension
