### PR TITLE
Update script to re-generate swagger.

### DIFF
--- a/build/versionize-docs.sh
+++ b/build/versionize-docs.sh
@@ -72,4 +72,5 @@ done
 $SED -ri -e "s|(releases.k8s.io)/[^/]+|\1/${NEW_VERSION}|" pkg/api/v[0-9]*/types.go
 
 ${KUBE_ROOT}/hack/update-generated-docs.sh
-${KUBE_ROOT}/hack/update-swagger-spec.sh
+${KUBE_ROOT}/hack/update-generated-swagger-docs.sh
+


### PR DESCRIPTION
@nikhiljindal @zmerlynn 

This was broken when I tried to cut the 1.1.0 release.
