### PR TITLE
Adding an e2e test for deployment

### DIFF
--- a/hack/e2e.go
+++ b/hack/e2e.go
@@ -178,6 +178,8 @@ func Up() bool {
 		}
 	}
 
+	// Enable deployments for e2e tests.
+	os.Setenv("KUBE_ENABLE_DEPLOYMENTS", "true")
 	return finishRunning("up", exec.Command(path.Join(*root, "hack/e2e-internal/e2e-up.sh")))
 }
 

--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -198,6 +198,7 @@ case ${JOB_NAME} in
           )"}
     : ${KUBE_GCE_INSTANCE_PREFIX="e2e-gce"}
     : ${PROJECT:="k8s-jkns-e2e-gce"}
+    : ${ENABLE_DEPLOYMENTS:=true}
     ;;
 
   # Runs only the examples tests on GCE.
@@ -265,6 +266,7 @@ case ${JOB_NAME} in
     : ${KUBE_GCE_INSTANCE_PREFIX:="pull-e2e-${EXECUTOR_NUMBER}"}
     : ${KUBE_GCS_STAGING_PATH_SUFFIX:="-${EXECUTOR_NUMBER}"}
     : ${PROJECT:="kubernetes-jenkins-pull"}
+    : ${ENABLE_DEPLOYMENTS:=true}
     # Override GCE defaults
     NUM_MINIONS=${NUM_MINIONS_PARALLEL}
     ;;
@@ -283,6 +285,7 @@ case ${JOB_NAME} in
           )"}
     : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-test-parallel"}
     : ${PROJECT:="kubernetes-jenkins"}
+    : ${ENABLE_DEPLOYMENTS:=true}
     # Override GCE defaults
     NUM_MINIONS=${NUM_MINIONS_PARALLEL}
     ;;
@@ -298,6 +301,7 @@ case ${JOB_NAME} in
           ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
           ${GCE_PARALLEL_FLAKY_TESTS[@]:+${GCE_PARALLEL_FLAKY_TESTS[@]}} \
           )"}
+    : ${ENABLE_DEPLOYMENTS:=true}
     # Override AWS defaults.
     NUM_MINIONS="6"
     ;;
@@ -526,6 +530,7 @@ fi
 export E2E_MIN_STARTUP_PODS=${E2E_MIN_STARTUP_PODS:-}
 export KUBE_ENABLE_CLUSTER_MONITORING=${ENABLE_CLUSTER_MONITORING:-}
 export KUBE_ENABLE_HORIZONTAL_POD_AUTOSCALER=${ENABLE_HORIZONTAL_POD_AUTOSCALER:-}
+export KUBE_ENABLE_DEPLOYMENTS=${ENABLE_DEPLOYMENTS:-}
 export MASTER_SIZE=${MASTER_SIZE:-}
 export MINION_SIZE=${MINION_SIZE:-}
 export NUM_MINIONS=${NUM_MINIONS:-}

