### PR TITLE
fix testclient prepend functions

### DIFF
--- a/pkg/client/unversioned/testclient/testclient.go
+++ b/pkg/client/unversioned/testclient/testclient.go
@@ -40,6 +40,8 @@ func NewSimpleFake(objects ...runtime.Object) *Fake {
 	fakeClient := &Fake{}
 	fakeClient.AddReactor("*", "*", ObjectReaction(o, api.RESTMapper))
 
+	fakeClient.AddWatchReactor("*", DefaultWatchReactor(watch.NewFake(), nil))
+
 	return fakeClient
 }
 
@@ -100,9 +102,7 @@ func (c *Fake) AddReactor(verb, resource string, reaction ReactionFunc) {
 
 // PrependReactor adds a reactor to the beginning of the chain
 func (c *Fake) PrependReactor(verb, resource string, reaction ReactionFunc) {
-	newChain := make([]Reactor, 0, len(c.ReactionChain)+1)
-	newChain[0] = &SimpleReactor{verb, resource, reaction}
-	newChain = append(newChain, c.ReactionChain...)
+	c.ReactionChain = append([]Reactor{&SimpleReactor{verb, resource, reaction}}, c.ReactionChain...)
 }
 
 // AddWatchReactor appends a reactor to the end of the chain
@@ -110,9 +110,19 @@ func (c *Fake) AddWatchReactor(resource string, reaction WatchReactionFunc) {
 	c.WatchReactionChain = append(c.WatchReactionChain, &SimpleWatchReactor{resource, reaction})
 }
 
+// PrependWatchReactor adds a reactor to the beginning of the chain
+func (c *Fake) PrependWatchReactor(resource string, reaction WatchReactionFunc) {
+	c.WatchReactionChain = append([]WatchReactor{&SimpleWatchReactor{resource, reaction}}, c.WatchReactionChain...)
+}
+
 // AddProxyReactor appends a reactor to the end of the chain
 func (c *Fake) AddProxyReactor(resource string, reaction ProxyReactionFunc) {
 	c.ProxyReactionChain = append(c.ProxyReactionChain, &SimpleProxyReactor{resource, reaction})
+}
+
+// PrependProxyReactor adds a reactor to the beginning of the chain
+func (c *Fake) PrependProxyReactor(resource string, reaction ProxyReactionFunc) {
+	c.ProxyReactionChain = append([]ProxyReactor{&SimpleProxyReactor{resource, reaction}}, c.ProxyReactionChain...)
 }
 
 // Invokes records the provided Action and then invokes the ReactFn (if provided).

--- a/pkg/controller/job/controller_test.go
+++ b/pkg/controller/job/controller_test.go
@@ -395,9 +395,9 @@ type FakeWatcher struct {
 }
 
 func TestWatchJobs(t *testing.T) {
+	client := testclient.NewSimpleFake()
 	fakeWatch := watch.NewFake()
-	client := &testclient.Fake{}
-	client.AddWatchReactor("*", testclient.DefaultWatchReactor(fakeWatch, nil))
+	client.PrependWatchReactor("*", testclient.DefaultWatchReactor(fakeWatch, nil))
 	manager := NewJobController(client)
 	manager.podStoreSynced = alwaysReady
 
@@ -458,9 +458,9 @@ func TestWatchJobs(t *testing.T) {
 }
 
 func TestWatchPods(t *testing.T) {
+	client := testclient.NewSimpleFake()
 	fakeWatch := watch.NewFake()
-	client := &testclient.Fake{}
-	client.AddWatchReactor("*", testclient.DefaultWatchReactor(fakeWatch, nil))
+	client.PrependWatchReactor("*", testclient.DefaultWatchReactor(fakeWatch, nil))
 	manager := NewJobController(client)
 	manager.podStoreSynced = alwaysReady
 

--- a/pkg/controller/replication/replication_controller_test.go
+++ b/pkg/controller/replication/replication_controller_test.go
@@ -502,10 +502,7 @@ func TestWatchPods(t *testing.T) {
 }
 
 func TestUpdatePods(t *testing.T) {
-	fakeWatch := watch.NewFake()
-	client := &testclient.Fake{}
-	client.AddWatchReactor("*", testclient.DefaultWatchReactor(fakeWatch, nil))
-	manager := NewReplicationManager(client, BurstReplicas)
+	manager := NewReplicationManager(testclient.NewSimpleFake(), BurstReplicas)
 	manager.podStoreSynced = alwaysReady
 
 	received := make(chan string)


### PR DESCRIPTION
`PrependReactor` had an index out of bound error and didn't reassign the `ReactorChain`.  This fixes those bugs and uses the functions inside tests to make sure it doesn't slip again.

Also make the `NewSimpleFake` more useful.

@kargakis this fixes our downstream issues.
