### PR TITLE
Refactor exec to make attach useful without a client.Config

### DIFF
--- a/pkg/client/unversioned/remotecommand/remotecommand.go
+++ b/pkg/client/unversioned/remotecommand/remotecommand.go
@@ -21,141 +21,127 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"sync"
 
 	"k8s.io/kubernetes/pkg/api"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
-	"k8s.io/kubernetes/pkg/conversion/queryparams"
-	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/httpstream"
 	"k8s.io/kubernetes/pkg/util/httpstream/spdy"
 )
 
-type upgrader interface {
-	upgrade(*client.Request, *client.Config) (httpstream.Connection, error)
+// Executor is an interface for transporting shell-style streams.
+type Executor interface {
+	// Stream initiates the transport of the standard shell streams. It will transport any
+	// non-nil stream to a remote system, and return an error if a problem occurs. If tty
+	// is set, the stderr stream is not used (raw TTY manages stdout and stderr over the
+	// stdout stream).
+	Stream(stdin io.Reader, stdout, stderr io.Writer, tty bool) error
 }
 
-type defaultUpgrader struct{}
-
-func (u *defaultUpgrader) upgrade(req *client.Request, config *client.Config) (httpstream.Connection, error) {
-	return req.Upgrade(config, spdy.NewRoundTripper)
+// StreamExecutor supports the ability to dial an httpstream connection and the ability to
+// run a command line stream protocol over that dialer.
+type StreamExecutor interface {
+	Executor
+	httpstream.Dialer
 }
 
-type Streamer struct {
-	req    *client.Request
-	config *client.Config
-	stdin  io.Reader
-	stdout io.Writer
-	stderr io.Writer
-	tty    bool
+// streamExecutor handles transporting standard shell streams over an httpstream connection.
+type streamExecutor struct {
+	upgrader  httpstream.UpgradeRoundTripper
+	transport http.RoundTripper
 
-	upgrader upgrader
+	method string
+	url    *url.URL
 }
 
-// Executor executes a command on a pod container
-type Executor struct {
-	Streamer
-	command []string
-}
-
-// New creates a new RemoteCommandExecutor
-func New(req *client.Request, config *client.Config, command []string, stdin io.Reader, stdout, stderr io.Writer, tty bool) *Executor {
-	return &Executor{
-		command: command,
-		Streamer: Streamer{
-			req:    req,
-			config: config,
-			stdin:  stdin,
-			stdout: stdout,
-			stderr: stderr,
-			tty:    tty,
-		},
-	}
-}
-
-type Attach struct {
-	Streamer
-}
-
-// NewAttach creates a new RemoteAttach
-func NewAttach(req *client.Request, config *client.Config, stdin io.Reader, stdout, stderr io.Writer, tty bool) *Attach {
-	return &Attach{
-		Streamer: Streamer{
-			req:    req,
-			config: config,
-			stdin:  stdin,
-			stdout: stdout,
-			stderr: stderr,
-			tty:    tty,
-		},
-	}
-}
-
-// Execute sends a remote command execution request, upgrading the
-// connection and creating streams to represent stdin/stdout/stderr. Data is
-// copied between these streams and the supplied stdin/stdout/stderr parameters.
-func (e *Attach) Execute() error {
-	opts := api.PodAttachOptions{
-		Stdin:  (e.stdin != nil),
-		Stdout: (e.stdout != nil),
-		Stderr: (!e.tty && e.stderr != nil),
-		TTY:    e.tty,
-	}
-
-	if err := e.setupRequestParameters(&opts); err != nil {
-		return err
-	}
-
-	return e.doStream()
-}
-
-// Execute sends a remote command execution request, upgrading the
-// connection and creating streams to represent stdin/stdout/stderr. Data is
-// copied between these streams and the supplied stdin/stdout/stderr parameters.
-func (e *Executor) Execute() error {
-	opts := api.PodExecOptions{
-		Stdin:   (e.stdin != nil),
-		Stdout:  (e.stdout != nil),
-		Stderr:  (!e.tty && e.stderr != nil),
-		TTY:     e.tty,
-		Command: e.command,
-	}
-
-	if err := e.setupRequestParameters(&opts); err != nil {
-		return err
-	}
-
-	return e.doStream()
-}
-
-func (e *Streamer) setupRequestParameters(obj runtime.Object) error {
-	versioned, err := api.Scheme.ConvertToVersion(obj, e.config.Version)
+// NewExecutor connects to the provided server and upgrades the connection to
+// multiplexed bidirectional streams. The current implementation uses SPDY,
+// but this could be replaced with HTTP/2 once it's available, or something else.
+// TODO: the common code between this and portforward could be abstracted.
+func NewExecutor(config *client.Config, method string, url *url.URL) (StreamExecutor, error) {
+	tlsConfig, err := client.TLSConfigFor(config)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	params, err := queryparams.Convert(versioned)
+
+	upgradeRoundTripper := spdy.NewRoundTripper(tlsConfig)
+	wrapper, err := client.HTTPWrappersForConfig(config, upgradeRoundTripper)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	for k, v := range params {
-		for _, vv := range v {
-			e.req.Param(k, vv)
-		}
-	}
-	return nil
+
+	return &streamExecutor{
+		upgrader:  upgradeRoundTripper,
+		transport: wrapper,
+		method:    method,
+		url:       url,
+	}, nil
 }
 
-func (e *Streamer) doStream() error {
-	if e.upgrader == nil {
-		e.upgrader = &defaultUpgrader{}
+// NewStreamExecutor upgrades the request so that it supports multiplexed bidirectional
+// streams. This method takes a stream upgrader and an optional function that is invoked
+// to wrap the round tripper. This method may be used by clients that are lower level than
+// Kubernetes clients or need to provide their own upgrade round tripper.
+func NewStreamExecutor(upgrader httpstream.UpgradeRoundTripper, fn func(http.RoundTripper) http.RoundTripper, method string, url *url.URL) (StreamExecutor, error) {
+	var rt http.RoundTripper = upgrader
+	if fn != nil {
+		rt = fn(rt)
 	}
-	conn, err := e.upgrader.upgrade(e.req, e.config)
+	return &streamExecutor{
+		upgrader:  upgrader,
+		transport: rt,
+		method:    method,
+		url:       url,
+	}, nil
+}
+
+// Dial opens a connection to a remote server and attempts to negotiate a SPDY connection.
+func (e *streamExecutor) Dial() (httpstream.Connection, error) {
+	client := &http.Client{Transport: e.transport}
+
+	req, err := http.NewRequest(e.method, e.url.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %s", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error sending request: %s", err)
+	}
+	defer resp.Body.Close()
+
+	// TODO: handle protocol selection in the future
+	return e.upgrader.NewConnection(resp)
+}
+
+// Stream opens a protocol streamer to the server and streams until a client closes
+// the connection or the server disconnects.
+func (e *streamExecutor) Stream(stdin io.Reader, stdout, stderr io.Writer, tty bool) error {
+	conn, err := e.Dial()
 	if err != nil {
 		return err
 	}
 	defer conn.Close()
+	// TODO: negotiate protocols
+	streamer := &streamProtocol{
+		stdin:  stdin,
+		stdout: stdout,
+		stderr: stderr,
+		tty:    tty,
+	}
+	return streamer.stream(conn)
+}
 
+type streamProtocol struct {
+	stdin  io.Reader
+	stdout io.Writer
+	stderr io.Writer
+	tty    bool
+}
+
+func (e *streamProtocol) stream(conn httpstream.Connection) error {
 	headers := http.Header{}
 
 	// set up error stream

--- a/pkg/client/unversioned/request.go
+++ b/pkg/client/unversioned/request.go
@@ -18,7 +18,6 @@ package unversioned
 
 import (
 	"bytes"
-	"crypto/tls"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -35,11 +34,11 @@ import (
 	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/client/metrics"
+	"k8s.io/kubernetes/pkg/conversion/queryparams"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
-	"k8s.io/kubernetes/pkg/util/httpstream"
 	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/watch"
 	watchjson "k8s.io/kubernetes/pkg/watch/json"
@@ -406,6 +405,31 @@ func (r *Request) Param(paramName, s string) *Request {
 	return r.setParam(paramName, s)
 }
 
+// VersionedParams will take the provided object, serialize it to a map[string][]string using the
+// implicit RESTClient API version and the provided object convertor, and then add those as parameters
+// to the request. Use this to provide versioned query parameters from client libraries.
+func (r *Request) VersionedParams(obj runtime.Object, convertor runtime.ObjectConvertor) *Request {
+	if r.err != nil {
+		return r
+	}
+	versioned, err := convertor.ConvertToVersion(obj, r.apiVersion)
+	if err != nil {
+		r.err = err
+		return r
+	}
+	params, err := queryparams.Convert(versioned)
+	if err != nil {
+		r.err = err
+		return r
+	}
+	for k, v := range params {
+		for _, vv := range v {
+			r.setParam(k, vv)
+		}
+	}
+	return r
+}
+
 func (r *Request) setParam(paramName, value string) *Request {
 	if specialParams.Has(paramName) {
 		r.err = fmt.Errorf("must set %v through the corresponding function, not directly.", paramName)
@@ -611,41 +635,6 @@ func (r *Request) Stream() (io.ReadCloser, error) {
 		bodyText := string(bodyBytes)
 		return nil, fmt.Errorf("%s while accessing %v: %s", resp.Status, url, bodyText)
 	}
-}
-
-// Upgrade upgrades the request so that it supports multiplexed bidirectional
-// streams. The current implementation uses SPDY, but this could be replaced
-// with HTTP/2 once it's available, or something else.
-func (r *Request) Upgrade(config *Config, newRoundTripperFunc func(*tls.Config) httpstream.UpgradeRoundTripper) (httpstream.Connection, error) {
-	if r.err != nil {
-		return nil, r.err
-	}
-
-	tlsConfig, err := TLSConfigFor(config)
-	if err != nil {
-		return nil, err
-	}
-
-	upgradeRoundTripper := newRoundTripperFunc(tlsConfig)
-	wrapper, err := HTTPWrappersForConfig(config, upgradeRoundTripper)
-	if err != nil {
-		return nil, err
-	}
-
-	r.client = &http.Client{Transport: wrapper}
-
-	req, err := http.NewRequest(r.verb, r.URL().String(), nil)
-	if err != nil {
-		return nil, fmt.Errorf("Error creating request: %s", err)
-	}
-
-	resp, err := r.client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("Error sending request: %s", err)
-	}
-	defer resp.Body.Close()
-
-	return upgradeRoundTripper.NewConnection(resp)
 }
 
 // request connects to the server and invokes the provided function when a server response is

--- a/pkg/kubectl/cmd/attach.go
+++ b/pkg/kubectl/cmd/attach.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"os/signal"
 	"syscall"
@@ -72,15 +73,18 @@ func NewCmdAttach(f *cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer)
 
 // RemoteAttach defines the interface accepted by the Attach command - provided for test stubbing
 type RemoteAttach interface {
-	Attach(req *client.Request, config *client.Config, stdin io.Reader, stdout, stderr io.Writer, tty bool) error
+	Attach(method string, url *url.URL, config *client.Config, stdin io.Reader, stdout, stderr io.Writer, tty bool) error
 }
 
 // DefaultRemoteAttach is the standard implementation of attaching
 type DefaultRemoteAttach struct{}
 
-func (*DefaultRemoteAttach) Attach(req *client.Request, config *client.Config, stdin io.Reader, stdout, stderr io.Writer, tty bool) error {
-	attach := remotecommand.NewAttach(req, config, stdin, stdout, stderr, tty)
-	return attach.Execute()
+func (*DefaultRemoteAttach) Attach(method string, url *url.URL, config *client.Config, stdin io.Reader, stdout, stderr io.Writer, tty bool) error {
+	exec, err := remotecommand.NewExecutor(config, method, url)
+	if err != nil {
+		return err
+	}
+	return exec.Stream(stdin, stdout, stderr, tty)
 }
 
 // AttachOptions declare the arguments accepted by the Exec command
@@ -201,7 +205,7 @@ func (p *AttachOptions) Run() error {
 		SubResource("attach").
 		Param("container", p.GetContainerName(pod))
 
-	return p.Attach.Attach(req, p.Config, stdin, p.Out, p.Err, tty)
+	return p.Attach.Attach("POST", req.URL(), p.Config, stdin, p.Out, p.Err, tty)
 }
 
 // GetContainerName returns the name of the container to attach to, with a fallback.

--- a/pkg/kubectl/cmd/exec.go
+++ b/pkg/kubectl/cmd/exec.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"os/signal"
 	"syscall"
@@ -73,15 +74,18 @@ func NewCmdExec(f *cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer) *
 
 // RemoteExecutor defines the interface accepted by the Exec command - provided for test stubbing
 type RemoteExecutor interface {
-	Execute(req *client.Request, config *client.Config, command []string, stdin io.Reader, stdout, stderr io.Writer, tty bool) error
+	Execute(method string, url *url.URL, config *client.Config, stdin io.Reader, stdout, stderr io.Writer, tty bool) error
 }
 
 // DefaultRemoteExecutor is the standard implementation of remote command execution
 type DefaultRemoteExecutor struct{}
 
-func (*DefaultRemoteExecutor) Execute(req *client.Request, config *client.Config, command []string, stdin io.Reader, stdout, stderr io.Writer, tty bool) error {
-	executor := remotecommand.New(req, config, command, stdin, stdout, stderr, tty)
-	return executor.Execute()
+func (*DefaultRemoteExecutor) Execute(method string, url *url.URL, config *client.Config, stdin io.Reader, stdout, stderr io.Writer, tty bool) error {
+	exec, err := remotecommand.NewExecutor(config, method, url)
+	if err != nil {
+		return err
+	}
+	return exec.Stream(stdin, stdout, stderr, tty)
 }
 
 // ExecOptions declare the arguments accepted by the Exec command
@@ -220,6 +224,14 @@ func (p *ExecOptions) Run() error {
 		Namespace(pod.Namespace).
 		SubResource("exec").
 		Param("container", containerName)
+	req.VersionedParams(&api.PodExecOptions{
+		Container: containerName,
+		Command:   p.Command,
+		Stdin:     stdin != nil,
+		Stdout:    p.Out != nil,
+		Stderr:    p.Err != nil,
+		TTY:       tty,
+	}, api.Scheme)
 
-	return p.Executor.Execute(req, p.Config, p.Command, stdin, p.Out, p.Err, tty)
+	return p.Executor.Execute("POST", req.URL(), p.Config, stdin, p.Out, p.Err, tty)
 }

--- a/pkg/kubectl/cmd/portforward.go
+++ b/pkg/kubectl/cmd/portforward.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"net/url"
 	"os"
 	"os/signal"
 
@@ -25,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/portforward"
+	"k8s.io/kubernetes/pkg/client/unversioned/remotecommand"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 )
 
@@ -60,13 +62,17 @@ func NewCmdPortForward(f *cmdutil.Factory) *cobra.Command {
 }
 
 type portForwarder interface {
-	ForwardPorts(req *client.Request, config *client.Config, ports []string, stopChan <-chan struct{}) error
+	ForwardPorts(method string, url *url.URL, config *client.Config, ports []string, stopChan <-chan struct{}) error
 }
 
 type defaultPortForwarder struct{}
 
-func (*defaultPortForwarder) ForwardPorts(req *client.Request, config *client.Config, ports []string, stopChan <-chan struct{}) error {
-	fw, err := portforward.New(req, config, ports, stopChan)
+func (*defaultPortForwarder) ForwardPorts(method string, url *url.URL, config *client.Config, ports []string, stopChan <-chan struct{}) error {
+	dialer, err := remotecommand.NewExecutor(config, method, url)
+	if err != nil {
+		return err
+	}
+	fw, err := portforward.New(dialer, ports, stopChan)
 	if err != nil {
 		return err
 	}
@@ -130,5 +136,5 @@ func RunPortForward(f *cmdutil.Factory, cmd *cobra.Command, args []string, fw po
 		Name(pod.Name).
 		SubResource("portforward")
 
-	return fw.ForwardPorts(req, config, args, stopCh)
+	return fw.ForwardPorts("POST", req.URL(), config, args, stopCh)
 }

--- a/pkg/util/httpstream/httpstream.go
+++ b/pkg/util/httpstream/httpstream.go
@@ -37,6 +37,11 @@ type NewStreamHandler func(Stream) error
 // performs no other logic.
 func NoOpNewStreamHandler(stream Stream) error { return nil }
 
+// Dialer knows how to open a streaming connection to a server.
+type Dialer interface {
+	Dial() (Connection, error)
+}
+
 // UpgradeRoundTripper is a type of http.RoundTripper that is able to upgrade
 // HTTP requests to support multiplexed bidirectional streams. After RoundTrip()
 // is invoked, if the upgrade is successful, clients may retrieve the upgraded


### PR DESCRIPTION
The current executor structure is too dependent on client.Request
and client.Config. In order to do an attach from the server, it needs
to be possible to create an Executor from crypto/tls#TLSConfig and to
bypassing having a client.Request.

Changes:
- remotecommand.streamExecutor - handles upgrading a request and getting a connection, then streaming multiple input streams over it
- remotecommand.NewAttach / New - moved to exec / portforward / attach since they handle requests
- Remove request.Upgrade() - it's too coupled to SPDY, and can live with the streamExecutor
- Add request.VersionedParams(runtime.Object, runtime.ObjectConvertor) to handle object -> query transform

@ncdc this blocks being able to push binary builds to the server
