### PR TITLE
Grafana 2.1.0 and InfluxDB 0.9.4 Support E2E

### DIFF
--- a/cluster/addons/cluster-monitoring/influxdb/grafana-image/Dockerfile
+++ b/cluster/addons/cluster-monitoring/influxdb/grafana-image/Dockerfile
@@ -1,0 +1,15 @@
+#
+# Stock Grafana + a few custom dashboards
+#
+
+FROM grafana/grafana:2.1.0
+
+RUN apt-get update && \
+    apt-get install -y curl
+
+COPY dashboards /dashboards
+COPY influxdb_service_discovery /influxdb_service_discovery
+COPY run.sh /run.sh
+
+EXPOSE 3000
+ENTRYPOINT /run.sh

--- a/cluster/addons/cluster-monitoring/influxdb/grafana-image/README.md
+++ b/cluster/addons/cluster-monitoring/influxdb/grafana-image/README.md
@@ -1,0 +1,32 @@
+# Grafana Image For Kubernetes
+
+## What's In It
+* Stock Grafana.
+* Logic to discover InfluxDB service endpoint and create a datasource for it.
+* Create a couple of dashboards during startup. These dashboards leverage templating and repeating of panels features in Grafana 2.0, to discover nodes, pods, and containers automatically.
+
+## How To Build It
+### Build influxdb_service_discovery.go
+
+```
+cd $GOPATH/src/k8s.io/kubernetes/cluster/addons/cluster-monitoring/influxdb/grafana-image
+
+docker run --rm -v "$GOPATH":/gopath -w /gopath/src/k8s.io/kubernetes/cluster/addons/cluster-monitoring/influxdb/grafana-image -e GOOS=linux -e GOARCH=amd64 -e GOPATH=/gopath golang:1.4 go build -v influxdb_service_discovery.go
+```
+
+This should create ```influxdb_service_discovery``` in the current folder.
+
+### Build Docker Image
+
+```
+cd $GOPATH/src/k8s.io/kubernetes/cluster/addons/cluster-monitoring/influxdb/grafana-image
+
+docker build -t gcr.io/google_containers/grafana:2.1.0 .
+
+docker push gcr.io/google_containers/grafana:2.1.0
+```
+
+### Update The Spec
+Make sure the YAML file refers to the latest version.
+
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/cluster/addons/cluster-monitoring/influxdb/grafana-image/README.md?pixel)]()

