### PR TITLE
Make gce cloud constructor public 

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -68,7 +68,7 @@ type Config struct {
 }
 
 func init() {
-	cloudprovider.RegisterCloudProvider(ProviderName, func(config io.Reader) (cloudprovider.Interface, error) { return newGCECloud(config) })
+	cloudprovider.RegisterCloudProvider(ProviderName, func(config io.Reader) (cloudprovider.Interface, error) { return NewGCECloud(config) })
 }
 
 func getProjectAndZone() (string, string, error) {
@@ -120,8 +120,8 @@ func getNetworkName() (string, error) {
 	return parts[3], nil
 }
 
-// newGCECloud creates a new instance of GCECloud.
-func newGCECloud(config io.Reader) (*GCECloud, error) {
+// NewGCECloud creates a new instance of GCECloud.
+func NewGCECloud(config io.Reader) (*GCECloud, error) {
 	projectID, zone, err := getProjectAndZone()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
I ment to include this in https://github.com/kubernetes/kubernetes/pull/13946. With it I can can keep a lot of code that shouldn't be in the cloudprovider, out (for reference see gce l7 controller https://github.com/kubernetes/kubernetes/pull/12825, that can exist standalone in contrib with this change). 
