### PR TITLE
Enabling deployments on kubernernetes-upgrade-gce test suite

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -602,6 +602,7 @@ case ${JOB_NAME} in
     : ${E2E_UP:="true"}
     : ${E2E_TEST:="false"}
     : ${E2E_DOWN:="false"}
+    : ${ENABLE_DEPLOYMENTS:=true}
     NUM_MINIONS=3
     ;;
 

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1585,7 +1585,7 @@ func waitForRCPodsGone(c *client.Client, rc *api.ReplicationController) error {
 // Waits for the deployment to reach desired state.
 // Returns an error if minAvailable or maxCreated is broken at any times.
 func waitForDeploymentStatus(c *client.Client, ns, deploymentName string, desiredUpdatedReplicas, minAvailable, maxCreated int) error {
-	return wait.Poll(poll, 2*time.Minute, func() (bool, error) {
+	return wait.Poll(poll, 5*time.Minute, func() (bool, error) {
 
 		deployment, err := c.Deployments(ns).Get(deploymentName)
 		if err != nil {


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/15038

Deployment e2e is broken on kubernetes-upgrade-gce as we did not enable deployments in that test suite (https://github.com/kubernetes/kubernetes/pull/14594)
The test suite was added in https://github.com/kubernetes/kubernetes/pull/14673.

Also fixing a bug due to which the second case was not failing.