--- a/cluster/addons/cluster-monitoring/influxdb/grafana-image/dashboards/cluster.json
+++ b/cluster/addons/cluster-monitoring/influxdb/grafana-image/dashboards/cluster.json
@@ -1,0 +1,1096 @@
+{
+  "dashboard":
+  {
+    "title": "Kubernetes Cluster",
+    "originalTitle": "Kubernetes Cluster",
+    "tags": [],
+    "style": "dark",
+    "timezone": "browser",
+    "editable": true,
+    "hideControls": false,
+    "sharedCrosshair": false,
+    "rows": [
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": null,
+            "decimals": 2,
+            "editable": true,
+            "error": false,
+            "fill": 3,
+            "grid": {
+              "leftLogBase": 1,
+              "leftMax": null,
+              "leftMin": null,
+              "rightLogBase": 1,
+              "rightMax": null,
+              "rightMin": null,
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 6,
+            "interval": "",
+            "leftYAxisLabel": "",
+            "legend": {
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 3,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+              {
+                "alias": "Used Memory",
+                "yaxis": 2
+              },
+              {
+                "alias": "Total Used Memory",
+                "yaxis": 1
+              },
+              {
+                "alias": "Total Working Set",
+                "yaxis": 1
+              }
+            ],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "alias": "Limit",
+                "fields": [
+                  {
+                    "func": "sum",
+                    "name": "value"
+                  }
+                ],
+                "groupByTags": [],
+                "measurement": "memory/limit_bytes_gauge",
+                "query": "SELECT sum(value) FROM \"memory/limit_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time(10s)",
+                "rawQuery": true,
+                "tags": [
+                  {
+                    "key": "hostname",
+                    "value": "/$node/"
+                  },
+                  {
+                    "condition": "AND",
+                    "key": "container_name",
+                    "value": "machine"
+                  }
+                ]
+              },
+              {
+                "alias": "Usage",
+                "fields": [
+                  {
+                    "func": "last",
+                    "name": "value"
+                  }
+                ],
+                "groupByTags": [],
+                "measurement": "memory/usage_bytes_gauge",
+                "query": "SELECT sum(value) FROM \"memory/usage_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time(10s)",
+                "rawQuery": true,
+                "tags": [
+                  {
+                    "key": "hostname",
+                    "value": "/$node/"
+                  },
+                  {
+                    "condition": "AND",
+                    "key": "container_name",
+                    "value": "machine"
+                  }
+                ]
+              },
+              {
+                "alias": "Working Set",
+                "fields": [
+                  {
+                    "func": "last",
+                    "name": "value"
+                  }
+                ],
+                "groupByTags": [],
+                "measurement": "memory/usage_bytes_gauge",
+                "query": "SELECT sum(value) FROM \"memory/working_set_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time(10s)",
+                "rawQuery": true,
+                "tags": [
+                  {
+                    "key": "hostname",
+                    "value": "/$node/"
+                  },
+                  {
+                    "condition": "AND",
+                    "key": "container_name",
+                    "value": "machine"
+                  }
+                ]
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Cluster Memory Usage",
+            "tooltip": {
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "x-axis": true,
+            "y-axis": true,
+            "y_formats": [
+              "bytes",
+              "bytes"
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": null,
+            "decimals": 2,
+            "editable": true,
+            "error": false,
+            "fill": 3,
+            "grid": {
+              "leftLogBase": 1,
+              "leftMax": null,
+              "leftMin": null,
+              "rightLogBase": 1,
+              "rightMax": null,
+              "rightMin": null,
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 7,
+            "leftYAxisLabel": "",
+            "legend": {
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 3,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+              {
+                "alias": "Used Memory",
+                "yaxis": 1
+              },
+              {
+                "alias": "Working Set",
+                "yaxis": 1
+              }
+            ],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "alias": "Limit",
+                "fields": [
+                  {
+                    "func": "last",
+                    "name": "value"
+                  }
+                ],
+                "groupByTags": [],
+                "measurement": "memory/limit_bytes_gauge",
+                "query": "SELECT last(value) FROM \"memory/limit_bytes_gauge\" WHERE \"hostname\" =~ /$node/ AND \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval)",
+                "tags": [
+                  {
+                    "key": "hostname",
+                    "value": "/$node/"
+                  },
+                  {
+                    "condition": "AND",
+                    "key": "container_name",
+                    "value": "machine"
+                  }
+                ]
+              },
+              {
+                "alias": "Usage",
+                "fields": [
+                  {
+                    "func": "last",
+                    "name": "value"
+                  }
+                ],
+                "groupByTags": [],
+                "measurement": "memory/usage_bytes_gauge",
+                "query": "SELECT last(value) FROM \"memory/usage_bytes_gauge\" WHERE \"hostname\" =~ /$node/ AND \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval)",
+                "tags": [
+                  {
+                    "key": "hostname",
+                    "value": "/$node/"
+                  },
+                  {
+                    "condition": "AND",
+                    "key": "container_name",
+                    "value": "machine"
+                  }
+                ]
+              },
+              {
+                "alias": "Working Set",
+                "fields": [
+                  {
+                    "func": "last",
+                    "name": "value"
+                  }
+                ],
+                "groupByTags": [],
+                "measurement": "memory/working_set_bytes_gauge",
+                "query": "SELECT last(value) FROM \"memory/working_set_bytes_gauge\" WHERE \"hostname\" =~ /$node/ AND \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval)",
+                "tags": [
+                  {
+                    "key": "hostname",
+                    "value": "/$node/"
+                  },
+                  {
+                    "condition": "AND",
+                    "key": "container_name",
+                    "value": "machine"
+                  }
+                ]
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "$node Memory Usage",
+            "tooltip": {
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "x-axis": true,
+            "y-axis": true,
+            "y_formats": [
+              "bytes",
+              "bytes"
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": null,
+            "decimals": null,
+            "editable": true,
+            "error": false,
+            "fill": 3,
+            "grid": {
+              "leftLogBase": 1,
+              "leftMax": null,
+              "leftMin": null,
+              "rightLogBase": 1,
+              "rightMax": null,
+              "rightMin": null,
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 8,
+            "leftYAxisLabel": "",
+            "legend": {
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 3,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+              {
+                "alias": "Used Memory",
+                "yaxis": 1
+              },
+              {
+                "alias": "Working Set",
+                "yaxis": 1
+              },
+              {
+                "alias": "Major Page Faults",
+                "yaxis": 2
+              }
+            ],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "alias": "Page Faults",
+                "fields": [
+                  {
+                    "func": "last",
+                    "name": "value"
+                  }
+                ],
+                "groupByTags": [],
+                "measurement": "memory/page_faults_cumulative",
+                "query": "SELECT last(value) FROM \"memory/page_faults_cumulative\" WHERE \"hostname\" =~ /$node/ AND \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval)",
+                "tags": [
+                  {
+                    "key": "hostname",
+                    "value": "/$node/"
+                  },
+                  {
+                    "condition": "AND",
+                    "key": "container_name",
+                    "value": "machine"
+                  }
+                ]
+              },
+              {
+                "alias": "Major Page Faults",
+                "fields": [
+                  {
+                    "func": "last",
+                    "name": "value"
+                  }
+                ],
+                "groupByTags": [],
+                "measurement": "memory/major_page_faults_cumulative",
+                "query": "SELECT last(value) FROM \"memory/major_page_faults_cumulative\" WHERE \"hostname\" =~ /$node/ AND \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval)",
+                "tags": [
+                  {
+                    "key": "hostname",
+                    "value": "/$node/"
+                  },
+                  {
+                    "condition": "AND",
+                    "key": "container_name",
+                    "value": "machine"
+                  }
+                ]
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "$node Page Faults",
+            "tooltip": {
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "x-axis": true,
+            "y-axis": true,
+            "y_formats": [
+              "none",
+              "none"
+            ]
+          }
+        ],
+        "showTitle": false,
+        "title": "Cluster Memory Usage"
+      },
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": null,
+            "decimals": 2,
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {
+              "leftLogBase": 1,
+              "leftMax": null,
+              "leftMin": null,
+              "rightLogBase": 1,
+              "rightMax": null,
+              "rightMin": null,
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 11,
+            "interval": "10s",
+            "legend": {
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+              {
+                "alias": "usage",
+                "yaxis": 2
+              }
+            ],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "alias": "Limit",
+                "fields": [
+                  {
+                    "func": "mean",
+                    "name": "value"
+                  }
+                ],
+                "groupByTags": [],
+                "measurement": "cpu/limit_gauge",
+                "query": "SELECT mean(value) FROM \"cpu/limit_gauge\" WHERE \"container_name\" = 'machine' AND \"hostname\" =~ /$node/ AND $timeFilter GROUP BY time($interval)",
+                "rawQuery": false,
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "machine"
+                  },
+                  {
+                    "condition": "AND",
+                    "key": "hostname",
+                    "value": "/$node/"
+                  }
+                ]
+              },
+              {
+                "alias": "Usage",
+                "fields": [
+                  {
+                    "func": "derivative",
+                    "name": "value"
+                  }
+                ],
+                "groupByTags": [],
+                "measurement": "cpu/usage_ns_cumulative",
+                "query": "SELECT derivative(value)/10000000 FROM \"cpu/usage_ns_cumulative\" WHERE \"container_name\" = 'machine' AND \"hostname\" =~ /$node/ AND $timeFilter GROUP BY time($interval)",
+                "rawQuery": true,
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "machine"
+                  },
+                  {
+                    "condition": "AND",
+                    "key": "hostname",
+                    "value": "/$node/"
+                  }
+                ],
+                "target": ""
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "$node CPU Usage",
+            "tooltip": {
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "x-axis": true,
+            "y-axis": true,
+            "y_formats": [
+              "ms",
+              "ms"
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": null,
+            "decimals": 2,
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {
+              "leftLogBase": 1,
+              "leftMax": null,
+              "leftMin": null,
+              "rightLogBase": 1,
+              "rightMax": null,
+              "rightMin": null,
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 9,
+            "legend": {
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+              {
+                "alias": "Used Disk",
+                "yaxis": 2
+              },
+              {
+                "alias": "Total Used Disk",
+                "yaxis": 2
+              }
+            ],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "alias": "Limit",
+                "fields": [
+                  {
+                    "func": "mean",
+                    "name": "value"
+                  }
+                ],
+                "groupByTags": [],
+                "query": "SELECT sum(value) FROM \"filesystem/limit_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time(10s)",
+                "rawQuery": true,
+                "tags": []
+              },
+              {
+                "alias": "Usage",
+                "fields": [
+                  {
+                    "func": "mean",
+                    "name": "value"
+                  }
+                ],
+                "groupByTags": [],
+                "query": "SELECT sum(value) FROM \"filesystem/usage_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time(10s)",
+                "rawQuery": true,
+                "tags": []
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Cluster Disk Usage",
+            "tooltip": {
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "x-axis": true,
+            "y-axis": true,
+            "y_formats": [
+              "bytes",
+              "bytes"
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": null,
+            "decimals": 2,
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {
+              "leftLogBase": 1,
+              "leftMax": null,
+              "leftMin": null,
+              "rightLogBase": 1,
+              "rightMax": null,
+              "rightMin": null,
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 10,
+            "legend": {
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+              {
+                "alias": "Used Disk",
+                "yaxis": 2
+              }
+            ],
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "alias": "Limit",
+                "fields": [
+                  {
+                    "func": "mean",
+                    "name": "value"
+                  }
+                ],
+                "groupByTags": [],
+                "query": "SELECT last(value) FROM \"filesystem/limit_bytes_gauge\" WHERE \"hostname\" =~ /$node/ AND \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval)",
+                "rawQuery": true,
+                "tags": []
+              },
+              {
+                "alias": "Usage",
+                "fields": [
+                  {
+                    "func": "mean",
+                    "name": "value"
+                  }
+                ],
+                "groupByTags": [],
+                "query": "SELECT last(value) FROM \"filesystem/usage_bytes_gauge\" WHERE \"hostname\" =~ /$node/ AND \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval)",
+                "rawQuery": true,
+                "tags": []
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "$node Disk Usage",
+            "tooltip": {
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "x-axis": true,
+            "y-axis": true,
+            "y_formats": [
+              "bytes",
+              "bytes"
+            ]
+          }
+        ],
+        "title": "Cluster Disk & CPU Usage"
+      },
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": null,
+            "decimals": 2,
+            "editable": true,
+            "error": false,
+            "fill": 3,
+            "grid": {
+              "leftLogBase": 1,
+              "leftMax": null,
+              "leftMin": null,
+              "rightLogBase": 1,
+              "rightMax": null,
+              "rightMin": null,
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "hideTimeOverride": false,
+            "id": 1,
+            "interval": "10s",
+            "legend": {
+              "avg": false,
+              "current": true,
+              "max": true,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 3,
+            "links": [],
+            "minSpan": 4,
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": "service_container",
+            "scopedVars": {
+            },
+            "seriesOverrides": [
+              {},
+              {
+                "alias": "Used Memory",
+                "yaxis": 1
+              }
+            ],
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "alias": "Limit",
+                "fields": [
+                  {
+                    "func": "last",
+                    "name": "value"
+                  }
+                ],
+                "fill": "null",
+                "groupByTags": [],
+                "hide": false,
+                "measurement": "memory/limit_bytes_gauge",
+                "query": "SELECT last(value) FROM \"memory/limit_bytes_gauge\" WHERE \"container_name\" =~ /$service_container/ AND $timeFilter GROUP BY time($interval) fill(null)",
+                "rawQuery": false,
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "/$service_container/"
+                  }
+                ]
+              },
+              {
+                "alias": "Usage",
+                "fields": [
+                  {
+                    "func": "last",
+                    "name": "value"
+                  }
+                ],
+                "fill": "null",
+                "groupByTags": [],
+                "hide": false,
+                "measurement": "memory/usage_bytes_gauge",
+                "query": "SELECT last(value) FROM \"memory/usage_bytes_gauge\" WHERE \"container_name\" =~ /$service_container/ AND $timeFilter GROUP BY time($interval) fill(null)",
+                "rawQuery": false,
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "/$service_container/"
+                  }
+                ]
+              },
+              {
+                "alias": "Working Set",
+                "fields": [
+                  {
+                    "func": "last",
+                    "name": "value"
+                  }
+                ],
+                "fill": "null",
+                "groupByTags": [],
+                "hide": false,
+                "measurement": "memory/working_set_bytes_gauge",
+                "query": "SELECT last(value) FROM \"memory/working_set_bytes_gauge\" WHERE \"container_name\" =~ /$service_container/ AND $timeFilter GROUP BY time($interval) fill(null)",
+                "rawQuery": false,
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "/$service_container/"
+                  }
+                ]
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Service Container \"$service_container\" Memory usage",
+            "tooltip": {
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "x-axis": true,
+            "y-axis": true,
+            "y_formats": [
+              "bytes",
+              "short"
+            ]
+          }
+        ],
+        "title": "Service Container Memory"
+      },
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": null,
+            "decimals": 2,
+            "editable": true,
+            "error": false,
+            "fill": 3,
+            "grid": {
+              "leftLogBase": 1,
+              "leftMax": null,
+              "leftMin": null,
+              "rightLogBase": 1,
+              "rightMax": null,
+              "rightMin": null,
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "hideTimeOverride": false,
+            "id": 14,
+            "interval": "10s",
+            "legend": {
+              "avg": false,
+              "current": true,
+              "max": true,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 3,
+            "links": [],
+            "minSpan": 4,
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": "service_container",
+            "scopedVars": {
+            },
+            "seriesOverrides": [
+              {},
+              {
+                "alias": "Used Memory",
+                "yaxis": 1
+              }
+            ],
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "alias": "Limit",
+                "fields": [
+                  {
+                    "func": "mean",
+                    "name": "value"
+                  }
+                ],
+                "fill": "null",
+                "groupByTags": [],
+                "hide": false,
+                "measurement": "cpu/limit_gauge",
+                "query": "SELECT mean(value) FROM \"cpu/limit_gauge\" WHERE \"container_name\" =~ /$service_container/ AND $timeFilter GROUP BY time($interval) fill(null)",
+                "rawQuery": true,
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "/$service_container/"
+                  }
+                ]
+              },
+              {
+                "alias": "Usage",
+                "fields": [
+                  {
+                    "func": "mean",
+                    "name": "value"
+                  }
+                ],
+                "fill": "null",
+                "groupByTags": [],
+                "hide": false,
+                "measurement": "cpu/limit_gauge",
+                "query": "SELECT derivative(value)/10000000 FROM \"cpu/usage_ns_cumulative\" WHERE \"container_name\" =~ /$service_container/ AND $timeFilter GROUP BY time($interval)",
+                "rawQuery": true,
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "/$service_container/"
+                  }
+                ]
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Service Container \"$service_container\" CPU Usage",
+            "tooltip": {
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "x-axis": true,
+            "y-axis": true,
+            "y_formats": [
+              "ms",
+              "short"
+            ]
+          }
+        ],
+        "title": "Service Container CPU"
+      }
+    ],
+    "nav": [
+      {
+        "collapse": false,
+        "enable": true,
+        "notice": false,
+        "now": true,
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ],
+        "status": "Stable",
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ],
+        "type": "timepicker"
+      }
+    ],
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "templating": {
+      "list": [
+        {
+          "allFormat": "wildcard",
+          "current": {
+          },
+          "datasource": null,
+          "includeAll": false,
+          "label": "Node",
+          "multi": false,
+          "multiFormat": "glob",
+          "name": "node",
+          "options": [
+          ],
+          "query": "SHOW TAG VALUES FROM \"uptime_ms_cumulative\" WITH KEY = \"hostname\"\t",
+          "refresh": true,
+          "refresh_on_load": true,
+          "regex": "",
+          "type": "query",
+          "useTags": false
+        },
+        {
+          "allFormat": "glob",
+          "current": {
+          },
+          "datasource": null,
+          "includeAll": false,
+          "multi": false,
+          "multiFormat": "glob",
+          "name": "service_pod",
+          "options": [
+          ],
+          "query": "SHOW TAG VALUES FROM \"uptime_ms_cumulative\" WITH KEY = \"pod_name\" WHERE labels =~ /cluster-service/",
+          "refresh": true,
+          "refresh_on_load": true,
+          "type": "query"
+        },
+        {
+          "allFormat": "glob",
+          "current": {
+          },
+          "datasource": null,
+          "includeAll": true,
+          "multi": false,
+          "multiFormat": "glob",
+          "name": "service_container",
+          "options": [
+          ],
+          "query": "SHOW TAG VALUES FROM \"uptime_ms_cumulative\" WITH KEY = \"container_name\" WHERE labels =~ /cluster-service/ and pod_name =~ /$service_pod/ ",
+          "refresh": true,
+          "refresh_on_load": true,
+          "type": "query"
+        }
+      ]
+    },
+    "annotations": {
+      "list": []
+    },
+    "schemaVersion": 6,
+    "version": 40,
+    "links": []
+  }
+}

