### PR TITLE
AWS Cloud Provider Cleanup

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -744,10 +744,6 @@ func (aws *AWSCloud) List(filter string) ([]string, error) {
 
 // GetZone implements Zones.GetZone
 func (self *AWSCloud) GetZone() (cloudprovider.Zone, error) {
-	if self.availabilityZone == "" {
-		// Should be unreachable
-		panic("availabilityZone not set")
-	}
 	return cloudprovider.Zone{
 		FailureDomain: self.availabilityZone,
 		Region:        self.region,

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -172,7 +172,6 @@ type InstanceGroupInfo interface {
 
 // AWSCloud is an implementation of Interface, TCPLoadBalancer and Instances for Amazon Web Services.
 type AWSCloud struct {
-	awsServices      AWSServices
 	ec2              EC2
 	elb              ELB
 	asg              ASG
@@ -544,7 +543,6 @@ func newAWSCloud(config io.Reader, awsServices AWSServices) (*AWSCloud, error) {
 	}
 
 	awsCloud := &AWSCloud{
-		awsServices:      awsServices,
 		ec2:              ec2,
 		elb:              elb,
 		asg:              asg,

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -1975,22 +1975,6 @@ func (s *AWSCloud) UpdateTCPLoadBalancer(name, region string, hosts []string) er
 	return nil
 }
 
-// TODO: Make efficient
-func (a *AWSCloud) getInstancesByIds(ids []string) ([]*ec2.Instance, error) {
-	instances := []*ec2.Instance{}
-	for _, id := range ids {
-		instance, err := a.getInstanceById(id)
-		if err != nil {
-			return nil, err
-		}
-		if instance == nil {
-			return nil, fmt.Errorf("unable to find instance " + id)
-		}
-		instances = append(instances, instance)
-	}
-	return instances, nil
-}
-
 // Returns the instance with the specified ID
 func (a *AWSCloud) getInstanceById(instanceID string) (*ec2.Instance, error) {
 	request := &ec2.DescribeInstancesInput{

--- a/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_test.go
@@ -383,10 +383,6 @@ func (ec2 *FakeEC2) RevokeSecurityGroupIngress(*ec2.RevokeSecurityGroupIngressIn
 	panic("Not implemented")
 }
 
-func (ec2 *FakeEC2) DescribeVPCs(*ec2.DescribeVpcsInput) ([]*ec2.Vpc, error) {
-	panic("Not implemented")
-}
-
 func (ec2 *FakeEC2) DescribeSubnets(request *ec2.DescribeSubnetsInput) ([]*ec2.Subnet, error) {
 	ec2.DescribeSubnetsInput = request
 	return ec2.Subnets, nil
@@ -728,9 +724,6 @@ func TestSubnetIDsinVPC(t *testing.T) {
 	}
 
 	vpcID := "vpc-deadbeef"
-	vpc := &ec2.Vpc{
-		VpcId: &vpcID,
-	}
 
 	// test with 3 subnets from 3 different AZs
 	subnets := make(map[int]map[string]string)
@@ -745,7 +738,7 @@ func TestSubnetIDsinVPC(t *testing.T) {
 	subnets[2]["az"] = "af-south-1c"
 	awsServices.ec2.Subnets = constructSubnets(subnets)
 
-	result, err := c.listSubnetIDsinVPC(vpc)
+	result, err := c.listSubnetIDsinVPC(vpcID)
 	if err != nil {
 		t.Errorf("Error listing subnets: %v", err)
 		return
@@ -775,7 +768,7 @@ func TestSubnetIDsinVPC(t *testing.T) {
 	subnets[3]["az"] = "af-south-1c"
 	awsServices.ec2.Subnets = constructSubnets(subnets)
 
-	result, err = c.listSubnetIDsinVPC(vpc)
+	result, err = c.listSubnetIDsinVPC(vpcID)
 	if err != nil {
 		t.Errorf("Error listing subnets: %v", err)
 		return

--- a/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_test.go
@@ -474,7 +474,6 @@ func (a *FakeASG) DescribeAutoScalingGroups(*autoscaling.DescribeAutoScalingGrou
 func mockInstancesResp(instances []*ec2.Instance) *AWSCloud {
 	awsServices := NewFakeAWSServices().withInstances(instances)
 	return &AWSCloud{
-		awsServices:      awsServices,
 		ec2:              awsServices.ec2,
 		availabilityZone: awsServices.availabilityZone,
 	}
@@ -483,7 +482,6 @@ func mockInstancesResp(instances []*ec2.Instance) *AWSCloud {
 func mockAvailabilityZone(region string, availabilityZone string) *AWSCloud {
 	awsServices := NewFakeAWSServices().withAz(availabilityZone)
 	return &AWSCloud{
-		awsServices:      awsServices,
 		ec2:              awsServices.ec2,
 		availabilityZone: awsServices.availabilityZone,
 		region:           region,


### PR DESCRIPTION
This is just some minor cleanup now that the new AWS SDK has been merged. It contains the following two changes:

1) Removes a field from the AWS services object that is constructor private and only used for testing.
2) Updates the cloud driver to always use the availability zone and region information obtained from the node's metadata service.
