### PR TITLE
Add bearer token support for kubelet client config

### DIFF
--- a/pkg/client/unversioned/helper.go
+++ b/pkg/client/unversioned/helper.go
@@ -100,6 +100,9 @@ type KubeletConfig struct {
 	// TLSClientConfig contains settings to enable transport layer security
 	TLSClientConfig
 
+	// Server requires Bearer authentication
+	BearerToken string
+
 	// HTTPTimeout is used by the client to timeout http requests to Kubelet.
 	HTTPTimeout time.Duration
 

--- a/pkg/client/unversioned/kubelet.go
+++ b/pkg/client/unversioned/kubelet.go
@@ -50,14 +50,20 @@ func MakeTransport(config *KubeletConfig) (http.RoundTripper, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	transport := http.DefaultTransport
 	if config.Dial != nil || tlsConfig != nil {
-		return util.SetTransportDefaults(&http.Transport{
+		transport = util.SetTransportDefaults(&http.Transport{
 			Dial:            config.Dial,
 			TLSClientConfig: tlsConfig,
-		}), nil
-	} else {
-		return http.DefaultTransport, nil
+		})
 	}
+
+	if len(config.BearerToken) > 0 {
+		transport = NewBearerAuthRoundTripper(config.BearerToken, transport)
+	}
+
+	return transport, nil
 }
 
 // TODO: this structure is questionable, it should be using client.Config and overriding defaults.


### PR DESCRIPTION
With the possibility of multiple authentication methods to kubelets in https://github.com/kubernetes/kubernetes/pull/14700, client side options for auth could use expanding. Adding bearer token first, since that seems most likely (integrations with service account tokens come to mind)
