### PR TITLE
fix label selector parser in case no value (or only whitespaces) is specified after the key

### DIFF
--- a/pkg/labels/selector.go
+++ b/pkg/labels/selector.go
@@ -600,7 +600,12 @@ func (p *Parser) parseIdentifiersList() (sets.String, error) {
 // parseExactValue parses the only value for exact match style
 func (p *Parser) parseExactValue() (sets.String, error) {
 	s := sets.NewString()
-	tok, lit := p.consume(Values)
+	tok, lit := p.lookahead(Values)
+	if tok == EndOfStringToken || tok == CommaToken {
+		s.Insert("")
+		return s, nil
+	}
+	tok, lit = p.consume(Values)
 	if tok == IdentifierToken {
 		s.Insert(lit)
 		return s, nil

--- a/pkg/labels/selector_test.go
+++ b/pkg/labels/selector_test.go
@@ -29,6 +29,10 @@ func TestSelectorParse(t *testing.T) {
 		"x=a,y=b,z=c",
 		"",
 		"x!=a,y=b",
+		"x=",
+		"x= ",
+		"x=,z= ",
+		"x= ,z= ",
 	}
 	testBadStrings := []string{
 		"x=a||y=b",
@@ -39,7 +43,7 @@ func TestSelectorParse(t *testing.T) {
 		if err != nil {
 			t.Errorf("%v: error %v (%#v)\n", test, err, err)
 		}
-		if test != lq.String() {
+		if strings.Replace(test, " ", "", -1) != lq.String() {
 			t.Errorf("%v restring gave: %v\n", test, lq.String())
 		}
 	}


### PR DESCRIPTION
fix #14622.

Now it will return an empty list if one visits

```
https://xx.xx.xx.xx/api/v1/namespaces/default/replicationcontrollers?labelSelector=environment%3D
```

or 3D+ or 3D%20

@bronger @lavalamp @brendandburns 
