### PR TITLE
fix groups exposed at apis/

### DIFF
--- a/pkg/api/util/group_version.go
+++ b/pkg/api/util/group_version.go
@@ -37,3 +37,9 @@ func GetGroup(groupVersion string) string {
 	}
 	return s[0]
 }
+
+// GetGroupVersion returns the "group/version". It removes the leading "/" if
+// group is empty.
+func GetGroupVersion(group, version string) string {
+	return strings.TrimLeft(group+"/"+version, "/")
+}

--- a/pkg/apiserver/api_installer.go
+++ b/pkg/apiserver/api_installer.go
@@ -91,7 +91,7 @@ func (a *APIInstaller) Install(ws *restful.WebService) (apiResources []api.APIRe
 func (a *APIInstaller) NewWebService() *restful.WebService {
 	ws := new(restful.WebService)
 	ws.Path(a.prefix)
-	ws.Doc("API at " + a.prefix + " version " + apiutil.GetGroupVersion(a.group.Group, a.group.Version))
+	ws.Doc("API at " + a.prefix + ", group " + a.group.Group + ", version " + a.group.Version)
 	// TODO: change to restful.MIME_JSON when we set content type in client
 	ws.Consumes("*/*")
 	ws.Produces(restful.MIME_JSON)

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/rest"
+	apiutil "k8s.io/kubernetes/pkg/api/util"
 	"k8s.io/kubernetes/pkg/api/v1"
 	expapi "k8s.io/kubernetes/pkg/apis/experimental"
 	"k8s.io/kubernetes/pkg/apiserver"
@@ -593,8 +594,8 @@ func (m *Master) init(c *Config) {
 		}
 		expAPIVersions := []api.GroupVersion{
 			{
-				GroupVersion: g.Group + "/" + expVersion.Version,
-				Version:      expVersion.Version,
+				GroupVersion: expVersion.Version,
+				Version:      apiutil.GetVersion(expVersion.Version),
 			},
 		}
 		storageVersion, found := c.StorageVersions[g.Group]
@@ -604,7 +605,7 @@ func (m *Master) init(c *Config) {
 		group := api.APIGroup{
 			Name:             g.Group,
 			Versions:         expAPIVersions,
-			PreferredVersion: api.GroupVersion{GroupVersion: g.Group + "/" + storageVersion, Version: storageVersion},
+			PreferredVersion: api.GroupVersion{GroupVersion: storageVersion, Version: apiutil.GetVersion(storageVersion)},
 		}
 		apiserver.AddGroupWebService(m.handlerContainer, c.APIGroupPrefix+"/"+latest.GroupOrDie("experimental").Group+"/", group)
 		allGroups = append(allGroups, group)

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -933,8 +933,6 @@ func (m *Master) thirdpartyapi(group, kind, version string) *apiserver.APIGroupV
 		strings.ToLower(kind) + "s": resourceStorage,
 	}
 
-	fmt.Println("CHAO: apiRoot:", apiRoot, "Group:", group, "Version:", version)
-
 	return &apiserver.APIGroupVersion{
 		Root: apiRoot,
 

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -927,16 +927,18 @@ func (m *Master) InstallThirdPartyResource(rsrc *expapi.ThirdPartyResource) erro
 func (m *Master) thirdpartyapi(group, kind, version string) *apiserver.APIGroupVersion {
 	resourceStorage := thirdpartyresourcedataetcd.NewREST(m.thirdPartyStorage, group, kind)
 
-	apiRoot := makeThirdPartyPath(group)
+	apiRoot := makeThirdPartyPath("")
 
 	storage := map[string]rest.Storage{
 		strings.ToLower(kind) + "s": resourceStorage,
 	}
 
+	fmt.Println("CHAO: apiRoot:", apiRoot, "Group:", group, "Version:", version)
+
 	return &apiserver.APIGroupVersion{
 		Root: apiRoot,
 
-		Creater:   thirdpartyresourcedata.NewObjectCreator(version, api.Scheme),
+		Creater:   thirdpartyresourcedata.NewObjectCreator(group, version, api.Scheme),
 		Convertor: api.Scheme,
 		Typer:     api.Scheme,
 

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -293,7 +293,8 @@ func TestExpapi(t *testing.T) {
 	assert.Equal(expAPIGroup.Mapper, latest.GroupOrDie("experimental").RESTMapper)
 	assert.Equal(expAPIGroup.Codec, latest.GroupOrDie("experimental").Codec)
 	assert.Equal(expAPIGroup.Linker, latest.GroupOrDie("experimental").SelfLinker)
-	assert.Equal(expAPIGroup.Version, latest.GroupOrDie("experimental").GroupVersion)
+	assert.Equal(expAPIGroup.Group, latest.GroupOrDie("experimental").Group)
+	assert.Equal(expAPIGroup.Version, latest.GroupOrDie("experimental").Version)
 }
 
 // TestSecondsSinceSync verifies that proper results are returned
@@ -681,7 +682,7 @@ func testInstallThirdPartyAPIPostForVersion(t *testing.T, version string) {
 		},
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "Foo",
-			APIVersion: version,
+			APIVersion: "company.com/" + version,
 		},
 		SomeField:  "test field",
 		OtherField: 10,

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	apiutil "k8s.io/kubernetes/pkg/api/util"
 	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/apis/experimental"
 	"k8s.io/kubernetes/pkg/apiserver"
@@ -67,7 +68,7 @@ func setUp(t *testing.T) (Master, Config, *assert.Assertions) {
 	config.DatabaseStorage = etcdstorage.NewEtcdStorage(fakeClient, testapi.Default.Codec(), etcdtest.PathPrefix())
 	storageVersions[""] = testapi.Default.Version()
 	config.ExpDatabaseStorage = etcdstorage.NewEtcdStorage(fakeClient, testapi.Experimental.Codec(), etcdtest.PathPrefix())
-	storageVersions["experimental"] = testapi.Experimental.Version()
+	storageVersions["experimental"] = testapi.Experimental.GroupAndVersion()
 	config.StorageVersions = storageVersions
 	master.nodeRegistry = registrytest.NewNodeRegistry([]string{"node1", "node2"}, api.NodeResources{})
 
@@ -429,6 +430,60 @@ func TestGenerateSSHKey(t *testing.T) {
 	os.Remove(publicKey)
 
 	// TODO: testing error cases where the file can not be removed?
+}
+
+func TestDiscoveryAtAPIS(t *testing.T) {
+	master, config, assert := setUp(t)
+	master.exp = true
+	// ================= preparation for master.init() ======================
+	portRange := util.PortRange{Base: 10, Size: 10}
+	master.serviceNodePortRange = portRange
+
+	_, ipnet, err := net.ParseCIDR("192.168.1.1/24")
+	if !assert.NoError(err) {
+		t.Errorf("unexpected error: %v", err)
+	}
+	master.serviceClusterIPRange = ipnet
+
+	mh := apiserver.MuxHelper{Mux: http.NewServeMux()}
+	master.muxHelper = &mh
+	master.rootWebService = new(restful.WebService)
+
+	master.handlerContainer = restful.NewContainer()
+
+	master.mux = http.NewServeMux()
+	master.requestContextMapper = api.NewRequestContextMapper()
+	// ======================= end of preparation ===========================
+
+	master.init(&config)
+	server := httptest.NewServer(master.handlerContainer.ServeMux)
+	resp, err := http.Get(server.URL + "/apis")
+	if !assert.NoError(err) {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	assert.Equal(http.StatusOK, resp.StatusCode)
+
+	groupList := api.APIGroupList{}
+	assert.NoError(decodeResponse(resp, &groupList))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectGroupName := "experimental"
+	expectVersions := []api.GroupVersion{
+		{
+			GroupVersion: testapi.Experimental.GroupAndVersion(),
+			Version:      testapi.Experimental.Version(),
+		},
+	}
+	expectPreferredVersion := api.GroupVersion{
+		GroupVersion: config.StorageVersions["experimental"],
+		Version:      apiutil.GetVersion(config.StorageVersions["experimental"]),
+	}
+	assert.Equal(expectGroupName, groupList.Groups[0].Name)
+	assert.Equal(expectVersions, groupList.Groups[0].Versions)
+	assert.Equal(expectPreferredVersion, groupList.Groups[0].PreferredVersion)
 }
 
 var versionsToTest = []string{"v1", "v3"}

--- a/pkg/master/thirdparty_controller.go
+++ b/pkg/master/thirdparty_controller.go
@@ -30,10 +30,13 @@ import (
 	"k8s.io/kubernetes/pkg/util/sets"
 )
 
-const thirdpartyprefix = "/apis/"
+const thirdpartyprefix = "/apis"
 
 func makeThirdPartyPath(group string) string {
-	return thirdpartyprefix + group
+	if len(group) == 0 {
+		return thirdpartyprefix
+	}
+	return thirdpartyprefix + "/" + group
 }
 
 // resourceInterface is the interface for the parts of the master that know how to add/remove

--- a/pkg/registry/thirdpartyresourcedata/codec.go
+++ b/pkg/registry/thirdpartyresourcedata/codec.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	apiutil "k8s.io/kubernetes/pkg/api/util"
 	"k8s.io/kubernetes/pkg/apis/experimental"
 	"k8s.io/kubernetes/pkg/runtime"
 )
@@ -48,12 +49,12 @@ func (t *thirdPartyResourceDataMapper) GroupForResource(resource string) (string
 	return t.mapper.GroupForResource(resource)
 }
 
-func (t *thirdPartyResourceDataMapper) RESTMapping(kind string, versions ...string) (*meta.RESTMapping, error) {
-	if len(versions) != 1 {
-		return nil, fmt.Errorf("unexpected set of versions: %v", versions)
+func (t *thirdPartyResourceDataMapper) RESTMapping(kind string, groupVersions ...string) (*meta.RESTMapping, error) {
+	if len(groupVersions) != 1 {
+		return nil, fmt.Errorf("unexpected set of groupVersions: %v", groupVersions)
 	}
-	if versions[0] != t.version {
-		return nil, fmt.Errorf("unknown version %s expected %s", versions[0], t.version)
+	if groupVersions[0] != apiutil.GetGroupVersion(t.group, t.version) {
+		return nil, fmt.Errorf("unknown version %s expected %s", groupVersions[0], apiutil.GetGroupVersion(t.group, t.version))
 	}
 	if kind != "ThirdPartyResourceData" {
 		return nil, fmt.Errorf("unknown kind %s expected %s", kind, t.kind)
@@ -266,28 +267,29 @@ func (t *thirdPartyResourceDataCodec) EncodeToStream(obj runtime.Object, stream 
 	}
 }
 
-func NewObjectCreator(version string, delegate runtime.ObjectCreater) runtime.ObjectCreater {
-	return &thirdPartyResourceDataCreator{version, delegate}
+func NewObjectCreator(group, version string, delegate runtime.ObjectCreater) runtime.ObjectCreater {
+	return &thirdPartyResourceDataCreator{group, version, delegate}
 }
 
 type thirdPartyResourceDataCreator struct {
+	group    string
 	version  string
 	delegate runtime.ObjectCreater
 }
 
-func (t *thirdPartyResourceDataCreator) New(version, kind string) (out runtime.Object, err error) {
+func (t *thirdPartyResourceDataCreator) New(groupVersion, kind string) (out runtime.Object, err error) {
 	switch kind {
 	case "ThirdPartyResourceData":
-		if t.version != version {
-			return nil, fmt.Errorf("unknown version %s for kind %s", version, kind)
+		if apiutil.GetGroupVersion(t.group, t.version) != groupVersion {
+			return nil, fmt.Errorf("unknown version %s for kind %s", groupVersion, kind)
 		}
 		return &experimental.ThirdPartyResourceData{}, nil
 	case "ThirdPartyResourceDataList":
-		if t.version != version {
-			return nil, fmt.Errorf("unknown version %s for kind %s", version, kind)
+		if apiutil.GetGroupVersion(t.group, t.version) != groupVersion {
+			return nil, fmt.Errorf("unknown version %s for kind %s", groupVersion, kind)
 		}
 		return &experimental.ThirdPartyResourceDataList{}, nil
 	default:
-		return t.delegate.New(version, kind)
+		return t.delegate.New(groupVersion, kind)
 	}
 }

--- a/pkg/registry/thirdpartyresourcedata/codec_test.go
+++ b/pkg/registry/thirdpartyresourcedata/codec_test.go
@@ -137,7 +137,7 @@ func TestCodec(t *testing.T) {
 }
 
 func TestCreater(t *testing.T) {
-	creater := NewObjectCreator("creater version", api.Scheme)
+	creater := NewObjectCreator("creater group", "creater version", api.Scheme)
 	tests := []struct {
 		name        string
 		version     string
@@ -147,7 +147,7 @@ func TestCreater(t *testing.T) {
 	}{
 		{
 			name:        "valid ThirdPartyResourceData creation",
-			version:     "creater version",
+			version:     "creater group/creater version",
 			kind:        "ThirdPartyResourceData",
 			expectedObj: &experimental.ThirdPartyResourceData{},
 			expectErr:   false,


### PR DESCRIPTION
After #14156, apiserver#APIGroupVersion.Version contains "group/version", instead of "version", so at apis/, the returned group information contains things like "experimental/experimental/v1alpha1". This PR fix the info exposed at apis/.

TODO: In another PR, we should renmae apiserver#APIGroupVersion.Version to GroupVersion to avoid future confusion.
Update: the TODO is addressed in this PR, GroupVersion is split to Group and Version. (supersede #14444, @deads2k)

@lavalamp 
