### PR TITLE
Sort the daemon pods by creation time before deleting

### DIFF
--- a/pkg/controller/daemon/controller.go
+++ b/pkg/controller/daemon/controller.go
@@ -366,7 +366,8 @@ func (dsc *DaemonSetsController) manage(ds *experimental.DaemonSet) {
 			nodesNeedingDaemonPods = append(nodesNeedingDaemonPods, nodeName)
 		} else if shouldRun && len(daemonPods) > 1 {
 			// If daemon pod is supposed to be running on node, but more than 1 daemon pod is running, delete the excess daemon pods.
-			// TODO: sort the daemon pods by creation time, so the the oldest is preserved.
+			// Sort the daemon pods by creation time, so the the oldest is preserved.
+			sort.Sort(podByCreationTimestamp(daemonPods))
 			for i := 1; i < len(daemonPods); i++ {
 				podsToDelete = append(podsToDelete, daemonPods[i].Name)
 			}
@@ -514,6 +515,18 @@ func (o byCreationTimestamp) Len() int      { return len(o) }
 func (o byCreationTimestamp) Swap(i, j int) { o[i], o[j] = o[j], o[i] }
 
 func (o byCreationTimestamp) Less(i, j int) bool {
+	if o[i].CreationTimestamp.Equal(o[j].CreationTimestamp) {
+		return o[i].Name < o[j].Name
+	}
+	return o[i].CreationTimestamp.Before(o[j].CreationTimestamp)
+}
+
+type podByCreationTimestamp []*api.Pod
+
+func (o podByCreationTimestamp) Len() int      { return len(o) }
+func (o podByCreationTimestamp) Swap(i, j int) { o[i], o[j] = o[j], o[i] }
+
+func (o podByCreationTimestamp) Less(i, j int) bool {
 	if o[i].CreationTimestamp.Equal(o[j].CreationTimestamp) {
 		return o[i].Name < o[j].Name
 	}


### PR DESCRIPTION
This PR sort the daemon pods by creation time before deleting and preserved the oldest one
- If more than 1 daemon pod is running on a pod, we delete the excess daemon pods, this PR Sort the daemon pods by creation time before deleting, so the the oldest one is preserved.
