### PR TITLE
Eliminate redundant field in node controller manager

### DIFF
--- a/pkg/controller/node/nodecontroller.go
+++ b/pkg/controller/node/nodecontroller.go
@@ -266,10 +266,7 @@ func (nc *NodeController) monitorNodeStatus() error {
 			}
 		}
 	}
-
-	if err != nil {
-		return err
-	}
+	
 	if nc.allocateNodeCIDRs {
 		// TODO (cjcullen): Use pkg/controller/framework to watch nodes and
 		// reduce lists/decouple this from monitoring status.


### PR DESCRIPTION
This PR eliminate redundant struct in node controller:
- 'knownNodeSet' in 'NodeController' is redundant, since the 'nodeStatusMap' has saved all kown nodes information. We can use 'nodeStatusMap' to determine whether the a new node is observed or an old node has been deleted. 
