### PR TITLE
Allow specifying scheme when proxying

### DIFF
--- a/pkg/registry/generic/rest/proxy_test.go
+++ b/pkg/registry/generic/rest/proxy_test.go
@@ -388,7 +388,7 @@ func TestDefaultProxyTransport(t *testing.T) {
 		h := UpgradeAwareProxyHandler{
 			Location: locURL,
 		}
-		result := h.defaultProxyTransport(URL)
+		result := h.defaultProxyTransport(URL, nil)
 		transport := result.(*corsRemovingTransport).RoundTripper.(*proxy.Transport)
 		if transport.Scheme != test.expectedScheme {
 			t.Errorf("%s: unexpected scheme. Actual: %s, Expected: %s", test.name, transport.Scheme, test.expectedScheme)

--- a/pkg/registry/node/strategy.go
+++ b/pkg/registry/node/strategy.go
@@ -137,7 +137,7 @@ func MatchNode(label labels.Selector, field fields.Selector) generic.Matcher {
 
 // ResourceLocation returns an URL and transport which one can use to send traffic for the specified node.
 func ResourceLocation(getter ResourceGetter, connection client.ConnectionInfoGetter, ctx api.Context, id string) (*url.URL, http.RoundTripper, error) {
-	name, portReq, valid := util.SplitPort(id)
+	schemeReq, name, portReq, valid := util.SplitSchemeNamePort(id)
 	if !valid {
 		return nil, nil, errors.NewBadRequest(fmt.Sprintf("invalid node request %q", id))
 	}
@@ -154,6 +154,7 @@ func ResourceLocation(getter ResourceGetter, connection client.ConnectionInfoGet
 	host := hostIP.String()
 
 	if portReq == "" || strconv.Itoa(ports.KubeletPort) == portReq {
+		// Ignore requested scheme, use scheme provided by GetConnectionInfo
 		scheme, port, transport, err := connection.GetConnectionInfo(host)
 		if err != nil {
 			return nil, nil, err
@@ -168,5 +169,5 @@ func ResourceLocation(getter ResourceGetter, connection client.ConnectionInfoGet
 			transport,
 			nil
 	}
-	return &url.URL{Host: net.JoinHostPort(host, portReq)}, nil, nil
+	return &url.URL{Scheme: schemeReq, Host: net.JoinHostPort(host, portReq)}, nil, nil
 }

--- a/pkg/registry/pod/strategy.go
+++ b/pkg/registry/pod/strategy.go
@@ -17,6 +17,7 @@ limitations under the License.
 package pod
 
 import (
+	"crypto/tls"
 	"fmt"
 	"net"
 	"net/http"
@@ -45,6 +46,13 @@ type podStrategy struct {
 // Strategy is the default logic that applies when creating and updating Pod
 // objects via the REST API.
 var Strategy = podStrategy{api.Scheme, api.SimpleNameGenerator}
+
+// PodProxyTransport is used by the API proxy to connect to pods
+// Exported to allow overriding TLS options (like adding a client certificate)
+var PodProxyTransport = util.SetTransportDefaults(&http.Transport{
+	// Turn off hostname verification, because connections are to assigned IPs, not deterministic
+	TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+})
 
 // NamespaceScoped is true for pods.
 func (podStrategy) NamespaceScoped() bool {
@@ -188,9 +196,9 @@ func getPod(getter ResourceGetter, ctx api.Context, name string) (*api.Pod, erro
 
 // ResourceLocation returns a URL to which one can send traffic for the specified pod.
 func ResourceLocation(getter ResourceGetter, ctx api.Context, id string) (*url.URL, http.RoundTripper, error) {
-	// Allow ID as "podname" or "podname:port".  If port is not specified,
-	// try to use the first defined port on the pod.
-	name, port, valid := util.SplitPort(id)
+	// Allow ID as "podname" or "podname:port" or "scheme:podname:port".
+	// If port is not specified, try to use the first defined port on the pod.
+	scheme, name, port, valid := util.SplitSchemeNamePort(id)
 	if !valid {
 		return nil, nil, errors.NewBadRequest(fmt.Sprintf("invalid pod request %q", id))
 	}
@@ -211,15 +219,15 @@ func ResourceLocation(getter ResourceGetter, ctx api.Context, id string) (*url.U
 		}
 	}
 
-	// We leave off the scheme ('http://') because we have no idea what sort of server
-	// is listening at this endpoint.
-	loc := &url.URL{}
+	loc := &url.URL{
+		Scheme: scheme,
+	}
 	if port == "" {
 		loc.Host = pod.Status.PodIP
 	} else {
 		loc.Host = net.JoinHostPort(pod.Status.PodIP, port)
 	}
-	return loc, nil, nil
+	return loc, PodProxyTransport, nil
 }
 
 // LogLocation returns the log URL for a pod container. If opts.Container is blank

--- a/pkg/registry/service/rest_test.go
+++ b/pkg/registry/service/rest_test.go
@@ -491,6 +491,18 @@ func TestServiceRegistryResourceLocation(t *testing.T) {
 		t.Errorf("Expected %v, but got %v", e, a)
 	}
 
+	// Test a scheme + name + port.
+	location, _, err = redirector.ResourceLocation(ctx, "https:foo:p")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if location == nil {
+		t.Errorf("Unexpected nil: %v", location)
+	}
+	if e, a := "https://1.2.3.4:93", location.String(); e != a {
+		t.Errorf("Expected %v, but got %v", e, a)
+	}
+
 	// Test a non-existent name + port.
 	location, _, err = redirector.ResourceLocation(ctx, "foo:q")
 	if err == nil {

--- a/pkg/util/port_split.go
+++ b/pkg/util/port_split.go
@@ -18,23 +18,60 @@ package util
 
 import (
 	"strings"
+
+	"k8s.io/kubernetes/pkg/util/sets"
 )
 
-// Takes a string of the form "name:port" or "name".
-//  * If id is of the form "name" or "name:", then return (name, "", true)
-//  * If id is of the form "name:port", then return (name, port, true)
-//  * Otherwise, return ("", "", false)
-// Additionally, name must be non-empty or valid will be returned false.
+var validSchemes = sets.NewString("http", "https", "")
+
+// SplitSchemeNamePort takes a string of the following forms:
+//  * "<name>",                 returns "",        "<name>","",      true
+//  * "<name>:<port>",          returns "",        "<name>","<port>",true
+//  * "<scheme>:<name>:<port>", returns "<scheme>","<name>","<port>",true
 //
+// Name must be non-empty or valid will be returned false.
+// Scheme must be "http" or "https" if specified
 // Port is returned as a string, and it is not required to be numeric (could be
 // used for a named port, for example).
-func SplitPort(id string) (name, port string, valid bool) {
+func SplitSchemeNamePort(id string) (scheme, name, port string, valid bool) {
 	parts := strings.Split(id, ":")
-	if len(parts) > 2 {
-		return "", "", false
+	switch len(parts) {
+	case 1:
+		name = parts[0]
+	case 2:
+		name = parts[0]
+		port = parts[1]
+	case 3:
+		scheme = parts[0]
+		name = parts[1]
+		port = parts[2]
+	default:
+		return "", "", "", false
 	}
-	if len(parts) == 2 {
-		return parts[0], parts[1], len(parts[0]) > 0
+
+	if len(name) > 0 && validSchemes.Has(scheme) {
+		return scheme, name, port, true
+	} else {
+		return "", "", "", false
 	}
-	return id, "", len(id) > 0
+}
+
+// JoinSchemeNamePort returns a string that specifies the scheme, name, and port:
+//  * "<name>"
+//  * "<name>:<port>"
+//  * "<scheme>:<name>:<port>"
+// None of the parameters may contain a ':' character
+// Name is required
+// Scheme must be "", "http", or "https"
+func JoinSchemeNamePort(scheme, name, port string) string {
+	if len(scheme) > 0 {
+		// Must include three segments to specify scheme
+		return scheme + ":" + name + ":" + port
+	}
+	if len(port) > 0 {
+		// Must include two segments to specify port
+		return name + ":" + port
+	}
+	// Return name alone
+	return name
 }

--- a/test/images/porter/pod.json
+++ b/test/images/porter/pod.json
@@ -8,7 +8,7 @@
     "containers": [
       {
         "name": "porter",
-        "image": "gcr.io/google_containers/porter:59ad46ed2c56ba50fa7f1dc176c07c37",
+        "image": "gcr.io/google_containers/porter:cd5cb5791ebaa8641955f0e8c2a9bed669b1eaab",
         "env": [
           {
             "name": "SERVE_PORT_80",


### PR DESCRIPTION
You can currently proxy through the API server to nodes, services, and pods with the following syntax:
- .../proxy/nodes/nodename[:port]/path/to/proxy
- .../proxy/namespace/foo/services/servicename[:port]/path/to/proxy
- .../proxy/namespace/foo/pods/podname[:port]/path/to/proxy
- .../namespace/foo/pods/podname[:port]/proxy/path/to/proxy

All of these assume the backend is http. This makes the proxy much less useful than it should be.

This PR:
- Adds support for `<scheme>:<name>:<port>` syntax (e.g. `.../namespace/foo/pods/https:podname:port/proxy/path/to/proxy`)
- Tolerates TLS verification errors proxying to pods (since a pod won't have a valid certificate for its allocated IP)
- Exports the transport used to proxy to pods to allow overriding or adding to TLS options
- Add tests for proxying to https pod endpoints (depends on updated porter test image in https://github.com/kubernetes/kubernetes/pull/14837 before e2e tests will pass)
