### PR TITLE
Filter out overlapping replicating controller 

### DIFF
--- a/cmd/kube-apiserver/app/plugins.go
+++ b/cmd/kube-apiserver/app/plugins.go
@@ -25,6 +25,7 @@ import (
 
 	// Admission policies
 	_ "k8s.io/kubernetes/plugin/pkg/admission/admit"
+	_ "k8s.io/kubernetes/plugin/pkg/admission/controller"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/deny"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/exec"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/initialresources"

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -1734,6 +1734,9 @@ func deepCopy_api_ReplicationControllerSpec(in ReplicationControllerSpec, out *R
 }
 
 func deepCopy_api_ReplicationControllerStatus(in ReplicationControllerStatus, out *ReplicationControllerStatus, c *conversion.Cloner) error {
+	out.Phase = ReplicationControllerPhase(in.Phase)
+	out.Reason = in.Reason
+	out.Message = in.Message
 	out.Replicas = in.Replicas
 	out.ObservedGeneration = in.ObservedGeneration
 	return nil

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1086,9 +1086,29 @@ type ReplicationControllerSpec struct {
 	Template *PodTemplateSpec `json:"template,omitempty"`
 }
 
+// ReplicationControllerPhase is a label for the condition of a replicationcontroller at the current time.
+type ReplicationControllerPhase string
+
+// These are the  statuses of replicationcontrollers
+const (
+// Conflicting means the replicationcontroller is conflicted with an older replicationcontroller,
+// which mean the newer rc has the same selector as the older one
+	ReplicationControllerConflicting	 ReplicationControllerPhase = "Conflicting"
+	ReplicationControllerRunning 		 ReplicationControllerPhase = "Running"
+)
+
 // ReplicationControllerStatus represents the current status of a replication
 // controller.
 type ReplicationControllerStatus struct {
+	// Phase indicates if a replicationcontroller is running or conflicting with others
+	Phase ReplicationControllerPhase `json:"phase,omitempty"`
+
+	// (brief) reason for the phase's last transition.
+	Reason string `json:"reason,omitempy"`
+
+	// Human readable message indicating details about the replication selector conflicting.
+	Message string `json:"message,omitempty"`
+
 	// Replicas is the number of actual replicas.
 	Replicas int `json:"replicas"`
 

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -1899,6 +1899,9 @@ func convert_api_ReplicationControllerStatus_To_v1_ReplicationControllerStatus(i
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*api.ReplicationControllerStatus))(in)
 	}
+	out.Phase = ReplicationControllerPhase(in.Phase)
+	out.Reason = in.Reason
+	out.Message = in.Message
 	out.Replicas = in.Replicas
 	out.ObservedGeneration = in.ObservedGeneration
 	return nil
@@ -4334,6 +4337,9 @@ func convert_v1_ReplicationControllerStatus_To_api_ReplicationControllerStatus(i
 	if defaulting, found := s.DefaultingInterface(reflect.TypeOf(*in)); found {
 		defaulting.(func(*ReplicationControllerStatus))(in)
 	}
+	out.Phase = api.ReplicationControllerPhase(in.Phase)
+	out.Reason = in.Reason
+	out.Message = in.Message
 	out.Replicas = in.Replicas
 	out.ObservedGeneration = in.ObservedGeneration
 	return nil

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -1760,6 +1760,9 @@ func deepCopy_v1_ReplicationControllerSpec(in ReplicationControllerSpec, out *Re
 }
 
 func deepCopy_v1_ReplicationControllerStatus(in ReplicationControllerStatus, out *ReplicationControllerStatus, c *conversion.Cloner) error {
+	out.Phase = ReplicationControllerPhase(in.Phase)
+	out.Reason = in.Reason
+	out.Message = in.Message
 	out.Replicas = in.Replicas
 	out.ObservedGeneration = in.ObservedGeneration
 	return nil

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -1371,9 +1371,29 @@ type ReplicationControllerSpec struct {
 	Template *PodTemplateSpec `json:"template,omitempty"`
 }
 
+// ReplicationControllerPhase is a label for the condition of a replicationcontroller at the current time.
+type ReplicationControllerPhase string
+
+// These are the  statuses of replicationcontrollers
+const (
+// Conflicting means the replicationcontroller is conflicted with an older replicationcontroller,
+// which mean the newer rc has the same selector as the older one
+	ReplicationControllerConflicting	 ReplicationControllerPhase = "Conflicting"
+	ReplicationControllerRunning 		 ReplicationControllerPhase = "Running"
+)
+
 // ReplicationControllerStatus represents the current status of a replication
 // controller.
 type ReplicationControllerStatus struct {
+	// Phase indicates if a replicationcontroller is running or conflicting with others
+	Phase ReplicationControllerPhase `json:"phase,omitempty"`
+
+	// (brief) reason for the phase's last transition.
+	Reason string `json:"reason,omitempy"`
+
+	// Human readable message indicating details about the replication selector conflicting.
+	Message string `json:"message,omitempty"`
+
 	// Replicas is the most recently oberved number of replicas.
 	// More info: http://releases.k8s.io/HEAD/docs/user-guide/replication-controller.md#what-is-a-replication-controller
 	Replicas int `json:"replicas"`

--- a/plugin/pkg/admission/controller/admission.go
+++ b/plugin/pkg/admission/controller/admission.go
@@ -1,0 +1,81 @@
+package controller
+
+import (
+	"fmt"
+	"io"
+
+	"k8s.io/kubernetes/pkg/admission"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/cache"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	controller "k8s.io/kubernetes/pkg/controller/replication"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/watch"
+
+)
+
+var (
+	selectorKeyFunc = controller.NamespaceSelectorKeyFunc
+)
+
+
+func init() {
+	admission.RegisterPlugin("ReplicationControllerExists", func(client client.Interface, config io.Reader) (admission.Interface, error) {
+		return NewExists(client), nil
+	})
+}
+
+// exists is an implementation of admission.Interface.
+// It rejects all incoming CREATE or UPDATE requests of replication controller if it exists
+// It is useful in deployments that want to filter out repeated replication controller
+type exists struct {
+	*admission.Handler
+	client client.Interface
+	store  cache.Store
+}
+
+func (e *exists) Admit(a admission.Attributes) (err error) {
+	if a.GetResource() == "replicationcontrollers" {
+		_, ok := a.GetObject().(*api.ReplicationController)
+		if !ok {
+			return nil
+		}
+		key, err := selectorKeyFunc(a.GetObject())
+		_, exists, err := e.store.GetByKey(key)
+		if err != nil {
+			return admission.NewForbidden(a, err)
+		}
+		if exists {
+			return admission.NewForbidden(a, fmt.Errorf("A replication with the same selctor has exist"))
+		}
+		return nil
+	}
+	return nil
+}
+
+
+// NewExists creates a new replication controller exists admission control handler
+func NewExists(client client.Interface) admission.Interface {
+	store := cache.NewStore(selectorKeyFunc)
+	reflector := cache.NewReflector(
+		&cache.ListWatch{
+			ListFunc: func() (runtime.Object, error) {
+				return client.ReplicationControllers(api.NamespaceAll).List(labels.Everything())
+			},
+			WatchFunc: func(resourceVersion string) (watch.Interface, error) {
+				return client.ReplicationControllers(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), resourceVersion)
+			},
+		},
+		&api.ReplicationController{},
+		store,
+		0,
+	)
+	reflector.Run()
+	return &exists{
+		client:  client,
+		store:   store,
+		Handler: admission.NewHandler(admission.Create, admission.Update),
+	}
+}

--- a/plugin/pkg/admission/controller/admission_test.go
+++ b/plugin/pkg/admission/controller/admission_test.go
@@ -1,0 +1,125 @@
+package controller
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/admission"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/cache"
+	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
+
+
+)
+
+func TestAdmissionNamespaceExistsCreate(t *testing.T) {
+	namespace1 := "test1"
+	namespace2 := "test2"
+
+	selector1 := map[string]string {
+		"key1" : "value1",
+		"key2" : "value2",
+	}
+	selector2 := map[string]string {
+		"key2" : "value2",
+		"key1" : "value1",
+	}
+	selector3 := map[string]string {
+		"key1" : "kkk",
+		"key2" : "hhh",
+	}
+
+	testCases := []struct {
+		rc 		api.ReplicationController
+		fit 	bool
+		info 	string
+	}{
+		{
+			rc:  api.ReplicationController {
+				ObjectMeta: api.ObjectMeta {
+					Name: "rc2",
+					Namespace: namespace1,
+				},
+				Spec: api.ReplicationControllerSpec{
+					Selector: selector1,
+				},
+			},
+			fit:  false,
+			info: "two same rc in the same namespace, should not fit",
+		},
+		{
+			rc:  api.ReplicationController {
+				ObjectMeta: api.ObjectMeta {
+					Name: "rc2",
+					Namespace: namespace1,
+				},
+				Spec: api.ReplicationControllerSpec{
+					Selector: selector2,
+				},
+			},
+			fit:  false,
+			info: "two same rc in the same namespace, should not fit",
+		},
+		{
+			rc:  api.ReplicationController {
+				ObjectMeta: api.ObjectMeta {
+					Name: "rc2",
+					Namespace: namespace2,
+				},
+				Spec: api.ReplicationControllerSpec{
+					Selector: selector1,
+				},
+			},
+			fit:  true,
+			info: "two same rc in different namespace, should fit",
+		},
+		{
+			rc:  api.ReplicationController {
+				ObjectMeta: api.ObjectMeta {
+					Name: "rc2",
+					Namespace: namespace2,
+				},
+				Spec: api.ReplicationControllerSpec{
+					Selector: selector2,
+				},
+			},
+			fit:  true,
+			info: "two same rc in different namespace, should fit",
+		},
+		{
+			rc:  api.ReplicationController {
+				ObjectMeta: api.ObjectMeta {
+					Name: "rc2",
+					Namespace: namespace2,
+				},
+				Spec: api.ReplicationControllerSpec{
+					Selector: selector3,
+				},
+			},
+			fit:  true,
+			info: "two different rc in different namespace, should fit",
+		},
+	}
+
+	mockClient := &testclient.Fake{}
+	store := cache.NewStore(NamespaceSelectorKeyFunc)
+	store.Add(&api.ReplicationController{
+		ObjectMeta: api.ObjectMeta{
+			Name: "rc1",
+			Namespace: namespace1,
+		},
+		Spec: api.ReplicationControllerSpec{
+			Selector: selector1,
+		},
+	})
+	handler := &exists{
+		client: mockClient,
+		store:  store,
+	}
+
+	for _, test := range testCases {
+		err := handler.Admit(admission.NewAttributesRecord(&test.rc, "ReplicationController", test.rc.Namespace, test.rc.Name, "replicationcontrollers", "", admission.Create, nil))
+		if test.fit && err != nil || !test.fit && err == nil {
+			t.Errorf("%s", test.info)
+		}
+	}
+}


### PR DESCRIPTION
This PR solve the  replica instability problem caused by overlapping replicating controller
- Write an Admission Control Plugin to filter overlapping replication controller at admission time, which can reject a majority of overlapping controller creation request. But it is not perfect since it's racy.
- A vast majority of overlapping controller can be rejected at admission time.However, unfortunately,  if several aipservers request to create replication controllers with the same selector simultaneously, it is still possible to create overlapping controller. So, we must filter those escaped controllers at controller-manager.
- Currently, controller-manager just ensure that the same controller is synced for a given pod. But when periodically relist all controllers there will still be some replica instability. This PR solve this problem and surface the conflict information to users

Currently, overlapping replication controller may lead to timeout when execute "kubectl delete rc XXX". Maybe the solution in this PR is not perfect, but it's a good start.
