### PR TITLE
expose: Truncate service names

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -702,6 +702,18 @@ __EOF__
   # Post-condition: the error message has "invalid resource" string
   kube::test::if_has_string "${output_message}" 'invalid resource'
 
+  ### Try to generate a service with invalid name (exceeding maximum valid size)
+  # Pre-condition: use --name flag
+  output_message=$(! kubectl expose -f hack/testdata/pod-with-large-name.yaml --name=invalid-large-service-name --port=8081 2>&1 "${kube_flags[@]}")
+  # Post-condition: should fail due to invalid name
+  kube::test::if_has_string "${output_message}" 'metadata.name: invalid value'
+  # Pre-condition: default run without --name flag; should succeed by truncating the inherited name
+  output_message=$(kubectl expose -f hack/testdata/pod-with-large-name.yaml --port=8081 2>&1 "${kube_flags[@]}")
+  # Post-condition: inherited name from pod has been truncated
+  kube::test::if_has_string "${output_message}" '\"kubernetes-serve-hostnam\" exposed'
+  # Clean-up
+  kubectl delete svc kubernetes-serve-hostnam "${kube_flags[@]}"
+
   ### Delete replication controller with id
   # Pre-condition: frontend replication controller is running
   kube::test::get_object_assert rc "{{range.items}}{{$id_field}}:{{end}}" 'frontend:'

--- a/hack/testdata/pod-with-large-name.yaml
+++ b/hack/testdata/pod-with-large-name.yaml
@@ -1,0 +1,11 @@
+# Used for testing name truncation in kubectl expose
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kubernetes-serve-hostname
+  labels:
+    name: kubernetes-serve-hostname
+spec:
+  containers:
+  - name: kubernetes-serve-hostname
+    image: gcr.io/google_containers/serve_hostname

--- a/pkg/kubectl/cmd/expose.go
+++ b/pkg/kubectl/cmd/expose.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
+	"k8s.io/kubernetes/pkg/util/validation"
 )
 
 // ExposeOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
@@ -133,7 +134,11 @@ func RunExpose(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []str
 	}
 	names := generator.ParamNames()
 	params := kubectl.MakeParams(cmd, names)
-	params["default-name"] = info.Name
+	name := info.Name
+	if len(name) > validation.DNS952LabelMaxLength {
+		name = name[:validation.DNS952LabelMaxLength]
+	}
+	params["default-name"] = name
 
 	// For objects that need a pod selector, derive it from the exposed object in case a user
 	// didn't explicitly specify one via --selector


### PR DESCRIPTION
In case the generated service inherits the exposed object's name (the user didn't specify
a name via --name), truncate it up to the maximum length for a valid service name

@smarterclayton @kubernetes/kubectl 