--- a/cluster/addons/cluster-monitoring/influxdb/grafana-image/dashboards/containers.json
+++ b/cluster/addons/cluster-monitoring/influxdb/grafana-image/dashboards/containers.json
@@ -1,0 +1,359 @@
+{
+  "dashboard":
+  {
+    "title": "Containers",
+    "originalTitle": "Containers",
+    "tags": [],
+    "style": "dark",
+    "timezone": "browser",
+    "editable": true,
+    "hideControls": false,
+    "sharedCrosshair": false,
+    "rows": [
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": null,
+            "decimals": 2,
+            "editable": true,
+            "error": false,
+            "fill": 3,
+            "grid": {
+              "leftLogBase": 1,
+              "leftMax": null,
+              "leftMin": null,
+              "rightLogBase": 1,
+              "rightMax": null,
+              "rightMin": null,
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "hideTimeOverride": false,
+            "id": 1,
+            "interval": "10s",
+            "legend": {
+              "avg": false,
+              "current": true,
+              "max": true,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 3,
+            "links": [],
+            "minSpan": 4,
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": "container",
+            "scopedVars": {
+            },
+            "seriesOverrides": [
+              {},
+              {
+                "alias": "Used Memory",
+                "yaxis": 1
+              }
+            ],
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "alias": "Limit",
+                "fields": [
+                  {
+                    "func": "last",
+                    "name": "value"
+                  }
+                ],
+                "fill": "null",
+                "groupByTags": [],
+                "hide": false,
+                "measurement": "memory/limit_bytes_gauge",
+                "query": "SELECT last(value) FROM \"memory/limit_bytes_gauge\" WHERE \"container_name\" =~ /$container/ AND $timeFilter GROUP BY time($interval) fill(null)",
+                "rawQuery": false,
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "/$container/"
+                  }
+                ]
+              },
+              {
+                "alias": "Usage",
+                "fields": [
+                  {
+                    "func": "last",
+                    "name": "value"
+                  }
+                ],
+                "fill": "null",
+                "groupByTags": [],
+                "hide": false,
+                "measurement": "memory/usage_bytes_gauge",
+                "query": "SELECT last(value) FROM \"memory/usage_bytes_gauge\" WHERE \"container_name\" =~ /$container/ AND $timeFilter GROUP BY time($interval) fill(null)",
+                "rawQuery": false,
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "/$container/"
+                  }
+                ]
+              },
+              {
+                "alias": "Working Set",
+                "fields": [
+                  {
+                    "func": "last",
+                    "name": "value"
+                  }
+                ],
+                "fill": "null",
+                "groupByTags": [],
+                "hide": false,
+                "measurement": "memory/working_set_bytes_gauge",
+                "query": "SELECT last(value) FROM \"memory/working_set_bytes_gauge\" WHERE \"container_name\" =~ /$container/ AND $timeFilter GROUP BY time($interval) fill(null)",
+                "rawQuery": false,
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "/$container/"
+                  }
+                ]
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Service Container \"$container\" Memory usage",
+            "tooltip": {
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "x-axis": true,
+            "y-axis": true,
+            "y_formats": [
+              "bytes",
+              "short"
+            ]
+          }
+        ],
+        "title": "Container Memory"
+      },
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": null,
+            "decimals": 2,
+            "editable": true,
+            "error": false,
+            "fill": 3,
+            "grid": {
+              "leftLogBase": 1,
+              "leftMax": null,
+              "leftMin": null,
+              "rightLogBase": 1,
+              "rightMax": null,
+              "rightMin": null,
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "hideTimeOverride": false,
+            "id": 14,
+            "interval": "10s",
+            "legend": {
+              "avg": false,
+              "current": true,
+              "max": true,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 3,
+            "links": [],
+            "minSpan": 4,
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": "container",
+            "scopedVars": {
+            },
+            "seriesOverrides": [
+              {},
+              {
+                "alias": "Used Memory",
+                "yaxis": 1
+              }
+            ],
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "alias": "Limit",
+                "fields": [
+                  {
+                    "func": "mean",
+                    "name": "value"
+                  }
+                ],
+                "fill": "null",
+                "groupByTags": [],
+                "hide": false,
+                "measurement": "cpu/limit_gauge",
+                "query": "SELECT mean(value) FROM \"cpu/limit_gauge\" WHERE \"container_name\" =~ /$container/ AND $timeFilter GROUP BY time($interval) fill(null)",
+                "rawQuery": true,
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "/$container/"
+                  }
+                ]
+              },
+              {
+                "alias": "Usage",
+                "fields": [
+                  {
+                    "func": "mean",
+                    "name": "value"
+                  }
+                ],
+                "fill": "null",
+                "groupByTags": [],
+                "hide": false,
+                "measurement": "cpu/limit_gauge",
+                "query": "SELECT derivative(value)/10000000 FROM \"cpu/usage_ns_cumulative\" WHERE \"container_name\" =~ /$container/ AND $timeFilter GROUP BY time($interval)",
+                "rawQuery": true,
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "/$container/"
+                  }
+                ]
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Service Container \"$container\" CPU Usage",
+            "tooltip": {
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "x-axis": true,
+            "y-axis": true,
+            "y_formats": [
+              "ms",
+              "short"
+            ]
+          }
+        ],
+        "title": "Container CPU"
+      }
+    ],
+    "nav": [
+      {
+        "collapse": false,
+        "enable": true,
+        "notice": false,
+        "now": true,
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ],
+        "status": "Stable",
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ],
+        "type": "timepicker"
+      }
+    ],
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "templating": {
+      "list": [
+        {
+          "allFormat": "glob",
+          "current": {
+          },
+          "datasource": null,
+          "includeAll": false,
+          "multi": false,
+          "multiFormat": "glob",
+          "name": "pod",
+          "options": [
+          ],
+          "query": "SHOW TAG VALUES FROM \"uptime_ms_cumulative\" WITH KEY = \"pod_name\"",
+          "refresh": true,
+          "refresh_on_load": true,
+          "type": "query"
+        },
+        {
+          "allFormat": "glob",
+          "current": {
+          },
+          "datasource": null,
+          "includeAll": true,
+          "multi": false,
+          "multiFormat": "glob",
+          "name": "container",
+          "options": [
+          ],
+          "query": "SHOW TAG VALUES FROM \"uptime_ms_cumulative\" WITH KEY = \"container_name\" WHERE pod_name =~ /$pod/ ",
+          "refresh": true,
+          "refresh_on_load": true,
+          "type": "query"
+        }
+      ]
+    },
+    "annotations": {
+      "list": []
+    },
+    "schemaVersion": 6,
+    "version": 6,
+    "links": []
+  }
+}

