### PR TITLE
Extend a timeout to reduce flakes.

### DIFF
--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -1240,7 +1240,7 @@ func startServeHostnameService(c *client.Client, ns, name string, port, replicas
 		Name:                 name,
 		Namespace:            ns,
 		PollInterval:         3 * time.Second,
-		Timeout:              30 * time.Second,
+		Timeout:              podReadyBeforeTimeout,
 		Replicas:             replicas,
 		CreatedPods:          &createdPods,
 		MaxContainerFailures: &maxContainerFailures,


### PR DESCRIPTION
This has flakes once in the last 30 runs on Jenkins.  30 seconds seems kind of short, move to 2 min.
