### PR TITLE
Add replication controller status subresource

### DIFF
--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -8025,6 +8025,65 @@
     ]
    },
    {
+    "path": "/api/v1/namespaces/{namespace}/replicationcontrollers/{name}/status",
+    "description": "API at /api/v1",
+    "operations": [
+     {
+      "type": "v1.ReplicationController",
+      "method": "PUT",
+      "summary": "replace status of the specified ReplicationController",
+      "nickname": "replaceNamespacedReplicationControllerStatus",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "query",
+        "name": "pretty",
+        "description": "If 'true', then the output is pretty printed.",
+        "required": false,
+        "allowMultiple": false
+       },
+       {
+        "type": "v1.ReplicationController",
+        "paramType": "body",
+        "name": "body",
+        "description": "",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "namespace",
+        "description": "object name and auth scope, such as for teams and projects",
+        "required": true,
+        "allowMultiple": false
+       },
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "name",
+        "description": "name of the ReplicationController",
+        "required": true,
+        "allowMultiple": false
+       }
+      ],
+      "responseMessages": [
+       {
+        "code": 200,
+        "message": "OK",
+        "responseModel": "v1.ReplicationController"
+       }
+      ],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "*/*"
+      ]
+     }
+    ]
+   },
+   {
     "path": "/api/v1/namespaces/{namespace}/resourcequotas",
     "description": "API at /api/v1",
     "operations": [

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -1352,6 +1352,15 @@ func ValidateReplicationControllerUpdate(oldController, controller *api.Replicat
 	return allErrs
 }
 
+// ValidateReplicationControllerStatusUpdate tests if required fields in the replication controller are set.
+func ValidateReplicationControllerStatusUpdate(oldController, controller *api.ReplicationController) errs.ValidationErrorList {
+	allErrs := errs.ValidationErrorList{}
+	allErrs = append(allErrs, ValidateObjectMetaUpdate(&controller.ObjectMeta, &oldController.ObjectMeta).Prefix("metadata")...)
+	allErrs = append(allErrs, ValidatePositiveField(int64(controller.Status.Replicas), "status.replicas")...)
+	allErrs = append(allErrs, ValidatePositiveField(int64(controller.Status.ObservedGeneration), "status.observedGeneration")...)
+	return allErrs
+}
+
 // Validates that the given selector is non-empty.
 func ValidateNonEmptySelector(selectorMap map[string]string, fieldName string) errs.ValidationErrorList {
 	allErrs := errs.ValidationErrorList{}

--- a/pkg/apis/experimental/v1alpha1/types_swagger_doc_generated.go
+++ b/pkg/apis/experimental/v1alpha1/types_swagger_doc_generated.go
@@ -356,7 +356,8 @@ func (JobStatus) SwaggerDoc() map[string]string {
 }
 
 var map_NodeUtilization = map[string]string{
-	"": "NodeUtilization describes what percentage of a particular resource is used on a node.",
+	"":      "NodeUtilization describes what percentage of a particular resource is used on a node.",
+	"value": "The accepted values are from 0 to 1.",
 }
 
 func (NodeUtilization) SwaggerDoc() map[string]string {

--- a/pkg/client/unversioned/replication_controllers.go
+++ b/pkg/client/unversioned/replication_controllers.go
@@ -34,6 +34,7 @@ type ReplicationControllerInterface interface {
 	Get(name string) (*api.ReplicationController, error)
 	Create(ctrl *api.ReplicationController) (*api.ReplicationController, error)
 	Update(ctrl *api.ReplicationController) (*api.ReplicationController, error)
+	UpdateStatus(ctrl *api.ReplicationController) (*api.ReplicationController, error)
 	Delete(name string) error
 	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
 }
@@ -74,6 +75,13 @@ func (c *replicationControllers) Create(controller *api.ReplicationController) (
 func (c *replicationControllers) Update(controller *api.ReplicationController) (result *api.ReplicationController, err error) {
 	result = &api.ReplicationController{}
 	err = c.r.Put().Namespace(c.ns).Resource("replicationControllers").Name(controller.Name).Body(controller).Do().Into(result)
+	return
+}
+
+// UpdateStatus updates an existing replication controller status
+func (c *replicationControllers) UpdateStatus(controller *api.ReplicationController) (result *api.ReplicationController, err error) {
+	result = &api.ReplicationController{}
+	err = c.r.Put().Namespace(c.ns).Resource("replicationControllers").Name(controller.Name).SubResource("status").Body(controller).Do().Into(result)
 	return
 }
 

--- a/pkg/client/unversioned/replication_controllers_test.go
+++ b/pkg/client/unversioned/replication_controllers_test.go
@@ -124,6 +124,36 @@ func TestUpdateController(t *testing.T) {
 	c.Validate(t, receivedController, err)
 }
 
+func TestUpdateStatusController(t *testing.T) {
+	ns := api.NamespaceDefault
+	requestController := &api.ReplicationController{
+		ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "1"},
+	}
+	c := &testClient{
+		Request: testRequest{Method: "PUT", Path: testapi.Default.ResourcePath(getRCResourceName(), ns, "foo") + "/status", Query: buildQueryValues(nil)},
+		Response: Response{
+			StatusCode: 200,
+			Body: &api.ReplicationController{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo":  "bar",
+						"name": "baz",
+					},
+				},
+				Spec: api.ReplicationControllerSpec{
+					Replicas: 2,
+					Template: &api.PodTemplateSpec{},
+				},
+				Status: api.ReplicationControllerStatus{
+					Replicas: 2,
+				},
+			},
+		},
+	}
+	receivedController, err := c.Setup(t).ReplicationControllers(ns).UpdateStatus(requestController)
+	c.Validate(t, receivedController, err)
+}
 func TestDeleteController(t *testing.T) {
 	ns := api.NamespaceDefault
 	c := &testClient{

--- a/pkg/client/unversioned/testclient/fake_replication_controllers.go
+++ b/pkg/client/unversioned/testclient/fake_replication_controllers.go
@@ -66,6 +66,14 @@ func (c *FakeReplicationControllers) Update(controller *api.ReplicationControlle
 	return obj.(*api.ReplicationController), err
 }
 
+func (c *FakeReplicationControllers) UpdateStatus(controller *api.ReplicationController) (*api.ReplicationController, error) {
+	obj, err := c.Fake.Invokes(NewUpdateSubresourceAction("replicationcontrollers", "status", c.Namespace, controller), &api.ReplicationController{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ReplicationController), err
+}
+
 func (c *FakeReplicationControllers) Delete(name string) error {
 	_, err := c.Fake.Invokes(NewDeleteAction("replicationcontrollers", c.Namespace, name), &api.ReplicationController{})
 	return err

--- a/pkg/controller/replication/replication_controller_test.go
+++ b/pkg/controller/replication/replication_controller_test.go
@@ -250,7 +250,7 @@ func TestStatusUpdatesWithoutReplicasChange(t *testing.T) {
 
 	rc.Status.ObservedGeneration = rc.Generation
 	updatedRc := runtime.EncodeOrDie(testapi.Default.Codec(), rc)
-	fakeHandler.ValidateRequest(t, testapi.Default.ResourcePath(replicationControllerResourceName(), rc.Namespace, rc.Name), "PUT", &updatedRc)
+	fakeHandler.ValidateRequest(t, testapi.Default.ResourcePath(replicationControllerResourceName(), rc.Namespace, rc.Name)+"/status", "PUT", &updatedRc)
 }
 
 func TestControllerUpdateReplicas(t *testing.T) {
@@ -288,7 +288,7 @@ func TestControllerUpdateReplicas(t *testing.T) {
 	rc.Status = api.ReplicationControllerStatus{Replicas: 4, ObservedGeneration: 1}
 
 	decRc := runtime.EncodeOrDie(testapi.Default.Codec(), rc)
-	fakeHandler.ValidateRequest(t, testapi.Default.ResourcePath(replicationControllerResourceName(), rc.Namespace, rc.Name), "PUT", &decRc)
+	fakeHandler.ValidateRequest(t, testapi.Default.ResourcePath(replicationControllerResourceName(), rc.Namespace, rc.Name)+"/status", "PUT", &decRc)
 	validateSyncReplication(t, &fakePodControl, 1, 0)
 }
 

--- a/pkg/controller/replication/replication_controller_utils.go
+++ b/pkg/controller/replication/replication_controller_utils.go
@@ -43,7 +43,7 @@ func updateReplicaCount(rcClient client.ReplicationControllerInterface, controll
 			controller.Name, controller.Status.Replicas, numReplicas, controller.Spec.Replicas, controller.Status.ObservedGeneration, generation)
 
 		rc.Status = api.ReplicationControllerStatus{Replicas: numReplicas, ObservedGeneration: generation}
-		_, updateErr = rcClient.Update(rc)
+		_, updateErr = rcClient.UpdateStatus(rc)
 		if updateErr == nil || i >= statusUpdateRetries {
 			return updateErr
 		}

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -551,7 +551,7 @@ func (m *Master) init(c *Config) {
 	})
 	m.serviceNodePortAllocator = serviceNodePortRegistry
 
-	controllerStorage := controlleretcd.NewREST(dbClient("replicationControllers"))
+	controllerStorage, controllerStatusStorage := controlleretcd.NewREST(dbClient("replicationControllers"))
 
 	// TODO: Factor out the core API registration
 	m.storage = map[string]rest.Storage{
@@ -567,12 +567,13 @@ func (m *Master) init(c *Config) {
 
 		"podTemplates": podTemplateStorage,
 
-		"replicationControllers": controllerStorage,
-		"services":               service.NewStorage(m.serviceRegistry, m.endpointRegistry, serviceClusterIPAllocator, serviceNodePortAllocator),
-		"endpoints":              endpointsStorage,
-		"nodes":                  nodeStorage,
-		"nodes/status":           nodeStatusStorage,
-		"events":                 eventStorage,
+		"replicationControllers":        controllerStorage,
+		"replicationControllers/status": controllerStatusStorage,
+		"services":                      service.NewStorage(m.serviceRegistry, m.endpointRegistry, serviceClusterIPAllocator, serviceNodePortAllocator),
+		"endpoints":                     endpointsStorage,
+		"nodes":                         nodeStorage,
+		"nodes/status":                  nodeStatusStorage,
+		"events":                        eventStorage,
 
 		"limitRanges":                   limitRangeStorage,
 		"resourceQuotas":                resourceQuotaStorage,

--- a/pkg/registry/controller/etcd/etcd_test.go
+++ b/pkg/registry/controller/etcd/etcd_test.go
@@ -27,9 +27,10 @@ import (
 	"k8s.io/kubernetes/pkg/tools"
 )
 
-func newStorage(t *testing.T) (*REST, *tools.FakeEtcdClient) {
+func newStorage(t *testing.T) (*REST, *StatusREST, *tools.FakeEtcdClient) {
 	etcdStorage, fakeClient := registrytest.NewEtcdStorage(t, "")
-	return NewREST(etcdStorage), fakeClient
+	storage, statusStorage := NewREST(etcdStorage)
+	return storage, statusStorage, fakeClient
 }
 
 // createController is a helper function that returns a controller with the updated resource version.
@@ -74,7 +75,7 @@ func validNewController() *api.ReplicationController {
 var validController = validNewController()
 
 func TestCreate(t *testing.T) {
-	storage, fakeClient := newStorage(t)
+	storage, _, fakeClient := newStorage(t)
 	test := registrytest.New(t, fakeClient, storage.Etcd)
 	controller := validNewController()
 	controller.ObjectMeta = api.ObjectMeta{}
@@ -93,7 +94,7 @@ func TestCreate(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
-	storage, fakeClient := newStorage(t)
+	storage, _, fakeClient := newStorage(t)
 	test := registrytest.New(t, fakeClient, storage.Etcd)
 	test.TestUpdate(
 		// valid
@@ -124,13 +125,13 @@ func TestUpdate(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
-	storage, fakeClient := newStorage(t)
+	storage, _, fakeClient := newStorage(t)
 	test := registrytest.New(t, fakeClient, storage.Etcd)
 	test.TestDelete(validNewController())
 }
 
 func TestGenerationNumber(t *testing.T) {
-	storage, _ := newStorage(t)
+	storage, _, _ := newStorage(t)
 	modifiedSno := *validNewController()
 	modifiedSno.Generation = 100
 	modifiedSno.Status.ObservedGeneration = 10
@@ -179,19 +180,19 @@ func TestGenerationNumber(t *testing.T) {
 }
 
 func TestGet(t *testing.T) {
-	storage, fakeClient := newStorage(t)
+	storage, _, fakeClient := newStorage(t)
 	test := registrytest.New(t, fakeClient, storage.Etcd)
 	test.TestGet(validNewController())
 }
 
 func TestList(t *testing.T) {
-	storage, fakeClient := newStorage(t)
+	storage, _, fakeClient := newStorage(t)
 	test := registrytest.New(t, fakeClient, storage.Etcd)
 	test.TestList(validNewController())
 }
 
 func TestWatch(t *testing.T) {
-	storage, fakeClient := newStorage(t)
+	storage, _, fakeClient := newStorage(t)
 	test := registrytest.New(t, fakeClient, storage.Etcd)
 	test.TestWatch(
 		validController,
@@ -220,3 +221,5 @@ func TestWatch(t *testing.T) {
 		},
 	)
 }
+
+//TODO TestUpdateStatus

--- a/pkg/registry/experimental/controller/etcd/etcd.go
+++ b/pkg/registry/experimental/controller/etcd/etcd.go
@@ -38,7 +38,9 @@ type ContainerStorage struct {
 }
 
 func NewStorage(s storage.Interface) ContainerStorage {
-	rcRegistry := controller.NewRegistry(etcd.NewREST(s))
+	// scale does not set status, only updates spec so we ignore the status
+	controllerREST, _ := etcd.NewREST(s)
+	rcRegistry := controller.NewRegistry(controllerREST)
 
 	return ContainerStorage{
 		ReplicationController: &RcREST{},


### PR DESCRIPTION
PR does the following:
- Add a /status endpoint for replication controller.
- Disable editing rc.Status when doing update
- Disable editing rc.Spec when doing updateStatus

Fixes https://github.com/kubernetes/kubernetes/issues/4909
