### PR TITLE
Correct example salt config

### DIFF
--- a/docs/admin/salt.md
+++ b/docs/admin/salt.md
@@ -82,7 +82,7 @@ An example file is presented below using the Vagrant based environment.
 [root@kubernetes-master] $ cat /etc/salt/minion.d/grains.conf
 grains:
   etcd_servers: $MASTER_IP
-  cloud_provider: vagrant
+  cloud: vagrant
   roles:
     - kubernetes-master
 ```


### PR DESCRIPTION
The correct parameter is cloud not cloud_provider.
