### PR TITLE
Remove glog dependency from fielderrors

### DIFF
--- a/pkg/util/fielderrors/fielderrors.go
+++ b/pkg/util/fielderrors/fielderrors.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/kubernetes/pkg/util/errors"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/golang/glog"
 )
 
 // ValidationErrorType is a machine readable value providing more detail about why
@@ -74,7 +73,7 @@ func (t ValidationErrorType) String() string {
 	case ValidationErrorTypeTooLong:
 		return "too long"
 	default:
-		glog.Errorf("unrecognized validation type: %#v", t)
+		panic(fmt.Sprintf("unrecognized validation type: %#v", t))
 		return ""
 	}
 }
@@ -161,7 +160,7 @@ func (list ValidationErrorList) Prefix(prefix string) ValidationErrorList {
 			}
 			list[i] = err
 		} else {
-			glog.Warningf("Programmer error: ValidationErrorList holds non-ValidationError: %#v", list[i])
+			panic(fmt.Sprintf("Programmer error: ValidationErrorList holds non-ValidationError: %#v", list[i]))
 		}
 	}
 	return list


### PR DESCRIPTION
Last part of #13698, the smallest but maybe also the most controversial. Both uses of glog in this package appear to indicate programmer error. Personally I would panic in this situation, but I don't know how maintainers feel about that, so I just took the log statements out. In the end I just want to get rid of the `glog` import, so it's not particularly important to me what replaces it here.
