### PR TITLE
Fix cherry pick hub pull-request call syntax

### DIFF
--- a/hack/cherry_pick_pull.sh
+++ b/hack/cherry_pick_pull.sh
@@ -136,7 +136,7 @@ gitamcleanup=false
 function make-a-pr() {
   local rel=$(basename ${BRANCH})
   echo "+++ Creating a pull request on github"
-  hub pull-request -F- -h "${GITHUB_USER}:${NEWBRANCH}" -b "kubernetes:${rel}" <<EOF
+  hub pull-request -F - -h "${GITHUB_USER}:${NEWBRANCH}" -b "kubernetes:${rel}" <<EOF
 Automated cherry pick of ${PULLSUBJ}
 
 Cherry pick of ${PULLSUBJ} on ${rel}.


### PR DESCRIPTION
Use `-F -` instead of `-F-` when invoking `hub pull-request`. The
latter seems to to be syntactically invalid according to:
- The hub manual and help: https://github.com/github/hub/blob/master/man/hub.1.ronn#L160
- Manual testing with hub-1.12.4-5.fc21.noarch

Without this fix, the cherry-pick operation fails when trying to create a PR.
