### PR TITLE
Fix documentation search styles

### DIFF
--- a/_layouts/docwithnav.html
+++ b/_layouts/docwithnav.html
@@ -1,8 +1,12 @@
 {% include dochead.html %}
 <!-- Search box for Google Custom Search Engine -->
-<div id="gcse-wrapper">
-	<gcse:search></gcse:search>
+<div class="gcse-wrapper" id="gcse-searchbox">
+	<gcse:searchbox></gcse:searchbox>
 </div>
+<div class="gcse-wrapper">
+  <gcse:searchresults></gcse:searchresults>
+</div>
+
 <!-- Navigation menu -->
 <div id="wrapper">
 	{% include nav_v1.0.html %}

--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -91,7 +91,23 @@ ul, ul ul {
     font-weight: normal;
 	margin-left:.6em;
 }
-#gcse-wrapper {
-  z-index: 1;
+
+#gcse-searchbox {
+  background-color: #fff;
+  padding: 13px;
   position: fixed;
+  z-index: 1;
+}
+
+/* Restore gcse default styles. */
+/* TODO: Don't overwrite root styles. This should not be necessary. */
+.gcse-wrapper * {
+  -webkit-box-sizing: content-box;
+  box-sizing: content-box;
+}
+.gcse-wrapper .gsc-cursor-page.gsc-cursor-current-page {
+  color: #fff !important;
+}
+.gcse-wrapper b {
+  font-weight: bold;
 }


### PR DESCRIPTION
Fixes:
- search results z-index
- overflowing relevance button in search results
- unreadable number in the search results current page
- bolded matching results
- restores default styling on the search bar

View the changes here: http://timstclair.github.io/kubernetes/v1.0/
