### PR TITLE
Ref #14084, Print output when error occurs in e2e test "in Services should be able to create a functioning external load balancer with user-provided load balancer ip"

### DIFF
--- a/test/e2e/google_compute.go
+++ b/test/e2e/google_compute.go
@@ -36,6 +36,8 @@ func createGCEStaticIP(name string) (string, error) {
 		name, "--project", testContext.CloudConfig.ProjectID,
 		"--region", "us-central1", "-q").CombinedOutput()
 	if err != nil {
+		glog.Errorf("Creating static IP with name:%s in project: %s", name, testContext.CloudConfig.ProjectID)
+		glog.Errorf("output: %s", output)
 		return "", err
 	}
 	glog.Errorf("Creating static IP with name:%s in project: %s", name, testContext.CloudConfig.ProjectID)


### PR DESCRIPTION
I can't reproduce #14084. Maybe it's caused by a quota limit on the number of external load balancers. Anyway, this PR prints the output so we can know what happens when this test fails again.

cc @lavalamp 
