### PR TITLE
Make PodTemplateSpec for Job not a pointer, since it's a required field

### DIFF
--- a/pkg/apis/extensions/deep_copy_generated.go
+++ b/pkg/apis/extensions/deep_copy_generated.go
@@ -1301,13 +1301,8 @@ func deepCopy_extensions_JobSpec(in JobSpec, out *JobSpec, c *conversion.Cloner)
 	} else {
 		out.Selector = nil
 	}
-	if in.Template != nil {
-		out.Template = new(api.PodTemplateSpec)
-		if err := deepCopy_api_PodTemplateSpec(*in.Template, out.Template, c); err != nil {
-			return err
-		}
-	} else {
-		out.Template = nil
+	if err := deepCopy_api_PodTemplateSpec(in.Template, &out.Template, c); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/apis/extensions/types.go
+++ b/pkg/apis/extensions/types.go
@@ -409,7 +409,7 @@ type JobSpec struct {
 
 	// Template is the object that describes the pod that will be created when
 	// executing a job.
-	Template *api.PodTemplateSpec `json:"template"`
+	Template api.PodTemplateSpec `json:"template"`
 }
 
 // JobStatus represents the current state of a Job.

--- a/pkg/apis/extensions/v1beta1/conversion_generated.go
+++ b/pkg/apis/extensions/v1beta1/conversion_generated.go
@@ -2792,13 +2792,8 @@ func autoconvert_extensions_JobSpec_To_v1beta1_JobSpec(in *extensions.JobSpec, o
 	} else {
 		out.Selector = nil
 	}
-	if in.Template != nil {
-		out.Template = new(v1.PodTemplateSpec)
-		if err := convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(in.Template, out.Template, s); err != nil {
-			return err
-		}
-	} else {
-		out.Template = nil
+	if err := convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
+		return err
 	}
 	return nil
 }
@@ -3714,13 +3709,8 @@ func autoconvert_v1beta1_JobSpec_To_extensions_JobSpec(in *JobSpec, out *extensi
 	} else {
 		out.Selector = nil
 	}
-	if in.Template != nil {
-		out.Template = new(api.PodTemplateSpec)
-		if err := convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(in.Template, out.Template, s); err != nil {
-			return err
-		}
-	} else {
-		out.Template = nil
+	if err := convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/apis/extensions/v1beta1/deep_copy_generated.go
+++ b/pkg/apis/extensions/v1beta1/deep_copy_generated.go
@@ -1313,13 +1313,8 @@ func deepCopy_v1beta1_JobSpec(in JobSpec, out *JobSpec, c *conversion.Cloner) er
 	} else {
 		out.Selector = nil
 	}
