### PR TITLE
Always set codec in setExperimentalDefaults

### DIFF
--- a/pkg/client/unversioned/experimental.go
+++ b/pkg/client/unversioned/experimental.go
@@ -143,9 +143,7 @@ func setExperimentalDefaults(config *Config) error {
 		return fmt.Errorf("Experimental API version '%s' is not recognized (valid values: %s)",
 			config.Version, strings.Join(latest.GroupOrDie("experimental").Versions, ", "))
 	}
-	if config.Codec == nil {
-		config.Codec = versionInterfaces.Codec
-	}
+	config.Codec = versionInterfaces.Codec
 	if config.QPS == 0 {
 		config.QPS = 5
 	}


### PR DESCRIPTION
Without this, the Jobs client used by
kubectl had codec type v1.  You would not notice this
on, say, a GET.  But when you tried to do an
Update, which did client-side conversion, then
you would get an error.
