### PR TITLE
Add ingress to kubectl-overview

### DIFF
--- a/docs/user-guide/kubectl-overview.md
+++ b/docs/user-guide/kubectl-overview.md
@@ -186,6 +186,7 @@ resourcequotas	|	quota
 replicationcontrollers	|	rc
 daemonsets	|	ds
 services	|	svc
+ingress		|	ing
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->
 [![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/user-guide/kubectl-overview.md?pixel)]()


### PR DESCRIPTION
I noticed that there is a newly added resource type `ingress`, so add ingress to `kubectl-overview.md`.

Please see `pkg/kubectl/kubectl.go` for short forms of different resource types:

``` go
    shortForms := map[string]string{
                ... ...
        "svc":    "services",
        "ing":    "ingress",
    }
```

TODO: auto-generate this file to stay up with `kubectl` changes. Please see [#14177](https://github.com/kubernetes/kubernetes/pull/14177).
