### PR TITLE
MESOS: Fix zero MaxOpenFiles in Mesos executor

### DIFF
--- a/contrib/mesos/pkg/executor/service/service.go
+++ b/contrib/mesos/pkg/executor/service/service.go
@@ -235,6 +235,7 @@ func (s *KubeletExecutorServer) Run(hks hyperkube.Interface, _ []string) error {
 		ResolverConfig:            s.ResolverConfig,
 		CPUCFSQuota:               s.CPUCFSQuota,
 		Writer:                    writer,
+		MaxOpenFiles:              s.MaxOpenFiles,
 	}
 
 	kcfg.NodeName = kcfg.Hostname


### PR DESCRIPTION
The Mesos executor was broken by https://github.com/kubernetes/kubernetes/pull/14381 because the KubeCfg value MaxOpenFiles was zero and the process complained about too many open files.

This kind of issue will be avoided with https://github.com/kubernetes/kubernetes/pull/13036.
