### PR TITLE
Making error "too old resource version" a NewInternalError

### DIFF
--- a/pkg/storage/watch_cache.go
+++ b/pkg/storage/watch_cache.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"sync"
 
+	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/client/cache"
 	"k8s.io/kubernetes/pkg/runtime"
@@ -265,7 +266,7 @@ func (w *watchCache) GetAllEventsSinceThreadUnsafe(resourceVersion uint64) ([]wa
 		return result, nil
 	}
 	if resourceVersion < oldest {
-		return nil, fmt.Errorf("too old resource version: %d (%d)", resourceVersion, oldest)
+		return nil, errors.NewInternalError(fmt.Errorf("too old resource version: %d (%d)", resourceVersion, oldest))
 	}
 
 	// Binary seatch the smallest index at which resourceVersion is not smaller than

--- a/pkg/storage/watch_cache_test.go
+++ b/pkg/storage/watch_cache_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/client/cache"
 	"k8s.io/kubernetes/pkg/runtime"
@@ -119,6 +120,9 @@ func TestEvents(t *testing.T) {
 		_, err := store.GetAllEventsSince(1)
 		if err == nil {
 			t.Errorf("expected error too old")
+		}
+		if _, ok := err.(*errors.StatusError); !ok {
+			t.Errorf("expected error to be of type StatusError")
 		}
 	}
 	{


### PR DESCRIPTION
fixes #14384

Making error "too old resource version" a NewInternalError
