### PR TITLE
Enable experimental API in vagrant setups

### DIFF
--- a/cluster/vagrant/config-default.sh
+++ b/cluster/vagrant/config-default.sh
@@ -55,6 +55,16 @@ MASTER_PASSWD=vagrant
 # Admission Controllers to invoke prior to persisting objects in cluster
 ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,DenyEscalatingExec,ResourceQuota
 
+# Optional: Enable experimental API features
+ENABLE_EXPERIMENTAL_API="${KUBE_ENABLE_EXPERIMENTAL_API:-true}"
+
+# Optional: Enable feature for autoscaling number of pods
+# Experimental feature, not ready for production use.
+ENABLE_HORIZONTAL_POD_AUTOSCALER="${KUBE_ENABLE_HORIZONTAL_POD_AUTOSCALER:-true}"
+if [[ "${ENABLE_HORIZONTAL_POD_AUTOSCALER}" == "true" ]]; then
+  ENABLE_EXPERIMENTAL_API=true
+fi
+
 # Optional: Enable node logging.
 ENABLE_NODE_LOGGING=false
 LOGGING_DESTINATION=elasticsearch
@@ -89,8 +99,7 @@ DNS_REPLICAS=1
 ENABLE_CLUSTER_UI="${KUBE_ENABLE_CLUSTER_UI:-true}"
 
 # Optional: Enable setting flags for kube-apiserver to turn on behavior in active-dev
-#RUNTIME_CONFIG=""
-RUNTIME_CONFIG="api/v1"
+RUNTIME_CONFIG="${KUBE_RUNTIME_CONFIG:-}"
 
 # Determine extra certificate names for master
 octets=($(echo "$SERVICE_CLUSTER_IP_RANGE" | sed -e 's|/.*||' -e 's/\./ /g'))

--- a/cluster/vagrant/util.sh
+++ b/cluster/vagrant/util.sh
@@ -34,6 +34,18 @@ function detect-minions {
 # Verify prereqs on host machine  Also sets exports USING_KUBE_SCRIPTS=true so
 # that our Vagrantfile doesn't error out.
 function verify-prereqs {
+  if [[ "${ENABLE_EXPERIMENTAL_API}" == "true" ]]; then
+    if [[ -z "${RUNTIME_CONFIG}" ]]; then
+      RUNTIME_CONFIG="experimental/v1alpha1"
+    else
+      # TODO: add checking if RUNTIME_CONFIG contains "experimental/v1=false" and appending "experimental/v1=true" if not.
+      if echo "${RUNTIME_CONFIG}" | grep -q -v "experimental/v1alpha1=true"; then
+        echo "Experimental API should be turned on, but is not turned on in RUNTIME_CONFIG!"
+        exit 1
+      fi
+    fi
+  fi
+  
   for x in vagrant; do
     if ! which "$x" >/dev/null; then
       echo "Can't find $x in PATH, please fix and retry."


### PR DESCRIPTION
Self explanatory, useful for trying out the new feature set.

Default to true since vagrant is inherently a kick the tires and learn about the system option.
