### PR TITLE
AWS: Log the distro when we don't recognize it

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -244,7 +244,7 @@ case "${KUBE_OS_DISTRIBUTION}" in
     detect-jessie-image
     ;;
   *)
-    echo "Please specify AWS_IMAGE directly (distro not recognized)"
+    echo "Please specify AWS_IMAGE directly (distro ${KUBE_OS_DISTRIBUTION} not recognized)"
     exit 2
     ;;
 esac


### PR DESCRIPTION
Similar to #15070, we should log the distro if we're going to tell the
user we can't match it (so the user can see if they have typoed it, and
so it will hopefully be included to us in error reports)
