### PR TITLE
Fixed util.sh to allow master-and-node (ai) config on ubuntu

### DIFF
--- a/cluster/ubuntu/util.sh
+++ b/cluster/ubuntu/util.sh
@@ -364,7 +364,7 @@ function provision-master() {
                             ${PROXY_SETTING} sudo -E ~/kube/make-ca-cert.sh ${MASTER_IP} IP:${MASTER_IP},IP:${SERVICE_CLUSTER_IP_RANGE%.*}.1,DNS:kubernetes,DNS:kubernetes.default,DNS:kubernetes.default.svc,DNS:kubernetes.default.svc.cluster.local; \
                             sudo mkdir -p /opt/bin/ && sudo cp ~/kube/master/* /opt/bin/; \
                             sudo service etcd start; \
-                            sudo FLANNEL_NET=${FLANNEL_NET} -b ~/kube/reconfDocker.sh "a";"
+                            sudo FLANNEL_NET=${FLANNEL_NET} ~/kube/reconfDocker.sh "a";" 
 }
 
 function provision-node() {
@@ -383,7 +383,7 @@ function provision-node() {
                          sudo -p '[sudo] password to start node: ' cp ~/kube/default/* /etc/default/ && sudo cp ~/kube/init_conf/* /etc/init/ && sudo cp ~/kube/init_scripts/* /etc/init.d/ \
                          && sudo mkdir -p /opt/bin/ && sudo cp ~/kube/minion/* /opt/bin; \
                          sudo service flanneld start; \
-                         sudo -b ~/kube/reconfDocker.sh "i";"
+                         sudo ~/kube/reconfDocker.sh "i";"
 }
 
 function provision-masterandnode() {
@@ -409,7 +409,7 @@ function provision-masterandnode() {
                             ${PROXY_SETTING} sudo -E ~/kube/make-ca-cert.sh ${MASTER_IP} IP:${MASTER_IP},IP:${SERVICE_CLUSTER_IP_RANGE%.*}.1,DNS:kubernetes,DNS:kubernetes.default,DNS:kubernetes.default.svc,DNS:kubernetes.default.svc.cluster.local; \
                             sudo mkdir -p /opt/bin/ && sudo cp ~/kube/master/* /opt/bin/ && sudo cp ~/kube/minion/* /opt/bin/; \
                             sudo service etcd start; \
-                            sudo FLANNEL_NET=${FLANNEL_NET} -b ~/kube/reconfDocker.sh "ai";"
+                            sudo FLANNEL_NET=${FLANNEL_NET} ~/kube/reconfDocker.sh "ai";" 
 }
 
 # Delete a kubernetes cluster


### PR DESCRIPTION
Tested on master and v1.1.0.
Flannel wasn't starting up properly because util.sh was not working properly at provision-\* functions.
