### PR TITLE
Add getters for labels.Requirement

### DIFF
--- a/pkg/labels/selector.go
+++ b/pkg/labels/selector.go
@@ -146,6 +146,20 @@ func (r *Requirement) Matches(ls Labels) bool {
 	}
 }
 
+func (r *Requirement) Key() string {
+	return r.key
+}
+func (r *Requirement) Operator() Operator {
+	return r.operator
+}
+func (r *Requirement) Values() sets.String {
+	ret := sets.String{}
+	for k := range r.strValues {
+		ret.Insert(k)
+	}
+	return ret
+}
+
 // Return true if the LabelSelector doesn't restrict selection space
 func (lsel LabelSelector) Empty() bool {
 	if lsel == nil {


### PR DESCRIPTION
I'm implementing a mapping from a RESTful API service to an API that supports label selectors. The idea is that if a selector includes `app=foo`, then I want it to map to an API request against `/api/app/foo`. In order to know what app to query, I have to be able to read the fields of the Requirement.

Sorry if this doesn't really explain the use case well. It's hard to describe without internal details.
