### PR TITLE
Fixed kubelet unit tests on osx

### DIFF
--- a/pkg/kubelet/container_manager_unsupported.go
+++ b/pkg/kubelet/container_manager_unsupported.go
@@ -42,3 +42,7 @@ func (unsupportedContainerManager) SystemContainersLimit() api.ResourceList {
 func newContainerManager(mounter mount.Interface, cadvisorInterface cadvisor.Interface, dockerDaemonContainer, systemContainer, kubeletContainer string) (containerManager, error) {
 	return &unsupportedContainerManager{}, nil
 }
+
+func validateSystemRequirements(mountUtil mount.Interface) error {
+	return nil
+}


### PR DESCRIPTION
Similar to https://github.com/kubernetes/kubernetes/pull/14615

Kubelet's unit tests were failing on OS X due to missing structs and funcs excluded by conditional build flags.

This PR makes fakeMountInterface common between platforms and fixes the unit tests.

```
# k8s.io/kubernetes/pkg/kubelet
_output/local/go/src/k8s.io/kubernetes/pkg/kubelet/kubelet_test.go:134: undefined: fakeContainerMgrMountInt
_output/local/go/src/k8s.io/kubernetes/pkg/kubelet/runonce_test.go:54: undefined: fakeContainerMgrMountInt
```

@brendandburns @smarterclayton 
