### PR TITLE
temporarily disable warning message in NegotiateVersion

### DIFF
--- a/pkg/client/unversioned/helper.go
+++ b/pkg/client/unversioned/helper.go
@@ -228,9 +228,11 @@ func NegotiateVersion(client *Client, c *Config, version string, clientRegistere
 		if serverVersions.Has(clientVersion) {
 			// Version was not explicitly requested in command config (--api-version).
 			// Ok to fall back to a supported version with a warning.
-			if len(version) != 0 {
-				glog.Warningf("Server does not support API version '%s'. Falling back to '%s'.", version, clientVersion)
-			}
+			// TODO: caesarxuchao: enable the warning message when we have
+			// proper fix. Please refer to issue #14895.
+			// if len(version) != 0 {
+			// 	glog.Warningf("Server does not support API version '%s'. Falling back to '%s'.", version, clientVersion)
+			// }
 			return clientVersion, nil
 		}
 	}


### PR DESCRIPTION
When running kubectl to create a resource in experimental/v1alpha1, kubectl warns "Server does not support API version 'experimental/v1alpha1'. Falling back to 'v1'".

This PR disables this warning message. This warning does not cause any real damage because we set the default version before creating a client, rather than using the negotiated version.

A proper fix is in #14592, but it needs to be split to smaller PRs and may not get cherry-picked to 1.1.

@nikhiljindal @lavalamp 
