### PR TITLE
Test config for release candidate e2e run

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -383,6 +383,24 @@ case ${JOB_NAME} in
     : ${PROJECT:="k8s-jkns-e2e-gce-release"}
     ;;
 
+  # Runs non-flaky tests on GCE on the release candidate branch,
+  # sequentially. As a reminder, if you need to change the skip list
+  # or flaky test list on the release branch, you'll need to propose a
+  # pull request directly to the release branch itself.
+  kubernetes-e2e-gce-rc)
+    : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-rc"}
+    : ${E2E_DOWN:="false"}
+    : ${E2E_NETWORK:="gce-e2e-rc"}
+    : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
+          ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
+          ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
+          ${GCE_SLOW_TESTS[@]:+${GCE_SLOW_TESTS[@]}} \
+          )"}
+    : ${KUBE_GCE_INSTANCE_PREFIX="e2e-gce-rc"}
+    : ${PROJECT:="k8s-jkns-e2e-gce-release"}
+    : ${ENABLE_DEPLOYMENTS:=true}
+    ;;
+
   kubernetes-e2e-gke-prod)
     : ${DOGFOOD_GCLOUD:="true"}
     : ${E2E_CLUSTER_NAME:="jkns-gke-e2e-prod"}


### PR DESCRIPTION
Adds config for a release candidate e2e jenkins job. Currently [passing](http://kubekins.dls.corp.google.com/view/Critical%20Builds/job/kubernetes-e2e-gce-rc/), targeting the release-1.1 branch. This should be cherry-picked onto 1.1.

Note the test filter used is not the same as the old release job. This is because the number of tests went from 99 to 170,  so running them all in 120min is infeasible. I copied the filter from `kubernetes-e2e-gce`, but a larger test set/timeout may be appropriate. See results [here](http://kubekins.dls.corp.google.com/view/Critical%20Builds/job/kubernetes-e2e-gce-rc/10/testReport/%28root%29/Kubernetes%20e2e%20suite/)

cc @brendandburns
