### PR TITLE
Remove kubectl expose from GCE_PARALLEL_FLAKY_TESTS

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -174,7 +174,6 @@ GCE_PARALLEL_FLAKY_TESTS=(
     "Services.*endpoint"
     "Services.*up\sand\sdown"
     "Networking\sshould\sfunction\sfor\sintra-pod\scommunication"  # possibly causing Ginkgo to get stuck, issue: #13485
-    "Kubectl\sexpose"
     )
 
 # Tests that should not run on soak cluster.


### PR DESCRIPTION
ref #14078. Not seeing any flakes from repeated parallel test runs with this test in the set, so tentatively removing it from the filter.
