### PR TITLE
support etcd tls in kube2sky

### DIFF
--- a/cluster/addons/dns/kube2sky/Makefile
+++ b/cluster/addons/dns/kube2sky/Makefile
@@ -4,7 +4,7 @@
 
 .PHONY: all kube2sky container push clean test
 
-TAG = 1.11
+TAG = 1.12
 PREFIX = gcr.io/google_containers
 
 all: container

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -77,6 +77,9 @@ etcd-config
 etcd-prefix
 etcd-server
 etcd-servers
+etcd-ca
+etcd-cert
+etcd-key
 event-burst
 event-qps
 event-ttl


### PR DESCRIPTION
adds support for connecting to a tls enabled etcd cluster.

because the cluster is tls enabled, the code that is used to validate the endpoint is available wouldn't work as expected - it uses a plain http client. i'm not sure what the motivation was behind that, but it felt like overkill since the etcd client itself will return error if the machine is not reachable. open to feedback on that if you feel like it's necessary.

the way it's written is, if any tls option is specified, it tries to create a tls client, which should fail fast on errors. if none are specified, it defaults to the existing behavior, so it shouldn't affect any existing setups.
