### PR TITLE
make update period for Node not a multiple of 5 in DaemonSet e2e to avoid version conflict

### DIFF
--- a/test/e2e/daemon_set.go
+++ b/test/e2e/daemon_set.go
@@ -37,7 +37,9 @@ import (
 )
 
 const (
-	updateRetryPeriod    = 5 * time.Second
+	// this should not be a multiple of 5, because node status updates
+	// every 5 seconds. See https://github.com/kubernetes/kubernetes/pull/14915.
+	updateRetryPeriod    = 2 * time.Second
 	updateRetryTimeout   = 30 * time.Second
 	daemonsetLabelPrefix = "daemonset-"
 	daemonsetNameLabel   = daemonsetLabelPrefix + "name"


### PR DESCRIPTION
Nod status update period is 5 seconds

https://github.com/kubernetes/kubernetes/blob/master/cmd/kube-controller-manager/app/controllermanager.go#L184

Node updateRetryPeriod was 5 seconds in daemon set test,

I think this could have led to some unfortunate timing.

Considering this approach @quinton-hoole 
