### PR TITLE
Tweak limits for system pods in manifest files.

### DIFF
--- a/cluster/saltbase/salt/etcd/etcd.manifest
+++ b/cluster/saltbase/salt/etcd/etcd.manifest
@@ -13,10 +13,7 @@
     "image": "gcr.io/google_containers/etcd:2.0.12",
     "resources": {
       "limits": {
-        "cpu": "200m"
-      },
-      "requests": {
-        "cpu": "100m"
+        "cpu": {{ cpulimit }}
       }
     },
     "command": [

--- a/cluster/saltbase/salt/etcd/init.sls
+++ b/cluster/saltbase/salt/etcd/init.sls
@@ -65,6 +65,7 @@ touch /var/log/etcd-events.log:
         suffix: ""
         port: 4001
         server_port: 2380
+        cpulimit: '"200m"'
 
 /etc/kubernetes/manifests/etcd-events.manifest:
   file.managed:
@@ -79,3 +80,4 @@ touch /var/log/etcd-events.log:
         suffix: "-events"
         port: 4002
         server_port: 2381
+        cpulimit: '"100m"'

--- a/cluster/saltbase/salt/kube-apiserver/kube-apiserver.manifest
+++ b/cluster/saltbase/salt/kube-apiserver/kube-apiserver.manifest
@@ -111,7 +111,7 @@
     "image": "gcr.io/google_containers/kube-apiserver:{{pillar['kube-apiserver_docker_tag']}}",
     "resources": {
       "limits": {
-        "cpu": "200m"
+        "cpu": "250m"
       }
     },
     "command": [

--- a/cluster/saltbase/salt/kube-scheduler/kube-scheduler.manifest
+++ b/cluster/saltbase/salt/kube-scheduler/kube-scheduler.manifest
@@ -24,7 +24,7 @@
     "image": "gcr.io/google_containers/kube-scheduler:{{pillar['kube-scheduler_docker_tag']}}",
     "resources": {
       "limits": {
-        "cpu": "200m"
+        "cpu": "100m"
       }
     },
     "command": [


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/14994 introduced visible regression in scalability tests (and it was expected)

This PR is restoring it.

[It's still not idea, but my experiments show that it's strictly better than without this change].

@dchen1107 @lavalamp @ArtfulCoder @mikedanese @brendandburns 
