### PR TITLE
Based on #14359, install the legacy v1 API for make_secret.go in http-nginx example

### DIFF
--- a/examples/https-nginx/README.md
+++ b/examples/https-nginx/README.md
@@ -38,7 +38,7 @@ It uses an [nginx server block](http://wiki.nginx.org/ServerBlockExample) to ser
 
 ### Generate certificates
 
-First generate a self signed rsa key and certificate that the server can use for TLS.
+First generate a self signed rsa key and certificate that the server can use for TLS. This step invokes the make_secret.go script in the same directory, which uses the kubernetes api to generate a secret json config in /tmp/secret.json.
 
 ```sh
 $ make keys secret KEY=/tmp/nginx.key CERT=/tmp/nginx.crt SECRET=/tmp/secret.json

--- a/examples/https-nginx/make_secret.go
+++ b/examples/https-nginx/make_secret.go
@@ -29,6 +29,9 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/runtime"
+
+	// This installs the legacy v1 API
+	_ "k8s.io/kubernetes/pkg/api/install"
 )
 
 // TODO:


### PR DESCRIPTION
fix #14558, based on #14359 

@bprashanth @linzichang 
