### PR TITLE
Fix for unit test failures on user 

### DIFF
--- a/pkg/kubectl/cmd/util/factory_test.go
+++ b/pkg/kubectl/cmd/util/factory_test.go
@@ -305,7 +305,11 @@ func TestValidateCachesSchema(t *testing.T) {
 }
 
 func TestSubstitueUser(t *testing.T) {
-	usr, _ := user.Current()
+	usr, err := user.Current()
+	if err != nil {
+		t.Logf("SKIPPING TEST: unexpected error: %v", err)
+		return
+	}
 	tests := []struct {
 		input     string
 		expected  string


### PR DESCRIPTION
In rebasing other changes I ran into this issue: 

Fix for unit test failures 'unexpected error: user: Current not implemented on linux/amd64'
running on Fedora 20 'go version go1.4.2 linux/amd64'
