### PR TITLE
Controller framework test flake fix

### DIFF
--- a/pkg/controller/framework/controller_test.go
+++ b/pkg/controller/framework/controller_test.go
@@ -384,7 +384,7 @@ func TestUpdate(t *testing.T) {
 			go func(name string, f func(string)) {
 				defer wg.Done()
 				f(name)
-			}(fmt.Sprintf("%v-%v", i, j), f)
+			}(fmt.Sprintf("%d-%d", i, j), f)
 		}
 	}
 	wg.Wait()

--- a/pkg/controller/framework/controller_test.go
+++ b/pkg/controller/framework/controller_test.go
@@ -133,7 +133,7 @@ func ExampleInformer() {
 		time.Millisecond*100,
 		framework.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
-				source.Delete(obj.(runtime.Object))
+				source.DeleteDropWatch(obj.(runtime.Object))
 			},
 			DeleteFunc: func(obj interface{}) {
 				key, err := framework.DeletionHandlingMetaNamespaceKeyFunc(obj)
@@ -327,7 +327,7 @@ func TestUpdate(t *testing.T) {
 				if !allowedTransitions[pair{from, to}] {
 					t.Errorf("observed transition %q -> %q for %v", from, to, n.Name)
 				}
-				source.Delete(n)
+				source.DeleteDropWatch(n)
 			},
 			DeleteFunc: func(obj interface{}) {
 				testDoneWG.Done()

--- a/pkg/controller/framework/fake_controller_source.go
+++ b/pkg/controller/framework/fake_controller_source.go
@@ -37,7 +37,7 @@ func NewFakeControllerSource() *FakeControllerSource {
 
 // FakeControllerSource implements listing/watching for testing.
 type FakeControllerSource struct {
-	lock        sync.RWMutex
+	sync.RWMutex
 	items       map[nnu]runtime.Object
 	changes     []watch.Event // one change per resourceVersion
 	broadcaster *watch.Broadcaster
@@ -95,8 +95,8 @@ func (f *FakeControllerSource) key(meta *api.ObjectMeta) nnu {
 // Change records the given event (setting the object's resource version) and
 // sends a watch event with the specified probability.
 func (f *FakeControllerSource) Change(e watch.Event, watchProbability float64) {
-	f.lock.Lock()
-	defer f.lock.Unlock()
+	f.Lock()
+	defer f.Unlock()
 
 	objMeta, err := api.ObjectMetaFor(e.Object)
 	if err != nil {
@@ -121,8 +121,8 @@ func (f *FakeControllerSource) Change(e watch.Event, watchProbability float64) {
 
 // List returns a list object, with its resource version set.
 func (f *FakeControllerSource) List() (runtime.Object, error) {
-	f.lock.RLock()
-	defer f.lock.RUnlock()
+	f.RLock()
+	defer f.RUnlock()
 	list := make([]runtime.Object, 0, len(f.items))
 	for _, obj := range f.items {
 		// Must make a copy to allow clients to modify the object.
@@ -151,8 +151,8 @@ func (f *FakeControllerSource) List() (runtime.Object, error) {
 // Watch returns a watch, which will be pre-populated with all changes
 // after resourceVersion.
 func (f *FakeControllerSource) Watch(resourceVersion string) (watch.Interface, error) {
-	f.lock.RLock()
-	defer f.lock.RUnlock()
+	f.RLock()
+	defer f.RUnlock()
 	rc, err := strconv.Atoi(resourceVersion)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
That flake happened 5-10% of the time, so it was biting us on Go 1.5 often. It didn't show up in Go 1.4 probably because of the deterministic scheduler.
