### PR TITLE
Eliminate misleading code

### DIFF
--- a/pkg/controller/node/nodecontroller.go
+++ b/pkg/controller/node/nodecontroller.go
@@ -457,7 +457,10 @@ func (nc *NodeController) tryUpdateNodeStatus(node *api.Node) (time.Duration, ap
 	//   - if 'LastProbeTime' have gone back in time its probably an error, currently we ignore it,
 	//   - currently only correct Ready State transition outside of Node Controller is marking it ready by Kubelet, we don't check
 	//     if that's the case, but it does not seem necessary.
-	savedCondition := nc.getCondition(&savedNodeStatus.status, api.NodeReady)
+	var savedCondition *api.NodeCondition
+	if found {
+		savedCondition = nc.getCondition(&savedNodeStatus.status, api.NodeReady)
+	}
 	observedCondition := nc.getCondition(&node.Status, api.NodeReady)
 	if !found {
 		glog.Warningf("Missing timestamp for Node %s. Assuming now as a timestamp.", node.Name)


### PR DESCRIPTION
This PR make a misleading code fragment more clear and easy to understand
- The original code fragment is like this:
  <pre>
  savedNodeStatus, found := nc.nodeStatusMap[node.Name]
  savedCondition := nc.getCondition(&savedNodeStatus.status, api.NodeReady)
  func (nc *NodeController) getCondition(status *api.NodeStatus, conditionType api.NodeConditionType) *api.NodeCondition {
      if status == nil {
          return nil
      }
      for i := range status.Conditions {
          if status.Conditions[i].Type == conditionType {
              return &status.Conditions[i]
          }
      }
      return nil
  }
  </pre>
- If there is no key `node.Name` in `nc.nodeStatusMap`, then `savedNodeStatus` will be `nodeStatusData{}`(an empty struct). In such a case, the original code just call function `getCondition()` using `&savedNodeStatus.status` as argument (`savedNodeStatus==nodeStatusData{}`, so `&savedNodeStatus.status` is a pointer pointing an empty struct, not a nil pointer) , without checking `if found==true`. 
  So, in function `getCondition()`, `status` is a pointer pointing to an empty struct, not a nil pointer. Then the clause
  
  <pre>
  if status == nil {
      return nil
  }
  </pre>
  
  will not run(in fact, this clause will never run, because we call this function 4 times in total, but every time we call the function, the parameter `status` is not nil ), then the for loop will run and scan the array `status.Conditions` but find noting, since `status` is an empty struct.  Finally function `getCondition()` will return nil, just as we expect in such a case.
- Sure, the code is initially correct and can _work_ as expected. But it is very misleading and confusing, since it may make readers falsely assume that `&nodeStatusData{}`(the address of an empty struct or a pointer pointing an empty struct) is nil
