### PR TITLE
Record event when node is lost

### DIFF
--- a/pkg/controller/daemon/controller.go
+++ b/pkg/controller/daemon/controller.go
@@ -351,7 +351,8 @@ func (dsc *DaemonSetsController) manage(ds *experimental.DaemonSet) {
 			nodesNeedingDaemonPods = append(nodesNeedingDaemonPods, nodeName)
 		} else if shouldRun && len(daemonPods) > 1 {
 			// If daemon pod is supposed to be running on node, but more than 1 daemon pod is running, delete the excess daemon pods.
-			// TODO: sort the daemon pods by creation time, so the the oldest is preserved.
+			// Sort the daemon pods by creation time, so the the oldest is preserved.
+			sort.Sort(podByCreationTimestamp(daemonPods))
 			for i := 1; i < len(daemonPods); i++ {
 				podsToDelete = append(podsToDelete, daemonPods[i].Name)
 			}
@@ -492,6 +493,18 @@ func (o byCreationTimestamp) Len() int      { return len(o) }
 func (o byCreationTimestamp) Swap(i, j int) { o[i], o[j] = o[j], o[i] }
 
 func (o byCreationTimestamp) Less(i, j int) bool {
+	if o[i].CreationTimestamp.Equal(o[j].CreationTimestamp) {
+		return o[i].Name < o[j].Name
+	}
+	return o[i].CreationTimestamp.Before(o[j].CreationTimestamp)
+}
+
+type podByCreationTimestamp []*api.Pod
+
+func (o podByCreationTimestamp) Len() int      { return len(o) }
+func (o podByCreationTimestamp) Swap(i, j int) { o[i], o[j] = o[j], o[i] }
+
+func (o podByCreationTimestamp) Less(i, j int) bool {
 	if o[i].CreationTimestamp.Equal(o[j].CreationTimestamp) {
 		return o[i].Name < o[j].Name
 	}

--- a/pkg/controller/node/nodecontroller.go
+++ b/pkg/controller/node/nodecontroller.go
@@ -531,6 +531,7 @@ func (nc *NodeController) tryUpdateNodeStatus(node *api.Node) (time.Duration, ap
 				// LastProbeTime is the last time we heard from kubelet.
 				readyCondition.LastHeartbeatTime = lastReadyCondition.LastHeartbeatTime
 				readyCondition.LastTransitionTime = nc.now()
+				nc.recordNodeEvent(node.Name, "NodeLost", fmt.Sprintf("Node %v is out of touch", node.Name))
 			}
 		}
 		if !api.Semantic.DeepEqual(nc.getCondition(&node.Status, api.NodeReady), lastReadyCondition) {


### PR DESCRIPTION
This PR record an node Event when node is lost:
- If node is lost, which means Kubelet stop posting node status for some reason, node-controller should report an Event. Such an event is very useful, since some upper applications need this information, for example, external loadbalance need to know a node is lost so that stop forwarding any traffic to this lost node
