### PR TITLE
examples/vitess: Update for Vitess v2.0.0-alpha3

### DIFF
--- a/examples/vitess/guestbook-controller.yaml
+++ b/examples/vitess/guestbook-controller.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
         - name: guestbook
-          image: vitess/guestbook:v2.0
+          image: vitess/guestbook:v2.0.0-alpha3
           ports:
             - name: http-server
               containerPort: 8080

--- a/examples/vitess/vtctld-controller.yaml
+++ b/examples/vitess/vtctld-controller.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
         - name: vtctld
-          image: vitess/lite:v2.0
+          image: vitess/lite:v2.0.0-alpha3
           volumeMounts:
             - name: syslog
               mountPath: /dev/log
@@ -35,8 +35,10 @@ spec:
               -log_dir $VTDATAROOT/tmp
               -alsologtostderr
               -port 15000
+              -service_map 'bsonrpc-vt-vtctl'
               -topo_implementation etcd
               -tablet_protocol grpc
+              -tablet_manager_protocol grpc
               -etcd_global_addrs http://$ETCD_GLOBAL_SERVICE_HOST:$ETCD_GLOBAL_SERVICE_PORT" vitess
       volumes:
         - name: syslog

--- a/examples/vitess/vtgate-controller-template.yaml
+++ b/examples/vitess/vtgate-controller-template.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
         - name: vtgate
-          image: vitess/lite:v2.0
+          image: vitess/lite:v2.0.0-alpha3
           volumeMounts:
             - name: syslog
               mountPath: /dev/log
@@ -35,6 +35,7 @@ spec:
               -alsologtostderr
               -port 15001
               -tablet_protocol grpc
+              -service_map 'bsonrpc-vt-vtgateservice'
               -cell test" vitess
       volumes:
         - name: syslog

--- a/examples/vitess/vttablet-pod-template.yaml
+++ b/examples/vitess/vttablet-pod-template.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   containers:
     - name: vttablet
-      image: vitess/lite:v2.0
+      image: vitess/lite:v2.0.0-alpha3
       volumeMounts:
         - name: syslog
           mountPath: /dev/log
@@ -48,7 +48,8 @@ spec:
           -alsologtostderr
           -port {{port}}
           -grpc_port {{grpc_port}}
-          -service_map 'grpc-queryservice'
+          -service_map 'grpc-queryservice,grpc-tabletmanager,grpc-updatestream'
+          -binlog_player_protocol grpc
           -tablet-path {{alias}}
           -tablet_hostname $(hostname -i)
           -init_keyspace {{keyspace}}
@@ -71,7 +72,7 @@ spec:
           -rowcache-bin /usr/bin/memcached
           -rowcache-socket $VTDATAROOT/{{tablet_subdir}}/memcache.sock" vitess
     - name: mysql
-      image: vitess/lite:v2.0
+      image: vitess/lite:v2.0.0-alpha3
       volumeMounts:
         - name: syslog
           mountPath: /dev/log


### PR DESCRIPTION
Also pin the images on a specific version, since breaking changes are
still possible during alpha.
