### PR TITLE
Use beta.gcr.io to activate v2 Registry support.

### DIFF
--- a/build/pause/Makefile
+++ b/build/pause/Makefile
@@ -5,9 +5,9 @@ TAG = 0.8.0
 
 build:
 	./prepare.sh
-	docker build -t gcr.io/google_containers/$(IMAGE):$(TAG) .
+	docker build -t beta.gcr.io/google_containers/$(IMAGE):$(TAG) .
 
 push:	build
-	gcloud docker push gcr.io/google_containers/$(IMAGE):$(TAG)
+	gcloud docker --server=beta.gcr.io push beta.gcr.io/google_containers/$(IMAGE):$(TAG)
 
 all:	push

--- a/cluster/addons/dns/skydns/Makefile
+++ b/cluster/addons/dns/skydns/Makefile
@@ -4,10 +4,10 @@ skydns:
 	CGO_ENABLED=0 go build -a -installsuffix cgo --ldflags '-w' github.com/skynetservices/skydns
 
 container: skydns
-	sudo docker build -t gcr.io/google_containers/skydns .
+	sudo docker build -t beta.gcr.io/google_containers/skydns .
 
 push:
-	sudo gcloud docker push gcr.io/google_containers/skydns
+	sudo gcloud docker --server=beta.gcr.io push beta.gcr.io/google_containers/skydns
 
 clean:
 	rm -f skydns

--- a/cluster/addons/fluentd-elasticsearch/es-image/Makefile
+++ b/cluster/addons/fluentd-elasticsearch/es-image/Makefile
@@ -5,10 +5,10 @@
 TAG = 1.7
 
 build:	elasticsearch_logging_discovery
-	docker build -t gcr.io/google_containers/elasticsearch:$(TAG) .
+	docker build -t beta.gcr.io/google_containers/elasticsearch:$(TAG) .
 
 push:
-	gcloud docker push gcr.io/google_containers/elasticsearch:$(TAG)
+	gcloud docker --server=beta.gcr.io push beta.gcr.io/google_containers/elasticsearch:$(TAG)
 
 elasticsearch_logging_discovery:
 	go build elasticsearch_logging_discovery.go

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Makefile
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Makefile
@@ -4,7 +4,7 @@ IMAGE = fluentd-elasticsearch
 TAG = 1.11
 
 build:	
-	docker build -t gcr.io/google_containers/$(IMAGE):$(TAG) .
+	docker build -t beta.gcr.io/google_containers/$(IMAGE):$(TAG) .
 
 push:	
-	gcloud docker push gcr.io/google_containers/$(IMAGE):$(TAG)
+	gcloud docker --server=beta.gcr.io push beta.gcr.io/google_containers/$(IMAGE):$(TAG)

--- a/cluster/addons/fluentd-elasticsearch/kibana-image/Makefile
+++ b/cluster/addons/fluentd-elasticsearch/kibana-image/Makefile
@@ -3,7 +3,7 @@
 TAG = 1.3
 
 build:
-	docker build -t gcr.io/google_containers/kibana:$(TAG) .
+	docker build -t beta.gcr.io/google_containers/kibana:$(TAG) .
 
 push:
-	gcloud docker push gcr.io/google_containers/kibana:$(TAG)
+	gcloud docker --server=beta.gcr.io push beta.gcr.io/google_containers/kibana:$(TAG)

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
@@ -29,8 +29,8 @@ kpush:
 # Rules for building the real image for deployment to gcr.io
 
 build:
-	docker build -t gcr.io/google_containers/fluentd-gcp:$(TAG) .
+	docker build -t beta.gcr.io/google_containers/fluentd-gcp:$(TAG) .
 
 
 push:
-	gcloud docker push gcr.io/google_containers/fluentd-gcp:$(TAG)
+	gcloud docker --server=beta.gcr.io push beta.gcr.io/google_containers/fluentd-gcp:$(TAG)

--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -13,9 +13,9 @@ build: clean
 	tar xzvf $(IMAGE)-v$(ETCD_VERSION)-linux-amd64.tar.gz
 	cp $(OUTPUT_DIR)/etcd .
 	cp $(OUTPUT_DIR)/etcdctl .
-	docker build -t gcr.io/google_containers/$(IMAGE):$(TAG) .
+	docker build -t beta.gcr.io/google_containers/$(IMAGE):$(TAG) .
 
 push: build
-	gcloud docker push gcr.io/google_containers/$(IMAGE):$(TAG)
+	gcloud docker --server=beta.gcr.io push beta.gcr.io/google_containers/$(IMAGE):$(TAG)
 
 all:	push

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -6,7 +6,7 @@ all:
 	cp ../../saltbase/salt/helpers/safe_format_and_mount .
 	curl -O https://storage.googleapis.com/kubernetes-release/release/${VERSION}/bin/linux/amd64/hyperkube
 	sed -i "s/VERSION/${VERSION}/g" master-multi.json master.json
-	docker build -t gcr.io/google_containers/hyperkube:${VERSION} .
-	gcloud docker push gcr.io/google_containers/hyperkube:${VERSION}
+	docker build -t beta.gcr.io/google_containers/hyperkube:${VERSION} .
+	gcloud docker --server=beta.gcr.io push beta.gcr.io/google_containers/hyperkube:${VERSION}
 
 .PHONY: all

