### PR TITLE
Fix bugs in daemonset controller and e2e tests

### DIFF
--- a/contrib/mesos/pkg/controllermanager/controllermanager.go
+++ b/contrib/mesos/pkg/controllermanager/controllermanager.go
@@ -29,6 +29,7 @@ import (
 	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/mesos"
+	"k8s.io/kubernetes/pkg/controller/daemon"
 	kendpoint "k8s.io/kubernetes/pkg/controller/endpoint"
 	"k8s.io/kubernetes/pkg/controller/namespace"
 	"k8s.io/kubernetes/pkg/controller/node"
@@ -47,7 +48,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/pflag"
-	"k8s.io/kubernetes/pkg/controller/daemon"
 )
 
 // CMServer is the main context object for the controller manager.

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -291,11 +291,11 @@ func (r RealPodControl) createPods(nodeName, namespace string, template *api.Pod
 			GenerateName: prefix,
 		},
 	}
-	if len(nodeName) != 0 {
-		pod.Spec.NodeName = nodeName
-	}
 	if err := api.Scheme.Convert(&template.Spec, &pod.Spec); err != nil {
 		return fmt.Errorf("unable to convert pod template: %v", err)
+	}
+	if len(nodeName) != 0 {
+		pod.Spec.NodeName = nodeName
 	}
 	if labels.Set(pod.Labels).AsSelector().Empty() {
 		return fmt.Errorf("unable to create pods, no labels")


### PR DESCRIPTION
This PR is a preparation to get daemonsets working on Mesos. On the way towards this, the following bugs were found and fixed by this PR:
- the e2e tests delete all node labels. Other e2e tests might rely on them, e.g. on kubernetes.io/hostname, or in the Mesos case on some other labels.
- the pods created by the daemonset controller don't have `spec.NodeName` set, although the code suggests it should. Hence, they are scheduled by the scheduler first, hopefully onto the right nodes. During this time, the daemonset controller thinks again and again that the nodes have no daemon pod created yet. As a consequence, it creates more and more pods until it sees the already created daemon pods scheduled to the nodes which match the selector. In the case of a slow scheduler you easily end up with tens of pods for a 2 node setup.
- the daemonset e2e test checks for resource version conflicts and tries to update again. But it does not base the update on the newest version. Hence, when the version conflict occurs, the code won't be able to fix it.
