### PR TITLE
Messages should be appended to "messages" slice.

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2362,13 +2362,12 @@ func (kl *Kubelet) setNodeStatus(node *api.Node) error {
 			LastHeartbeatTime: currentTime,
 		}
 	} else {
-		var reasons []string
 		var messages []string
 		if !containerRuntimeUp {
 			messages = append(messages, "container runtime is down")
 		}
 		if !networkConfigured {
-			messages = append(reasons, "network not configured correctly")
+			messages = append(messages, "network not configured correctly")
 		}
 		newNodeReadyCondition = api.NodeCondition{
 			Type:              api.NodeReady,


### PR DESCRIPTION
Network configuration error message while setting Kubelet status was
being written to "reasons" slice. Write this message to "messages" slice
instead.

Also remove "reasons" slice entirely since it is not used anywhere.
