### PR TITLE
Make grafana accessible via apiserver proxy.

### DIFF
--- a/cluster/addons/cluster-monitoring/influxdb/grafana-service.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/grafana-service.yaml
@@ -7,7 +7,6 @@ metadata:
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "Grafana"
 spec:
-  type: LoadBalancer
   ports: 
     - port: 80
       targetPort: 3000

--- a/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
@@ -40,7 +40,24 @@ spec:
             limits:
               cpu: 100m
               memory: 100Mi
+          env:
+            - name: "GF_AUTH_BASIC_ENABLED"
+              value: "false"
+            - name: "GF_AUTH_ANONYMOUS_ENABLED"
+              value: "true"
+            - name: "GF_AUTH_ANONYMOUS_ORG_ROLE"
+              value: "Admin"
+            - name: "GF_SERVER_ROOT_URL"
+              value: "/api/v1/proxy/namespaces/kube-system/services/monitoring-grafana/"
+          volumeMounts:
+          - name: grafana-persistent-storage
+            mountPath: /var
+
+              
       volumes:
       - name: influxdb-persistent-storage
         emptyDir: {}
+      - name: grafana-persistent-storage
+        emptyDir: {}
+
 


### PR DESCRIPTION
Other changes include:
- Removing external loadbalancers - External Loadbalancers only work on certain cloud deployments by default like GCE and AWS. The current setup breaks in deployments where external loadbalancer mode for services are not available by default.
- Adding a persistent storage for grafana - prevents data loss during simple restarts.
  Related to #14624 
  cc @dchen1107 
