### PR TITLE
Record event when node become unavailable

### DIFF
--- a/pkg/controller/node/nodecontroller.go
+++ b/pkg/controller/node/nodecontroller.go
@@ -531,6 +531,7 @@ func (nc *NodeController) tryUpdateNodeStatus(node *api.Node) (time.Duration, ap
 				// LastProbeTime is the last time we heard from kubelet.
 				readyCondition.LastHeartbeatTime = lastReadyCondition.LastHeartbeatTime
 				readyCondition.LastTransitionTime = nc.now()
+				nc.recordNodeEvent(node.Name, "NodeLost", fmt.Sprintf("Node %v is unavailable", node.Name))
 			}
 		}
 		if !api.Semantic.DeepEqual(nc.getCondition(&node.Status, api.NodeReady), lastReadyCondition) {


### PR DESCRIPTION
This PR record an node Event when node become unavailable:
- If node become unavailable, which means Kubelet stop posting node status for some reasons, node-controller should report an Event. Such an event is very useful, since some upper applications need this information, for example, external loadbalance need to know a node become unavailable so that stop forwarding any traffic to this  unavailable node
