### PR TITLE
split Root into prefix and group

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -78,7 +78,8 @@ type Mux interface {
 type APIGroupVersion struct {
 	Storage map[string]rest.Storage
 
-	Root    string
+	Prefix  string
+	Group   string
 	Version string
 
 	// ServerVersion controls the Kubernetes APIVersion used for common objects in the apiserver
@@ -151,9 +152,9 @@ func (g *APIGroupVersion) UpdateREST(container *restful.Container) error {
 
 // newInstaller is a helper to create the installer.  Used by InstallREST and UpdateREST.
 func (g *APIGroupVersion) newInstaller() *APIInstaller {
-	info := &APIRequestInfoResolver{sets.NewString(strings.TrimPrefix(g.Root, "/")), g.Mapper}
+	info := &APIRequestInfoResolver{sets.NewString(strings.TrimPrefix(g.Prefix, "/")), g.Mapper}
 
-	prefix := path.Join(g.Root, g.Version)
+	prefix := path.Join(g.Prefix, g.Group, g.Version)
 	installer := &APIInstaller{
 		group:             g,
 		info:              info,

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -194,7 +194,7 @@ func handleInternal(legacy bool, storage map[string]rest.Storage, admissionContr
 	group := &APIGroupVersion{
 		Storage: storage,
 
-		Root: "/api",
+		Prefix: "/api",
 
 		Creater:   api.Scheme,
 		Convertor: api.Scheme,
@@ -2015,7 +2015,7 @@ func TestUpdateREST(t *testing.T) {
 	makeGroup := func(storage map[string]rest.Storage) *APIGroupVersion {
 		return &APIGroupVersion{
 			Storage:   storage,
-			Root:      "/api",
+			Prefix:    "/api",
 			Creater:   api.Scheme,
 			Convertor: api.Scheme,
 			Typer:     api.Scheme,
@@ -2080,7 +2080,7 @@ func TestUpdateREST(t *testing.T) {
 	// try to update a group that does not have an existing webservice with a matching prefix
 	// should not affect the existing registered webservice
 	invalidGroup := makeGroup(storage1)
-	invalidGroup.Root = "bad"
+	invalidGroup.Prefix = "bad"
 	if err := invalidGroup.UpdateREST(container); err == nil {
 		t.Fatal("expected an error from UpdateREST when updating a non-existing prefix but got none")
 	}
@@ -2096,7 +2096,7 @@ func TestParentResourceIsRequired(t *testing.T) {
 		Storage: map[string]rest.Storage{
 			"simple/sub": storage,
 		},
-		Root:      "/api",
+		Prefix:    "/api",
 		Creater:   api.Scheme,
 		Convertor: api.Scheme,
 		Typer:     api.Scheme,
@@ -2124,7 +2124,7 @@ func TestParentResourceIsRequired(t *testing.T) {
 			"simple":     &SimpleRESTStorage{},
 			"simple/sub": storage,
 		},
-		Root:      "/api",
+		Prefix:    "/api",
 		Creater:   api.Scheme,
 		Convertor: api.Scheme,
 		Typer:     api.Scheme,

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -573,7 +573,7 @@ func (m *Master) init(c *Config) {
 	apiserver.InstallSupport(m.muxHelper, m.rootWebService, c.EnableProfiling, healthzChecks...)
 	apiserver.AddApiWebService(m.handlerContainer, c.APIPrefix, apiVersions)
 	defaultVersion := m.defaultAPIGroupVersion()
-	requestInfoResolver := &apiserver.APIRequestInfoResolver{APIPrefixes: sets.NewString(strings.TrimPrefix(defaultVersion.Root, "/")), RestMapper: defaultVersion.Mapper}
+	requestInfoResolver := &apiserver.APIRequestInfoResolver{APIPrefixes: sets.NewString(strings.TrimPrefix(defaultVersion.Prefix, "/")), RestMapper: defaultVersion.Mapper}
 	apiserver.InstallServiceErrorHandler(m.handlerContainer, requestInfoResolver, apiVersions)
 
 	// allGroups records all supported groups at /apis
@@ -608,7 +608,7 @@ func (m *Master) init(c *Config) {
 		}
 		apiserver.AddGroupWebService(m.handlerContainer, c.APIGroupPrefix+"/"+latest.GroupOrDie("experimental").Group+"/", group)
 		allGroups = append(allGroups, group)
-		expRequestInfoResolver := &apiserver.APIRequestInfoResolver{APIPrefixes: sets.NewString(strings.TrimPrefix(expVersion.Root, "/")), RestMapper: expVersion.Mapper}
+		expRequestInfoResolver := &apiserver.APIRequestInfoResolver{APIPrefixes: sets.NewString(strings.TrimPrefix(expVersion.Prefix, "/")), RestMapper: expVersion.Mapper}
 		apiserver.InstallServiceErrorHandler(m.handlerContainer, expRequestInfoResolver, []string{expVersion.Version})
 	}
 
@@ -780,7 +780,7 @@ func (m *Master) getServersToValidate(c *Config) map[string]apiserver.Server {
 
 func (m *Master) defaultAPIGroupVersion() *apiserver.APIGroupVersion {
 	return &apiserver.APIGroupVersion{
-		Root: m.apiPrefix,
+		Prefix: m.apiPrefix,
 
 		Mapper: latest.GroupOrDie("").RESTMapper,
 
@@ -926,14 +926,14 @@ func (m *Master) InstallThirdPartyResource(rsrc *expapi.ThirdPartyResource) erro
 func (m *Master) thirdpartyapi(group, kind, version string) *apiserver.APIGroupVersion {
 	resourceStorage := thirdpartyresourcedataetcd.NewREST(m.thirdPartyStorage, group, kind)
 
-	apiRoot := makeThirdPartyPath(group)
-
 	storage := map[string]rest.Storage{
 		strings.ToLower(kind) + "s": resourceStorage,
 	}
 
 	return &apiserver.APIGroupVersion{
-		Root: apiRoot,
+		Prefix:  thirdpartyprefix,
+		Group:   group,
+		Version: version,
 
 		Creater:   thirdpartyresourcedata.NewObjectCreator(version, api.Scheme),
 		Convertor: api.Scheme,
@@ -943,7 +943,6 @@ func (m *Master) thirdpartyapi(group, kind, version string) *apiserver.APIGroupV
 		Codec:         thirdpartyresourcedata.NewCodec(latest.GroupOrDie("experimental").Codec, kind),
 		Linker:        latest.GroupOrDie("experimental").SelfLinker,
 		Storage:       storage,
-		Version:       version,
 		ServerVersion: latest.GroupOrDie("").GroupVersion,
 
 		Context: m.requestContextMapper,
@@ -985,7 +984,9 @@ func (m *Master) experimental(c *Config) *apiserver.APIGroupVersion {
 	}
 
 	return &apiserver.APIGroupVersion{
-		Root: m.apiGroupPrefix + "/" + latest.GroupOrDie("experimental").Group,
+		Prefix:  m.apiGroupPrefix,
+		Group:   latest.GroupOrDie("experimental").Group,
+		Version: latest.GroupOrDie("experimental").Version,
 
 		Creater:   api.Scheme,
 		Convertor: api.Scheme,
@@ -995,7 +996,6 @@ func (m *Master) experimental(c *Config) *apiserver.APIGroupVersion {
 		Codec:   latest.GroupOrDie("experimental").Codec,
 		Linker:  latest.GroupOrDie("experimental").SelfLinker,
 		Storage: storage,
-		Version: latest.GroupOrDie("experimental").Version,
 
 		Admit:   m.admissionControl,
 		Context: m.requestContextMapper,

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -272,7 +272,7 @@ func TestDefaultAPIGroupVersion(t *testing.T) {
 
 	apiGroup := master.defaultAPIGroupVersion()
 
-	assert.Equal(apiGroup.Root, master.apiPrefix)
+	assert.Equal(apiGroup.Prefix, master.apiPrefix)
 	assert.Equal(apiGroup.Admit, master.admissionControl)
 	assert.Equal(apiGroup.Context, master.requestContextMapper)
 	assert.Equal(apiGroup.MinRequestTimeout, master.minRequestTimeout)
@@ -289,11 +289,12 @@ func TestExpapi(t *testing.T) {
 	master, config, assert := setUp(t)
 
 	expAPIGroup := master.experimental(&config)
-	assert.Equal(expAPIGroup.Root, master.apiGroupPrefix+"/"+latest.GroupOrDie("experimental").Group)
+	assert.Equal(expAPIGroup.Prefix, master.apiGroupPrefix)
+	assert.Equal(expAPIGroup.Group, latest.GroupOrDie("experimental").Group)
+	assert.Equal(expAPIGroup.Version, latest.GroupOrDie("experimental").Version)
 	assert.Equal(expAPIGroup.Mapper, latest.GroupOrDie("experimental").RESTMapper)
 	assert.Equal(expAPIGroup.Codec, latest.GroupOrDie("experimental").Codec)
 	assert.Equal(expAPIGroup.Linker, latest.GroupOrDie("experimental").SelfLinker)
-	assert.Equal(expAPIGroup.Version, latest.GroupOrDie("experimental").Version)
 }
 
 // TestSecondsSinceSync verifies that proper results are returned


### PR DESCRIPTION
Fixes #14433 .

This splits logically separate fields into separate fields instead of smashing them together.  It creates a cleaner factorization that is easier to explain and reuse.

@smarterclayton @liggitt not sure who to tag.
