### PR TITLE
KubeProxy e2e test is still slow

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -144,6 +144,7 @@ GCE_SLOW_TESTS=(
     "Nodes\sResize"                                   # 3 min 30 sec, file: resize_nodes.go,         issue: #13323
     "resource\susage\stracking"                       # 1 hour,       file: kubelet_perf.go,         slow by design
     "monotonically\sincreasing\srestart\scount"       # 1.5 to 5 min, file: pods.go,                 slow by design
+    "KubeProxy\sshould\stest\skube-proxy"             # 9 min 30 sec, file: kubeproxy.go,            issue: #14204
     )
 
 # Tests which are not able to be run in parallel.


### PR DESCRIPTION
Despite the improvements in #14286, this test is still taking 9.5m+, so demote it to slow tests again.

ref #14204

cc @ArtfulCoder @kubernetes/goog-testing 