--- a/cluster/addons/cluster-monitoring/influxdb/grafana-image/influxdb_service_discovery.go
+++ b/cluster/addons/cluster-monitoring/influxdb/grafana-image/influxdb_service_discovery.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/api"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+)
+
+func main() {
+	glog.Info("influxdb service discovery")
+
+	c, err := client.NewInCluster()
+	if err != nil {
+		glog.Fatalf("Failed to make client: %v", err)
+	}
+
+	glog.Info("Looking up monitoring-influxdb service...")
+	var influxdb *api.Service
+	// Wait a bit longer for influxdb loadBalancer to be created
+	for t := time.Now(); time.Since(t) < 5*time.Minute; time.Sleep(10 * time.Second) {
+		influxdb, err = c.Services(api.NamespaceSystem).Get("monitoring-influxdb")
+		if err == nil && len(influxdb.Status.LoadBalancer.Ingress) > 0 {
+			break
+		} else if err == nil {
+			glog.Info("Service is up. Waiting for load balancer to be created...")
+		} else {
+			glog.Info("Waiting for service to come up...")
+		}
+	}
+	if influxdb == nil {
+		glog.Error("Failed to find the monitoring-influxdb service.")
+		return
+	}
+
+	var serviceIP string
+	if len(influxdb.Status.LoadBalancer.Ingress) > 0 {
+		ingress := influxdb.Status.LoadBalancer.Ingress[0]
+		serviceIP = ingress.IP
+		if serviceIP == "" {
+			serviceIP = ingress.Hostname
+		}
+		glog.Infof("Found monitoring-influxdb service with external IP: '%s'", serviceIP)
+	} else {
+		glog.Warning("Service monitoring-influxdb exists but there's no load balancer.")
+		return
+	}
+
+	var servicePort = 8086
+	for _, port := range influxdb.Spec.Ports {
+		if port.Name == "api" {
+			servicePort = port.Port
+			glog.Infof("Found API port for monitoring-influxdb service: %d", servicePort)
+			break
+		}
+	}
+
+	fmt.Printf("http://%s:%s", serviceIP, strconv.Itoa(servicePort))
+}

