### PR TITLE
Add test of kubectl support for multiple resources

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -173,6 +173,7 @@ runTests() {
   fi
   id_field=".metadata.name"
   labels_field=".metadata.labels"
+  annotations_field=".metadata.annotations"
   service_selector_field=".spec.selector"
   rc_replicas_field=".spec.replicas"
   rc_status_replicas_field=".status.replicas"
@@ -725,6 +726,110 @@ __EOF__
   kubectl stop rc frontend redis-slave "${kube_flags[@]}" # delete multiple controllers at once
   # Post-condition: no replication controller is running
   kube::test::get_object_assert rc "{{range.items}}{{$id_field}}:{{end}}" ''
+
+  ######################
+  # Multiple Resources #
+  ######################
+
+  kube::log::status "Testing kubectl(${version}:multiple resources)"
+  # TODO: add test for types like ReplicationControllerList, ServiceList
+
+  ### Create, get, describe, replace, label, annotate, and then delete service nginxsvc and replication controller my-nginx from YAML, separated by ---
+  # Pre-condition: no service (other than default kubernetes services) or replication controller is running
+  kube::test::get_object_assert services "{{range.items}}{{$id_field}}:{{end}}" 'kubernetes:'
+  kube::test::get_object_assert rc "{{range.items}}{{$id_field}}:{{end}}" ''
+  # Command
+  kubectl create -f examples/https-nginx/nginx-app.yaml "${kube_flags[@]}"
+  # Post-condition: nginxsvc service is running
+  kube::test::get_object_assert services "{{range.items}}{{$id_field}}:{{end}}" 'kubernetes:nginxsvc:'
+  # Post-condition: my-nginx rc is running
+  kube::test::get_object_assert rc "{{range.items}}{{$id_field}}:{{end}}" 'my-nginx:'
+  # Command
+  kubectl get -f examples/https-nginx/nginx-app.yaml "${kube_flags[@]}"
+  kubectl describe -f examples/https-nginx/nginx-app.yaml "${kube_flags[@]}"
+  # Command
+  kubectl replace -f hack/testdata/nginx-app-modify.yaml --force "${kube_flags[@]}"
+  # Post-condition: nginxsvc service and mock rc are replaced
+  kube::test::get_object_assert 'services nginxsvc' "{{${labels_field}.status}}" 'replaced'
+  kube::test::get_object_assert 'rc my-nginx' "{{${labels_field}.status}}" 'replaced'
+  # Command
+  kubectl label -f examples/https-nginx/nginx-app.yaml labeled=true "${kube_flags[@]}"
+  # Post-condition: nginxsvc service and my-nginx rc are labeled
+  kube::test::get_object_assert 'services nginxsvc' "{{${labels_field}.labeled}}" 'true'
+  kube::test::get_object_assert 'rc my-nginx' "{{${labels_field}.labeled}}" 'true'
+  # Command
+  kubectl annotate -f examples/https-nginx/nginx-app.yaml annotated=true "${kube_flags[@]}"
+  # Post-condition: nginxsvc service and my-nginx rc are annotated
+  kube::test::get_object_assert 'services nginxsvc' "{{${annotations_field}.annotated}}" 'true'
+  kube::test::get_object_assert 'rc my-nginx' "{{${annotations_field}.annotated}}" 'true'
+  # Cleanup service and rc
+  kubectl delete -f examples/https-nginx/nginx-app.yaml "${kube_flags[@]}"
+
+  ### Create, get, describe, replace, label, annotate, and then delete service nginxsvc and replication controller my-nginx from JSON, with a List type
+  # Pre-condition: no service (other than default kubernetes services) or replication controller is running
+  kube::test::get_object_assert services "{{range.items}}{{$id_field}}:{{end}}" 'kubernetes:'
+  kube::test::get_object_assert rc "{{range.items}}{{$id_field}}:{{end}}" ''
+  # Command
+  # TODO: remove --validate=false when PR "Add validate support for list kind #14726" is merged
+  kubectl create -f hack/testdata/multi-resource-list.json --validate=false "${kube_flags[@]}"
+  # Post-condition: mock service is running
+  kube::test::get_object_assert services "{{range.items}}{{$id_field}}:{{end}}" 'kubernetes:mock:'
+  # Post-condition: mock rc is running
+  kube::test::get_object_assert rc "{{range.items}}{{$id_field}}:{{end}}" 'mock:'
+  # Command
+  # kubectl create -f hack/testdata/multi-resource.json "${kube_flags[@]}" # test fails here now
+  # TODO: test get when PR "Fix get with List #14888" is merged
+  # kubectl get -f hack/testdata/multi-resource-list.json "${kube_flags[@]}"
+  kubectl describe -f hack/testdata/multi-resource-list.json "${kube_flags[@]}"
+  # Command
+  # TODO: remove --validate=false when PR "Add validate support for list kind #14726" is merged
+  kubectl replace -f hack/testdata/multi-resource-list-modify.json --force --validate=false "${kube_flags[@]}"
+  # Post-condition: mock service and mock rc are replaced
+  kube::test::get_object_assert 'services mock' "{{${labels_field}.status}}" 'replaced'
+  kube::test::get_object_assert 'rc mock' "{{${labels_field}.status}}" 'replaced'
+  # Command
+  kubectl label -f hack/testdata/multi-resource-list.json labeled=true "${kube_flags[@]}"
+  # Post-condition: mock service and mock rc are labeled
+  kube::test::get_object_assert 'services mock' "{{${labels_field}.labeled}}" 'true'
+  kube::test::get_object_assert 'rc mock' "{{${labels_field}.labeled}}" 'true'
+  # Command
+  kubectl annotate -f hack/testdata/multi-resource-list.json annotated=true "${kube_flags[@]}"
+  # Post-condition: mock service and mock rc are annotated
+  kube::test::get_object_assert 'services mock' "{{${annotations_field}.annotated}}" 'true'
+  kube::test::get_object_assert 'rc mock' "{{${annotations_field}.annotated}}" 'true'
+  # Cleanup services and rc
+  kubectl delete -f hack/testdata/multi-resource-list.json "${kube_flags[@]}"
+
+  ### Create, get, describe, replace, label, annotate, and then delete service nginxsvc and replication controller my-nginx from JSON, with JSON object concatenation
+  # Pre-condition: no service (other than default kubernetes services) or replication controller is running
+  kube::test::get_object_assert services "{{range.items}}{{$id_field}}:{{end}}" 'kubernetes:'
+  kube::test::get_object_assert rc "{{range.items}}{{$id_field}}:{{end}}" ''
+  # Command
+  kubectl create -f hack/testdata/multi-resource.json "${kube_flags[@]}"
+  # Post-condition: mock service is running
+  kube::test::get_object_assert services "{{range.items}}{{$id_field}}:{{end}}" 'kubernetes:mock:'
+  # Post-condition: mock rc is running
+  kube::test::get_object_assert rc "{{range.items}}{{$id_field}}:{{end}}" 'mock:'
+  # Command
+  kubectl get -f hack/testdata/multi-resource.json "${kube_flags[@]}"
+  kubectl describe -f hack/testdata/multi-resource.json "${kube_flags[@]}"
+  # Command
+  kubectl replace -f hack/testdata/multi-resource-modify.json --force "${kube_flags[@]}"
+  # Post-condition: mock service and mock rc are replaced
+  kube::test::get_object_assert 'services mock' "{{${labels_field}.status}}" 'replaced'
+  kube::test::get_object_assert 'rc mock' "{{${labels_field}.status}}" 'replaced'
+  # Command
+  kubectl label -f hack/testdata/multi-resource.json labeled=true "${kube_flags[@]}"
+  # Post-condition: mock service and mock rc are labeled
+  kube::test::get_object_assert 'services mock' "{{${labels_field}.labeled}}" 'true'
+  kube::test::get_object_assert 'rc mock' "{{${labels_field}.labeled}}" 'true'
+  # Command
+  kubectl annotate -f hack/testdata/multi-resource.json annotated=true "${kube_flags[@]}"
+  # Post-condition: mock service and mock rc are annotated
+  kube::test::get_object_assert 'services mock' "{{${annotations_field}.annotated}}" 'true'
+  kube::test::get_object_assert 'rc mock' "{{${annotations_field}.annotated}}" 'true'
+  # Cleanup services and rc
+  kubectl delete -f hack/testdata/multi-resource.json "${kube_flags[@]}"
 
   ######################
   # Persistent Volumes #

--- a/hack/testdata/multi-resource-list-modify.json
+++ b/hack/testdata/multi-resource-list-modify.json
@@ -1,0 +1,61 @@
+{
+   "kind":"List",
+   "apiVersion":"v1",
+   "items":[
+      {
+        "kind":"Service",
+        "apiVersion":"v1",
+        "metadata":{
+          "name":"mock",
+          "labels":{
+            "app":"mock",
+            "status":"replaced"
+          }
+        },
+        "spec":{
+          "ports": [{
+            "protocol": "TCP",
+            "port": 99,
+            "targetPort": 9949
+          }],
+          "selector":{
+            "app":"mock"
+          }
+        }
+      },
+      {
+         "kind":"ReplicationController",
+         "apiVersion":"v1",
+         "metadata":{
+            "name":"mock",
+            "labels":{
+              "app":"mock",
+              "status":"replaced"
+            }
+         },
+         "spec":{
+            "replicas":1,
+            "selector":{
+               "app":"mock"
+            },
+            "template":{
+               "metadata":{
+                  "labels":{
+                     "app":"mock"
+                  }
+               },
+               "spec":{
+                  "containers":[{
+                    "name": "mock-container",
+                    "image": "kubernetes/pause",
+                    "ports":[{
+                        "containerPort":9949,
+                        "protocol":"TCP"
+                     }]
+                  }]
+               }
+            }
+         }
+      }
+   ]
+}

--- a/hack/testdata/multi-resource-list.json
+++ b/hack/testdata/multi-resource-list.json
@@ -1,0 +1,59 @@
+{
+   "kind":"List",
+   "apiVersion":"v1",
+   "items":[
+      {
+        "kind":"Service",
+        "apiVersion":"v1",
+        "metadata":{
+          "name":"mock",
+          "labels":{
+            "app":"mock"
+          }
+        },
+        "spec":{
+          "ports": [{
+            "protocol": "TCP",
+            "port": 99,
+            "targetPort": 9949
+          }],
+          "selector":{
+            "app":"mock"
+          }
+        }
+      },
+      {
+         "kind":"ReplicationController",
+         "apiVersion":"v1",
+         "metadata":{
+            "name":"mock",
+            "labels":{
+               "app":"mock"
+            }
+         },
+         "spec":{
+            "replicas":1,
+            "selector":{
+               "app":"mock"
+            },
+            "template":{
+               "metadata":{
+                  "labels":{
+                     "app":"mock"
+                  }
+               },
+               "spec":{
+                  "containers":[{
+                    "name": "mock-container",
+                    "image": "kubernetes/pause",
+                    "ports":[{
+                        "containerPort":9949,
+                        "protocol":"TCP"
+                     }]
+                  }]
+               }
+            }
+         }
+      }
+   ]
+}

--- a/hack/testdata/multi-resource-modify.json
+++ b/hack/testdata/multi-resource-modify.json
@@ -1,0 +1,55 @@
+{
+   "kind":"Service",
+   "apiVersion":"v1",
+   "metadata":{
+     "name":"mock",
+     "labels":{
+       "app":"mock",
+       "status":"replaced"
+     }
+   },
+   "spec":{
+     "ports": [{
+       "protocol": "TCP",
+       "port": 99,
+       "targetPort": 9949
+     }],
+     "selector":{
+       "app":"mock"
+     }
+   }
+}
+{
+   "kind":"ReplicationController",
+   "apiVersion":"v1",
+   "metadata":{
+     "name":"mock",
+     "labels":{
+       "app":"mock",
+       "status":"replaced"
+     }
+   },
+   "spec":{
+     "replicas":1,
+     "selector":{
+       "app":"mock"
+     },
+     "template":{
+       "metadata":{
+         "labels":{
+           "app":"mock"
+         }
+       },
+       "spec":{
+         "containers":[{
+           "name": "mock-container",
+           "image": "kubernetes/pause",
+           "ports":[{
+             "containerPort":9949,
+             "protocol":"TCP"
+           }]
+         }]
+       }
+     }
+   }
+}

--- a/hack/testdata/multi-resource.json
+++ b/hack/testdata/multi-resource.json
@@ -1,0 +1,53 @@
+{
+   "kind":"Service",
+   "apiVersion":"v1",
+   "metadata":{
+     "name":"mock",
+     "labels":{
+       "app":"mock"
+     }
+   },
+   "spec":{
+     "ports": [{
+       "protocol": "TCP",
+       "port": 99,
+       "targetPort": 9949
+     }],
+     "selector":{
+       "app":"mock"
+     }
+   }
+}
+{
+   "kind":"ReplicationController",
+   "apiVersion":"v1",
+   "metadata":{
+     "name":"mock",
+     "labels":{
+       "app":"mock"
+     }
+   },
+   "spec":{
+     "replicas":1,
+     "selector":{
+       "app":"mock"
+     },
+     "template":{
+       "metadata":{
+         "labels":{
+           "app":"mock"
+         }
+       },
+       "spec":{
+         "containers":[{
+           "name": "mock-container",
+           "image": "kubernetes/pause",
+           "ports":[{
+             "containerPort":9949,
+             "protocol":"TCP"
+           }]
+         }]
+       }
+     }
+   }
+}

--- a/hack/testdata/nginx-app-modify.yaml
+++ b/hack/testdata/nginx-app-modify.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginxsvc
+  labels:
+    app: nginx
+    status: replaced
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+    protocol: TCP
+    name: http
+  - port: 443
+    protocol: TCP
+    name: https
+  selector:
+    app: nginx
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: my-nginx
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: nginx
+        status: replaced
+    spec:
+      volumes:
+      - name: secret-volume
+        secret:
+          secretName: nginxsecret
+      containers:
+      - name: nginxhttps
+        image: bprashanth/nginxhttps:1.0
+        ports:
+        - containerPort: 443
+        - containerPort: 80
+        volumeMounts:
+        - mountPath: /etc/nginx/ssl
+          name: secret-volume


### PR DESCRIPTION
#14775

Test `kubectl create -f` with multiple resource (rc + svc) using YAML (separated by ---) and JSON (List typed). 

cc @bgrant0607 