--- a/cluster/images/hyperkube/master-multi.json
+++ b/cluster/images/hyperkube/master-multi.json
@@ -7,7 +7,7 @@
   "containers":[
     {
       "name": "controller-manager",
-      "image": "gcr.io/google_containers/hyperkube:VERSION",
+      "image": "beta.gcr.io/google_containers/hyperkube:VERSION",
       "command": [
               "/hyperkube",
               "controller-manager",
@@ -17,7 +17,7 @@
     },
     {
       "name": "apiserver",
-      "image": "gcr.io/google_containers/hyperkube:VERSION",
+      "image": "beta.gcr.io/google_containers/hyperkube:VERSION",
       "command": [
               "/hyperkube",
               "apiserver",
@@ -30,7 +30,7 @@
     },
     {
       "name": "scheduler",
-      "image": "gcr.io/google_containers/hyperkube:VERSION",
+      "image": "beta.gcr.io/google_containers/hyperkube:VERSION",
       "command": [
               "/hyperkube",
               "scheduler",

--- a/cluster/images/hyperkube/master.json
+++ b/cluster/images/hyperkube/master.json
@@ -7,7 +7,7 @@
   "containers":[
     {
       "name": "controller-manager",
-      "image": "gcr.io/google_containers/hyperkube:VERSION",
+      "image": "beta.gcr.io/google_containers/hyperkube:VERSION",
       "command": [
               "/hyperkube",
               "controller-manager",
@@ -17,7 +17,7 @@
     },
     {
       "name": "apiserver",
-      "image": "gcr.io/google_containers/hyperkube:VERSION",
+      "image": "beta.gcr.io/google_containers/hyperkube:VERSION",
       "command": [
               "/hyperkube",
               "apiserver",
@@ -30,7 +30,7 @@
     },
     {
       "name": "scheduler",
-      "image": "gcr.io/google_containers/hyperkube:VERSION",
+      "image": "beta.gcr.io/google_containers/hyperkube:VERSION",
       "command": [
               "/hyperkube",
               "scheduler",

--- a/cluster/images/kubelet/Makefile
+++ b/cluster/images/kubelet/Makefile
@@ -10,12 +10,12 @@ LOCAL_OUTPUT_DIR=../../../_output/local
 
 release: clean
 	curl -O https://storage.googleapis.com/kubernetes-release/release/${VERSION}/${BIN_DIR}/kubelet
-	docker build -t gcr.io/google_containers/kubelet:${VERSION} .
-	gcloud docker push gcr.io/google_containers/kubelet:${VERSION}
+	docker build -t beta.gcr.io/google_containers/kubelet:${VERSION} .
+	gcloud docker --server=beta.gcr.io push beta.gcr.io/google_containers/kubelet:${VERSION}
 
 local: clean
 	cp ${LOCAL_OUTPUT_DIR}/${BIN_DIR}/kubelet .
-	docker build -t gcr.io/google_containers/kubelet .
+	docker build -t beta.gcr.io/google_containers/kubelet .
 
 clean:
 	rm -f kubelet

--- a/cluster/images/nginx/Makefile
+++ b/cluster/images/nginx/Makefile
@@ -7,8 +7,8 @@
 VERSION=v2
 
 all:
-	docker build -t gcr.io/google_containers/nginx:${VERSION} .
-	gcloud docker push gcr.io/google_containers/nginx:${VERSION}
+	docker build -t beta.gcr.io/google_containers/nginx:${VERSION} .
+	gcloud docker --server=beta.gcr.io push beta.gcr.io/google_containers/nginx:${VERSION}
 
 .PHONY: all
 

--- a/cluster/saltbase/salt/etcd/etcd.manifest
+++ b/cluster/saltbase/salt/etcd/etcd.manifest
@@ -10,7 +10,7 @@
 "containers":[
     {
     "name": "etcd-container",
-    "image": "gcr.io/google_containers/etcd:2.0.12",
+    "image": "beta.gcr.io/google_containers/etcd:2.0.12",
     "resources": {
       "limits": {
         "cpu": "200m"

--- a/cluster/saltbase/salt/kube-apiserver/kube-apiserver.manifest
+++ b/cluster/saltbase/salt/kube-apiserver/kube-apiserver.manifest
@@ -108,7 +108,7 @@
 "containers":[
     {
     "name": "kube-apiserver",
-    "image": "gcr.io/google_containers/kube-apiserver:{{pillar['kube-apiserver_docker_tag']}}",
+    "image": "beta.gcr.io/google_containers/kube-apiserver:{{pillar['kube-apiserver_docker_tag']}}",
     "resources": {
       "limits": {
         "cpu": "200m"

--- a/cluster/saltbase/salt/kube-controller-manager/kube-controller-manager.manifest
+++ b/cluster/saltbase/salt/kube-controller-manager/kube-controller-manager.manifest
@@ -61,7 +61,7 @@
 "containers":[
     {
     "name": "kube-controller-manager",
-    "image": "gcr.io/google_containers/kube-controller-manager:{{pillar['kube-controller-manager_docker_tag']}}",
+    "image": "beta.gcr.io/google_containers/kube-controller-manager:{{pillar['kube-controller-manager_docker_tag']}}",
     "resources": {
       "limits": {
         "cpu": "200m"

--- a/cluster/saltbase/salt/kube-scheduler/kube-scheduler.manifest
+++ b/cluster/saltbase/salt/kube-scheduler/kube-scheduler.manifest
@@ -21,7 +21,7 @@
 "containers":[
     {
     "name": "kube-scheduler",
-    "image": "gcr.io/google_containers/kube-scheduler:{{pillar['kube-scheduler_docker_tag']}}",
+    "image": "beta.gcr.io/google_containers/kube-scheduler:{{pillar['kube-scheduler_docker_tag']}}",
     "resources": {
       "limits": {
         "cpu": "200m"

--- a/contrib/for-tests/netexec/Makefile
+++ b/contrib/for-tests/netexec/Makefile
@@ -1,7 +1,8 @@
 .PHONY: all netexec image push clean
 
 TAG = 1.1
-PREFIX = gcr.io/google_containers
+REGISTRY = beta.gcr.io
+PREFIX = $(REGISTRY)/google_containers
 
 all: push
 
@@ -12,7 +13,7 @@ image: netexec
 	docker build -t $(PREFIX)/netexec:$(TAG) .
 
 push: image
-	gcloud docker push $(PREFIX)/netexec:$(TAG)
+	gcloud docker --server=$(REGISTRY) push $(PREFIX)/netexec:$(TAG)
 
 clean:
 	rm -f netexec

--- a/contrib/for-tests/volumes-tester/ceph/Makefile
+++ b/contrib/for-tests/volumes-tester/ceph/Makefile
@@ -3,11 +3,11 @@ all: push
 TAG = 0.1
 
 container:
-	docker build -t gcr.io/google_containers/volume-ceph . # Build new image and automatically tag it as latest
-	docker tag gcr.io/google_containers/volume-ceph gcr.io/google_containers/volume-ceph:$(TAG)  # Add the version tag to the latest image 
+	docker build -t beta.gcr.io/google_containers/volume-ceph . # Build new image and automatically tag it as latest
+	docker tag beta.gcr.io/google_containers/volume-ceph beta.gcr.io/google_containers/volume-ceph:$(TAG)  # Add the version tag to the latest image 
 
 push: container
-	gcloud preview docker push gcr.io/google_containers/volume-ceph # Push image tagged as latest to repository
-	gcloud preview docker push gcr.io/google_containers/volume-ceph:$(TAG) # Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
+	gcloud docker --server=beta.gcr.io push beta.gcr.io/google_containers/volume-ceph # Push image tagged as latest to repository
+	gcloud docker --server=beta.gcr.io push beta.gcr.io/google_containers/volume-ceph:$(TAG) # Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
 
 clean:

--- a/docs/user-guide/liveness/image/Makefile
+++ b/docs/user-guide/liveness/image/Makefile
@@ -4,10 +4,10 @@ server: server.go
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' ./server.go
 
 container: server
-	docker build -t gcr.io/google_containers/liveness .
+	docker build -t beta.gcr.io/google_containers/liveness .
 
 push: container
-	gcloud docker push gcr.io/google_containers/liveness
+	gcloud docker --server=beta.gcr.io push beta.gcr.io/google_containers/liveness
 
 clean:
 	rm -f server

--- a/examples/explorer/Makefile
+++ b/examples/explorer/Makefile
@@ -7,10 +7,10 @@ explorer: explorer.go
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' ./explorer.go
 
 container: explorer
-	docker build -t gcr.io/google_containers/explorer:$(TAG) .
+	docker build -t beta.gcr.io/google_containers/explorer:$(TAG) .
 
 push: container
-	gcloud docker push gcr.io/google_containers/explorer:$(TAG)
+	gcloud docker --server=beta.gcr.io push beta.gcr.io/google_containers/explorer:$(TAG)
 
 clean:
 	rm -f explorer

--- a/examples/kubectl-container/Makefile
+++ b/examples/kubectl-container/Makefile
@@ -19,11 +19,11 @@ tag: .tag
 
 container:
 	$(if $(TAG),,$(error TAG is not defined. Use 'make tag' to see a suggestion))
-	docker build -t gcr.io/google_containers/kubectl:$(TAG) .
+	docker build -t beta.gcr.io/google_containers/kubectl:$(TAG) .
 
 push: container
 	$(if $(TAG),,$(error TAG is not defined. Use 'make tag' to see a suggestion))
-	gcloud docker push gcr.io/google_containers/kubectl:$(TAG)
+	gcloud docker --server=beta.gcr.io push beta.gcr.io/google_containers/kubectl:$(TAG)
 
 clean:
 	rm -f kubectl

--- a/hack/gen-swagger-doc/README.md
+++ b/hack/gen-swagger-doc/README.md
@@ -3,7 +3,7 @@ This folder contains the sources needed to build the gen-swagger-doc container.
 To build the container image, 
 
 ```
-$ sudo docker build -t gcr.io/google_containers/gen-swagger-docs:v1 .
+$ sudo docker build -t beta.gcr.io/google_containers/gen-swagger-docs:v1 .
 ```
 
 To generate the html docs,

--- a/pkg/api/pod_example.json
+++ b/pkg/api/pod_example.json
@@ -33,7 +33,7 @@
         "containers": [
             {
                 "name": "etcd-container",
-                "image": "gcr.io/google_containers/etcd:2.0.9",
+                "image": "beta.gcr.io/google_containers/etcd:2.0.9",
                 "command": [
                     "/usr/local/bin/etcd",
                     "--addr",
@@ -93,7 +93,7 @@
                 "lastState": {},
                 "ready": true,
                 "restartCount": 0,
-                "image": "gcr.io/google_containers/etcd:2.0.9",
+                "image": "beta.gcr.io/google_containers/etcd:2.0.9",
                 "imageID": "docker://b6b9a86dc06aa1361357ca1b105feba961f6a4145adca6c54e142c0be0fe87b0",
                 "containerID": "docker://3cbbf818f1addfc252957b4504f56ef2907a313fe6afc47fc75373674255d46d"
             }

--- a/pkg/api/replication_controller_example.json
+++ b/pkg/api/replication_controller_example.json
@@ -46,7 +46,7 @@
                 "containers": [
                     {
                         "name": "elasticsearch-logging",
-                        "image": "gcr.io/google_containers/elasticsearch:1.0",
+                        "image": "beta.gcr.io/google_containers/elasticsearch:1.0",
                         "ports": [
                             {
                                 "name": "db",

--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -41,7 +41,7 @@ import (
 const (
 	PodInfraContainerName  = leaky.PodInfraContainerName
 	DockerPrefix           = "docker://"
-	PodInfraContainerImage = "gcr.io/google_containers/pause:0.8.0"
+	PodInfraContainerImage = "beta.gcr.io/google_containers/pause:0.8.0"
 	LogSuffix              = "log"
 )
 

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -403,7 +403,7 @@ func NewPersistentVolumeRecyclerPodTemplate() *api.Pod {
 			Containers: []api.Container{
 				{
 					Name:    "pv-recycler",
-					Image:   "gcr.io/google_containers/busybox",
+					Image:   "beta.gcr.io/google_containers/busybox",
 					Command: []string{"/bin/sh"},
 					Args:    []string{"-c", "test -e /scrub && echo $(date) > /scrub/trash.txt && rm -rf /scrub/* /scrub/.* && test -z \"$(ls -A /scrub)\" || exit 1"},
 					VolumeMounts: []api.VolumeMount{

--- a/test/e2e/autoscaling.go
+++ b/test/e2e/autoscaling.go
@@ -128,7 +128,7 @@ func ReserveCpu(f *Framework, id string, millicores int) {
 		Name:       id,
 		Namespace:  f.Namespace.Name,
 		Timeout:    10 * time.Minute,
-		Image:      "gcr.io/google_containers/pause",
+		Image:      "beta.gcr.io/google_containers/pause",
 		Replicas:   millicores / 100,
 		CpuRequest: 100,
 	}
@@ -142,7 +142,7 @@ func ReserveMemory(f *Framework, id string, megabytes int) {
 		Name:       id,
 		Namespace:  f.Namespace.Name,
 		Timeout:    10 * time.Minute,
-		Image:      "gcr.io/google_containers/pause",
+		Image:      "beta.gcr.io/google_containers/pause",
 		Replicas:   megabytes / 500,
 		MemRequest: 500 * 1024 * 1024,
 	}

--- a/test/e2e/autoscaling_utils.go
+++ b/test/e2e/autoscaling_utils.go
@@ -38,7 +38,7 @@ const (
 	timeoutRC                       = 120 * time.Second
 	startServiceTimeout             = time.Minute
 	startServiceInterval            = 5 * time.Second
-	image                           = "gcr.io/google_containers/resource_consumer:beta"
+	image                           = "beta.gcr.io/google_containers/resource_consumer:beta"
 	rcIsNil                         = "ERROR: replicationController = nil"
 )
 

--- a/test/e2e/container_probe.go
+++ b/test/e2e/container_probe.go
@@ -115,7 +115,7 @@ func makePodSpec(readinessProbe, livenessProbe *api.Probe) *api.Pod {
 			Containers: []api.Container{
 				{
 					Name:           "test-webserver",
-					Image:          "gcr.io/google_containers/test-webserver",
+					Image:          "beta.gcr.io/google_containers/test-webserver",
 					LivenessProbe:  livenessProbe,
 					ReadinessProbe: readinessProbe,
 				},

--- a/test/e2e/daemon_set.go
+++ b/test/e2e/daemon_set.go
@@ -183,7 +183,7 @@ func testDaemonSets(f *Framework) {
 	ns := f.Namespace.Name
 	c := f.Client
 	simpleDSName := "simple-daemon-set"
-	image := "gcr.io/google_containers/serve_hostname:1.1"
+	image := "beta.gcr.io/google_containers/serve_hostname:1.1"
 	label := map[string]string{daemonsetNameLabel: simpleDSName}
 	retryTimeout := 1 * time.Minute
 	retryInterval := 5 * time.Second

--- a/test/e2e/density.go
+++ b/test/e2e/density.go
@@ -190,7 +190,7 @@ var _ = Describe("Density", func() {
 			expectNoError(err)
 			defer fileHndl.Close()
 			config := RCConfig{Client: c,
-				Image:                "gcr.io/google_containers/pause:go",
+				Image:                "beta.gcr.io/google_containers/pause:go",
 				Name:                 RCName,
 				Namespace:            ns,
 				PollInterval:         itArg.interval,
@@ -320,7 +320,7 @@ var _ = Describe("Density", func() {
 				}
 				for i := 1; i <= nodeCount; i++ {
 					name := additionalPodsPrefix + "-" + strconv.Itoa(i)
-					go createRunningPod(&wg, c, name, ns, "gcr.io/google_containers/pause:go", podLabels)
+					go createRunningPod(&wg, c, name, ns, "beta.gcr.io/google_containers/pause:go", podLabels)
 					time.Sleep(200 * time.Millisecond)
 				}
 				wg.Wait()

--- a/test/e2e/dns.go
+++ b/test/e2e/dns.go
@@ -62,7 +62,7 @@ func createDNSPod(namespace, wheezyProbeCmd, jessieProbeCmd string) *api.Pod {
 				// TODO: Consider scraping logs instead of running a webserver.
 				{
 					Name:  "webserver",
-					Image: "gcr.io/google_containers/test-webserver",
+					Image: "beta.gcr.io/google_containers/test-webserver",
 					Ports: []api.ContainerPort{
 						{
 							Name:          "http",
@@ -78,7 +78,7 @@ func createDNSPod(namespace, wheezyProbeCmd, jessieProbeCmd string) *api.Pod {
 				},
 				{
 					Name:    "querier",
-					Image:   "gcr.io/google_containers/dnsutils",
+					Image:   "beta.gcr.io/google_containers/dnsutils",
 					Command: []string{"sh", "-c", wheezyProbeCmd},
 					VolumeMounts: []api.VolumeMount{
 						{
@@ -89,7 +89,7 @@ func createDNSPod(namespace, wheezyProbeCmd, jessieProbeCmd string) *api.Pod {
 				},
 				{
 					Name:    "jessie-querier",
-					Image:   "gcr.io/google_containers/jessie-dnsutils",
+					Image:   "beta.gcr.io/google_containers/jessie-dnsutils",
 					Command: []string{"sh", "-c", jessieProbeCmd},
 					VolumeMounts: []api.VolumeMount{
 						{

--- a/test/e2e/docker_containers.go
+++ b/test/e2e/docker_containers.go
@@ -97,7 +97,7 @@ func entrypointTestPod() *api.Pod {
 			Containers: []api.Container{
 				{
 					Name:  testContainerName,
-					Image: "gcr.io/google_containers/eptest:0.1",
+					Image: "beta.gcr.io/google_containers/eptest:0.1",
 				},
 			},
 			RestartPolicy: api.RestartPolicyNever,

--- a/test/e2e/downward_api.go
+++ b/test/e2e/downward_api.go
@@ -39,7 +39,7 @@ var _ = Describe("Downward API", func() {
 				Containers: []api.Container{
 					{
 						Name:    "dapi-container",
-						Image:   "gcr.io/google_containers/busybox",
+						Image:   "beta.gcr.io/google_containers/busybox",
 						Command: []string{"sh", "-c", "env"},
 						Env: []api.EnvVar{
 							{

--- a/test/e2e/downwardapi_volume.go
+++ b/test/e2e/downwardapi_volume.go
@@ -40,7 +40,7 @@ var _ = Describe("Downward API volume", func() {
 				Containers: []api.Container{
 					{
 						Name:    "client-container",
-						Image:   "gcr.io/google_containers/busybox",
+						Image:   "beta.gcr.io/google_containers/busybox",
 						Command: []string{"sh", "-c", "cat /etc/labels /etc/annotations /etc/podname"},
 						VolumeMounts: []api.VolumeMount{
 							{

--- a/test/e2e/empty_dir.go
+++ b/test/e2e/empty_dir.go
@@ -29,8 +29,8 @@ import (
 )
 
 const (
-	testImageRootUid    = "gcr.io/google_containers/mounttest:0.4"
-	testImageNonRootUid = "gcr.io/google_containers/mounttest-user:0.2"
+	testImageRootUid    = "beta.gcr.io/google_containers/mounttest:0.4"
+	testImageNonRootUid = "beta.gcr.io/google_containers/mounttest-user:0.2"
 )
 
 var _ = Describe("EmptyDir volumes", func() {

--- a/test/e2e/es_cluster_logging.go
+++ b/test/e2e/es_cluster_logging.go
@@ -218,7 +218,7 @@ func ClusterLevelLoggingWithElasticsearch(f *Framework) {
 				Containers: []api.Container{
 					{
 						Name:  "synth-logger",
-						Image: "gcr.io/google_containers/ubuntu:14.04",
+						Image: "beta.gcr.io/google_containers/ubuntu:14.04",
 						// notice: the subshell syntax is escaped with `$$`
 						Command: []string{"bash", "-c", fmt.Sprintf("i=0; while ((i < %d)); do echo \"%d %s $i %s\"; i=$$(($i+1)); done", countTo, i, taintName, podName)},
 					},

--- a/test/e2e/etcd_failure.go
+++ b/test/e2e/etcd_failure.go
@@ -49,7 +49,7 @@ var _ = Describe("Etcd failure", func() {
 			Client:    framework.Client,
 			Name:      "baz",
 			Namespace: framework.Namespace.Name,
-			Image:     "gcr.io/google_containers/nginx",
+			Image:     "beta.gcr.io/google_containers/nginx",
 			Replicas:  1,
 		})).NotTo(HaveOccurred())
 	})
@@ -84,7 +84,7 @@ func etcdFailTest(framework Framework, failCommand, fixCommand string) {
 
 	checkExistingRCRecovers(framework)
 
-	ServeImageOrFail(&framework, "basic", "gcr.io/google_containers/serve_hostname:1.1")
+	ServeImageOrFail(&framework, "basic", "beta.gcr.io/google_containers/serve_hostname:1.1")
 }
 
 // For this duration, etcd will be failed by executing a failCommand on the master.

--- a/test/e2e/events.go
+++ b/test/e2e/events.go
@@ -53,7 +53,7 @@ var _ = Describe("Events", func() {
 				Containers: []api.Container{
 					{
 						Name:  "p",
-						Image: "gcr.io/google_containers/serve_hostname:1.1",
+						Image: "beta.gcr.io/google_containers/serve_hostname:1.1",
 						Ports: []api.ContainerPort{{ContainerPort: 80}},
 					},
 				},

--- a/test/e2e/expansion.go
+++ b/test/e2e/expansion.go
@@ -37,7 +37,7 @@ var _ = Describe("Variable Expansion", func() {
 				Containers: []api.Container{
 					{
 						Name:    "dapi-container",
-						Image:   "gcr.io/google_containers/busybox",
+						Image:   "beta.gcr.io/google_containers/busybox",
 						Command: []string{"sh", "-c", "env"},
 						Env: []api.EnvVar{
 							{
@@ -77,7 +77,7 @@ var _ = Describe("Variable Expansion", func() {
 				Containers: []api.Container{
 					{
 						Name:    "dapi-container",
-						Image:   "gcr.io/google_containers/busybox",
+						Image:   "beta.gcr.io/google_containers/busybox",
 						Command: []string{"sh", "-c", "TEST_VAR=wrong echo \"$(TEST_VAR)\""},
 						Env: []api.EnvVar{
 							{
@@ -107,7 +107,7 @@ var _ = Describe("Variable Expansion", func() {
 				Containers: []api.Container{
 					{
 						Name:    "dapi-container",
-						Image:   "gcr.io/google_containers/busybox",
+						Image:   "beta.gcr.io/google_containers/busybox",
 						Command: []string{"sh", "-c"},
 						Args:    []string{"TEST_VAR=wrong echo \"$(TEST_VAR)\""},
 						Env: []api.EnvVar{

--- a/test/e2e/host_path.go
+++ b/test/e2e/host_path.go
@@ -135,7 +135,7 @@ func testPodWithHostVol(path string, source *api.HostPathVolumeSource) *api.Pod 
 			Containers: []api.Container{
 				{
 					Name:  containerName1,
-					Image: "gcr.io/google_containers/mounttest:0.4",
+					Image: "beta.gcr.io/google_containers/mounttest:0.4",
 					VolumeMounts: []api.VolumeMount{
 						{
 							Name:      volumeName,
@@ -145,7 +145,7 @@ func testPodWithHostVol(path string, source *api.HostPathVolumeSource) *api.Pod 
 				},
 				{
 					Name:  containerName2,
-					Image: "gcr.io/google_containers/mounttest:0.4",
+					Image: "beta.gcr.io/google_containers/mounttest:0.4",
 					VolumeMounts: []api.VolumeMount{
 						{
 							Name:      volumeName,

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -44,8 +44,8 @@ import (
 )
 
 const (
-	nautilusImage            = "gcr.io/google_containers/update-demo:nautilus"
-	kittenImage              = "gcr.io/google_containers/update-demo:kitten"
+	nautilusImage            = "beta.gcr.io/google_containers/update-demo:nautilus"
+	kittenImage              = "beta.gcr.io/google_containers/update-demo:kitten"
 	updateDemoSelector       = "name=update-demo"
 	updateDemoContainer      = "update-demo"
 	frontendSelector         = "name=frontend"

--- a/test/e2e/kubelet.go
+++ b/test/e2e/kubelet.go
@@ -130,7 +130,7 @@ var _ = Describe("kubelet", func() {
 					Client:    framework.Client,
 					Name:      rcName,
 					Namespace: framework.Namespace.Name,
-					Image:     "gcr.io/google_containers/pause:go",
+					Image:     "beta.gcr.io/google_containers/pause:go",
 					Replicas:  totalPods,
 				})).NotTo(HaveOccurred())
 				// Perform a sanity check so that we know all desired pods are

--- a/test/e2e/kubeproxy.go
+++ b/test/e2e/kubeproxy.go
@@ -46,7 +46,7 @@ const (
 	nodeHttpPort            = 32080
 	nodeUdpPort             = 32081
 	loadBalancerHttpPort    = 100
-	netexecImageName        = "gcr.io/google_containers/netexec:1.0"
+	netexecImageName        = "beta.gcr.io/google_containers/netexec:1.0"
 	testPodName             = "test-container-pod"
 	nodePortServiceName     = "node-port-service"
 	loadBalancerServiceName = "load-balancer-service"

--- a/test/e2e/load.go
+++ b/test/e2e/load.go
@@ -93,7 +93,7 @@ var _ = Describe("Load capacity", func() {
 	loadTests := []Load{
 		// The container will consume 1 cpu and 512mb of memory.
 		{podsPerNode: 3, image: "jess/stress", command: []string{"stress", "-c", "1", "-m", "2"}},
-		{podsPerNode: 30, image: "gcr.io/google_containers/serve_hostname:1.1"},
+		{podsPerNode: 30, image: "beta.gcr.io/google_containers/serve_hostname:1.1"},
 	}
 
 	for _, testArg := range loadTests {

--- a/test/e2e/networking.go
+++ b/test/e2e/networking.go
@@ -66,7 +66,7 @@ var _ = Describe("Networking", func() {
 				Containers: []api.Container{
 					{
 						Name:    contName,
-						Image:   "gcr.io/google_containers/busybox",
+						Image:   "beta.gcr.io/google_containers/busybox",
 						Command: []string{"wget", "-s", "google.com"},
 					},
 				},
@@ -267,7 +267,7 @@ func LaunchNetTestPodPerNode(f *Framework, nodes *api.NodeList, name, version st
 				Containers: []api.Container{
 					{
 						Name:  "webserver",
-						Image: "gcr.io/google_containers/nettest:" + version,
+						Image: "beta.gcr.io/google_containers/nettest:" + version,
 						Args: []string{
 							"-service=" + name,
 							//peers >= totalPods should be asserted by the container.

--- a/test/e2e/pd.go
+++ b/test/e2e/pd.go
@@ -394,7 +394,7 @@ func testPDPod(diskNames []string, targetHost string, readOnly bool, numContaine
 			containers[i].Name = fmt.Sprintf("mycontainer%v", i+1)
 		}
 
-		containers[i].Image = "gcr.io/google_containers/busybox"
+		containers[i].Image = "beta.gcr.io/google_containers/busybox"
 
 		containers[i].Command = []string{"sleep", "6000"}
 

--- a/test/e2e/persistent_volumes.go
+++ b/test/e2e/persistent_volumes.go
@@ -56,7 +56,7 @@ var _ = Describe("[Skipped] persistentVolumes", func() {
 		config := VolumeTestConfig{
 			namespace:   ns,
 			prefix:      "nfs",
-			serverImage: "gcr.io/google_containers/volume-nfs",
+			serverImage: "beta.gcr.io/google_containers/volume-nfs",
 			serverPorts: []int{2049},
 		}
 
@@ -174,7 +174,7 @@ func makeCheckPod(ns string, nfsserver string) *api.Pod {
 			Containers: []api.Container{
 				{
 					Name:    "scrub-checker",
-					Image:   "gcr.io/google_containers/busybox",
+					Image:   "beta.gcr.io/google_containers/busybox",
 					Command: []string{"/bin/sh"},
 					Args:    []string{"-c", "test ! -e /mnt/index.html || exit 1"},
 					VolumeMounts: []api.VolumeMount{

--- a/test/e2e/pods.go
+++ b/test/e2e/pods.go
@@ -142,7 +142,7 @@ var _ = Describe("Pods", func() {
 				Containers: []api.Container{
 					{
 						Name:  "test",
-						Image: "gcr.io/google_containers/pause",
+						Image: "beta.gcr.io/google_containers/pause",
 					},
 				},
 			},
@@ -167,7 +167,7 @@ var _ = Describe("Pods", func() {
 				Containers: []api.Container{
 					{
 						Name:  "nginx",
-						Image: "gcr.io/google_containers/pause",
+						Image: "beta.gcr.io/google_containers/pause",
 						Resources: api.ResourceRequirements{
 							Limits: api.ResourceList{
 								api.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),
@@ -204,7 +204,7 @@ var _ = Describe("Pods", func() {
 				Containers: []api.Container{
 					{
 						Name:  "nginx",
-						Image: "gcr.io/google_containers/nginx:1.7.9",
+						Image: "beta.gcr.io/google_containers/nginx:1.7.9",
 						Ports: []api.ContainerPort{{ContainerPort: 80}},
 						LivenessProbe: &api.Probe{
 							Handler: api.Handler{
@@ -312,7 +312,7 @@ var _ = Describe("Pods", func() {
 				Containers: []api.Container{
 					{
 						Name:  "nginx",
-						Image: "gcr.io/google_containers/nginx:1.7.9",
+						Image: "beta.gcr.io/google_containers/nginx:1.7.9",
 						Ports: []api.ContainerPort{{ContainerPort: 80}},
 						LivenessProbe: &api.Probe{
 							Handler: api.Handler{
@@ -389,7 +389,7 @@ var _ = Describe("Pods", func() {
 				Containers: []api.Container{
 					{
 						Name:  "srv",
-						Image: "gcr.io/google_containers/serve_hostname:1.1",
+						Image: "beta.gcr.io/google_containers/serve_hostname:1.1",
 						Ports: []api.ContainerPort{{ContainerPort: 9376}},
 					},
 				},
@@ -444,7 +444,7 @@ var _ = Describe("Pods", func() {
 				Containers: []api.Container{
 					{
 						Name:    "env3cont",
-						Image:   "gcr.io/google_containers/busybox",
+						Image:   "beta.gcr.io/google_containers/busybox",
 						Command: []string{"sh", "-c", "env"},
 					},
 				},
@@ -473,7 +473,7 @@ var _ = Describe("Pods", func() {
 				Containers: []api.Container{
 					{
 						Name:    "liveness",
-						Image:   "gcr.io/google_containers/busybox",
+						Image:   "beta.gcr.io/google_containers/busybox",
 						Command: []string{"/bin/sh", "-c", "echo ok >/tmp/health; sleep 10; rm -rf /tmp/health; sleep 600"},
 						LivenessProbe: &api.Probe{
 							Handler: api.Handler{
@@ -499,7 +499,7 @@ var _ = Describe("Pods", func() {
 				Containers: []api.Container{
 					{
 						Name:    "liveness",
-						Image:   "gcr.io/google_containers/busybox",
+						Image:   "beta.gcr.io/google_containers/busybox",
 						Command: []string{"/bin/sh", "-c", "echo ok >/tmp/health; sleep 600"},
 						LivenessProbe: &api.Probe{
 							Handler: api.Handler{
@@ -525,7 +525,7 @@ var _ = Describe("Pods", func() {
 				Containers: []api.Container{
 					{
 						Name:    "liveness",
-						Image:   "gcr.io/google_containers/liveness",
+						Image:   "beta.gcr.io/google_containers/liveness",
 						Command: []string{"/server"},
 						LivenessProbe: &api.Probe{
 							Handler: api.Handler{
@@ -552,7 +552,7 @@ var _ = Describe("Pods", func() {
 				Containers: []api.Container{
 					{
 						Name:    "liveness",
-						Image:   "gcr.io/google_containers/liveness",
+						Image:   "beta.gcr.io/google_containers/liveness",
 						Command: []string{"/server"},
 						LivenessProbe: &api.Probe{
 							Handler: api.Handler{
@@ -579,7 +579,7 @@ var _ = Describe("Pods", func() {
 				Containers: []api.Container{
 					{
 						Name:  "liveness",
-						Image: "gcr.io/google_containers/nettest:1.6",
+						Image: "beta.gcr.io/google_containers/nettest:1.6",
 						// These args are garbage but the image will exit if they're not there
 						// we just care about /read serving a 200, which it always does.
 						Args: []string{
@@ -631,7 +631,7 @@ var _ = Describe("Pods", func() {
 					Containers: []api.Container{
 						{
 							Name:  "nginx",
-							Image: "gcr.io/google_containers/nginx:1.7.9",
+							Image: "beta.gcr.io/google_containers/nginx:1.7.9",
 						},
 					},
 				},
@@ -703,7 +703,7 @@ var _ = Describe("Pods", func() {
 					Containers: []api.Container{
 						{
 							Name:  "nginx",
-							Image: "gcr.io/google_containers/nginx:1.7.9",
+							Image: "beta.gcr.io/google_containers/nginx:1.7.9",
 							Ports: []api.Port{{ContainerPort: 80}},
 						},
 					},

--- a/test/e2e/pre_stop.go
+++ b/test/e2e/pre_stop.go
@@ -43,7 +43,7 @@ func testPreStop(c *client.Client, ns string) {
 			Containers: []api.Container{
 				{
 					Name:  "server",
-					Image: "gcr.io/google_containers/nettest:1.6",
+					Image: "beta.gcr.io/google_containers/nettest:1.6",
 					Ports: []api.ContainerPort{{ContainerPort: 8080}},
 				},
 			},
@@ -76,7 +76,7 @@ func testPreStop(c *client.Client, ns string) {
 			Containers: []api.Container{
 				{
 					Name:    "tester",
-					Image:   "gcr.io/google_containers/busybox",
+					Image:   "beta.gcr.io/google_containers/busybox",
 					Command: []string{"sleep", "600"},
 					Lifecycle: &api.Lifecycle{
 						PreStop: &api.Handler{

--- a/test/e2e/proxy.go
+++ b/test/e2e/proxy.go
@@ -93,7 +93,7 @@ func proxyContext(version string) {
 		pods := []*api.Pod{}
 		cfg := RCConfig{
 			Client:       f.Client,
-			Image:        "gcr.io/google_containers/porter:59ad46ed2c56ba50fa7f1dc176c07c37",
+			Image:        "beta.gcr.io/google_containers/porter:59ad46ed2c56ba50fa7f1dc176c07c37",
 			Name:         service.Name,
 			Namespace:    f.Namespace.Name,
 			Replicas:     1,

--- a/test/e2e/rc.go
+++ b/test/e2e/rc.go
@@ -34,7 +34,7 @@ var _ = Describe("ReplicationController", func() {
 	framework := NewFramework("replication-controller")
 
 	It("should serve a basic image on each replica with a public image", func() {
-		ServeImageOrFail(framework, "basic", "gcr.io/google_containers/serve_hostname:1.1")
+		ServeImageOrFail(framework, "basic", "beta.gcr.io/google_containers/serve_hostname:1.1")
 	})
 
 	It("should serve a basic image on each replica with a private image", func() {

--- a/test/e2e/resize_nodes.go
+++ b/test/e2e/resize_nodes.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	serveHostnameImage        = "gcr.io/google_containers/serve_hostname:1.1"
+	serveHostnameImage        = "beta.gcr.io/google_containers/serve_hostname:1.1"
 	resizeNodeReadyTimeout    = 2 * time.Minute
 	resizeNodeNotReadyTimeout = 2 * time.Minute
 )

--- a/test/e2e/scheduler_predicates.go
+++ b/test/e2e/scheduler_predicates.go
@@ -208,7 +208,7 @@ var _ = Describe("SchedulerPredicates", func() {
 				Containers: []api.Container{
 					{
 						Name:  "",
-						Image: "gcr.io/google_containers/pause:go",
+						Image: "beta.gcr.io/google_containers/pause:go",
 					},
 				},
 			},
@@ -227,7 +227,7 @@ var _ = Describe("SchedulerPredicates", func() {
 				Containers: []api.Container{
 					{
 						Name:  podName,
-						Image: "gcr.io/google_containers/pause:go",
+						Image: "beta.gcr.io/google_containers/pause:go",
 					},
 				},
 			},
@@ -288,7 +288,7 @@ var _ = Describe("SchedulerPredicates", func() {
 				Containers: []api.Container{
 					{
 						Name:  "",
-						Image: "gcr.io/google_containers/pause:go",
+						Image: "beta.gcr.io/google_containers/pause:go",
 						Resources: api.ResourceRequirements{
 							Limits: api.ResourceList{
 								"cpu": *resource.NewMilliQuantity(milliCpuPerPod, "DecimalSI"),
@@ -312,7 +312,7 @@ var _ = Describe("SchedulerPredicates", func() {
 				Containers: []api.Container{
 					{
 						Name:  podName,
-						Image: "gcr.io/google_containers/pause:go",
+						Image: "beta.gcr.io/google_containers/pause:go",
 						Resources: api.ResourceRequirements{
 							Limits: api.ResourceList{
 								"cpu": *resource.NewMilliQuantity(milliCpuPerPod, "DecimalSI"),
@@ -354,7 +354,7 @@ var _ = Describe("SchedulerPredicates", func() {
 				Containers: []api.Container{
 					{
 						Name:  podName,
-						Image: "gcr.io/google_containers/pause:go",
+						Image: "beta.gcr.io/google_containers/pause:go",
 					},
 				},
 				NodeSelector: map[string]string{

--- a/test/e2e/secrets.go
+++ b/test/e2e/secrets.go
@@ -75,7 +75,7 @@ var _ = Describe("Secrets", func() {
 				Containers: []api.Container{
 					{
 						Name:  "secret-test",
-						Image: "gcr.io/google_containers/mounttest:0.2",
+						Image: "beta.gcr.io/google_containers/mounttest:0.2",
 						Args: []string{
 							"--file_content=/etc/secret-volume/data-1",
 							"--file_mode=/etc/secret-volume/data-1"},

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -1225,7 +1225,7 @@ func addEndpointPodOrFail(c *client.Client, ns, name string, labels map[string]s
 			Containers: []api.Container{
 				{
 					Name:  "test",
-					Image: "gcr.io/google_containers/pause",
+					Image: "beta.gcr.io/google_containers/pause",
 					Ports: containerPorts,
 				},
 			},
@@ -1382,7 +1382,7 @@ func startServeHostnameService(c *client.Client, ns, name string, port, replicas
 	maxContainerFailures := 0
 	config := RCConfig{
 		Client:               c,
-		Image:                "gcr.io/google_containers/serve_hostname:1.1",
+		Image:                "beta.gcr.io/google_containers/serve_hostname:1.1",
 		Name:                 name,
 		Namespace:            ns,
 		PollInterval:         3 * time.Second,
@@ -1524,7 +1524,7 @@ func NewWebserverTest(client *client.Client, namespace string, serviceName strin
 	t.services = make(map[string]bool)
 
 	t.name = "webserver"
-	t.image = "gcr.io/google_containers/test-webserver"
+	t.image = "beta.gcr.io/google_containers/test-webserver"
 
 	return t
 }

--- a/test/e2e/service_accounts.go
+++ b/test/e2e/service_accounts.go
@@ -67,14 +67,14 @@ var _ = Describe("ServiceAccounts", func() {
 				Containers: []api.Container{
 					{
 						Name:  "token-test",
-						Image: "gcr.io/google_containers/mounttest:0.2",
+						Image: "beta.gcr.io/google_containers/mounttest:0.2",
 						Args: []string{
 							fmt.Sprintf("--file_content=%s/%s", serviceaccount.DefaultAPITokenMountPath, api.ServiceAccountTokenKey),
 						},
 					},
 					{
 						Name:  "root-ca-test",
-						Image: "gcr.io/google_containers/mounttest:0.2",
+						Image: "beta.gcr.io/google_containers/mounttest:0.2",
 						Args: []string{
 							fmt.Sprintf("--file_content=%s/%s", serviceaccount.DefaultAPITokenMountPath, api.ServiceAccountRootCAKey),
 						},

--- a/test/e2e/service_latency.go
+++ b/test/e2e/service_latency.go
@@ -119,7 +119,7 @@ var _ = Describe("Service endpoints latency", func() {
 func runServiceLatencies(f *Framework, inParallel, total int) (output []time.Duration, err error) {
 	cfg := RCConfig{
 		Client:       f.Client,
-		Image:        "gcr.io/google_containers/pause:1.0",
+		Image:        "beta.gcr.io/google_containers/pause:1.0",
 		Name:         "svc-latency-rc",
 		Namespace:    f.Namespace.Name,
 		Replicas:     1,

--- a/test/e2e/volumes.go
+++ b/test/e2e/volumes.go
@@ -175,7 +175,7 @@ func testVolumeClient(client *client.Client, config VolumeTestConfig, volume api
 			Containers: []api.Container{
 				{
 					Name:  config.prefix + "-client",
-					Image: "gcr.io/google_containers/nginx:1.7.9",
+					Image: "beta.gcr.io/google_containers/nginx:1.7.9",
 					Ports: []api.ContainerPort{
 						{
 							Name:          "web",
@@ -254,7 +254,7 @@ var _ = Describe("Volumes", func() {
 			config := VolumeTestConfig{
 				namespace:   namespace.Name,
 				prefix:      "nfs",
-				serverImage: "gcr.io/google_containers/volume-nfs",
+				serverImage: "beta.gcr.io/google_containers/volume-nfs",
 				serverPorts: []int{2049},
 			}
 
@@ -291,7 +291,7 @@ var _ = Describe("Volumes", func() {
 			config := VolumeTestConfig{
 				namespace:   namespace.Name,
 				prefix:      "gluster",
-				serverImage: "gcr.io/google_containers/volume-gluster",
+				serverImage: "beta.gcr.io/google_containers/volume-gluster",
 				serverPorts: []int{24007, 24008, 49152},
 			}
 
@@ -371,7 +371,7 @@ var _ = Describe("Volumes", func() {
 			config := VolumeTestConfig{
 				namespace:   namespace.Name,
 				prefix:      "iscsi",
-				serverImage: "gcr.io/google_containers/volume-iscsi",
+				serverImage: "beta.gcr.io/google_containers/volume-iscsi",
 				serverPorts: []int{3260},
 				volumes: map[string]string{
 					// iSCSI container needs to insert modules from the host
@@ -417,7 +417,7 @@ var _ = Describe("Volumes", func() {
 			config := VolumeTestConfig{
 				namespace:   namespace.Name,
 				prefix:      "rbd",
-				serverImage: "gcr.io/google_containers/volume-rbd",
+				serverImage: "beta.gcr.io/google_containers/volume-rbd",
 				serverPorts: []int{6789},
 				volumes: map[string]string{
 					// iSCSI container needs to insert modules from the host
@@ -492,7 +492,7 @@ var _ = Describe("Volumes", func() {
 			config := VolumeTestConfig{
 				namespace:   namespace.Name,
 				prefix:      "cephfs",
-				serverImage: "gcr.io/google_containers/volume-ceph",
+				serverImage: "beta.gcr.io/google_containers/volume-ceph",
 				serverPorts: []int{6789},
 			}
 

--- a/test/images/dnsutils/Makefile
+++ b/test/images/dnsutils/Makefile
@@ -2,7 +2,7 @@ all:
 	@echo "try 'make image' or 'make push'"
 
 image:
-	docker build -t gcr.io/google_containers/dnsutils .
+	docker build -t beta.gcr.io/google_containers/dnsutils .
 
 push:
-	gcloud docker push gcr.io/google_containers/dnsutils
+	gcloud docker --server=beta.gcr.io push beta.gcr.io/google_containers/dnsutils

--- a/test/images/jessie-dnsutils/Makefile
+++ b/test/images/jessie-dnsutils/Makefile
@@ -2,7 +2,7 @@ all:
 	@echo "try 'make image' or 'make push'"
 
 image:
-	docker build -t gcr.io/google_containers/jessie-dnsutils .
+	docker build -t beta.gcr.io/google_containers/jessie-dnsutils .
 
 push:
-	gcloud docker push gcr.io/google_containers/jessie-dnsutils
+	gcloud docker --server=beta.gcr.io push beta.gcr.io/google_containers/jessie-dnsutils

--- a/test/images/mount-tester-user/Makefile
+++ b/test/images/mount-tester-user/Makefile
@@ -3,7 +3,7 @@ all: push
 TAG = 0.2
 
 image:
-	sudo docker build -t gcr.io/google_containers/mounttest-user:$(TAG) .
+	sudo docker build -t beta.gcr.io/google_containers/mounttest-user:$(TAG) .
 
 push: image
-	gcloud docker push gcr.io/google_containers/mounttest-user:$(TAG)
+	gcloud docker --server=beta.gcr.io push beta.gcr.io/google_containers/mounttest-user:$(TAG)

--- a/test/images/mount-tester/Makefile
+++ b/test/images/mount-tester/Makefile
@@ -6,10 +6,10 @@ mt: mt.go
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' ./mt.go
 
 image: mt
-	sudo docker build -t gcr.io/google_containers/mounttest:$(TAG) .
+	sudo docker build -t beta.gcr.io/google_containers/mounttest:$(TAG) .
 
 push: image
-	gcloud docker push gcr.io/google_containers/mounttest:$(TAG)
+	gcloud docker --server=beta.gcr.io push beta.gcr.io/google_containers/mounttest:$(TAG)
 
 clean:
 	rm -f mt

--- a/test/images/network-tester/Makefile
+++ b/test/images/network-tester/Makefile
@@ -7,10 +7,10 @@ webserver: webserver.go
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' ./webserver.go
 
 container: webserver
-	docker build -t gcr.io/google_containers/nettest:$(TAG) .
+	docker build -t beta.gcr.io/google_containers/nettest:$(TAG) .
 
 push: container
-	gcloud docker push gcr.io/google_containers/nettest:$(TAG)
+	gcloud docker --server=beta.gcr.io push beta.gcr.io/google_containers/nettest:$(TAG)
 
 clean:
 	rm -f webserver

--- a/test/images/network-tester/rc.json
+++ b/test/images/network-tester/rc.json
@@ -22,7 +22,7 @@
         "containers": [
           {
             "name": "webserver",
-            "image": "gcr.io/google_containers/nettest:1.6",
+            "image": "beta.gcr.io/google_containers/nettest:1.6",
             "imagePullPolicy": "Always",
             "args": [
               "-service=nettest",

--- a/test/images/network-tester/slow-pod.json
+++ b/test/images/network-tester/slow-pod.json
@@ -11,7 +11,7 @@
     "containers": [
       {
         "name": "webserver",
-        "image": "gcr.io/google_containers/nettest:1.5",
+        "image": "beta.gcr.io/google_containers/nettest:1.5",
         "args": [
           "-service=nettest",
           "-delay-shutdown=10"

--- a/test/images/network-tester/slow-rc.json
+++ b/test/images/network-tester/slow-rc.json
@@ -23,7 +23,7 @@
         "containers": [
           {
             "name": "webserver",
-            "image": "gcr.io/google_containers/nettest:1.5",
+            "image": "beta.gcr.io/google_containers/nettest:1.5",
             "args": [
               "-service=nettest",
               "-delay-shutdown=10"

--- a/test/images/porter/pod.json
+++ b/test/images/porter/pod.json
@@ -8,7 +8,7 @@
     "containers": [
       {
         "name": "porter",
-        "image": "gcr.io/google_containers/porter:59ad46ed2c56ba50fa7f1dc176c07c37",
+        "image": "beta.gcr.io/google_containers/porter:59ad46ed2c56ba50fa7f1dc176c07c37",
         "env": [
           {
             "name": "SERVE_PORT_80",

--- a/test/images/resource-consumer/Makefile
+++ b/test/images/resource-consumer/Makefile
@@ -7,7 +7,7 @@ consumer:
 	CGO_ENABLED=0 godep go build -a -installsuffix cgo --ldflags '-w' -o consumer .
 
 container:
-	sudo docker build -t gcr.io/google_containers/resource_consumer:$(TAG) .	
+	sudo docker build -t beta.gcr.io/google_containers/resource_consumer:$(TAG) .	
 
 run_container:
 	docker run --publish=8080:8080 gcr.io/google_containers/resource_consumer:$(TAG)

--- a/test/images/volumes-tester/gluster/Makefile
+++ b/test/images/volumes-tester/gluster/Makefile
@@ -3,11 +3,11 @@ all: push
 TAG = 0.2
 
 container:
-	docker build -t gcr.io/google_containers/volume-gluster . # Build new image and automatically tag it as latest
-	docker tag gcr.io/google_containers/volume-gluster gcr.io/google_containers/volume-gluster:$(TAG)  # Add the version tag to the latest image 
+	docker build -t beta.gcr.io/google_containers/volume-gluster . # Build new image and automatically tag it as latest
+	docker tag beta.gcr.io/google_containers/volume-gluster gcr.io/google_containers/volume-gluster:$(TAG)  # Add the version tag to the latest image 
 
 push: container
-	gcloud docker push gcr.io/google_containers/volume-gluster # Push image tagged as latest to repository
-	gcloud docker push gcr.io/google_containers/volume-gluster:$(TAG) # Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
+	gcloud docker --server=beta.gcr.io push beta.gcr.io/google_containers/volume-gluster # Push image tagged as latest to repository
+	gcloud docker --server=beta.gcr.io push beta.gcr.io/google_containers/volume-gluster:$(TAG) # Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
 
 clean:

--- a/test/images/volumes-tester/iscsi/Makefile
+++ b/test/images/volumes-tester/iscsi/Makefile
@@ -4,9 +4,9 @@ TAG = 0.1
 
 container:
 	# Build new image and automatically tag it as latest
-	docker build -t gcr.io/google_containers/volume-iscsi .
+	docker build -t beta.gcr.io/google_containers/volume-iscsi .
 	# Add the version tag to the latest image
-	docker tag gcr.io/google_containers/volume-iscsi gcr.io/google_containers/volume-iscsi:$(TAG)
+	docker tag beta.gcr.io/google_containers/volume-iscsi beta.gcr.io/google_containers/volume-iscsi:$(TAG)
 
 block:
 	# Create block.tar.gz with ext2 block device with index.html inside.
@@ -17,6 +17,6 @@ block:
 
 push: container
 	# Push image tagged as latest to repository
-	gcloud docker push gcr.io/google_containers/volume-iscsi
+	gcloud docker --server=beta.gcr.io push beta.gcr.io/google_containers/volume-iscsi
 	# Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
-	gcloud docker push gcr.io/google_containers/volume-iscsi:$(TAG)
+	gcloud docker --server=beta.gcr.io push beta.gcr.io/google_containers/volume-iscsi:$(TAG)

--- a/test/images/volumes-tester/nfs/Makefile
+++ b/test/images/volumes-tester/nfs/Makefile
@@ -3,11 +3,11 @@ all: push
 TAG = 0.3
 
 container:
-	docker build -t gcr.io/google_containers/volume-nfs . # Build new image and automatically tag it as latest
-	docker tag gcr.io/google_containers/volume-nfs gcr.io/google_containers/volume-nfs:$(TAG) # Add the version tag to the latest image 
+	docker build -t beta.gcr.io/google_containers/volume-nfs . # Build new image and automatically tag it as latest
+	docker tag beta.gcr.io/google_containers/volume-nfs beta.gcr.io/google_containers/volume-nfs:$(TAG) # Add the version tag to the latest image 
 
 push: container
-	gcloud docker push gcr.io/google_containers/volume-nfs # Push image tagged as latest to repository
-	gcloud docker push gcr.io/google_containers/volume-nfs:$(TAG) # Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
+	gcloud docker --server=beta.gcr.io push beta.gcr.io/google_containers/volume-nfs # Push image tagged as latest to repository
+	gcloud docker --server=beta.gcr.io push beta.gcr.io/google_containers/volume-nfs:$(TAG) # Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
 
 clean:

--- a/test/images/volumes-tester/rbd/Makefile
+++ b/test/images/volumes-tester/rbd/Makefile
@@ -4,9 +4,9 @@ TAG = 0.1
 
 container:
 	# Build new image and automatically tag it as latest
-	docker build -t gcr.io/google_containers/volume-rbd .
+	docker build -t beta.gcr.io/google_containers/volume-rbd .
 	# Add the version tag to the latest image 
-	docker tag gcr.io/google_containers/volume-rbd gcr.io/google_containers/volume-rbd:$(TAG)
+	docker tag beta.gcr.io/google_containers/volume-rbd beta.gcr.io/google_containers/volume-rbd:$(TAG)
 
 block:
 	# Create block.tar.gz with ext2 block device with index.html inside.
@@ -17,6 +17,6 @@ block:
 
 push: container
 	# Push image tagged as latest to repository
-	gcloud docker push gcr.io/google_containers/volume-rbd
+	gcloud docker --server=beta.gcr.io push beta.gcr.io/google_containers/volume-rbd
 	# Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
-	gcloud docker push gcr.io/google_containers/volume-rbd:$(TAG)
+	gcloud docker --server=beta.gcr.io push beta.gcr.io/google_containers/volume-rbd:$(TAG)

--- a/test/soak/cauldron/cauldron.go
+++ b/test/soak/cauldron/cauldron.go
@@ -179,7 +179,7 @@ func main() {
 						Containers: []api.Container{
 							{
 								Name:  "serve-hostname",
-								Image: "gcr.io/google_containers/serve_hostname:1.1",
+								Image: "beta.gcr.io/google_containers/serve_hostname:1.1",
 								Ports: []api.ContainerPort{{ContainerPort: 9376}},
 							},
 						},

--- a/test/soak/serve_hostnames/serve_hostnames.go
+++ b/test/soak/serve_hostnames/serve_hostnames.go
@@ -200,7 +200,7 @@ func main() {
 						Containers: []api.Container{
 							{
 								Name:  "serve-hostname",
-								Image: "gcr.io/google_containers/serve_hostname:1.1",
+								Image: "beta.gcr.io/google_containers/serve_hostname:1.1",
 								Ports: []api.ContainerPort{{ContainerPort: 9376}},
 							},
 						},


### PR DESCRIPTION
This change migrates all of the "build", "tag" and "push"
logic (google-containers only) to use `beta.gcr.io`, which activates GCR's
support for the Registry v2 API.

This also changes most other references throughout the codebase (I
avoided docs and examples).

NOTE: `beta.gcr.io` will still serve images using v1 until they are repushed with v2.  Pulls through `gcr.io` will still work after pushing through `beta.gcr.io`, but will be served over v1 (via compat logic).
