### PR TITLE
Unrevert #14608 and decrease the latency of GCE load balancer deletions

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -387,32 +387,32 @@ func (gce *GCECloud) EnsureTCPLoadBalancer(name, region string, loadBalancerIP n
 		}
 		if !exists {
 			// Note, though static addresses that _aren't_ in use cost money, ones that _are_ in use don't.
-			// However, quota is limited.  TODO: determine quota here
+			// However, quota is limited to only 7 addresses per region by default.
 			op, err := gce.service.Addresses.Insert(gce.projectID, region, &compute.Address{Name: name}).Do()
 			if err != nil {
-				return nil, fmt.Errorf("error creating gce address: %v", err)
+				return nil, fmt.Errorf("error creating gce static IP address: %v", err)
 			}
 			if err := gce.waitForRegionOp(op, region); err != nil {
-				return nil, fmt.Errorf("error waiting for gce address to complete: %v", err)
+				return nil, fmt.Errorf("error waiting for gce static IP address to complete: %v", err)
 			}
 			address, exists, err = gce.getAddress(name, region)
 			if err != nil {
-				return nil, fmt.Errorf("error re-getting gce address: %v", err)
+				return nil, fmt.Errorf("error re-getting gce static IP address: %v", err)
 			}
 			if !exists {
-				return nil, fmt.Errorf("failed to re-get gce address for %s", name)
+				return nil, fmt.Errorf("failed to re-get gce static IP address for %s", name)
 			}
 		}
 		if loadBalancerIP = net.ParseIP(address); loadBalancerIP == nil {
-			return nil, fmt.Errorf("error parsing external IP: %s", address)
+			return nil, fmt.Errorf("error parsing gce static IP address: %s", address)
 		}
 	} else {
 		addresses, err := gce.service.Addresses.List(gce.projectID, region).Do()
 		if err != nil {
-			return nil, fmt.Errorf("failed to list gce addresses: %v", err)
+			return nil, fmt.Errorf("failed to list gce IP addresses: %v", err)
 		}
 		if !ownsAddress(loadBalancerIP, addresses.Items) {
-			return nil, fmt.Errorf("don't own the address: %s", loadBalancerIP.String())
+			return nil, fmt.Errorf("this gce project don't own the IP address: %s", loadBalancerIP.String())
 		}
 	}
 
@@ -458,9 +458,6 @@ func (gce *GCECloud) EnsureTCPLoadBalancer(name, region string, loadBalancerIP n
 		IPProtocol: "TCP",
 		PortRange:  fmt.Sprintf("%d-%d", minPort, maxPort),
 		Target:     gce.targetPoolURL(name, region),
-	}
-	if loadBalancerIP != nil {
-		req.IPAddress = loadBalancerIP.String()
 	}
 
 	op, err := gce.service.ForwardingRules.Insert(gce.projectID, region, req).Do()
