### PR TITLE
Revert "Remove dead code"

### DIFF
--- a/pkg/storage/etcd/etcd_helper.go
+++ b/pkg/storage/etcd/etcd_helper.go
@@ -176,6 +176,15 @@ func (h *etcdHelper) Delete(key string, out runtime.Object) error {
 }
 
 // Implements storage.Interface.
+func (h *etcdHelper) RecursiveDelete(key string, recursive bool) error {
+	key = h.prefixEtcdKey(key)
+	startTime := time.Now()
+	_, err := h.client.Delete(key, recursive)
+	metrics.RecordEtcdRequestLatency("delete", "UNKNOWN", startTime)
+	return err
+}
+
+// Implements storage.Interface.
 func (h *etcdHelper) Watch(key string, resourceVersion uint64, filter storage.FilterFunc) (watch.Interface, error) {
 	key = h.prefixEtcdKey(key)
 	w := newEtcdWatcher(false, nil, filter, h.codec, h.versioner, nil, h)

--- a/pkg/storage/interfaces.go
+++ b/pkg/storage/interfaces.go
@@ -92,6 +92,10 @@ type Interface interface {
 	// Delete removes the specified key and returns the value that existed at that spot.
 	Delete(key string, out runtime.Object) error
 
+	// RecursiveDelete removes the specified key.
+	// TODO: Get rid of this method and use Delete() instead.
+	RecursiveDelete(key string, recursive bool) error
+
 	// Watch begins watching the specified key. Events are decoded into API objects,
 	// and any items passing 'filter' are sent down to returned watch.Interface.
 	// resourceVersion may be used to specify what version to begin watching


### PR DESCRIPTION
Reverts kubernetes/kubernetes#12584

This functionality was removed, but it resulted in power being lost.  The existing `Delete` method doesn't do a recurse and even if it wanted to, it wouldn't be able to fulfill the contract for the `out` value.

We use this downstream and this pull: https://github.com/kubernetes/kubernetes/pull/7372, tried to replace the functionality.  I'd like to restore this until we get a proper replacement.

@smarterclayton @derekwaynecarr we use this downstream for cleanup.
