### PR TITLE
Fixed flakiness in autoscaling e2e with no scheduling pods

### DIFF
--- a/test/e2e/autoscaling.go
+++ b/test/e2e/autoscaling.go
@@ -53,10 +53,10 @@ var _ = Describe("Autoscaling", func() {
 	})
 
 	It("[Skipped][Autoscaling Suite] should scale cluster size based on cpu utilization", func() {
-		setUpAutoscaler("cpu/node_utilization", 0.5, nodeCount, nodeCount+1)
+		setUpAutoscaler("cpu/node_utilization", 0.4, nodeCount, nodeCount+1)
 
-		// Consume 60% CPU
-		millicoresPerReplica := 600
+		// Consume 50% CPU
+		millicoresPerReplica := 500
 		rc := NewStaticResourceConsumer("cpu-utilization", nodeCount*coresPerNode, millicoresPerReplica*nodeCount*coresPerNode, 0, int64(millicoresPerReplica), 100, f)
 		expectNoError(waitForClusterSize(f.Client, nodeCount+1, 20*time.Minute))
 

--- a/test/e2e/autoscaling_utils.go
+++ b/test/e2e/autoscaling_utils.go
@@ -260,14 +260,16 @@ func runServiceAndRCForResourceConsumer(c *client.Client, ns, name string, repli
 	})
 	expectNoError(err)
 	config := RCConfig{
-		Client:    c,
-		Image:     image,
-		Name:      name,
-		Namespace: ns,
-		Timeout:   timeoutRC,
-		Replicas:  replicas,
-		CpuLimit:  cpuLimitMillis,
-		MemLimit:  memLimitMb * 1024 * 1024, // MemLimit is in bytes
+		Client:     c,
+		Image:      image,
+		Name:       name,
+		Namespace:  ns,
+		Timeout:    timeoutRC,
+		Replicas:   replicas,
+		CpuRequest: cpuLimitMillis,
+		CpuLimit:   cpuLimitMillis,
+		MemRequest: memLimitMb * 1024 * 1024, // MemLimit is in bytes
+		MemLimit:   memLimitMb * 1024 * 1024,
 	}
 	expectNoError(RunRC(config))
 	// Make sure endpoints are propagated.


### PR DESCRIPTION
Decreased pods cpu limit to make sure they are scheduled properly.

part of #14737
