### PR TITLE
fix the title of the operations.html

### DIFF
--- a/hack/gen-swagger-doc/gen-swagger-docs.sh
+++ b/hack/gen-swagger-doc/gen-swagger-docs.sh
@@ -51,6 +51,9 @@ sed -i -e 's|<<\(.*\)\.\(.*\)>>|link:definitions.html#_\L\1_\2\E[\1.\2]|g' ./pat
 sed -i -e 's|<<any>>|link:#_any[any]|g' ./definitions.adoc
 sed -i -e 's|<<any>>|link:definitions.html#_any[any]|g' ./paths.adoc
 
+# change the title of paths.adoc from "paths" to "operations"
+sed -i 's|== Paths|== Operations|g' ./paths.adoc
+
 echo -e "=== any\nRepresents an untyped JSON map - see the description of the field for more info about the structure of this object." >> ./definitions.adoc
 
 asciidoctor definitions.adoc

--- a/hack/gen-swagger-doc/run-gen-swagger-docs.sh
+++ b/hack/gen-swagger-doc/run-gen-swagger-docs.sh
@@ -20,5 +20,4 @@ if [ "$#" -lt 1 ]; then
 fi
 OUTPUT=${2:-${PWD}}
 
-docker run -v ${OUTPUT}:/output gcr.io/google_containers/gen-swagger-docs:v1 https://raw.githubusercontent.com/kubernetes/kubernetes/master/api/swagger-spec/$1.json https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/api/$1/register.go
-
+docker run -v ${OUTPUT}:/output gcr.io/google_containers/gen-swagger-docs:v1.1 https://raw.githubusercontent.com/kubernetes/kubernetes/master/api/swagger-spec/$1.json https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/api/$1/register.go


### PR DESCRIPTION
@RichieEscarez you raised an issue on the title of docs/api-reference/operations.html is "paths" rather than "operations". ([here](https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/blob/master/docs/api-reference/operations.html))

I couldn't find the exact issue number. Anyway, this PR fixes that, and I have pushed a v1.1 image to gcr.io.

@nikhiljindal @RichieEscarez 
