### PR TITLE
Bumbed Heapster to v0.18.2 and changed its config

### DIFF
--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -1,26 +1,26 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: heapster-v9
+  name: heapster-v10
   namespace: kube-system
   labels:
     k8s-app: heapster
-    version: v9
+    version: v10
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 1
   selector:
     k8s-app: heapster
-    version: v9
+    version: v10
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v9
+        version: v10
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v0.18.1
+        - image: gcr.io/google_containers/heapster:v0.18.2
           name: heapster
           resources:
             limits:
@@ -32,7 +32,8 @@ spec:
             - --sink=gcm
             - --sink=gcmautoscaling
             - --sink=gcl
-            - --sink_frequency=2m
+            - --stats_resolution=30s
+            - --sink_frequency=1m
           volumeMounts:
             - name: ssl-certs
               mountPath: /etc/ssl/certs

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -1,26 +1,26 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: heapster-v9
+  name: heapster-v10
   namespace: kube-system
   labels:
     k8s-app: heapster
-    version: v9
+    version: v10
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 1
   selector:
     k8s-app: heapster
-    version: v9
+    version: v10
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v9
+        version: v10
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v0.18.1
+        - image: gcr.io/google_containers/heapster:v0.18.2
           name: heapster
           resources:
             limits:
@@ -32,7 +32,8 @@ spec:
             - --sink=gcl
             - --sink=gcmautoscaling
             - --sink=influxdb:http://monitoring-influxdb:8086
-            - --sink_frequency=2m
+            - --stats_resolution=30s
+            - --sink_frequency=1m
           volumeMounts:
             - name: ssl-certs
               mountPath: /etc/ssl/certs

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -1,26 +1,26 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: heapster-v9
+  name: heapster-v10
   namespace: kube-system
   labels:
     k8s-app: heapster
-    version: v9
+    version: v10
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 1
   selector:
     k8s-app: heapster
-    version: v9
+    version: v10
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v9
+        version: v10
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v0.18.1
+        - image: gcr.io/google_containers/heapster:v0.18.2
           name: heapster
           resources:
             limits:
@@ -30,3 +30,5 @@ spec:
             - /heapster
             - --source=kubernetes:''
             - --sink=influxdb:http://monitoring-influxdb:8086
+            - --stats_resolution=30s
+            - --sink_frequency=1m

--- a/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -1,26 +1,26 @@
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: heapster-v9
+  name: heapster-v10
   namespace: kube-system
   labels:
     k8s-app: heapster
-    version: v9
+    version: v10
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 1
   selector:
     k8s-app: heapster
-    version: v9
+    version: v10
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v9
+        version: v10
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v0.18.1
+        - image: gcr.io/google_containers/heapster:v0.18.2
           name: heapster
           resources:
             limits:


### PR DESCRIPTION
The new version fixes problem with missing metrics.
The new config decreases load on GCM/InfluxDB.

Increased stats resolution from default 5s to 30s.
Decreased sink frequency from 2m to 1m.
