### PR TITLE
Add a munger check for files that end in preformat

### DIFF
--- a/cmd/mungedocs/mungedocs.go
+++ b/cmd/mungedocs/mungedocs.go
@@ -46,6 +46,9 @@ Examples:
 	// All of the munge operations to perform.
 	// TODO: allow selection from command line. (e.g., just check links in the examples directory.)
 	allMunges = []munge{
+		// Simple "check something" functions must run first.
+		{"preformat-balance", checkPreformatBalance},
+		// Functions which modify state.
 		{"remove-whitespace", updateWhitespace},
 		{"table-of-contents", updateTOC},
 		{"unversioned-warning", updateUnversionedWarning},

--- a/cmd/mungedocs/preformatted.go
+++ b/cmd/mungedocs/preformatted.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package main
 
+import "fmt"
+
 // Blocks of ``` need to have blank lines on both sides or they don't look
 // right in HTML.
 func updatePreformatted(filePath string, mlines mungeLines) (mungeLines, error) {
@@ -38,4 +40,12 @@ func updatePreformatted(filePath string, mlines mungeLines) (mungeLines, error) 
 		}
 	}
 	return out, nil
+}
+
+// If the file ends on a preformatted line, there must have been an imbalance.
+func checkPreformatBalance(filePath string, mlines mungeLines) (mungeLines, error) {
+	if len(mlines) > 0 && mlines[len(mlines)-1].preformatted {
+		return nil, fmt.Errorf("file ends in preformatted block")
+	}
+	return mlines, nil
 }

--- a/cmd/mungedocs/preformatted_test.go
+++ b/cmd/mungedocs/preformatted_test.go
@@ -55,3 +55,26 @@ func TestPreformatted(t *testing.T) {
 		}
 	}
 }
+
+func TestPreformattedImbalance(t *testing.T) {
+	var cases = []struct {
+		in string
+		ok bool
+	}{
+		{"", true},
+		{"```\nin\n```", true},
+		{"```\nin\n```\nout", true},
+		{"```", false},
+		{"```\nin\n```\nout\n```", false},
+	}
+	for i, c := range cases {
+		in := getMungeLines(c.in)
+		_, err := checkPreformatBalance("filename.md", in)
+		if err != nil && c.ok {
+			t.Errorf("case[%d]: expected success", i)
+		}
+		if err == nil && !c.ok {
+			t.Errorf("case[%d]: expected failure", i)
+		}
+	}
+}


### PR DESCRIPTION
This bug wasted a few hours of my day.
