### PR TITLE
Avoid assumption of a fixed list of cgroups in e2e conformance tests

### DIFF
--- a/hack/conformance-test.sh
+++ b/hack/conformance-test.sh
@@ -103,7 +103,7 @@ echo "Conformance test checking conformance with Kubernetes version 1.0"
 #  MaxPods\slimit\snumber\sof\spods: not sure why this wasn't working on GCE but it wasn't.
 #  Kubectl\sclient\sSimple\spod: not sure why this wasn't working on GCE but it wasn't
 #  DNS: not sure why this wasn't working on GCE but it wasn't
-export CONFORMANCE_TEST_SKIP_REGEX="Cadvisor|MasterCerts|Density|Cluster\slevel\slogging|Etcd\sfailure|Load\sCapacity|Monitoring|Namespaces.*seconds|Pod\sdisks|Reboot|Restart|Nodes|Scale|Services.*load\sbalancer|Services.*NodePort|Services.*nodeport|Shell|SSH|Addon\supdate|Volumes|Clean\sup\spods\son\snode|Skipped|skipped|MaxPods\slimit\snumber\sof\spods|Kubectl\sclient\sSimple\spod|DNS"
+export CONFORMANCE_TEST_SKIP_REGEX="Cadvisor|MasterCerts|Density|Cluster\slevel\slogging|Etcd\sfailure|Load\sCapacity|Monitoring|Namespaces.*seconds|Pod\sdisks|Reboot|Restart|Nodes|Scale|Services.*load\sbalancer|Services.*NodePort|Services.*nodeport|Shell|SSH|Addon\supdate|Volumes|Clean\sup\spods\son\snode|Skipped|skipped|MaxPods\slimit\snumber\sof\spods|Kubectl\sclient\sSimple\spod|DNS|Resource\susage\sof\ssystem\scontainers"
 
 declare -x KUBERNETES_CONFORMANCE_TEST="y"
 declare -x NUM_MINIONS=4

--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -117,7 +117,7 @@ GKE_REQUIRED_SKIP_TESTS=(
 GCE_FLAKY_TESTS=(
     "DaemonRestart"
     "Daemon\sset\sshould\slaunch\sa\sdaemon\spod\son\severy\snode\sof\sthe\scluster"
-    "ResourceUsage"
+    "Resource\susage\sof\ssystem\scontainers"
     "monotonically\sincreasing\srestart\scount"
     "should\sbe\sable\sto\schange\sthe\stype\sand\snodeport\ssettings\sof\sa\sservice" # file: service.go, issue: #13032
     "allows\sscheduling\sof\spods\son\sa\sminion\safter\sit\srejoins\sthe\scluster" # file: resize_nodes.go, issue: #13258
@@ -141,7 +141,7 @@ GCE_PARALLEL_SKIP_TESTS=(
     "Nodes\sNetwork"
     "Nodes\sResize"
     "MaxPods"
-    "ResourceUsage"
+    "Resource\susage\sof\ssystem\scontainers"
     "SchedulerPredicates"
     "Services.*restarting"
     "Shell.*services"

--- a/test/e2e/kubelet.go
+++ b/test/e2e/kubelet.go
@@ -103,7 +103,7 @@ var _ = Describe("kubelet", func() {
 		for _, node := range nodes.Items {
 			nodeNames.Insert(node.Name)
 		}
-		resourceMonitor = newResourceMonitor(framework.Client, targetContainers, containerStatsPollingInterval)
+		resourceMonitor = newResourceMonitor(framework.Client, targetContainers(), containerStatsPollingInterval)
 		resourceMonitor.Start()
 	})
 

--- a/test/e2e/monitor_resources.go
+++ b/test/e2e/monitor_resources.go
@@ -83,9 +83,9 @@ func computeAverage(sliceOfUsages []resourceUsagePerContainer) (result resourceU
 	return
 }
 
-// This tests does nothing except checking current resource usage of containers defained in kubelet_stats systemContainers variable.
+// This tests does nothing except checking current resource usage of containers defined in kubelet_stats systemContainers variable.
 // Test fails if an average container resource consumption over datapointAmount tries exceeds amount defined in allowedUsage.
-var _ = Describe("ResourceUsage", func() {
+var _ = Describe("Resource usage of system containers", func() {
 	var c *client.Client
 	BeforeEach(func() {
 		var err error


### PR DESCRIPTION
As a follow-up of the discussion with @gmarek today and that in https://github.com/mesosphere/kubernetes-mesos/issues/489 this PR reduces the assumptions of e2e tests about the list of cgroups ("containers") a kubelet is managing.

**Problem**

The default list has been:

```
"/",
"/docker-daemon",
"/kubelet",
"/kube-proxy",
"/system",
```

In setups other than gce/gke the kubelet will probably run in different cgroups hierarchies. In the case of Mesos the cgroup hierarchy is provided by the Mesos slave. K8s is configured to stay in this hierarchy. Especially the kubelet is not allowed to move any system processes around.

**Solution**
The solution in this PR does two things:
- it excludes @gmarek's "Resource usage of system containers" test from the conformance test suite
- it reduces the list of containers to `"/"` only for provider other than gce and gke in the "Kubelet monitors resource usage on node" test.

**Rational**

According to @gmarek the "Resource usage of system containers" test was not meant as a general e2e test for every cluster setup. In addition to the list of cgroups it assumes fixed resource limits and checks these: "it was supposed to run mainly on our soak cluster to look for regressions".

The "Kubelet monitors resource usage on node" test should mainly check that the kubelet is able to monitor and to return proper logs. By reducing this to `"/"` only this test stays functional on every cluster.

Fixes half of https://github.com/mesosphere/kubernetes-mesos/issues/489: https://github.com/mesosphere/kubernetes-mesos/issues/436, https://github.com/mesosphere/kubernetes-mesos/issues/439
