### PR TITLE
Use "group/version" in the config files of thirdparty resource. Splitting #14668

### DIFF
--- a/pkg/api/util/group_version.go
+++ b/pkg/api/util/group_version.go
@@ -37,3 +37,12 @@ func GetGroup(groupVersion string) string {
 	}
 	return s[0]
 }
+
+// GetGroupVersion returns the "group/version". It returns "version" is if group
+// is empty. It returns "group/" if version is empty.
+func GetGroupVersion(group, version string) string {
+	if len(group) == 0 {
+		return version
+	}
+	return group + "/" + version
+}

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/rest"
+	apiutil "k8s.io/kubernetes/pkg/api/util"
 	"k8s.io/kubernetes/pkg/api/v1"
 	expapi "k8s.io/kubernetes/pkg/apis/experimental"
 	"k8s.io/kubernetes/pkg/apiserver"
@@ -930,7 +931,7 @@ func (m *Master) InstallThirdPartyResource(rsrc *expapi.ThirdPartyResource) erro
 func (m *Master) thirdpartyapi(group, kind, version string) *apiserver.APIGroupVersion {
 	resourceStorage := thirdpartyresourcedataetcd.NewREST(m.thirdPartyStorage, group, kind)
 
-	apiRoot := makeThirdPartyPath(group)
+	apiRoot := makeThirdPartyPath("")
 
 	storage := map[string]rest.Storage{
 		strings.ToLower(kind) + "s": resourceStorage,
@@ -938,10 +939,10 @@ func (m *Master) thirdpartyapi(group, kind, version string) *apiserver.APIGroupV
 
 	return &apiserver.APIGroupVersion{
 		Root:                   apiRoot,
-		Version:                version,
+		Version:                apiutil.GetGroupVersion(group, version),
 		APIRequestInfoResolver: m.newAPIRequestInfoResolver(),
 
-		Creater:   thirdpartyresourcedata.NewObjectCreator(version, api.Scheme),
+		Creater:   thirdpartyresourcedata.NewObjectCreator(group, version, api.Scheme),
 		Convertor: api.Scheme,
 		Typer:     api.Scheme,
 

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -681,7 +681,7 @@ func testInstallThirdPartyAPIPostForVersion(t *testing.T, version string) {
 		},
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "Foo",
-			APIVersion: version,
+			APIVersion: "company.com/" + version,
 		},
 		SomeField:  "test field",
 		OtherField: 10,

--- a/pkg/master/thirdparty_controller.go
+++ b/pkg/master/thirdparty_controller.go
@@ -30,10 +30,13 @@ import (
 	"k8s.io/kubernetes/pkg/util/sets"
 )
 
-const thirdpartyprefix = "/apis/"
+const thirdpartyprefix = "/apis"
 
 func makeThirdPartyPath(group string) string {
-	return thirdpartyprefix + group
+	if len(group) == 0 {
+		return thirdpartyprefix
+	}
+	return thirdpartyprefix + "/" + group
 }
 
 // resourceInterface is the interface for the parts of the master that know how to add/remove

--- a/pkg/registry/thirdpartyresourcedata/codec.go
+++ b/pkg/registry/thirdpartyresourcedata/codec.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	apiutil "k8s.io/kubernetes/pkg/api/util"
 	"k8s.io/kubernetes/pkg/apis/experimental"
 	"k8s.io/kubernetes/pkg/runtime"
 )
@@ -48,12 +49,12 @@ func (t *thirdPartyResourceDataMapper) GroupForResource(resource string) (string
 	return t.mapper.GroupForResource(resource)
 }
 
-func (t *thirdPartyResourceDataMapper) RESTMapping(kind string, versions ...string) (*meta.RESTMapping, error) {
-	if len(versions) != 1 {
-		return nil, fmt.Errorf("unexpected set of versions: %v", versions)
+func (t *thirdPartyResourceDataMapper) RESTMapping(kind string, groupVersions ...string) (*meta.RESTMapping, error) {
+	if len(groupVersions) != 1 {
+		return nil, fmt.Errorf("unexpected set of groupVersions: %v", groupVersions)
 	}
-	if versions[0] != t.version {
-		return nil, fmt.Errorf("unknown version %s expected %s", versions[0], t.version)
+	if groupVersions[0] != apiutil.GetGroupVersion(t.group, t.version) {
+		return nil, fmt.Errorf("unknown version %s expected %s", groupVersions[0], apiutil.GetGroupVersion(t.group, t.version))
 	}
 	if kind != "ThirdPartyResourceData" {
 		return nil, fmt.Errorf("unknown kind %s expected %s", kind, t.kind)
@@ -266,28 +267,29 @@ func (t *thirdPartyResourceDataCodec) EncodeToStream(obj runtime.Object, stream 
 	}
 }
 
-func NewObjectCreator(version string, delegate runtime.ObjectCreater) runtime.ObjectCreater {
-	return &thirdPartyResourceDataCreator{version, delegate}
+func NewObjectCreator(group, version string, delegate runtime.ObjectCreater) runtime.ObjectCreater {
+	return &thirdPartyResourceDataCreator{group, version, delegate}
 }
 
 type thirdPartyResourceDataCreator struct {
+	group    string
 	version  string
 	delegate runtime.ObjectCreater
 }
 
-func (t *thirdPartyResourceDataCreator) New(version, kind string) (out runtime.Object, err error) {
+func (t *thirdPartyResourceDataCreator) New(groupVersion, kind string) (out runtime.Object, err error) {
 	switch kind {
 	case "ThirdPartyResourceData":
-		if t.version != version {
-			return nil, fmt.Errorf("unknown version %s for kind %s", version, kind)
+		if apiutil.GetGroupVersion(t.group, t.version) != groupVersion {
+			return nil, fmt.Errorf("unknown version %s for kind %s", groupVersion, kind)
 		}
 		return &experimental.ThirdPartyResourceData{}, nil
 	case "ThirdPartyResourceDataList":
-		if t.version != version {
-			return nil, fmt.Errorf("unknown version %s for kind %s", version, kind)
+		if apiutil.GetGroupVersion(t.group, t.version) != groupVersion {
+			return nil, fmt.Errorf("unknown version %s for kind %s", groupVersion, kind)
 		}
 		return &experimental.ThirdPartyResourceDataList{}, nil
 	default:
-		return t.delegate.New(version, kind)
+		return t.delegate.New(groupVersion, kind)
 	}
 }

--- a/pkg/registry/thirdpartyresourcedata/codec_test.go
+++ b/pkg/registry/thirdpartyresourcedata/codec_test.go
@@ -137,7 +137,7 @@ func TestCodec(t *testing.T) {
 }
 
 func TestCreater(t *testing.T) {
-	creater := NewObjectCreator("creater version", api.Scheme)
+	creater := NewObjectCreator("creater group", "creater version", api.Scheme)
 	tests := []struct {
 		name        string
 		version     string
@@ -147,7 +147,7 @@ func TestCreater(t *testing.T) {
 	}{
 		{
 			name:        "valid ThirdPartyResourceData creation",
-			version:     "creater version",
+			version:     "creater group/creater version",
 			kind:        "ThirdPartyResourceData",
 			expectedObj: &experimental.ThirdPartyResourceData{},
 			expectErr:   false,


### PR DESCRIPTION
Another piece of #14668.

Before this PR, the APIVersion field of a config file for a thirdparty resource would take "version", after 
this PR, it would take "group/version" (see [here](https://github.com/caesarxuchao/kubernetes/blob/fix-thirdparty-apiversion/pkg/master/master_test.go#L684)), which is consistent with the config file of non-thirdparty resource.

@lavalamp @brendandburns 
