### PR TITLE
Don't check if all test namespaces are deleted

### DIFF
--- a/test/e2e/resize_nodes.go
+++ b/test/e2e/resize_nodes.go
@@ -405,9 +405,6 @@ var _ = Describe("Nodes", func() {
 		if err := deleteNS(c, ns, 5*time.Minute /* namespace deletion timeout */); err != nil {
 			Failf("Couldn't delete namespace '%s', %v", ns, err)
 		}
-		if err := checkTestingNSDeletedExcept(c, ""); err != nil {
-			Failf("Couldn't delete testing namespaces '%s', %v", ns, err)
-		}
 	})
 
 	Describe("Resize", func() {


### PR DESCRIPTION
Checking if all namespaces are deleted, may fail the test if other tests did not delete their namespace. `deleteNs` already checks if our namespace is deleted so checking other namespaces is not needed.

Ref #14695
