### PR TITLE
Fixes crash when proxy is run with --cleanup-iptables=true.

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -159,6 +159,7 @@ func NewProxyServerDefault(config *ProxyServerConfig) (*ProxyServer, error) {
 	// We ommit creation of pretty much everything if we run in cleanup mode
 	if config.CleanupAndExit {
 		return &ProxyServer{
+			Config:       config,
 			IptInterface: iptInterface,
 		}, nil
 	}


### PR DESCRIPTION
Fixes crash when proxy is run with --cleanup-iptables=true.
