### PR TITLE
Add --quiet to a bunch of gcloud usages to get rid of interactive prompts.

### DIFF
--- a/test/e2e/pd.go
+++ b/test/e2e/pd.go
@@ -327,7 +327,7 @@ func createPD() (string, error) {
 
 		zone := testContext.CloudConfig.Zone
 		// TODO: make this hit the compute API directly instread of shelling out to gcloud.
-		err := exec.Command("gcloud", "compute", "--project="+testContext.CloudConfig.ProjectID, "disks", "create", "--zone="+zone, "--size=10GB", pdName).Run()
+		err := exec.Command("gcloud", "compute", "--quiet", "--project="+testContext.CloudConfig.ProjectID, "disks", "create", "--zone="+zone, "--size=10GB", pdName).Run()
 		if err != nil {
 			return "", err
 		}
@@ -348,7 +348,7 @@ func deletePD(pdName string) error {
 		zone := testContext.CloudConfig.Zone
 
 		// TODO: make this hit the compute API directly.
-		cmd := exec.Command("gcloud", "compute", "--project="+testContext.CloudConfig.ProjectID, "disks", "delete", "--zone="+zone, pdName)
+		cmd := exec.Command("gcloud", "compute", "--quiet", "--project="+testContext.CloudConfig.ProjectID, "disks", "delete", "--zone="+zone, pdName)
 		data, err := cmd.CombinedOutput()
 		if err != nil {
 			Logf("Error deleting PD: %s (%v)", string(data), err)
@@ -370,7 +370,7 @@ func detachPD(hostName, pdName string) error {
 		zone := testContext.CloudConfig.Zone
 
 		// TODO: make this hit the compute API directly.
-		return exec.Command("gcloud", "compute", "--project="+testContext.CloudConfig.ProjectID, "detach-disk", "--zone="+zone, "--disk="+pdName, instanceName).Run()
+		return exec.Command("gcloud", "compute", "--quiet", "--project="+testContext.CloudConfig.ProjectID, "detach-disk", "--zone="+zone, "--disk="+pdName, instanceName).Run()
 	} else {
 		volumes, ok := testContext.CloudConfig.Provider.(aws_cloud.Volumes)
 		if !ok {


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/14787
