### PR TITLE
Add a custom generator that uses template files

### DIFF
--- a/pkg/kubectl/cmd/autoscale.go
+++ b/pkg/kubectl/cmd/autoscale.go
@@ -101,9 +101,9 @@ func RunAutoscale(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []
 
 	// Get the generator, setup and validate all required parameters
 	generatorName := cmdutil.GetFlagString(cmd, "generator")
-	generator, found := f.Generator(generatorName)
-	if !found {
-		return cmdutil.UsageError(cmd, fmt.Sprintf("generator %q not found.", generatorName))
+	generator, err := f.Generator(generatorName)
+	if err != nil {
+		return cmdutil.UsageError(cmd, fmt.Sprintf("generator %q not found (%v).", generatorName, err))
 	}
 	names := generator.ParamNames()
 	params := kubectl.MakeParams(cmd, names)

--- a/pkg/kubectl/cmd/cmd_test.go
+++ b/pkg/kubectl/cmd/cmd_test.go
@@ -228,9 +228,18 @@ func NewAPIFactory() (*cmdutil.Factory, *testFactory, runtime.Codec) {
 		ClientConfig: func() (*client.Config, error) {
 			return t.ClientConfig, t.Err
 		},
-		Generator: func(name string) (kubectl.Generator, bool) {
+		CanBeExposed: func(kind string) error {
+			if kind != "ReplicationController" && kind != "Service" && kind != "Pod" {
+				return fmt.Errorf("invalid resource provided: %v, only a replication controller, service or pod is accepted", kind)
+			}
+			return nil
+		},
+		Generator: func(name string) (kubectl.Generator, error) {
 			generator, ok := generators[name]
-			return generator, ok
+			if !ok {
+				return nil, fmt.Errorf("generator: %s not found", name)
+			}
+			return generator, nil
 		},
 	}
 	rf := cmdutil.NewFactory(nil)

--- a/pkg/kubectl/cmd/expose.go
+++ b/pkg/kubectl/cmd/expose.go
@@ -128,9 +128,9 @@ func RunExpose(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []str
 
 	// Get the generator, setup and validate all required parameters
 	generatorName := cmdutil.GetFlagString(cmd, "generator")
-	generator, found := f.Generator(generatorName)
-	if !found {
-		return cmdutil.UsageError(cmd, fmt.Sprintf("generator %q not found.", generatorName))
+	generator, err := f.Generator(generatorName)
+	if err != nil {
+		return cmdutil.UsageError(cmd, fmt.Sprintf("error loading generator %q. (%v)", generatorName, err))
 	}
 	names := generator.ParamNames()
 	params := kubectl.MakeParams(cmd, names)

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -147,9 +147,9 @@ func Run(f *cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer, cmd *cob
 			generatorName = "run-pod/v1"
 		}
 	}
-	generator, found := f.Generator(generatorName)
-	if !found {
-		return cmdutil.UsageError(cmd, fmt.Sprintf("Generator: %s not found.", generatorName))
+	generator, err := f.Generator(generatorName)
+	if err != nil {
+		return cmdutil.UsageError(cmd, fmt.Sprintf("error loading generator %s: (%v)", generatorName, err))
 	}
 	names := generator.ParamNames()
 	params := kubectl.MakeParams(cmd, names)
@@ -305,9 +305,9 @@ func getRestartPolicy(cmd *cobra.Command, interactive bool) (api.RestartPolicy, 
 }
 
 func generateService(f *cmdutil.Factory, cmd *cobra.Command, args []string, serviceGenerator string, paramsIn map[string]interface{}, namespace string, out io.Writer) error {
-	generator, found := f.Generator(serviceGenerator)
-	if !found {
-		return fmt.Errorf("missing service generator: %s", serviceGenerator)
+	generator, err := f.Generator(serviceGenerator)
+	if err != nil {
+		return fmt.Errorf("missing service generator: %s (%v)", serviceGenerator, err)
 	}
 	names := generator.ParamNames()
 

--- a/pkg/kubectl/generic_generator.go
+++ b/pkg/kubectl/generic_generator.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"regexp"
+	"strings"
+
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+// GenericGenerator is an implementation of Generator that loads its generator from a template file.
+// Files are expected to have parameters enclosed with double curly braces, e.g.
+//    field1: {{ param1 }}
+//    field2:
+//      - {{param2}} : {{param3}}
+//
+//  The template must be structured as either YAML or JSON
+type GenericGenerator struct {
+	Codec        runtime.Codec
+	TemplateData []byte
+	Params       []GeneratorParam
+}
+
+var paramRE = regexp.MustCompile("\\{\\{[^\\}]+\\}\\}")
+
+// ValidationError is an error that occurs if template
+type ValidationError struct {
+	LineNumber int
+	LineValue  string
+}
+
+func (v *ValidationError) Error() string {
+	return fmt.Sprintf("mis-matched braces in line %d: %s", v.LineNumber, v.LineValue)
+}
+
+func validateTemplate(data []byte) error {
+	scanner := bufio.NewScanner(bytes.NewBuffer(data))
+	line := 1
+	for scanner.Scan() {
+		str := scanner.Text()
+		// Simplistic validation, do a better job here...
+		opens := strings.Count(str, "{{")
+		closes := strings.Count(str, "}}")
+
+		if opens != closes {
+			return &ValidationError{
+				LineNumber: line,
+				LineValue:  str,
+			}
+		}
+		line++
+	}
+	return nil
+}
+
+func getParams(data []byte) []GeneratorParam {
+	params := []GeneratorParam{}
+	matches := paramRE.FindAll(data, -1)
+	for ix := range matches {
+		params = append(params, GeneratorParam{
+			Name:     extractParamName(matches[ix]),
+			Required: true,
+		})
+	}
+	return params
+}
+
+func NewGenericGeneratorFromFile(filename string, codec runtime.Codec) (Generator, error) {
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	return NewGenericGeneratorFromBytes(data, codec)
+}
+
+func NewGenericGeneratorFromBytes(data []byte, codec runtime.Codec) (Generator, error) {
+	if err := validateTemplate(data); err != nil {
+		return nil, err
+	}
+	return &GenericGenerator{
+		TemplateData: data,
+		Params:       getParams(data),
+		Codec:        runtime.YAMLDecoder(codec),
+	}, nil
+}
+
+func extractParamName(match []byte) string {
+	str := string(match)
+	return strings.TrimSpace(str[2 : len(str)-2])
+}
+
+func regexpReplace(template []byte, params map[string]interface{}) ([]byte, error) {
+	missing := []string{}
+	data := paramRE.ReplaceAllFunc(template, func(match []byte) []byte {
+		name := extractParamName(match)
+		val, found := params[name]
+		if !found {
+			missing = append(missing, name)
+			return []byte("!MISSING!")
+		}
+		return []byte(fmt.Sprintf("%v", val))
+	})
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("missing parameters: %v", missing)
+	}
+	return data, nil
+}
+
+func (g *GenericGenerator) Generate(params map[string]interface{}) (runtime.Object, error) {
+	data, err := regexpReplace(g.TemplateData, params)
+	if err != nil {
+		return nil, err
+	}
+	return g.Codec.Decode(data)
+}
+
+func (g *GenericGenerator) ParamNames() []GeneratorParam {
+	return g.Params
+}

--- a/pkg/kubectl/generic_generator_test.go
+++ b/pkg/kubectl/generic_generator_test.go
@@ -1,0 +1,225 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/sets"
+)
+
+func TestGetParams(t *testing.T) {
+	tests := []struct {
+		template   string
+		paramNames sets.String
+	}{
+		{
+			template:   "{{ foo }} {{ bar }}",
+			paramNames: sets.NewString("foo", "bar"),
+		},
+		{
+			template: `{{ foo }}
+			           {{ bar }} {{ baz }}`,
+			paramNames: sets.NewString("foo", "bar", "baz"),
+		},
+	}
+
+	for _, test := range tests {
+		params := getParams([]byte(test.template))
+		if len(params) != len(test.paramNames) {
+			t.Errorf("unexpected params: %v, for %s", params, test.template)
+		}
+		for ix := range params {
+			if !test.paramNames.Has(params[ix].Name) {
+				t.Errorf("unexpected param: %v", params[ix])
+			}
+		}
+	}
+}
+
+func TestValidateTemplate(t *testing.T) {
+	tests := []struct {
+		template  string
+		valid     bool
+		errorLine int
+	}{
+		{
+			template: `{{ ok }}
+					   {{ template }}`,
+			valid: true,
+		},
+		{
+			template:  "{{ invalid }} {{ template",
+			valid:     false,
+			errorLine: 1,
+		},
+		{
+			template: `{{ ok-line-one }}
+			           {{ error-line-two`,
+			valid:     false,
+			errorLine: 2,
+		},
+	}
+	for _, test := range tests {
+		err := validateTemplate([]byte(test.template))
+		if test.valid {
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		} else {
+			if err == nil {
+				t.Error("unexpected non error")
+			}
+			if err.(*ValidationError).LineNumber != test.errorLine {
+				t.Errorf("unexpected error line: %d, expected: %d for %s", err.(*ValidationError).LineNumber, test.errorLine, test.template)
+			}
+		}
+	}
+}
+
+func TestRegexReplace(t *testing.T) {
+	tests := []struct {
+		input     string
+		expected  string
+		params    map[string]interface{}
+		expectErr bool
+	}{
+		{
+			input:    "{{ simple }}",
+			params:   map[string]interface{}{"simple": "foo"},
+			expected: "foo",
+		},
+		{
+			input:     "{{ missing }}",
+			params:    map[string]interface{}{"simple": "foo"},
+			expectErr: true,
+		},
+		{
+			input: "{{multiple }} {{  values }} {{with}} {{ different }} {{	spacing	}}",
+			params: map[string]interface{}{
+				"multiple":  "this",
+				"values":    "is",
+				"with":      "the",
+				"different": "expected",
+				"spacing":   "output",
+			},
+			expected: "this is the expected output",
+		},
+		{
+			input: `{{ handles }}
+{{ newlines }}`,
+			params: map[string]interface{}{"handles": "foo", "newlines": "bar"},
+			expected: `foo
+bar`,
+		},
+	}
+
+	for _, test := range tests {
+		data, err := regexpReplace([]byte(test.input), test.params)
+		if test.expectErr {
+			if err == nil {
+				t.Error("unexpected non-error")
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		output := string(data)
+		if output != test.expected {
+			t.Errorf("expected: %s, saw: %s", test.expected, output)
+		}
+	}
+}
+
+const podTemplate = `apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ name }}
+  labels:
+    name: {{ name }}
+spec:
+  containers:
+  - name: {{ name }}
+    image: {{ image }}
+    ports:
+    - containerPort: {{ port }}`
+
+func int64Ptr(val int64) *int64 {
+	return &val
+}
+
+func TestDecode(t *testing.T) {
+	tests := []struct {
+		template string
+		params   map[string]interface{}
+		expected runtime.Object
+	}{
+		{
+			template: podTemplate,
+			params: map[string]interface{}{
+				"name":  "foo",
+				"image": "bar",
+				"port":  "80",
+			},
+			expected: &api.Pod{
+				ObjectMeta: api.ObjectMeta{
+					Name:   "foo",
+					Labels: map[string]string{"name": "foo"},
+				},
+				Spec: api.PodSpec{
+					Containers: []api.Container{
+						{
+							Name:  "foo",
+							Image: "bar",
+							Ports: []api.ContainerPort{
+								{
+									ContainerPort: 80,
+									Protocol:      "TCP",
+								},
+							},
+							TerminationMessagePath: "/dev/termination-log",
+							ImagePullPolicy:        api.PullIfNotPresent,
+						},
+					},
+					RestartPolicy:                 api.RestartPolicyAlways,
+					DNSPolicy:                     api.DNSClusterFirst,
+					TerminationGracePeriodSeconds: int64Ptr(30),
+					SecurityContext:               &api.PodSecurityContext{false, false, false},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		generator, err := NewGenericGeneratorFromBytes([]byte(test.template), testapi.Default.Codec())
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		obj, err := generator.Generate(test.params)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if !reflect.DeepEqual(obj, test.expected) {
+			t.Errorf("expected:\n%#v\nsaw:\n%#v\n%v", test.expected, obj, *obj.(*api.Pod).Spec.SecurityContext)
+		}
+	}
+}


### PR DESCRIPTION
@bgrant0607 @mikedanese @smarterclayton @deads2k @ghodss 

Ref: https://github.com/kubernetes/kubernetes/issues/10527
Ref: https://github.com/kubernetes/kubernetes/issues/14039
Ref: https://github.com/kubernetes/kubernetes/issues/11492

Also facilitates https://github.com/kubernetes/kubernetes/issues/2837

This enables you to write a `Generator` which is defined by an external`template.yaml` file like:

``` yaml
apiVersion: v1
kind: Pod
metadata:
  name: {{ name }}
  labels:
    name: {{name }}
spec:
  containers:
  - name: {{ name }}
    image: {{ image }}
    ports:
    - containerPort: {{ port }}
```

You then parameterize this generator for `kubectl run` as follows:

``` console
kubectl run --generator=template.yaml --name=foo --image=nginx --port=8080
```

to get:

``` yaml
apiVersion: v1
kind: Pod
metadata:
  name: foo
  labels:
    name: foo
spec:
  containers:
  - name: foo
    image: nginx
    ports:
    - containerPort: 8080
```