--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/experimental"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Deployment", func() {
+	f := NewFramework("deployment")
+
+	It("deployment should create new pods", func() {
+		testNewDeployment(f)
+	})
+	It("deployment should delete old pods and create new ones", func() {
+		testDeploymentDeletesOldPods(f)
+	})
+})
+
+func testNewDeployment(f *Framework) {
+	ns := f.Namespace.Name
+	c := f.Client
+	deploymentName := "nginx-deployment"
+	podLabels := map[string]string{"name": "nginx"}
+	Logf("Creating simple deployment %s", deploymentName)
+	_, err := c.Deployments(ns).Create(&experimental.Deployment{
+		ObjectMeta: api.ObjectMeta{
+			Name: deploymentName,
+		},
+		Spec: experimental.DeploymentSpec{
+			Replicas:       1,
+			Selector:       podLabels,
+			UniqueLabelKey: "deployment.kubernetes.io/podTemplateHash",
+			Template: &api.PodTemplateSpec{
+				ObjectMeta: api.ObjectMeta{
+					Labels: podLabels,
+				},
+				Spec: api.PodSpec{
+					Containers: []api.Container{
+						{
+							Name:  "nginx",
+							Image: "nginx",
+						},
+					},
+				},
+			},
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+	defer func() {
+		Logf("deleting deployment %s", deploymentName)
+		Expect(c.Deployments(ns).Delete(deploymentName, nil)).NotTo(HaveOccurred())
+	}()
+	// Check that deployment is created fine.
+	deployment, err := c.Deployments(ns).Get(deploymentName)
+	Expect(err).NotTo(HaveOccurred())
+	Logf("Deployment: %s", deployment)
+
+	// Verify that the required pods have come up.
+	err = verifyPods(c, ns, "nginx", false, 1)
+	if err != nil {
+		Logf("error in waiting for pods to come up: %s", err)
+		return
+	}
+	// DeploymentStatus should be appropriately updated.
+	deployment, err = c.Deployments(ns).Get(deploymentName)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(deployment.Status.Replicas).Should(Equal(1))
+	Expect(deployment.Status.UpdatedReplicas).Should(Equal(1))
+}
+
+func testDeploymentDeletesOldPods(f *Framework) {
+	ns := f.Namespace.Name
+	c := f.Client
+	// Create redis pods.
+	podLabels := map[string]string{"name": "sample-pod"}
+	rcName := "redis-controller"
+	_, err := c.ReplicationControllers(ns).Create(&api.ReplicationController{
+		ObjectMeta: api.ObjectMeta{
+			Name: rcName,
+		},
+		Spec: api.ReplicationControllerSpec{
+			Replicas: 1,
+			Selector: podLabels,
+			Template: &api.PodTemplateSpec{
+				ObjectMeta: api.ObjectMeta{
+					Labels: podLabels,
+				},
+				Spec: api.PodSpec{
+					Containers: []api.Container{
+						{
+							Name:  "redis",
+							Image: "redis",
+						},
+					},
+				},
+			},
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+	defer func() {
+		Logf("deleting replication controller %s", rcName)
+		Expect(c.ReplicationControllers(ns).Delete(rcName)).NotTo(HaveOccurred())
+	}()
+	// Verify that the required pods have come up.
+	err = verifyPods(c, ns, "sample-pod", false, 1)
+	if err != nil {
+		Logf("error in waiting for pods to come up: %s", err)
+		return
+	}
+
+	// Create a deployment to delete redis pods and instead bring up nginx pods.
+	deploymentName := "nginx-deployment"
+	Logf("Creating deployment %s", deploymentName)
+	_, err = c.Deployments(ns).Create(&experimental.Deployment{
+		ObjectMeta: api.ObjectMeta{
+			Name: deploymentName,
+		},
+		Spec: experimental.DeploymentSpec{
+			Replicas:       1,
+			Selector:       podLabels,
+			UniqueLabelKey: "deployment.kubernetes.io/podTemplateHash",
+			Template: &api.PodTemplateSpec{
+				ObjectMeta: api.ObjectMeta{
+					Labels: podLabels,
+				},
+				Spec: api.PodSpec{
+					Containers: []api.Container{
+						{
+							Name:  "nginx",
+							Image: "nginx",
+						},
+					},
+				},
+			},
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+	defer func() {
+		Logf("deleting deployment %s", deploymentName)
+		Expect(c.Deployments(ns).Delete(deploymentName, nil)).NotTo(HaveOccurred())
+	}()
+
+	// Verify that the required pods have come up.
+	verifyPods(c, ns, "nginx", false, 1)
+	// DeploymentStatus should be appropriately updated.
+	deployment, err := c.Deployments(ns).Get(deploymentName)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(deployment.Status.Replicas).Should(Equal(1))
+	Expect(deployment.Status.UpdatedReplicas).Should(Equal(1))
+}

--- a/test/e2e/resize_nodes.go
+++ b/test/e2e/resize_nodes.go
@@ -226,7 +226,7 @@ func resizeRC(c *client.Client, ns, name string, replicas int) error {
 }
 
 func podsCreated(c *client.Client, ns, name string, replicas int) (*api.PodList, error) {
-	timeout := time.Minute
+	timeout := 2 * time.Minute
 	// List the pods, making sure we observe all the replicas.
 	label := labels.SelectorFromSet(labels.Set(map[string]string{"name": name}))
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(5 * time.Second) {


### PR DESCRIPTION
Ref #1743 

This a basic test that just tests the end state (old pods should have vanished and new pods should be scaled to the desired replicas).
We are not testing that we dont break maxSurge and maxAvailability during the update.
Will add tests for that when we have updated deployment controller to raise events each time it scales up or down (being done by https://github.com/kubernetes/kubernetes/pull/14130)

cc @ghodss @ironcladlou 
