### PR TITLE
Move the vagrant+libvirt cluster from Fedora 20 to 21

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -68,8 +68,8 @@ $kube_provider_boxes = {
   },
   :libvirt => {
     'fedora' => {
-      :box_name => 'kube-fedora20',
-      :box_url => 'http://citozin.com/opscode_fedora-20_chef-provisionerless_libvirt.box'
+      :box_name => 'kube-fedora21',
+      :box_url => 'https://amadeus.box.com/shared/static/93mj2fajrii6afeh8b5v5ihuk2ows2yn.box'
     }
   },
   :vmware_desktop => {


### PR DESCRIPTION
While the `vagrant+virtualbox` and the `vagrant+vmware` clusters are deploying kubernetes on Fedora 21, the `vagrant+libvirt` one was still deploying kubernetes on Fedora 21.

This PR makes the `vagrant+libvirt` cluster use the same image as the `vagrant+virtualbox` one.

Concretely, I took the `vagrant+virtualbox` box at http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_fedora-21_chef-provisionerless.box and I converted it to the `libvirt` format with:

```
vagrant mutate --input_provider virtualbox kube-fedora21 libvirt
```
