### PR TITLE
Extend the timeout on initial validation of reboot tests.

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -84,9 +84,8 @@ const (
 	// be "ready" before the test starts, so this is small.
 	nodeReadyInitialTimeout = 20 * time.Second
 
-	// How long pods have to be "ready" when a test begins. They should already
-	// be "ready" before the test starts, so this is small.
-	podReadyBeforeTimeout = 20 * time.Second
+	// How long pods have to be "ready" when a test begins.
+	podReadyBeforeTimeout = 2 * time.Minute
 
 	podRespondingTimeout     = 2 * time.Minute
 	serviceRespondingTimeout = 2 * time.Minute


### PR DESCRIPTION
An attempt to improve https://github.com/kubernetes/kubernetes/issues/14772

All flakes that I've seen recently are waiting for a pod to transition from (Running, ready=false) to (Running, read=true)

No reason to not just extend the timeout.
