### PR TITLE
Vagrant - master bump memory to increase tmpfs size for salt-provision

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -104,7 +104,7 @@ end
 # In Fedora VM, tmpfs device is mapped to /tmp.  tmpfs is given 50% of RAM allocation.
 # When doing Salt provisioning, we copy approximately 200MB of content in /tmp before anything else happens.
 # This causes problems if anything else was in /tmp or the other directories that are bound to tmpfs device (i.e /run, etc.)
-$vm_master_mem = (ENV['KUBERNETES_MASTER_MEMORY'] || ENV['KUBERNETES_MEMORY'] || 1024).to_i
+$vm_master_mem = (ENV['KUBERNETES_MASTER_MEMORY'] || ENV['KUBERNETES_MEMORY'] || 1280).to_i
 $vm_minion_mem = (ENV['KUBERNETES_MINION_MEMORY'] || ENV['KUBERNETES_MEMORY'] || 1024).to_i
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|


### PR DESCRIPTION
Salt provisions the tar files to a temp dir which maps to tmpfs that is 50% of machine ram.

I started getting tar errors when untarring the release this morning.

Bumping the default memory slightly unblocked and things were good.
