### PR TITLE
Wait longer for job to complete

### DIFF
--- a/test/e2e/job.go
+++ b/test/e2e/job.go
@@ -34,7 +34,7 @@ import (
 
 const (
 	// How long to wait for a job to finish.
-	jobTimeout = 5 * time.Minute
+	jobTimeout = 15 * time.Minute
 
 	// Job selector name
 	jobSelectorKey = "job"


### PR DESCRIPTION
2 timeouts in last 30 e2e runs.
Tripling timeout.
Should normally not that that long.
Uses polling so will terminate early in normal case.