--- a/cluster/addons/cluster-monitoring/influxdb/grafana-image/run.sh
+++ b/cluster/addons/cluster-monitoring/influxdb/grafana-image/run.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+HEADER_CONTENT_TYPE="Content-Type: application/json"
+HEADER_ACCEPT="Accept: application/json"
+
+GRAFANA_USER=${GRAFANA_USER:-admin}
+GRAFANA_PASSWD=${GRAFANA_PASSWD:-admin}
+GRAFANA_PORT=${GRAFANA_PORT:-3000}
+
+INFLUXDB_HOST=${INFLUXDB_HOST:-"monitoring-influxdb"}
+INFLUXDB_DATABASE=${INFLUXDB_DATABASE:-k8s}
+INFLUXDB_PASSWORD=${INFLUXDB_PASSWORD:-root}
+INFLUXDB_PORT=${INFLUXDB_PORT:-8086}
+INFLUXDB_USER=${INFLUXDB_USER:-root}
+
+DASHBOARD_LOCATION=${DASHBOARD_LOCATION:-"/dashboards"}
+
+# Allow access to dashboards without having to log in
+export GF_AUTH_ANONYMOUS_ENABLED=true
+export GF_SERVER_HTTP_PORT=${GRAFANA_PORT}
+
+BACKEND_ACCESS_MODE=${BACKEND_ACCESS_MODE:-proxy}
+INFLUXDB_SERVICE_ENDPOINT=${INFLUXDB_SERVICE_ENDPOINT}
+if [ -n "$INFLUXDB_SERVICE_ENDPOINT" ]; then
+  echo "Influxdb endpoint is provided."
+else
+  echo "Discovering influxdb endpoint..."
+  INFLUXDB_SERVICE_ENDPOINT=$(/influxdb_service_discovery)
+  if [ -n "$INFLUXDB_SERVICE_ENDPOINT" ]; then
+    echo "Use InfluxDB external endpoint, and 'direct' access mode from Grafana."
+    BACKEND_ACCESS_MODE=direct
+  else
+    echo "Unable to get external service endpoint for InfluxDB."
+    echo "Use internal endpoint, and 'proxy' access mode from Grafana."
+    INFLUXDB_SERVICE_ENDPOINT="http://${INFLUXDB_HOST}:${INFLUXDB_PORT}"
+    BACKEND_ACCESS_MODE=proxy
+  fi
+fi
+
+echo "Using the following endpoint for InfluxDB: ${INFLUXDB_SERVICE_ENDPOINT}"
+echo "Using the following backend access mode for InfluxDB: ${BACKEND_ACCESS_MODE}"
+
+set -m
+echo "Starting Grafana in the background"
+exec /usr/sbin/grafana-server --config=/etc/grafana/grafana.ini cfg:default.paths.data=/var/lib/grafana cfg:default.paths.logs=/var/log/grafana &
+
+echo "Waiting for Grafana to come up..."
+until $(curl --fail --output /dev/null --silent http://${GRAFANA_USER}:${GRAFANA_PASSWD}@localhost:${GRAFANA_PORT}/api/org); do
+  printf "."
+  sleep 2
+done
+echo "Grafana is up and running."
+echo "Creating default influxdb datasource..."
+curl -i -XPOST -H "${HEADER_ACCEPT}" -H "${HEADER_CONTENT_TYPE}" "http://${GRAFANA_USER}:${GRAFANA_PASSWD}@localhost:${GRAFANA_PORT}/api/datasources" -d '
+{ 
+  "name": "influxdb-datasource",
+  "type": "influxdb",
+  "access": "'"${BACKEND_ACCESS_MODE}"'",
+  "isDefault": true,
+  "url": "'"${INFLUXDB_SERVICE_ENDPOINT}"'",
+  "password": "'"${INFLUXDB_PASSWORD}"'",
+  "user": "'"${INFLUXDB_USER}"'",
+  "database": "'"${INFLUXDB_DATABASE}"'"
+}'
+
+echo ""
+echo "Importing default dashboards..."
+for filename in ${DASHBOARD_LOCATION}/*.json; do
+  echo "Importing ${filename} ..."
+  curl -i -XPOST --data "@${filename}" -H "${HEADER_ACCEPT}" -H "${HEADER_CONTENT_TYPE}" "http://${GRAFANA_USER}:${GRAFANA_PASSWD}@localhost:${GRAFANA_PORT}/api/dashboards/db"
+  echo ""
+  echo "Done importing ${filename}"
+done
+echo ""
+echo "Bringing Grafana back to the foreground"
+fg
+

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -20,7 +20,7 @@ spec:
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v0.18.1
+        - image: thuctnguyen/heapster:v0.18.2-rc1
           name: heapster
           resources:
             limits:

--- a/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
@@ -20,7 +20,7 @@ spec:
         kubernetes.io/cluster-service: "true"
     spec: 
       containers: 
-        - image: gcr.io/google_containers/heapster_influxdb:v0.4
+        - image: gcr.io/google_containers/heapster_influxdb:v0.5
           name: influxdb
           resources:
             limits:
@@ -34,12 +34,18 @@ spec:
           volumeMounts:
           - name: influxdb-persistent-storage
             mountPath: /data
-        - image: grafana/grafana:2.1.0
+        - image: thuctnguyen/grafana:2.1.0
           name: grafana
           resources:
             limits:
               cpu: 100m
               memory: 100Mi
+          ports:
+            - containerPort: 3000
+              hostPort: 3000
+          env:
+            - name: "INFLUXDB_SERVICE_ENDPOINT"
+              value: "http://monitoring-influxdb:8086"
       volumes:
       - name: influxdb-persistent-storage
         emptyDir: {}


### PR DESCRIPTION
- Discover InfluxDB service endpoint and create a datasource using Grafana API.
- Import a couple of dashboards which use templating and repeated panels in Grafana 2.1.0.
- The dashboards pick up nodes, pods, and containers automatically with zero configurations.
