### PR TITLE
Increase allowed memory usage for KubeProxy

### DIFF
--- a/test/e2e/monitor_resources.go
+++ b/test/e2e/monitor_resources.go
@@ -47,8 +47,8 @@ var allowedUsage = resourceUsagePerContainer{
 	},
 	"/kube-proxy": &containerResourceUsage{
 		CPUUsageInCores:         0.025,
-		MemoryUsageInBytes:      12000000,
-		MemoryWorkingSetInBytes: 12000000,
+		MemoryUsageInBytes:      100000000,
+		MemoryWorkingSetInBytes: 100000000,
 	},
 	"/system": &containerResourceUsage{
 		CPUUsageInCores:         0.03,


### PR DESCRIPTION
I wasn't paying attention to this test recently and KubeProxy memory usage increased noticeably. I've seen KubeProxy using over 50MB of memory, even though a month ago it was usually happy with 10 - is this expected? @thockin @karlkfi 

I'm assuming that this is an effect of development, not regression and I'm going to increase limits in the test.
