### PR TITLE
Update rollback process

### DIFF
--- a/pkg/kubectl/cmd/rollingupdate_test.go
+++ b/pkg/kubectl/cmd/rollingupdate_test.go
@@ -79,7 +79,7 @@ func TestValidateArgs(t *testing.T) {
 				cmd.Flags().Set(key, val)
 			}
 		}
-		_, _, _, _, err := validateArguments(cmd, test.filenames, test.args)
+		err := validateArguments(cmd, test.filenames, test.args)
 		if err != nil && !test.expectErr {
 			t.Errorf("unexpected error: %v (%s)", err, test.testName)
 		}


### PR DESCRIPTION
Two rc:
my-web-v1:

```
apiVersion: v1
kind: ReplicationController
metadata:
  name: my-web-v1
spec:
  selector:
    app: my-web
    version: v1
  template:
    metadata:
      labels:
        app: my-web
        version: v1
    spec:
      containers:
      - name: my-web
        image: my-web:v1
        ports:
        - containerPort: 80
          protocol: TCP
```

my-web-v2:

```
apiVersion: v1
kind: ReplicationController
metadata:
  name: my-web-v2
spec:
  selector:
    app: my-web
    version: v2
  template:
    metadata:
      labels:
        app: my-web
        version: v2
    spec:
      containers:
      - name: my-web
        image: my-web:v2
        ports:
        - containerPort: 80
          protocol: TCP
```

After create my-web-v1, and then ·rolling-update·  my-web-v1 to my-web-v2:

```
kubectl create -f my-web-v1-rc.yaml
kubectl scale rc my-web-v1 --replicas=4

kubectl rolling-update my-web-v1 --update-period=6s -f my-web-v2-rc.yaml
```

Abort the  ·rolling-update·:
If I just add the --rollback with original command , it fails:

```
kubectl rolling-update my-web-v1 --update-period=6s -f my-web-v2-rc.yaml --rollback
error: Missing/unexpected annotations for controller my-web-v1, expected my-web-v2: : map[kubectl.kubernetes.io/update-source-id:my-web-v2:]
```

I figure this failure out , because [it creates a newRc from file](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/rollingupdate.go#L174~L212), but the newRc's UID is empty. Should find the newRc from previous rolling-update process

so I update the rollback command:

```
kubectl rolling-update my-web-v1 my-web-v2 --rollback
error: Must specify --filename or --image for new controller
```

It asks me to specify  --image, which is unnecessary on rollback.

So I commit this PR.

On rollback， don't specify --filename or --image, because the newRc was created already, just fetch it .
