### PR TITLE
make jobstatus documenation more accurate

### DIFF
--- a/pkg/apis/experimental/types.go
+++ b/pkg/apis/experimental/types.go
@@ -435,8 +435,7 @@ type JobStatus struct {
 	// Successful is the number of pods which reached Phase Succeeded.
 	Successful int `json:"successful,omitempty"`
 
-	// Unsuccessful is the number of pods failures, this applies only to jobs
-	// created with RestartPolicyNever, otherwise this value will always be 0.
+	// Unsuccessful is the number of pods which reached Phase Failed.
 	Unsuccessful int `json:"unsuccessful,omitempty"`
 }
 

--- a/pkg/apis/experimental/v1alpha1/types.go
+++ b/pkg/apis/experimental/v1alpha1/types.go
@@ -444,8 +444,7 @@ type JobStatus struct {
 	// Successful is the number of pods which reached Phase Succeeded.
 	Successful int `json:"successful,omitempty"`
 
-	// Unsuccessful is the number of pods failures, this applies only to jobs
-	// created with RestartPolicyNever, otherwise this value will always be 0.
+	// Unsuccessful is the number of pods which reached Phase Failed.
 	Unsuccessful int `json:"unsuccessful,omitempty"`
 }
 

--- a/pkg/apis/experimental/v1alpha1/types_swagger_doc_generated.go
+++ b/pkg/apis/experimental/v1alpha1/types_swagger_doc_generated.go
@@ -302,7 +302,7 @@ var map_JobStatus = map[string]string{
 	"completionTime": "CompletionTime represents time when the job was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.",
 	"active":         "Active is the number of actively running pods.",
 	"successful":     "Successful is the number of pods which reached Phase Succeeded.",
-	"unsuccessful":   "Unsuccessful is the number of pods failures, this applies only to jobs created with RestartPolicyNever, otherwise this value will always be 0.",
+	"unsuccessful":   "Unsuccessful is the number of pods which reached Phase Failed.",
 }
 
 func (JobStatus) SwaggerDoc() map[string]string {


### PR DESCRIPTION
RestartOnFailure and RestartAlways pods can have status failed too e.g. during a node eviction.