@@ -616,9 +613,23 @@ func (gce *GCECloud) UpdateTCPLoadBalancer(name, region string, hosts []string) 
 
 // EnsureTCPLoadBalancerDeleted is an implementation of TCPLoadBalancer.EnsureTCPLoadBalancerDeleted.
 func (gce *GCECloud) EnsureTCPLoadBalancerDeleted(name, region string) error {
-	op, err := gce.service.ForwardingRules.Delete(gce.projectID, region, name).Do()
+	fwName := makeFirewallName(name)
+	op, err := gce.service.Firewalls.Delete(gce.projectID, fwName).Do()
 	if err != nil && isHTTPErrorCode(err, http.StatusNotFound) {
-		glog.Infof("Forwarding rule %s already deleted. Continuing to delete target pool.", name)
+		glog.Infof("Firewall %s already deleted. Moving on to delete forwarding rule.", name)
+	} else if err != nil {
+		glog.Warningf("Failed to delete firewall %s, got error %v", fwName, err)
+		return err
+	} else {
+		if err = gce.waitForGlobalOp(op); err != nil {
+			glog.Warningf("Failed waiting for Firewall %s to be deleted.  Got error: %v", fwName, err)
+			return err
+		}
+	}
+
+	op, err = gce.service.ForwardingRules.Delete(gce.projectID, region, name).Do()
+	if err != nil && isHTTPErrorCode(err, http.StatusNotFound) {
+		glog.Infof("Forwarding rule %s already deleted. Moving on to delete target pool.", name)
 	} else if err != nil {
 		glog.Warningf("Failed to delete Forwarding Rules %s: got error %s.", name, err.Error())
 		return err
@@ -630,44 +641,33 @@ func (gce *GCECloud) EnsureTCPLoadBalancerDeleted(name, region string) error {
 		}
 	}
 
-	op, err = gce.service.Addresses.Delete(gce.projectID, region, name).Do()
-	if err != nil && isHTTPErrorCode(err, http.StatusNotFound) {
-		glog.Infof("Address %s is already deleted.", name)
-	} else if err != nil {
-		glog.Warningf("Failed to delete Address %s, got error %v", name, err)
-		return err
-	}
-	if err := gce.waitForRegionOp(op, region); err != nil {
-		glog.Warningf("Failed waiting for address %s to be deleted, got error: %v", name, err)
-		return err
-	}
-
 	op, err = gce.service.TargetPools.Delete(gce.projectID, region, name).Do()
 	if err != nil && isHTTPErrorCode(err, http.StatusNotFound) {
-		glog.Infof("Target pool %s already deleted.", name)
-		return nil
+		glog.Infof("Target pool %s already deleted. Moving on to delete static IP address.", name)
 	} else if err != nil {
 		glog.Warningf("Failed to delete Target Pool %s, got error %s.", name, err.Error())
 		return err
-	}
-	err = gce.waitForRegionOp(op, region)
-	if err != nil {
-		glog.Warningf("Failed waiting for Target Pool %s to be deleted: got error %s.", name, err.Error())
-	}
-	fwName := makeFirewallName(name)
-	op, err = gce.service.Firewalls.Delete(gce.projectID, fwName).Do()
-	if err != nil && isHTTPErrorCode(err, http.StatusNotFound) {
-		glog.Infof("Firewall doesn't exist, moving on to deleting target pool.")
-	} else if err != nil {
-		glog.Warningf("Failed to delete firewall %s, got error %v", fwName, err)
-		return err
 	} else {
-		if err = gce.waitForGlobalOp(op); err != nil {
-			glog.Warningf("Failed waiting for Firewall %s to be deleted.  Got error: %v", fwName, err)
+		if err := gce.waitForRegionOp(op, region); err != nil {
+			glog.Warningf("Failed waiting for Target Pool %s to be deleted: got error %s.", name, err.Error())
 			return err
 		}
 	}
-	return err
+
+	op, err = gce.service.Addresses.Delete(gce.projectID, region, name).Do()
+	if err != nil && isHTTPErrorCode(err, http.StatusNotFound) {
+		glog.Infof("Static IP address %s already deleted. Done deleting load balancer.", name)
+	} else if err != nil {
+		glog.Warningf("Failed to delete static IP Address %s, got error %v", name, err)
+		return err
+	} else {
+		if err := gce.waitForRegionOp(op, region); err != nil {
+			glog.Warningf("Failed waiting for address %s to be deleted, got error: %v", name, err)
+			return err
+		}
+	}
+
+	return nil
 }
 
 // UrlMap management

--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -349,6 +349,27 @@ func makeFirewallName(name string) string {
 	return fmt.Sprintf("k8s-fw-%s", name)
 }
 
+func (gce *GCECloud) getAddress(name, region string) (string, bool, error) {
+	address, err := gce.service.Addresses.Get(gce.projectID, region, name).Do()
+	if err == nil {
+		return address.Address, true, nil
+	}
+	if isHTTPErrorCode(err, http.StatusNotFound) {
+		return "", false, nil
+	}
+	return "", false, err
+}
+
+func ownsAddress(ip net.IP, addrs []*compute.Address) bool {
+	ipStr := ip.String()
+	for _, addr := range addrs {
+		if addr.Address == ipStr {
+			return true
+		}
+	}
+	return false
+}
+
 // EnsureTCPLoadBalancer is an implementation of TCPLoadBalancer.EnsureTCPLoadBalancer.
 // TODO(a-robinson): Don't just ignore specified IP addresses. Check if they're
 // owned by the project and available to be used, and use them if they are.
@@ -358,6 +379,44 @@ func (gce *GCECloud) EnsureTCPLoadBalancer(name, region string, loadBalancerIP n
 	}
 
 	glog.V(2).Infof("Checking if load balancer already exists: %s", name)
+	if loadBalancerIP == nil {
+		glog.V(2).Info("Checking if the external ip address already exists: %s", name)
+		address, exists, err := gce.getAddress(name, region)
+		if err != nil {
+			return nil, fmt.Errorf("error looking for gce address: %v", err)
+		}
+		if !exists {
+			// Note, though static addresses that _aren't_ in use cost money, ones that _are_ in use don't.
+			// However, quota is limited.  TODO: determine quota here
+			op, err := gce.service.Addresses.Insert(gce.projectID, region, &compute.Address{Name: name}).Do()
+			if err != nil {
+				return nil, fmt.Errorf("error creating gce address: %v", err)
+			}
+			if err := gce.waitForRegionOp(op, region); err != nil {
+				return nil, fmt.Errorf("error waiting for gce address to complete: %v", err)
+			}
+			address, exists, err = gce.getAddress(name, region)
+			if err != nil {
+				return nil, fmt.Errorf("error re-getting gce address: %v", err)
+			}
+			if !exists {
+				return nil, fmt.Errorf("failed to re-get gce address for %s", name)
+			}
+		}
+		if loadBalancerIP = net.ParseIP(address); loadBalancerIP == nil {
+			return nil, fmt.Errorf("error parsing external IP: %s", address)
+		}
+	} else {
+		addresses, err := gce.service.Addresses.List(gce.projectID, region).Do()
+		if err != nil {
+			return nil, fmt.Errorf("failed to list gce addresses: %v", err)
+		}
+		if !ownsAddress(loadBalancerIP, addresses.Items) {
+			return nil, fmt.Errorf("don't own the address: %s", loadBalancerIP.String())
+		}
+	}
+
+	glog.V(2).Info("Checking if load balancer already exists: %s", name)
 	_, exists, err := gce.GetTCPLoadBalancer(name, region)
 	if err != nil {
 		return nil, fmt.Errorf("error checking if GCE load balancer already exists: %v", err)
@@ -395,6 +454,7 @@ func (gce *GCECloud) EnsureTCPLoadBalancer(name, region string, loadBalancerIP n
 	}
 	req := &compute.ForwardingRule{
 		Name:       name,
+		IPAddress:  loadBalancerIP.String(),
 		IPProtocol: "TCP",
 		PortRange:  fmt.Sprintf("%d-%d", minPort, maxPort),
 		Target:     gce.targetPoolURL(name, region),
@@ -569,6 +629,19 @@ func (gce *GCECloud) EnsureTCPLoadBalancerDeleted(name, region string) error {
 			return err
 		}
 	}
+
+	op, err = gce.service.Addresses.Delete(gce.projectID, region, name).Do()
+	if err != nil && isHTTPErrorCode(err, http.StatusNotFound) {
+		glog.Infof("Address %s is already deleted.", name)
+	} else if err != nil {
+		glog.Warningf("Failed to delete Address %s, got error %v", name, err)
+		return err
+	}
+	if err := gce.waitForRegionOp(op, region); err != nil {
+		glog.Warningf("Failed waiting for address %s to be deleted, got error: %v", name, err)
+		return err
+	}
+
 	op, err = gce.service.TargetPools.Delete(gce.projectID, region, name).Do()
 	if err != nil && isHTTPErrorCode(err, http.StatusNotFound) {
 		glog.Infof("Target pool %s already deleted.", name)

--- a/pkg/cloudprovider/providers/gce/gce_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_test.go
@@ -17,8 +17,67 @@ limitations under the License.
 package gce_cloud
 
 import (
+	"net"
 	"testing"
+
+	compute "google.golang.org/api/compute/v1"
 )
+
+func TestOwnsAddress(t *testing.T) {
+	tests := []struct {
+		ip        net.IP
+		addrs     []*compute.Address
+		expectOwn bool
+	}{
+		{
+			ip:        net.ParseIP("1.2.3.4"),
+			addrs:     []*compute.Address{},
+			expectOwn: false,
+		},
+		{
+			ip: net.ParseIP("1.2.3.4"),
+			addrs: []*compute.Address{
+				{Address: "2.3.4.5"},
+				{Address: "2.3.4.6"},
+				{Address: "2.3.4.7"},
+			},
+			expectOwn: false,
+		},
+		{
+			ip: net.ParseIP("2.3.4.5"),
+			addrs: []*compute.Address{
+				{Address: "2.3.4.5"},
+				{Address: "2.3.4.6"},
+				{Address: "2.3.4.7"},
+			},
+			expectOwn: true,
+		},
+		{
+			ip: net.ParseIP("2.3.4.6"),
+			addrs: []*compute.Address{
+				{Address: "2.3.4.5"},
+				{Address: "2.3.4.6"},
+				{Address: "2.3.4.7"},
+			},
+			expectOwn: true,
+		},
+		{
+			ip: net.ParseIP("2.3.4.7"),
+			addrs: []*compute.Address{
+				{Address: "2.3.4.5"},
+				{Address: "2.3.4.6"},
+				{Address: "2.3.4.7"},
+			},
+			expectOwn: true,
+		},
+	}
+	for _, test := range tests {
+		own := ownsAddress(test.ip, test.addrs)
+		if own != test.expectOwn {
+			t.Errorf("expected: %v, got %v for %v", test.expectOwn, own, test)
+		}
+	}
+}
 
 func TestGetRegion(t *testing.T) {
 	gce := &GCECloud{

--- a/pkg/util/errors/errors_test.go
+++ b/pkg/util/errors/errors_test.go
@@ -221,3 +221,66 @@ func TestFlatten(t *testing.T) {
 		}
 	}
 }
+
+func TestAggregateGoroutines(t *testing.T) {
+	testCases := []struct {
+		errs     []error
+		expected map[string]bool // can't compare directly to Aggregate due to non-deterministic ordering
+	}{
+		{
+			[]error{},
+			nil,
+		},
+		{
+			[]error{nil},
+			nil,
+		},
+		{
+			[]error{nil, nil},
+			nil,
+		},
+		{
+			[]error{fmt.Errorf("1")},
+			map[string]bool{"1": true},
+		},
+		{
+			[]error{fmt.Errorf("1"), nil},
+			map[string]bool{"1": true},
+		},
+		{
+			[]error{fmt.Errorf("1"), fmt.Errorf("267")},
+			map[string]bool{"1": true, "267": true},
+		},
+		{
+			[]error{fmt.Errorf("1"), nil, fmt.Errorf("1234")},
+			map[string]bool{"1": true, "1234": true},
+		},
+		{
+			[]error{nil, fmt.Errorf("1"), nil, fmt.Errorf("1234"), fmt.Errorf("22")},
+			map[string]bool{"1": true, "1234": true, "22": true},
+		},
+	}
+	for i, testCase := range testCases {
+		funcs := make([]func() error, len(testCase.errs))
+		for i := range testCase.errs {
+			err := testCase.errs[i]
+			funcs[i] = func() error { return err }
+		}
+		agg := AggregateGoroutines(funcs...)
+		if agg == nil {
+			if len(testCase.expected) > 0 {
+				t.Errorf("%d: expected %v, got nil", i, testCase.expected)
+			}
+			continue
+		}
+		if len(agg.Errors()) != len(testCase.expected) {
+			t.Errorf("%d: expected %d errors in aggregate, got %v", i, len(testCase.expected), agg)
+			continue
+		}
+		for _, err := range agg.Errors() {
+			if !testCase.expected[err.Error()] {
+				t.Errorf("%d: expected %v, got aggregate containing %v", i, testCase.expected, err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This shouldn't be merged until my many requests for increased GCE static IP quota are filled, but I'm getting it out now so that it's ready once that happens.

As discussed in #14597, having load balancers use static IPs led to much greater static IP usage as well as leaks, since the IPs are deleted after everything else (meaning that if a target pool leaks, the IP is guaranteed to be leaked as well).

In addition to unreverting the original static IP change, this PR adds a utility function for running goroutines in parallel and coalescing the errors into the existing Aggregate type, then uses that function to delete the load balancer resources with as much parallelism as GCE's API allows. This should make it less likely that a master will still be waiting on resources to be deleted when it's torn down by jenkins.

We'd probably also find this pattern useful for decreasing the latency of LB creations, but that's less immediately necessary. If you don't think it's insane, I'll send that out separately after this.

@thockin @brendandburns @cjcullen 
