### PR TITLE
Use the cluster name instead of the minion tag as the prefix for the firewall rules created in e2e tests. 

### DIFF
--- a/cluster/gke/util.sh
+++ b/cluster/gke/util.sh
@@ -175,14 +175,14 @@ function test-setup() {
 
   # Open up port 80 & 8080 so common containers on minions can be reached.
   "${GCLOUD}" compute firewall-rules create \
-    "${MINION_TAG}-http-alt" \
+    "${CLUSTER_NAME}-http-alt" \
     --allow tcp:80,tcp:8080 \
     --project "${PROJECT}" \
     --target-tags "${MINION_TAG},${OLD_MINION_TAG}" \
     --network="${NETWORK}"
 
   "${GCLOUD}" compute firewall-rules create \
-    "${MINION_TAG}-nodeports" \
+    "${CLUSTER_NAME}-nodeports" \
     --allow tcp:30000-32767,udp:30000-32767 \
     --project "${PROJECT}" \
     --target-tags "${MINION_TAG},${OLD_MINION_TAG}" \
@@ -293,15 +293,12 @@ function test-teardown() {
   echo "... in test-teardown()" >&2
 
   detect-project >&2
-  detect-minions >&2
-  # At this point, CLUSTER_NAME should have been used, so its value is final.
-  MINION_TAG=$($GCLOUD compute instances describe ${MINION_NAMES[0]} --project="${PROJECT}" --zone="${ZONE}" | grep -o "gke-${CLUSTER_NAME}-.\{8\}-node" | head -1)
 
   # First, remove anything we did with test-setup (currently, the firewall).
   # NOTE: Keep in sync with names above in test-setup.
-  "${GCLOUD}" compute firewall-rules delete "${MINION_TAG}-http-alt" \
+  "${GCLOUD}" compute firewall-rules delete "${CLUSTER_NAME}-http-alt" \
     --project="${PROJECT}" || true
-  "${GCLOUD}" compute firewall-rules delete "${MINION_TAG}-nodeports" \
+  "${GCLOUD}" compute firewall-rules delete "${CLUSTER_NAME}-nodeports" \
     --project="${PROJECT}" || true
 
   # Then actually turn down the cluster.


### PR DESCRIPTION
This allows the teardown code to run without needing to inspect the managed instance group for the cluster (which may no longer exist) and should make e2e teardown much more resilient.
