### PR TITLE
Add authentication/authorization interfaces to the kubelet

### DIFF
--- a/contrib/mesos/pkg/executor/service/service.go
+++ b/contrib/mesos/pkg/executor/service/service.go
@@ -433,7 +433,7 @@ type kubeletExecutor struct {
 	clientConfig    *client.Config
 }
 
-func (kl *kubeletExecutor) ListenAndServe(address net.IP, port uint, tlsOptions *kubelet.TLSOptions, enableDebuggingHandlers bool) {
+func (kl *kubeletExecutor) ListenAndServe(address net.IP, port uint, tlsOptions *kubelet.TLSOptions, auth kubelet.AuthInterface, enableDebuggingHandlers bool) {
 	// this func could be called many times, depending how often the HTTP server crashes,
 	// so only execute certain initialization procs once
 	kl.initialize.Do(func() {
@@ -445,7 +445,7 @@ func (kl *kubeletExecutor) ListenAndServe(address net.IP, port uint, tlsOptions 
 		}()
 	})
 	log.Infof("Starting kubelet server...")
-	kubelet.ListenAndServeKubeletServer(kl, address, port, tlsOptions, enableDebuggingHandlers)
+	kubelet.ListenAndServeKubeletServer(kl, address, port, tlsOptions, auth, enableDebuggingHandlers)
 }
 
 // runs the main kubelet loop, closing the kubeletFinished chan when the loop exits.

--- a/docs/admin/kubelet.md
+++ b/docs/admin/kubelet.md
@@ -104,7 +104,7 @@ HTTP server: The kubelet can also listen for HTTP and respond to a simple API
       --pod-cidr="": The CIDR to use for pod IP addresses, only used in standalone mode.  In cluster mode, this is obtained from the master.
       --pod-infra-container-image="": The image whose network/ipc namespaces containers in each pod will use.
       --port=0: The port for the Kubelet to serve on. Note that "kubectl logs" will not work if you set this flag.
-      --read-only-port=0: The read-only port for the Kubelet to serve on (set to 0 to disable)
+      --read-only-port=0: The read-only port for the Kubelet to serve on with no authentication/authorization (set to 0 to disable)
       --really-crash-for-testing=false: If true, when panics occur crash. Intended for testing.
       --register-node=false: Register the node with the apiserver (defaults to true if --api-server is set)
       --registry-burst=0: Maximum size of a bursty pulls, temporarily allows pulls to burst to this number, while still not exceeding registry-qps.  Only used if --registry-qps > 0

--- a/pkg/auth/authorizer/interfaces.go
+++ b/pkg/auth/authorizer/interfaces.go
@@ -17,6 +17,8 @@ limitations under the License.
 package authorizer
 
 import (
+	"net/http"
+
 	"k8s.io/kubernetes/pkg/auth/user"
 )
 
@@ -61,6 +63,11 @@ type AuthorizerFunc func(a Attributes) error
 
 func (f AuthorizerFunc) Authorize(a Attributes) error {
 	return f(a)
+}
+
+// RequestAttributesGetter provides a function that extracts Attributes from an http.Request
+type RequestAttributesGetter interface {
+	GetRequestAttributes(user.Info, *http.Request) Attributes
 }
 
 // AttributesRecord implements Attributes interface.

--- a/pkg/kubelet/auth.go
+++ b/pkg/kubelet/auth.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet
+
+import (
+	"k8s.io/kubernetes/pkg/auth/authenticator"
+	"k8s.io/kubernetes/pkg/auth/authorizer"
+)
+
+// KubeletAuth implements AuthInterface
+type KubeletAuth struct {
+	// authenticator identifies the user for requests to the Kubelet API
+	authenticator.Request
+	// authorizerAttributeGetter builds authorization.Attributes for a request to the Kubelet API
+	authorizer.RequestAttributesGetter
+	// authorizer determines whether a given authorization.Attributes is allowed
+	authorizer.Authorizer
+}
+
+// NewKubeletAuth returns a kubelet.AuthInterface composed of the given authenticator, attribute getter, and authorizer
+func NewKubeletAuth(authenticator authenticator.Request, authorizerAttributeGetter authorizer.RequestAttributesGetter, authorizer authorizer.Authorizer) AuthInterface {
+	return &KubeletAuth{authenticator, authorizerAttributeGetter, authorizer}
+}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2786,8 +2786,8 @@ func (kl *Kubelet) GetCachedMachineInfo() (*cadvisorApi.MachineInfo, error) {
 	return kl.machineInfo, nil
 }
 
-func (kl *Kubelet) ListenAndServe(address net.IP, port uint, tlsOptions *TLSOptions, enableDebuggingHandlers bool) {
-	ListenAndServeKubeletServer(kl, address, port, tlsOptions, enableDebuggingHandlers)
+func (kl *Kubelet) ListenAndServe(address net.IP, port uint, tlsOptions *TLSOptions, auth AuthInterface, enableDebuggingHandlers bool) {
+	ListenAndServeKubeletServer(kl, address, port, tlsOptions, auth, enableDebuggingHandlers)
 }
 
 func (kl *Kubelet) ListenAndServeReadOnly(address net.IP, port uint) {


### PR DESCRIPTION
This PR:
- unifies metrics endpoint registration in the kubelet between readonly and secured paths (feedback wanted from @roberthbailey and @jimmidyson on whether this is appropriate)
- enables restful filter usage in the kubelet
- adds plumbing needed to authenticate/authorize requests to the kubelet

This is necessary to do things like:
- subdivide access to the kubelet API
- surface metrics/stats without making them world-readable (see https://github.com/kubernetes/kubernetes/issues/5028)
- offload log streaming or exec/attach/run connections to proxies
