### PR TITLE
printf->print in hack/verify-flags-underscore.py script

### DIFF
--- a/hack/verify-flags-underscore.py
+++ b/hack/verify-flags-underscore.py
@@ -197,7 +197,7 @@ def load_exceptions(rootdir):
     for exception in exception_file.read().splitlines():
         out = exception.split(":", 1)
         if len(out) != 2:
-            printf("Invalid line in exceptions file: %s" % exception)
+            print("Invalid line in exceptions file: %s" % exception)
             continue
         filename = out[0]
         line = out[1]


### PR DESCRIPTION
Fixing printing error in hack/verify-flags-underscore.py.

From https://travis-ci.org/kubernetes/kubernetes/builds/81889537

```
hack/verify-flags-underscore.py
Traceback (most recent call last):
  File "hack/verify-flags-underscore.py", line 242, in <module>
    sys.exit(main())
  File "hack/verify-flags-underscore.py", line 211, in main
    exceptions = load_exceptions(rootdir)
  File "hack/verify-flags-underscore.py", line 200, in load_exceptions
    printf("Invalid line in exceptions file: %s" % exception)
NameError: global name 'printf' is not defined
```
