### PR TITLE
Increase the kube-proxy memory footprint.  Improve test failure output.

### DIFF
--- a/test/e2e/monitor_resources.go
+++ b/test/e2e/monitor_resources.go
@@ -119,7 +119,16 @@ var _ = Describe("Resource usage of system containers", func() {
 			for container, cUsage := range usage {
 				Logf("%v on %v usage: %#v", container, node, cUsage)
 				if !allowedUsage[container].isStrictlyGreaterThan(cUsage) {
-					violating[node] = usage
+					if allowedUsage[container].CPUUsageInCores < cUsage.CPUUsageInCores {
+						Logf("CPU is too high for %s (%v)", container, cUsage.CPUUsageInCores)
+					}
+					if allowedUsage[container].MemoryUsageInBytes < cUsage.MemoryUsageInBytes {
+						Logf("Memory use is too high for %s (%v)", container, cUsage.MemoryUsageInBytes)
+					}
+					if allowedUsage[container].MemoryWorkingSetInBytes < cUsage.MemoryWorkingSetInBytes {
+						Logf("Working set is too high for %s (%v)", container, cUsage.MemoryWorkingSetInBytes)
+					}
+					violating[node][container] = usage[container]
 				}
 			}
 		}


### PR DESCRIPTION
@thockin @dchen1107 

Fixes https://github.com/kubernetes/kubernetes/issues/12429 (I think)

I've observed kube-proxy usage as high as 26MB, so set to 30MB, assuming this is expected and not a regression.
