### PR TITLE
AWS: Recognize cn-north-1 & us-gov-west-1 regions

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -513,6 +513,8 @@ func isRegionValid(region string) bool {
 		"ap-southeast-1",
 		"ap-southeast-2",
 		"ap-northeast-1",
+		"cn-north-1",
+		"us-gov-west-1",
 		"sa-east-1",
 	}
 	for _, r := range regions {


### PR DESCRIPTION
These two regions were accidentally omitted.  This list now matches the
list we use elsewhere (e.g. when choosing an AMI).

Fixes #14420