-	if in.Template != nil {
-		out.Template = new(v1.PodTemplateSpec)
-		if err := deepCopy_v1_PodTemplateSpec(*in.Template, out.Template, c); err != nil {
-			return err
-		}
-	} else {
-		out.Template = nil
+	if err := deepCopy_v1_PodTemplateSpec(in.Template, &out.Template, c); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/apis/extensions/v1beta1/defaults.go
+++ b/pkg/apis/extensions/v1beta1/defaults.go
@@ -89,10 +89,7 @@ func addDefaultingFuncs() {
 			}
 		},
 		func(obj *Job) {
-			var labels map[string]string
-			if obj.Spec.Template != nil {
-				labels = obj.Spec.Template.Labels
-			}
+			labels := obj.Spec.Template.Labels
 			// TODO: support templates defined elsewhere when we support them in the API
 			if labels != nil {
 				if len(obj.Spec.Selector) == 0 {

--- a/pkg/apis/extensions/v1beta1/defaults_test.go
+++ b/pkg/apis/extensions/v1beta1/defaults_test.go
@@ -207,7 +207,7 @@ func TestSetDefaultJob(t *testing.T) {
 		// selector from template labels, completions and parallelism - default
 		{
 			Spec: JobSpec{
-				Template: &v1.PodTemplateSpec{
+				Template: v1.PodTemplateSpec{
 					ObjectMeta: v1.ObjectMeta{
 						Labels: map[string]string{"job": "selector"},
 					},
@@ -218,7 +218,7 @@ func TestSetDefaultJob(t *testing.T) {
 		{
 			Spec: JobSpec{
 				Completions: newInt(1),
-				Template: &v1.PodTemplateSpec{
+				Template: v1.PodTemplateSpec{
 					ObjectMeta: v1.ObjectMeta{
 						Labels: map[string]string{"job": "selector"},
 					},
@@ -229,7 +229,7 @@ func TestSetDefaultJob(t *testing.T) {
 		{
 			Spec: JobSpec{
 				Parallelism: newInt(1),
-				Template: &v1.PodTemplateSpec{
+				Template: v1.PodTemplateSpec{
 					ObjectMeta: v1.ObjectMeta{
 						Labels: map[string]string{"job": "selector"},
 					},

--- a/pkg/apis/extensions/v1beta1/types.go
+++ b/pkg/apis/extensions/v1beta1/types.go
@@ -417,7 +417,7 @@ type JobSpec struct {
 	// Template is the object that describes the pod that will be created when
 	// executing a job.
 	// More info: http://releases.k8s.io/HEAD/docs/user-guide/jobs.md
-	Template *v1.PodTemplateSpec `json:"template"`
+	Template v1.PodTemplateSpec `json:"template"`
 }
 
 // JobStatus represents the current state of a Job.

--- a/pkg/apis/extensions/validation/validation.go
+++ b/pkg/apis/extensions/validation/validation.go
@@ -351,19 +351,15 @@ func ValidateJobSpec(spec *extensions.JobSpec) errs.ValidationErrorList {
 		allErrs = append(allErrs, errs.NewFieldRequired("selector"))
 	}
 
-	if spec.Template == nil {
-		allErrs = append(allErrs, errs.NewFieldRequired("template"))
-	} else {
-		labels := labels.Set(spec.Template.Labels)
-		if !selector.Matches(labels) {
-			allErrs = append(allErrs, errs.NewFieldInvalid("template.labels", spec.Template.Labels, "selector does not match template"))
-		}
-		allErrs = append(allErrs, apivalidation.ValidatePodTemplateSpec(spec.Template).Prefix("template")...)
-		if spec.Template.Spec.RestartPolicy != api.RestartPolicyOnFailure &&
-			spec.Template.Spec.RestartPolicy != api.RestartPolicyNever {
-			allErrs = append(allErrs, errs.NewFieldValueNotSupported("template.spec.restartPolicy",
-				spec.Template.Spec.RestartPolicy, []string{string(api.RestartPolicyOnFailure), string(api.RestartPolicyNever)}))
-		}
+	labels := labels.Set(spec.Template.Labels)
+	if !selector.Matches(labels) {
+		allErrs = append(allErrs, errs.NewFieldInvalid("template.labels", spec.Template.Labels, "selector does not match template"))
+	}
+	allErrs = append(allErrs, apivalidation.ValidatePodTemplateSpec(&spec.Template).Prefix("template")...)
+	if spec.Template.Spec.RestartPolicy != api.RestartPolicyOnFailure &&
+		spec.Template.Spec.RestartPolicy != api.RestartPolicyNever {
+		allErrs = append(allErrs, errs.NewFieldValueNotSupported("template.spec.restartPolicy",
+			spec.Template.Spec.RestartPolicy, []string{string(api.RestartPolicyOnFailure), string(api.RestartPolicyNever)}))
 	}
 	return allErrs
 }

--- a/pkg/apis/extensions/validation/validation_test.go
+++ b/pkg/apis/extensions/validation/validation_test.go
@@ -744,7 +744,7 @@ func TestValidateJob(t *testing.T) {
 			},
 			Spec: extensions.JobSpec{
 				Selector: validSelector,
-				Template: &validPodTemplateSpec,
+				Template: validPodTemplateSpec,
 			},
 		},
 	}
@@ -763,7 +763,7 @@ func TestValidateJob(t *testing.T) {
 			Spec: extensions.JobSpec{
 				Parallelism: &negative,
 				Selector:    validSelector,
-				Template:    &validPodTemplateSpec,
+				Template:    validPodTemplateSpec,
 			},
 		},
 		"spec.completions:must be non-negative": {
@@ -774,7 +774,7 @@ func TestValidateJob(t *testing.T) {
 			Spec: extensions.JobSpec{
 				Completions: &negative,
 				Selector:    validSelector,
-				Template:    &validPodTemplateSpec,
+				Template:    validPodTemplateSpec,
 			},
 		},
 		"spec.selector:required value": {
@@ -784,16 +784,7 @@ func TestValidateJob(t *testing.T) {
 			},
 			Spec: extensions.JobSpec{
 				Selector: map[string]string{},
-				Template: &validPodTemplateSpec,
-			},
-		},
-		"spec.template:required value": {
-			ObjectMeta: api.ObjectMeta{
-				Name:      "myjob",
-				Namespace: api.NamespaceDefault,
-			},
-			Spec: extensions.JobSpec{
-				Selector: validSelector,
+				Template: validPodTemplateSpec,
 			},
 		},
 		"spec.template.labels:selector does not match template": {
@@ -803,7 +794,7 @@ func TestValidateJob(t *testing.T) {
 			},
 			Spec: extensions.JobSpec{
 				Selector: validSelector,
-				Template: &api.PodTemplateSpec{
+				Template: api.PodTemplateSpec{
 					ObjectMeta: api.ObjectMeta{
 						Labels: map[string]string{"y": "z"},
 					},
@@ -822,7 +813,7 @@ func TestValidateJob(t *testing.T) {
 			},
 			Spec: extensions.JobSpec{
 				Selector: validSelector,
-				Template: &api.PodTemplateSpec{
+				Template: api.PodTemplateSpec{
 					ObjectMeta: api.ObjectMeta{
 						Labels: validSelector,
 					},

--- a/pkg/client/unversioned/jobs_test.go
+++ b/pkg/client/unversioned/jobs_test.go
@@ -49,7 +49,7 @@ func TestListJobs(t *testing.T) {
 							},
 						},
 						Spec: extensions.JobSpec{
-							Template: &api.PodTemplateSpec{},
+							Template: api.PodTemplateSpec{},
 						},
 					},
 				},
@@ -79,7 +79,7 @@ func TestGetJob(t *testing.T) {
 					},
 				},
 				Spec: extensions.JobSpec{
-					Template: &api.PodTemplateSpec{},
+					Template: api.PodTemplateSpec{},
 				},
 			},
 		},
@@ -125,7 +125,7 @@ func TestUpdateJob(t *testing.T) {
 					},
 				},
 				Spec: extensions.JobSpec{
-					Template: &api.PodTemplateSpec{},
+					Template: api.PodTemplateSpec{},
 				},
 			},
 		},
@@ -160,7 +160,7 @@ func TestUpdateJobStatus(t *testing.T) {
 					},
 				},
 				Spec: extensions.JobSpec{
-					Template: &api.PodTemplateSpec{},
+					Template: api.PodTemplateSpec{},
 				},
 				Status: extensions.JobStatus{
 					Active: 1,
@@ -212,7 +212,7 @@ func TestCreateJob(t *testing.T) {
 					},
 				},
 				Spec: extensions.JobSpec{
-					Template: &api.PodTemplateSpec{},
+					Template: api.PodTemplateSpec{},
 				},
 			},
 		},

--- a/pkg/controller/job/controller.go
+++ b/pkg/controller/job/controller.go
@@ -414,7 +414,7 @@ func (jm *JobController) manageJob(activePods []*api.Pod, succeeded int, job *ex
 		for i := 0; i < diff; i++ {
 			go func() {
 				defer wait.Done()
-				if err := jm.podControl.CreatePods(job.Namespace, job.Spec.Template, job); err != nil {
+				if err := jm.podControl.CreatePods(job.Namespace, &job.Spec.Template, job); err != nil {
 					defer util.HandleError(err)
 					// Decrement the expected number of creates because the informer won't observe this pod
 					jm.expectations.CreationObserved(jobKey)

--- a/pkg/controller/job/controller_test.go
+++ b/pkg/controller/job/controller_test.go
@@ -44,7 +44,7 @@ func newJob(parallelism, completions int) *extensions.Job {
 			Parallelism: &parallelism,
 			Completions: &completions,
 			Selector:    map[string]string{"foo": "bar"},
-			Template: &api.PodTemplateSpec{
+			Template: api.PodTemplateSpec{
 				ObjectMeta: api.ObjectMeta{
 					Labels: map[string]string{
 						"foo": "bar",

--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -884,19 +884,13 @@ func describeJob(job *extensions.Job, events *api.EventList) (string, error) {
 	return tabbedString(func(out io.Writer) error {
 		fmt.Fprintf(out, "Name:\t%s\n", job.Name)
 		fmt.Fprintf(out, "Namespace:\t%s\n", job.Namespace)
-		if job.Spec.Template != nil {
-			fmt.Fprintf(out, "Image(s):\t%s\n", makeImageList(&job.Spec.Template.Spec))
-		} else {
-			fmt.Fprintf(out, "Image(s):\t%s\n", "<no template>")
-		}
+		fmt.Fprintf(out, "Image(s):\t%s\n", makeImageList(&job.Spec.Template.Spec))
 		fmt.Fprintf(out, "Selector:\t%s\n", labels.FormatLabels(job.Spec.Selector))
 		fmt.Fprintf(out, "Parallelism:\t%d\n", *job.Spec.Parallelism)
 		fmt.Fprintf(out, "Completions:\t%d\n", *job.Spec.Completions)
 		fmt.Fprintf(out, "Labels:\t%s\n", labels.FormatLabels(job.Labels))
 		fmt.Fprintf(out, "Pods Statuses:\t%d Running / %d Succeeded / %d Failed\n", job.Status.Active, job.Status.Succeeded, job.Status.Failed)
-		if job.Spec.Template != nil {
-			describeVolumes(job.Spec.Template.Spec.Volumes, out)
-		}
+		describeVolumes(job.Spec.Template.Spec.Volumes, out)
 		if events != nil {
 			DescribeEvents(events, out)
 		}

--- a/pkg/registry/job/etcd/etcd_test.go
+++ b/pkg/registry/job/etcd/etcd_test.go
@@ -48,7 +48,7 @@ func validNewJob() *extensions.Job {
 			Completions: &completions,
 			Parallelism: &parallelism,
 			Selector:    map[string]string{"a": "b"},
-			Template: &api.PodTemplateSpec{
+			Template: api.PodTemplateSpec{
 				ObjectMeta: api.ObjectMeta{
 					Labels: map[string]string{"a": "b"},
 				},

--- a/pkg/registry/job/strategy_test.go
+++ b/pkg/registry/job/strategy_test.go
@@ -50,7 +50,7 @@ func TestJobStrategy(t *testing.T) {
 		},
 		Spec: extensions.JobSpec{
 			Selector: validSelector,
-			Template: &validPodTemplateSpec,
+			Template: validPodTemplateSpec,
 		},
 		Status: extensions.JobStatus{
 			Active: 11,
@@ -116,7 +116,7 @@ func TestJobStatusStrategy(t *testing.T) {
 		},
 		Spec: extensions.JobSpec{
 			Selector:    validSelector,
-			Template:    &validPodTemplateSpec,
+			Template:    validPodTemplateSpec,
 			Parallelism: &oldParallelism,
 		},
 		Status: extensions.JobStatus{
@@ -131,7 +131,7 @@ func TestJobStatusStrategy(t *testing.T) {
 		},
 		Spec: extensions.JobSpec{
 			Selector:    validSelector,
-			Template:    &validPodTemplateSpec,
+			Template:    validPodTemplateSpec,
 			Parallelism: &newParallelism,
 		},
 		Status: extensions.JobStatus{

--- a/test/e2e/job.go
+++ b/test/e2e/job.go
@@ -191,7 +191,7 @@ func newTestJob(behavior, name string, rPol api.RestartPolicy, parallelism, comp
 		Spec: extensions.JobSpec{
 			Parallelism: &parallelism,
 			Completions: &completions,
-			Template: &api.PodTemplateSpec{
+			Template: api.PodTemplateSpec{
 				ObjectMeta: api.ObjectMeta{
 					Labels: map[string]string{jobSelectorKey: name},
 				},


### PR DESCRIPTION
@erictune this addresses @bgrant0607's [comment](https://github.com/kubernetes/kubernetes/pull/14079/files#r40389805) regarding making PodTemplateSpec not a pointer. ptal.
