### PR TITLE
allow yaml as argument to patch

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -389,6 +389,11 @@ runTests() {
   kubectl patch "${kube_flags[@]}" pod valid-pod -p='{"spec":{"containers":[{"name": "kubernetes-serve-hostname", "image": "nginx"}]}}'
   # Post-condition: valid-pod POD has image nginx
   kube::test::get_object_assert pods "{{range.items}}{{$image_field}}:{{end}}" 'nginx:'
+  # prove that yaml input works too
+  YAML_PATCH=$'spec:\n  containers:\n  - name: kubernetes-serve-hostname\n    image: changed-with-yaml\n'
+  kubectl patch "${kube_flags[@]}" pod valid-pod -p="${YAML_PATCH}"
+  # Post-condition: valid-pod POD has image nginx
+  kube::test::get_object_assert pods "{{range.items}}{{$image_field}}:{{end}}" 'changed-with-yaml:'
   ## Patch pod from JSON can change image
   # Command
   kubectl patch "${kube_flags[@]}" -f docs/admin/limitrange/valid-pod.yaml -p='{"spec":{"containers":[{"name": "kubernetes-serve-hostname", "image": "kubernetes/pause"}]}}'


### PR DESCRIPTION
The help says that `kubectl patch` should accept `-p` as YAML.  This brings the code up to date with the help.

@kubernetes/kubectl 
