### PR TITLE
Move the hooks section to the commit section.

### DIFF
--- a/docs/devel/development.md
+++ b/docs/devel/development.md
@@ -89,6 +89,16 @@ git remote set-url --push upstream no_push
 
 ### Committing changes to your fork
 
+Before committing any changes, please link/copy these pre-commit hooks into your .git
+directory. This will keep you from accidentally committing non-gofmt'd go code.
+
+```sh
+cd kubernetes/.git/hooks/
+ln -s ../../hooks/pre-commit .
+```
+
+Then you can commit your changes and push them to your fork:
+
 ```sh
 git commit
 git push -f origin myfeature
@@ -202,16 +212,6 @@ updated by godeps.  It then may be necessary to perform a `godep save ./...` to 
 It is sometimes expedient to manually fix the /Godeps/godeps.json file to minimize the changes.
 
 Please send dependency updates in separate commits within your PR, for easier reviewing.
-
-## Hooks
-
-Before committing any changes, please link/copy these hooks into your .git
-directory. This will keep you from accidentally committing non-gofmt'd go code.
-
-```sh
-cd kubernetes/.git/hooks/
-ln -s ../../hooks/pre-commit .
-```
 
 ## Unit tests
 


### PR DESCRIPTION
It doesn't make much sense to have a separate section for hooks right now
because we only have a pre-commit hook at the moment and we should have it
setup before making the first commit. We can probably create a separate
section for hooks again when we have other types of hooks.
