### PR TITLE
fix ServerAPIVersions. Splitting #14592

### DIFF
--- a/pkg/client/unversioned/helper.go
+++ b/pkg/client/unversioned/helper.go
@@ -205,41 +205,30 @@ func ServerAPIVersions(c *Config) (groupVersions []string, err error) {
 		return nil, err
 	}
 	// Get the groupVersions exposed at /api
-	req, err := http.NewRequest("GET", baseURL.String()+"/api", nil)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	body, err := ioutil.ReadAll(resp.Body)
+	baseURL.Path = "/api"
+	resp, err := client.Get(baseURL.String())
 	if err != nil {
 		return nil, err
 	}
 	var v api.APIVersions
-	err = json.Unmarshal(body, &v)
+	defer resp.Body.Close()
+	err = json.NewDecoder(resp.Body).Decode(&v)
 	if err != nil {
-		return nil, fmt.Errorf("got '%s': %v", string(body), err)
+		return nil, fmt.Errorf("unexpected error: %v", err)
 	}
+
 	groupVersions = append(groupVersions, v.Versions...)
 	// Get the groupVersions exposed at /apis
-	req, err = http.NewRequest("GET", baseURL.String()+"/apis", nil)
-	if err != nil {
-		return nil, err
-	}
-	resp, err = client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	body, err = ioutil.ReadAll(resp.Body)
+	baseURL.Path = "/apis"
+	resp2, err := client.Get(baseURL.String())
 	if err != nil {
 		return nil, err
 	}
 	var apiGroupList api.APIGroupList
-	err = json.Unmarshal(body, &apiGroupList)
+	defer resp2.Body.Close()
+	err = json.NewDecoder(resp2.Body).Decode(&apiGroupList)
 	if err != nil {
-		return nil, fmt.Errorf("got '%s': %v", string(body), err)
+		return nil, fmt.Errorf("unexpected error: %v", err)
 	}
 	groupVersions = append(groupVersions, extractGroupVersions(&apiGroupList)...)
 


### PR DESCRIPTION
This PR adds a ServerAPIVersions function that visits both /api and /apis, and doesn't require a high-level client.

This is the first piece of #14592. This is required to fix NegotiateVersion.

I pushed two version of this PR, the first commit uses a RESTClient to talk to server, and the second commit uses a http.client. Please let me know which one is more favorable.

@lavalamp @krousey 
