### PR TITLE
Support asymmetric rolling rollbacks

### DIFF
--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -296,7 +296,10 @@ func RunRollingUpdate(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, arg
 		MaxSurge:       util.NewIntOrStringFromInt(1),
 	}
 	if cmdutil.GetFlagBool(cmd, "rollback") {
-		kubectl.AbortRollingUpdate(config)
+		err = kubectl.AbortRollingUpdate(config)
+		if err != nil {
+			return err
+		}
 		client.ReplicationControllers(config.NewRc.Namespace).Update(config.NewRc)
 	}
 	err = updater.Update(config)

--- a/pkg/kubectl/rolling_updater.go
+++ b/pkg/kubectl/rolling_updater.go
@@ -562,7 +562,7 @@ func CreateNewControllerFromCurrentController(c *client.Client, namespace, oldNa
 	return newRc, nil
 }
 
-func AbortRollingUpdate(c *RollingUpdaterConfig) {
+func AbortRollingUpdate(c *RollingUpdaterConfig) error {
 	// Swap the controllers
 	tmp := c.OldRc
 	c.OldRc = c.NewRc
@@ -572,12 +572,18 @@ func AbortRollingUpdate(c *RollingUpdaterConfig) {
 		c.NewRc.Annotations = map[string]string{}
 	}
 	c.NewRc.Annotations[sourceIdAnnotation] = fmt.Sprintf("%s:%s", c.OldRc.Name, c.OldRc.UID)
-	desiredSize, found := c.OldRc.Annotations[desiredReplicasAnnotation]
-	if found {
-		fmt.Printf("Found desired replicas.")
-		c.NewRc.Annotations[desiredReplicasAnnotation] = desiredSize
+
+	// Use the original value since the replica count change from old to new
+	// could be asymmetric. If we don't know the original count, we can't safely
+	// roll back to a known good size.
+	originalSize, foundOriginal := tmp.Annotations[originalReplicasAnnotation]
+	if !foundOriginal {
+		return fmt.Errorf("couldn't find original replica count of %q", tmp.Name)
 	}
+	fmt.Fprintf(c.Out, "Setting %q replicas to %s\n", c.NewRc.Name, originalSize)
+	c.NewRc.Annotations[desiredReplicasAnnotation] = originalSize
 	c.CleanupPolicy = DeleteRollingUpdateCleanupPolicy
+	return nil
 }
 
 func GetNextControllerAnnotation(rc *api.ReplicationController) (string, bool) {


### PR DESCRIPTION
Improve the rolling updater rollback/abort function by making it aware
of the original replicas annotation: if the rollback target has the
original replica count recorded, prefer it over the desired annotation
since the update from old to new could have been asymmetrical.

For example, when scaling from 5 to 10, aborting should scale back to 5.

Ported for #14669
