### PR TITLE
Fix race condition in kubectl run --attach

### DIFF
--- a/pkg/kubectl/cmd/attach.go
+++ b/pkg/kubectl/cmd/attach.go
@@ -156,12 +156,6 @@ func (p *AttachOptions) Run() error {
 		return fmt.Errorf("pod %s is not running and cannot be attached to; current phase is %s", p.PodName, pod.Status.Phase)
 	}
 
-	containerName := p.ContainerName
-	if len(containerName) == 0 {
-		glog.V(4).Infof("defaulting container name to %s", pod.Spec.Containers[0].Name)
-		containerName = pod.Spec.Containers[0].Name
-	}
-
 	// TODO: refactor with terminal helpers from the edit utility once that is merged
 	var stdin io.Reader
 	tty := p.TTY
@@ -205,7 +199,17 @@ func (p *AttachOptions) Run() error {
 		Name(pod.Name).
 		Namespace(pod.Namespace).
 		SubResource("attach").
-		Param("container", containerName)
+		Param("container", p.GetContainerName(pod))
 
 	return p.Attach.Attach(req, p.Config, stdin, p.Out, p.Err, tty)
+}
+
+// GetContainerName returns the name of the container to attach to, with a fallback.
+func (p *AttachOptions) GetContainerName(pod *api.Pod) string {
+	if len(p.ContainerName) > 0 {
+		return p.ContainerName
+	}
+
+	glog.V(4).Infof("defaulting container name to %s", pod.Spec.Containers[0].Name)
+	return pod.Spec.Containers[0].Name
 }

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -291,12 +291,16 @@ func handleAttachPod(c *client.Client, pod *api.Pod, opts *AttachOptions) error 
 		return err
 	}
 	if status == api.PodSucceeded || status == api.PodFailed {
-		return handleLog(c, pod.Namespace, pod.Name, &api.PodLogOptions{Container: pod.Spec.Containers[0].Name}, opts.Out)
+		return handleLog(c, pod.Namespace, pod.Name, &api.PodLogOptions{Container: opts.GetContainerName(pod)}, opts.Out)
 	}
 	opts.Client = c
 	opts.PodName = pod.Name
 	opts.Namespace = pod.Namespace
-	return opts.Run()
+	if err := opts.Run(); err != nil {
+		fmt.Fprintf(opts.Out, "Error attaching, falling back to logs: %v\n", err)
+		return handleLog(c, pod.Namespace, pod.Name, &api.PodLogOptions{Container: opts.GetContainerName(pod)}, opts.Out)
+	}
+	return nil
 }
 
 func getRestartPolicy(cmd *cobra.Command, interactive bool) (api.RestartPolicy, error) {


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/14703

Unfortunately the status cannot be checked for termination after attach fails, as the status cached by the API server can still be out of date (experiments on my e2e cluster took about 7" to report the terminated state). To compromise, I print out the attach error, but it produces messages like:

``` console
Error attaching, falling back to logs: error executing remote command: Error executing command in container: container not found ("run-test")
```

Let me know if you have a suggestion for a better approach.

Also, fix log fall back container selection logic to match the attach logic.
