### PR TITLE
Fix for Invalidation of DeviceMapping Cache when Detaching Volumes

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -1144,7 +1144,7 @@ func (aws *AWSCloud) AttachDisk(instanceName string, diskName string, readOnly b
 	attached := false
 	defer func() {
 		if !attached {
-			awsInstance.releaseMountDevice(disk.awsID, ec2Device)
+			awsInstance.releaseMountDevice(disk.awsID, mountpoint)
 		}
 	}()
 
@@ -1192,6 +1192,24 @@ func (aws *AWSCloud) DetachDisk(instanceName string, diskName string) error {
 	if response == nil {
 		return errors.New("no response from DetachVolume")
 	}
+
+	// At this point we are waiting for the volume being detached. This
+	// releases the volume and invalidates the cache even when there is a timeout.
+	//
+	// TODO: A timeout leaves the cache in an inconsistent state. The volume is still
+	// detaching though the cache shows it as ready to be attached again. Subsequent
+	// attach operations will fail. The attach is being retried and eventually
+	// works though. An option would be to completely flush the cache upon timeouts.
+	//
+	defer func() {
+		for mountDevice, existingVolumeID := range awsInstance.deviceMappings {
+			if existingVolumeID == disk.awsID {
+				awsInstance.releaseMountDevice(disk.awsID, mountDevice)
+				return
+			}
+		}
+	}()
+
 	err = disk.waitForAttachmentStatus("detached")
 	if err != nil {
 		return err


### PR DESCRIPTION
There is a `deviceMapping` cache that keeps the state of the block device mappings in local memory. When a device is detached the cache does not get invalidated. A subsequent attachment for the same volume then falsely assumes that the device is already attached. It skip the actual API call to attach the volume and gets stuck in an endless loop waiting for the attachment to finish. It eventually times out and immediately starts to wait again. This only resolves once the kubelet is restarted.

This fix releases the device from the `deviceMapping` cache when a volume is detached. 

With this fix volume attach/detach operations work perfectly for me. I'm a bit unsure though how such a fundamental bug wasn't noticed before? Did this ever work and this is a regression? It could be that previous tests had the pods scheduled to a different kubelet with cold cache? Maybe @justinsb has some insight.
