### PR TITLE
Fix missing display of BestEffort resources in kubectl describe

### DIFF
--- a/pkg/kubelet/qos/util/qos.go
+++ b/pkg/kubelet/qos/util/qos.go
@@ -23,7 +23,7 @@ import (
 const (
 	Guaranteed = "Guaranteed"
 	Burstable  = "Burstable"
-	BestEffort = "Best-Effort"
+	BestEffort = "BestEffort"
 )
 
 // isResourceGuaranteed returns true if the container's resource requirements are Guaranteed.
@@ -62,9 +62,17 @@ func GetQoS(container *api.Container) map[api.ResourceName]string {
 	return resourceToQoS
 }
 
-// allResources returns a set of resources the container has
+// supportedComputeResources returns a list of supported compute resources
+func supportedComputeResources() []api.ResourceName {
+	return []api.ResourceName{api.ResourceCPU, api.ResourceMemory}
+}
+
+// allResources returns a set of all possible resources whose mapped key value is true if present on the container
 func allResources(container *api.Container) map[api.ResourceName]bool {
 	resources := map[api.ResourceName]bool{}
+	for _, resource := range supportedComputeResources() {
+		resources[resource] = false
+	}
 	for resource := range container.Resources.Requests {
 		resources[resource] = true
 	}


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/kubernetes/issues/14786

Previously, we did not state the QoS tier on the pod as BestEffort because it was not an enumerated resource name on the container.

Adjusted internal constant to follow api-conventions for CamelCase.

```
$ kubectl run nginx --image=nginx
$ kubectl describe pods <xyz>
Name:               nginx-h72ji
Namespace:          default
Image(s):           nginx
Node:               10.245.1.3/10.245.1.3
Start Time:         Wed, 30 Sep 2015 14:48:40 -0400
Labels:             run=nginx
Status:             Pending
Reason:             
Message:            
IP:             10.246.86.6
Replication Controllers:    nginx (1/1 replicas created)
Containers:
  nginx:
    Container ID:   
    Image:      nginx
    Image ID:       
    QoS Tier:
      cpu:  Burstable
      memory:   BestEffort
    Requests:
      cpu:      100m
    State:      Waiting
      Reason:       PullImageError
    Ready:      False
    Restart Count:  0
    Environment Variables:
...
```

/cc @JanetKuo 
