### PR TITLE
Fix NegotiateVersion. Split from #14592

### DIFF
--- a/pkg/apiserver/api_installer.go
+++ b/pkg/apiserver/api_installer.go
@@ -90,7 +90,8 @@ func (a *APIInstaller) Install(ws *restful.WebService) (apiResources []api.APIRe
 func (a *APIInstaller) NewWebService() *restful.WebService {
 	ws := new(restful.WebService)
 	ws.Path(a.prefix)
-	ws.Doc("API at " + a.prefix + " version " + a.group.Version)
+	// a.prefix contains "prefix/group/version"
+	ws.Doc("API at " + a.prefix)
 	// TODO: change to restful.MIME_JSON when we set content type in client
 	ws.Consumes("*/*")
 	ws.Produces(restful.MIME_JSON)

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -77,7 +77,8 @@ type Mux interface {
 type APIGroupVersion struct {
 	Storage map[string]rest.Storage
 
-	Root    string
+	Root string
+	// TODO: caesarxuchao: Version actually contains "group/version", refactor it to avoid confusion.
 	Version string
 
 	// APIRequestInfoResolver is used to parse URLs for the legacy proxy handler.  Don't use this for anything else
@@ -88,6 +89,8 @@ type APIGroupVersion struct {
 	// schema like api.Status, api.DeleteOptions, and api.ListOptions. Other implementors may
 	// define a version "v1beta1" but want to use the Kubernetes "v1" internal objects. If
 	// empty, defaults to Version.
+	// TODO: caesarxuchao: ServerVersion actually contains "group/version",
+	// refactor it to avoid confusion.
 	ServerVersion string
 
 	Mapper meta.RESTMapper

--- a/pkg/client/unversioned/helper.go
+++ b/pkg/client/unversioned/helper.go
@@ -355,15 +355,23 @@ func NewInCluster() (*Client, error) {
 // SetKubernetesDefaults sets default values on the provided client config for accessing the
 // Kubernetes API or returns an error if any of the defaults are impossible or invalid.
 func SetKubernetesDefaults(config *Config) error {
-	if config.Prefix == "" {
-		config.Prefix = "/api"
-	}
+	// TODO: caesarxuchao: re-enable the "if" when we have a config for each group.
+	// We need to comment it out now because the config maybe for the experimental
+	// group.
+	//if config.Prefix == "" {
+	config.Prefix = "/api"
+	//}
 	if len(config.UserAgent) == 0 {
 		config.UserAgent = DefaultKubernetesUserAgent()
 	}
-	if len(config.Version) == 0 {
-		config.Version = defaultVersionFor(config)
-	}
+	// TODO: caesarxuchao: re-enable the "if" when we have a config for each group.
+	// We need to comment it out now because the config maybe for the experimental
+	// group.
+	//if len(config.Version) == 0 {
+	//config.Version = defaultVersionFor(config)
+	//}
+	config.Version = latest.GroupOrDie("").GroupVersion
+
 	version := config.Version
 	versionInterfaces, err := latest.GroupOrDie("").InterfacesFor(version)
 	if err != nil {

--- a/pkg/kubectl/cmd/util/clientcache.go
+++ b/pkg/kubectl/cmd/util/clientcache.go
@@ -60,7 +60,7 @@ func (c *ClientCache) ClientConfigForVersion(version string) (*client.Config, er
 	}
 	// TODO: have a better config copy method
 	config := *c.defaultConfig
-	negotiatedVersion, err := client.NegotiateVersion(c.defaultClient, &config, version, registered.RegisteredVersions)
+	negotiatedVersion, err := client.NegotiateVersion(&config, version, registered.RegisteredVersions)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/rest"
+	apiutil "k8s.io/kubernetes/pkg/api/util"
 	"k8s.io/kubernetes/pkg/api/v1"
 	expapi "k8s.io/kubernetes/pkg/apis/experimental"
 	"k8s.io/kubernetes/pkg/apiserver"
@@ -591,8 +592,8 @@ func (m *Master) init(c *Config) {
 		}
 		expAPIVersions := []api.GroupVersion{
 			{
-				GroupVersion: g.Group + "/" + expVersion.Version,
-				Version:      expVersion.Version,
+				GroupVersion: expVersion.Version,
+				Version:      apiutil.GetVersion(expVersion.Version),
 			},
 		}
 		storageVersion, found := c.StorageVersions[g.Group]
@@ -602,7 +603,7 @@ func (m *Master) init(c *Config) {
 		group := api.APIGroup{
 			Name:             g.Group,
 			Versions:         expAPIVersions,
-			PreferredVersion: api.GroupVersion{GroupVersion: g.Group + "/" + storageVersion, Version: storageVersion},
+			PreferredVersion: api.GroupVersion{GroupVersion: storageVersion, Version: apiutil.GetVersion(storageVersion)},
 		}
 		apiserver.AddGroupWebService(m.handlerContainer, c.APIGroupPrefix+"/"+latest.GroupOrDie("experimental").Group+"/", group)
 		allGroups = append(allGroups, group)


### PR DESCRIPTION
 Split from #14952.

**Only last two commits are relevant**. Other commits are in other PRs.
1. commit "fix NegotiateVersion":
   Let the NegotiateVersion use the ServerAPIVersions() function that checks both /api and /apis.
2. commit "hardcoding the config for v1 RESTClient":
   The "fix NegotiateVersion" commit exposes a problem in ClientForVersion(version), which uses the config with the negotiated version to initialize both the RESTClient and ExperimentalClient, so sometimes the code will try to create a v1 RESTClient out of a config for experimental/v1alpha1, of course that wil fail. As a temporary fix, this commit hardcodes the config before initialize the v1 RESTClient.

@lavalamp @krousey 
