### PR TITLE
HorizontalPodAutoscaler.Status kept by value, not by pointer.

### DIFF
--- a/pkg/apis/experimental/deep_copy_generated.go
+++ b/pkg/apis/experimental/deep_copy_generated.go
@@ -976,13 +976,8 @@ func deepCopy_experimental_HorizontalPodAutoscaler(in HorizontalPodAutoscaler, o
 	if err := deepCopy_experimental_HorizontalPodAutoscalerSpec(in.Spec, &out.Spec, c); err != nil {
 		return err
 	}
-	if in.Status != nil {
-		out.Status = new(HorizontalPodAutoscalerStatus)
-		if err := deepCopy_experimental_HorizontalPodAutoscalerStatus(*in.Status, out.Status, c); err != nil {
-			return err
-		}
-	} else {
-		out.Status = nil
+	if err := deepCopy_experimental_HorizontalPodAutoscalerStatus(in.Status, &out.Status, c); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/apis/experimental/types.go
+++ b/pkg/apis/experimental/types.go
@@ -130,7 +130,7 @@ type HorizontalPodAutoscaler struct {
 	Spec HorizontalPodAutoscalerSpec `json:"spec,omitempty"`
 
 	// Status represents the current information about the autoscaler.
-	Status *HorizontalPodAutoscalerStatus `json:"status,omitempty"`
+	Status HorizontalPodAutoscalerStatus `json:"status,omitempty"`
 }
 
 // HorizontalPodAutoscaler is a collection of pod autoscalers.

--- a/pkg/apis/experimental/v1alpha1/conversion_generated.go
+++ b/pkg/apis/experimental/v1alpha1/conversion_generated.go
@@ -2309,13 +2309,8 @@ func autoconvert_experimental_HorizontalPodAutoscaler_To_v1alpha1_HorizontalPodA
 	if err := convert_experimental_HorizontalPodAutoscalerSpec_To_v1alpha1_HorizontalPodAutoscalerSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if in.Status != nil {
-		out.Status = new(HorizontalPodAutoscalerStatus)
-		if err := convert_experimental_HorizontalPodAutoscalerStatus_To_v1alpha1_HorizontalPodAutoscalerStatus(in.Status, out.Status, s); err != nil {
-			return err
-		}
-	} else {
-		out.Status = nil
+	if err := convert_experimental_HorizontalPodAutoscalerStatus_To_v1alpha1_HorizontalPodAutoscalerStatus(&in.Status, &out.Status, s); err != nil {
+		return err
 	}
 	return nil
 }
@@ -3115,13 +3110,8 @@ func autoconvert_v1alpha1_HorizontalPodAutoscaler_To_experimental_HorizontalPodA
 	if err := convert_v1alpha1_HorizontalPodAutoscalerSpec_To_experimental_HorizontalPodAutoscalerSpec(&in.Spec, &out.Spec, s); err != nil {
 		return err
 	}
-	if in.Status != nil {
-		out.Status = new(experimental.HorizontalPodAutoscalerStatus)
-		if err := convert_v1alpha1_HorizontalPodAutoscalerStatus_To_experimental_HorizontalPodAutoscalerStatus(in.Status, out.Status, s); err != nil {
-			return err
-		}
-	} else {
-		out.Status = nil
+	if err := convert_v1alpha1_HorizontalPodAutoscalerStatus_To_experimental_HorizontalPodAutoscalerStatus(&in.Status, &out.Status, s); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/apis/experimental/v1alpha1/deep_copy_generated.go
+++ b/pkg/apis/experimental/v1alpha1/deep_copy_generated.go
@@ -988,13 +988,8 @@ func deepCopy_v1alpha1_HorizontalPodAutoscaler(in HorizontalPodAutoscaler, out *
 	if err := deepCopy_v1alpha1_HorizontalPodAutoscalerSpec(in.Spec, &out.Spec, c); err != nil {
 		return err
 	}
-	if in.Status != nil {
-		out.Status = new(HorizontalPodAutoscalerStatus)
-		if err := deepCopy_v1alpha1_HorizontalPodAutoscalerStatus(*in.Status, out.Status, c); err != nil {
-			return err
-		}
-	} else {
-		out.Status = nil
+	if err := deepCopy_v1alpha1_HorizontalPodAutoscalerStatus(in.Status, &out.Status, c); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/apis/experimental/v1alpha1/types.go
+++ b/pkg/apis/experimental/v1alpha1/types.go
@@ -120,7 +120,7 @@ type HorizontalPodAutoscaler struct {
 	Spec HorizontalPodAutoscalerSpec `json:"spec,omitempty"`
 
 	// Status represents the current information about the autoscaler.
-	Status *HorizontalPodAutoscalerStatus `json:"status,omitempty"`
+	Status HorizontalPodAutoscalerStatus `json:"status,omitempty"`
 }
 
 // HorizontalPodAutoscalerList is a list of HorizontalPodAutoscalers.

--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -109,7 +109,7 @@ func (a *HorizontalController) reconcileAutoscaler(hpa experimental.HorizontalPo
 		// Going down only if the usageRatio dropped significantly below the target
 		// and there was no rescaling in the last downscaleForbiddenWindow.
 		if desiredReplicas < currentReplicas && usageRatio < (1-tolerance) &&
-			(hpa.Status == nil || hpa.Status.LastScaleTimestamp == nil ||
+			(hpa.Status.LastScaleTimestamp == nil ||
 				hpa.Status.LastScaleTimestamp.Add(downscaleForbiddenWindow).Before(now)) {
 			rescale = true
 		}
@@ -117,7 +117,7 @@ func (a *HorizontalController) reconcileAutoscaler(hpa experimental.HorizontalPo
 		// Going up only if the usage ratio increased significantly above the target
 		// and there was no rescaling in the last upscaleForbiddenWindow.
 		if desiredReplicas > currentReplicas && usageRatio > (1+tolerance) &&
-			(hpa.Status == nil || hpa.Status.LastScaleTimestamp == nil ||
+			(hpa.Status.LastScaleTimestamp == nil ||
 				hpa.Status.LastScaleTimestamp.Add(upscaleForbiddenWindow).Before(now)) {
 			rescale = true
 		}
@@ -135,12 +135,11 @@ func (a *HorizontalController) reconcileAutoscaler(hpa experimental.HorizontalPo
 		desiredReplicas = currentReplicas
 	}
 
-	status := experimental.HorizontalPodAutoscalerStatus{
+	hpa.Status = experimental.HorizontalPodAutoscalerStatus{
 		CurrentReplicas:    currentReplicas,
 		DesiredReplicas:    desiredReplicas,
 		CurrentConsumption: currentConsumption,
 	}
-	hpa.Status = &status
 	if rescale {
 		now := unversioned.NewTime(now)
 		hpa.Status.LastScaleTimestamp = &now

--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -1254,7 +1254,7 @@ func (d *HorizontalPodAutoscalerDescriber) Describe(namespace, name string) (str
 			hpa.Spec.Target.Resource)
 		fmt.Fprintf(out, "Current resource consumption:\t")
 
-		if hpa.Status != nil && hpa.Status.CurrentConsumption != nil {
+		if hpa.Status.CurrentConsumption != nil {
 			fmt.Fprintf(out, "%s %s\n",
 				hpa.Status.CurrentConsumption.Quantity.String(),
 				hpa.Status.CurrentConsumption.Resource)

--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -1281,7 +1281,7 @@ func printHorizontalPodAutoscaler(hpa *experimental.HorizontalPodAutoscaler, w i
 	target := fmt.Sprintf("%s %v", hpa.Spec.Target.Quantity.String(), hpa.Spec.Target.Resource)
 
 	current := "<waiting>"
-	if hpa.Status != nil && hpa.Status.CurrentConsumption != nil {
+	if hpa.Status.CurrentConsumption != nil {
 		current = fmt.Sprintf("%s %v", hpa.Status.CurrentConsumption.Quantity.String(), hpa.Status.CurrentConsumption.Resource)
 	}
 	minPods := hpa.Spec.MinReplicas


### PR DESCRIPTION
HorizontalPodAutoscaler.Status kept by value, not by pointer. Fixes #14567.
