### PR TITLE
Use kube::release::gcs::publish_latest_official logic in mark-stable-release.sh

### DIFF
--- a/build/mark-stable-release.sh
+++ b/build/mark-stable-release.sh
@@ -20,31 +20,20 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [[ -z "$1" ]]; then
-  echo "Usage: $0 <version>"
+KUBE_RELEASE_VERSION="${1-}"
+
+KUBE_GCS_MAKE_PUBLIC='y'
+KUBE_GCS_RELEASE_BUCKET='kubernetes-release'
+KUBE_GCS_RELEASE_PREFIX="release/${KUBE_RELEASE_VERSION}"
+KUBE_GCS_PUBLISH_FILE='release/stable.txt'
+KUBE_GCS_PUBLISH_VERSION="${KUBE_RELEASE_VERSION}"
+
+KUBE_ROOT="$(dirname "${BASH_SOURCE}")/.."
+source "${KUBE_ROOT}/build/common.sh"
+
+if "${KUBE_ROOT}/cluster/kubectl.sh" 'version' | grep 'Client' | grep 'dirty'; then
+  echo "!!! Tag at invalid point, or something else is bad. Build is dirty. Don't push this build." >&2
   exit 1
 fi
 
-if ! gsutil ls gs://kubernetes-release/release/${1}/kubernetes.tar.gz; then
-  echo "Release files don't exist, aborting."
-  exit 2
-fi
-
-STABLE_FILE_LOCATION="kubernetes-release/release/stable.txt"
-
-version_file=$(mktemp -t stable.XXXXXX)
-
-echo $1 >> ${version_file}
-echo "Uploading stable version $1 to google storage"
-gsutil cp ${version_file} "gs://${STABLE_FILE_LOCATION}"
-echo "Making it world readable"
-gsutil acl ch -R -g all:R "gs://${STABLE_FILE_LOCATION}"
-
-rm ${version_file}
-
-value=$(curl -s https://storage.googleapis.com/${STABLE_FILE_LOCATION})
-echo "Validating version file"
-if [[ "${value}" != "${1}" ]]; then
-  echo "Error validating upload, :${value}: vs expected :${1}:"
-  exit 1
-fi
+kube::release::gcs::publish_official

--- a/build/push-ci-build.sh
+++ b/build/push-ci-build.sh
@@ -36,21 +36,21 @@ function kube::release::semantic_version() {
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 LATEST=$(kube::release::semantic_version)
 
-KUBE_GCS_NO_CACHING=n
-KUBE_GCS_MAKE_PUBLIC=y
-KUBE_GCS_UPLOAD_RELEASE=y
-KUBE_GCS_DELETE_EXISTING=y
-KUBE_GCS_RELEASE_BUCKET=kubernetes-release
+KUBE_GCS_NO_CACHING='n'
+KUBE_GCS_MAKE_PUBLIC='y'
+KUBE_GCS_UPLOAD_RELEASE='y'
+KUBE_GCS_DELETE_EXISTING='y'
+KUBE_GCS_RELEASE_BUCKET='kubernetes-release'
 KUBE_GCS_RELEASE_PREFIX="ci/${LATEST}"
-KUBE_GCS_LATEST_FILE="ci/latest.txt"
-KUBE_GCS_LATEST_CONTENTS=${LATEST}
+KUBE_GCS_PUBLISH_FILE='ci/latest.txt'
+KUBE_GCS_PUBLISH_VERSION="${LATEST}"
 
 source "$KUBE_ROOT/build/common.sh"
 
 MAX_ATTEMPTS=3
 attempt=0
 while [[ ${attempt} -lt ${MAX_ATTEMPTS} ]]; do
-  kube::release::gcs::release && kube::release::gcs::publish_latest && break || true
+  kube::release::gcs::release && kube::release::gcs::publish && break || true
   attempt=$((attempt + 1))
   sleep 5
 done

--- a/build/push-official-release.sh
+++ b/build/push-official-release.sh
@@ -20,29 +20,24 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_RELEASE_VERSION=${1-}
+KUBE_RELEASE_VERSION="${1-}"
 
-VERSION_REGEX="^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
-[[ ${KUBE_RELEASE_VERSION} =~ $VERSION_REGEX ]] || {
-  echo "!!! You must specify the version you are releasing in the form of '$VERSION_REGEX'" >&2
-  exit 1
-}
+KUBE_GCS_NO_CACHING='n'
+KUBE_GCS_MAKE_PUBLIC='y'
+KUBE_GCS_UPLOAD_RELEASE='y'
+KUBE_GCS_RELEASE_BUCKET='kubernetes-release'
+KUBE_GCS_RELEASE_PREFIX="release/${KUBE_RELEASE_VERSION}"
+KUBE_GCS_PUBLISH_FILE='release/latest.txt'
+KUBE_GCS_PUBLISH_VERSION="${KUBE_RELEASE_VERSION}"
 
-KUBE_GCS_NO_CACHING=n
-KUBE_GCS_MAKE_PUBLIC=y
-KUBE_GCS_UPLOAD_RELEASE=y
-KUBE_GCS_RELEASE_BUCKET=kubernetes-release
-KUBE_GCS_RELEASE_PREFIX=release/${KUBE_RELEASE_VERSION}
-KUBE_GCS_LATEST_FILE="release/latest.txt"
-KUBE_GCS_LATEST_CONTENTS=${KUBE_RELEASE_VERSION}
+KUBE_ROOT="$(dirname "${BASH_SOURCE}")/.."
+source "${KUBE_ROOT}/build/common.sh"
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "$KUBE_ROOT/build/common.sh"
-
-if ${KUBE_ROOT}/cluster/kubectl.sh version | grep Client | grep dirty; then
+if "${KUBE_ROOT}/cluster/kubectl.sh" 'version' | grep 'Client' | grep 'dirty'; then
   echo "!!! Tag at invalid point, or something else is bad. Build is dirty. Don't push this build." >&2
   exit 1
 fi
 
+kube::release::gcs::validate_release_version "${KUBE_RELEASE_VERSION}"
 kube::release::gcs::release
-kube::release::gcs::publish_latest_official
+kube::release::gcs::publish_official


### PR DESCRIPTION
Fixes #14785.

@zmerlynn please give this a very skeptical review.  I haven't checked to make sure this works properly; wanted to check with you about how to do so.  My intention was to replace `KUBE_GCS_RELEASE_BUCKET` with my own bucket and run through things.  Concerns about that approach?
