### PR TITLE
Use strong type for container ID

### DIFF
--- a/pkg/kubelet/container/container_reference_manager.go
+++ b/pkg/kubelet/container/container_reference_manager.go
@@ -28,32 +28,31 @@ import (
 // for the caller.
 type RefManager struct {
 	sync.RWMutex
-	// TODO(yifan): To use strong type.
-	containerIDToRef map[string]*api.ObjectReference
+	containerIDToRef map[ContainerID]*api.ObjectReference
 }
 
 // NewRefManager creates and returns a container reference manager
 // with empty contents.
 func NewRefManager() *RefManager {
-	return &RefManager{containerIDToRef: make(map[string]*api.ObjectReference)}
+	return &RefManager{containerIDToRef: make(map[ContainerID]*api.ObjectReference)}
 }
 
 // SetRef stores a reference to a pod's container, associating it with the given container ID.
-func (c *RefManager) SetRef(id string, ref *api.ObjectReference) {
+func (c *RefManager) SetRef(id ContainerID, ref *api.ObjectReference) {
 	c.Lock()
 	defer c.Unlock()
 	c.containerIDToRef[id] = ref
 }
 
 // ClearRef forgets the given container id and its associated container reference.
-func (c *RefManager) ClearRef(id string) {
+func (c *RefManager) ClearRef(id ContainerID) {
 	c.Lock()
 	defer c.Unlock()
 	delete(c.containerIDToRef, id)
 }
 
 // GetRef returns the container reference of the given ID, or (nil, false) if none is stored.
-func (c *RefManager) GetRef(id string) (ref *api.ObjectReference, ok bool) {
+func (c *RefManager) GetRef(id ContainerID) (ref *api.ObjectReference, ok bool) {
 	c.RLock()
 	defer c.RUnlock()
 	ref, ok = c.containerIDToRef[id]

--- a/pkg/kubelet/container/fake_runtime.go
+++ b/pkg/kubelet/container/fake_runtime.go
@@ -217,7 +217,7 @@ func (f *FakeRuntime) GetPodStatus(*api.Pod) (*api.PodStatus, error) {
 	return &status, f.Err
 }
 
-func (f *FakeRuntime) ExecInContainer(containerID string, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool) error {
+func (f *FakeRuntime) ExecInContainer(containerID ContainerID, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool) error {
 	f.Lock()
 	defer f.Unlock()
 
@@ -225,7 +225,7 @@ func (f *FakeRuntime) ExecInContainer(containerID string, cmd []string, stdin io
 	return f.Err
 }
 
-func (f *FakeRuntime) AttachContainer(containerID string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool) error {
+func (f *FakeRuntime) AttachContainer(containerID ContainerID, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool) error {
 	f.Lock()
 	defer f.Unlock()
 
@@ -233,7 +233,7 @@ func (f *FakeRuntime) AttachContainer(containerID string, stdin io.Reader, stdou
 	return f.Err
 }
 
-func (f *FakeRuntime) RunInContainer(containerID string, cmd []string) ([]byte, error) {
+func (f *FakeRuntime) RunInContainer(containerID ContainerID, cmd []string) ([]byte, error) {
 	f.Lock()
 	defer f.Unlock()
 
@@ -241,7 +241,7 @@ func (f *FakeRuntime) RunInContainer(containerID string, cmd []string) ([]byte, 
 	return []byte{}, f.Err
 }
 
-func (f *FakeRuntime) GetContainerLogs(pod *api.Pod, containerID string, logOptions *api.PodLogOptions, stdout, stderr io.Writer) (err error) {
+func (f *FakeRuntime) GetContainerLogs(pod *api.Pod, containerID ContainerID, logOptions *api.PodLogOptions, stdout, stderr io.Writer) (err error) {
 	f.Lock()
 	defer f.Unlock()
 

--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -18,7 +18,6 @@ package container
 
 import (
 	"hash/adler32"
-	"strings"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/util"
@@ -29,24 +28,13 @@ import (
 
 // HandlerRunner runs a lifecycle handler for a container.
 type HandlerRunner interface {
-	Run(containerID string, pod *api.Pod, container *api.Container, handler *api.Handler) error
+	Run(containerID ContainerID, pod *api.Pod, container *api.Container, handler *api.Handler) error
 }
 
 // RunContainerOptionsGenerator generates the options that necessary for
 // container runtime to run a container.
 type RunContainerOptionsGenerator interface {
 	GenerateRunContainerOptions(pod *api.Pod, container *api.Container) (*RunContainerOptions, error)
-}
-
-// Trims runtime prefix from ID or image name (e.g.: docker://busybox -> busybox).
-func TrimRuntimePrefix(fullString string) string {
-	const prefixSeparator = "://"
-
-	idx := strings.Index(fullString, prefixSeparator)
-	if idx < 0 {
-		return fullString
-	}
-	return fullString[idx+len(prefixSeparator):]
 }
 
 // ShouldContainerBeRestarted checks whether a container needs to be restarted.

--- a/pkg/kubelet/dockertools/convert.go
+++ b/pkg/kubelet/dockertools/convert.go
@@ -21,7 +21,7 @@ import (
 
 	docker "github.com/fsouza/go-dockerclient"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
-	"k8s.io/kubernetes/pkg/types"
+	kubeletTypes "k8s.io/kubernetes/pkg/kubelet/types"
 )
 
 // This file contains helper functions to convert docker API types to runtime
@@ -38,7 +38,7 @@ func toRuntimeContainer(c *docker.APIContainers) (*kubecontainer.Container, erro
 		return nil, err
 	}
 	return &kubecontainer.Container{
-		ID:      types.UID(c.ID),
+		ID:      kubeletTypes.DockerID(c.ID).ContainerID(),
 		Name:    dockerName.ContainerName,
 		Image:   c.Image,
 		Hash:    hash,

--- a/pkg/kubelet/dockertools/convert_test.go
+++ b/pkg/kubelet/dockertools/convert_test.go
@@ -22,7 +22,6 @@ import (
 
 	docker "github.com/fsouza/go-dockerclient"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
-	"k8s.io/kubernetes/pkg/types"
 )
 
 func TestToRuntimeContainer(t *testing.T) {
@@ -33,7 +32,7 @@ func TestToRuntimeContainer(t *testing.T) {
 		Names:   []string{"/k8s_bar.5678_foo_ns_1234_42"},
 	}
 	expected := &kubecontainer.Container{
-		ID:      types.UID("ab2cdf"),
+		ID:      kubecontainer.ContainerID{"docker", "ab2cdf"},
 		Name:    "bar",
 		Image:   "bar_image",
 		Hash:    0x5678,

--- a/pkg/kubelet/dockertools/docker_test.go
+++ b/pkg/kubelet/dockertools/docker_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/kubernetes/pkg/credentialprovider"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/network"
+	kubeletTypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util"
 )
@@ -171,10 +172,10 @@ func TestExecSupportNotExists(t *testing.T) {
 
 func TestDockerContainerCommand(t *testing.T) {
 	runner := &DockerManager{}
-	containerID := "1234"
+	containerID := kubeletTypes.DockerID("1234").ContainerID()
 	command := []string{"ls"}
 	cmd, _ := runner.getRunInContainerCommand(containerID, command)
-	if cmd.Dir != "/var/lib/docker/execdriver/native/"+containerID {
+	if cmd.Dir != "/var/lib/docker/execdriver/native/"+containerID.ID {
 		t.Errorf("unexpected command CWD: %s", cmd.Dir)
 	}
 	if !reflect.DeepEqual(cmd.Args, []string{"/usr/sbin/nsinit", "exec", "ls"}) {
@@ -517,7 +518,7 @@ type containersByID []*kubecontainer.Container
 
 func (b containersByID) Len() int           { return len(b) }
 func (b containersByID) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
-func (b containersByID) Less(i, j int) bool { return b[i].ID < b[j].ID }
+func (b containersByID) Less(i, j int) bool { return b[i].ID.ID < b[j].ID.ID }
 
 func TestFindContainersByPod(t *testing.T) {
 	tests := []struct {
@@ -560,12 +561,12 @@ func TestFindContainersByPod(t *testing.T) {
 					Namespace: "ns",
 					Containers: []*kubecontainer.Container{
 						{
-							ID:   "foobar",
+							ID:   kubeletTypes.DockerID("foobar").ContainerID(),
 							Name: "foobar",
 							Hash: 0x1234,
 						},
 						{
-							ID:   "baz",
+							ID:   kubeletTypes.DockerID("baz").ContainerID(),
 							Name: "baz",
 							Hash: 0x1234,
 						},
@@ -577,7 +578,7 @@ func TestFindContainersByPod(t *testing.T) {
 					Namespace: "ns",
 					Containers: []*kubecontainer.Container{
 						{
-							ID:   "barbar",
+							ID:   kubeletTypes.DockerID("barbar").ContainerID(),
 							Name: "barbar",
 							Hash: 0x1234,
 						},
@@ -618,17 +619,17 @@ func TestFindContainersByPod(t *testing.T) {
 					Namespace: "ns",
 					Containers: []*kubecontainer.Container{
 						{
-							ID:   "foobar",
+							ID:   kubeletTypes.DockerID("foobar").ContainerID(),
 							Name: "foobar",
 							Hash: 0x1234,
 						},
 						{
-							ID:   "barfoo",
+							ID:   kubeletTypes.DockerID("barfoo").ContainerID(),
 							Name: "barfoo",
 							Hash: 0x1234,
 						},
 						{
-							ID:   "baz",
+							ID:   kubeletTypes.DockerID("baz").ContainerID(),
 							Name: "baz",
 							Hash: 0x1234,
 						},
@@ -640,7 +641,7 @@ func TestFindContainersByPod(t *testing.T) {
 					Namespace: "ns",
 					Containers: []*kubecontainer.Container{
 						{
-							ID:   "barbar",
+							ID:   kubeletTypes.DockerID("barbar").ContainerID(),
 							Name: "barbar",
 							Hash: 0x1234,
 						},
@@ -652,7 +653,7 @@ func TestFindContainersByPod(t *testing.T) {
 					Namespace: "ns",
 					Containers: []*kubecontainer.Container{
 						{
-							ID:   "bazbaz",
+							ID:   kubeletTypes.DockerID("bazbaz").ContainerID(),
 							Name: "bazbaz",
 							Hash: 0x1234,
 						},

--- a/pkg/kubelet/dockertools/manager_test.go
+++ b/pkg/kubelet/dockertools/manager_test.go
@@ -346,7 +346,7 @@ func apiContainerToContainer(c docker.APIContainers) kubecontainer.Container {
 		return kubecontainer.Container{}
 	}
 	return kubecontainer.Container{
-		ID:   types.UID(c.ID),
+		ID:   kubecontainer.ContainerID{"docker", c.ID},
 		Name: dockerName.ContainerName,
 		Hash: hash,
 	}
@@ -360,7 +360,7 @@ func dockerContainersToPod(containers DockerContainers) kubecontainer.Pod {
 			continue
 		}
 		pod.Containers = append(pod.Containers, &kubecontainer.Container{
-			ID:    types.UID(c.ID),
+			ID:    kubecontainer.ContainerID{"docker", c.ID},
 			Name:  dockerName.ContainerName,
 			Hash:  hash,
 			Image: c.Image,
@@ -399,7 +399,7 @@ func TestKillContainerInPod(t *testing.T) {
 	containerToSpare := &containers[1]
 	fakeDocker.ContainerList = containers
 
-	if err := manager.KillContainerInPod("", &pod.Spec.Containers[0], pod); err != nil {
+	if err := manager.KillContainerInPod(kubecontainer.ContainerID{}, &pod.Spec.Containers[0], pod); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 	// Assert the container has been stopped.
@@ -464,7 +464,7 @@ func TestKillContainerInPodWithPreStop(t *testing.T) {
 		},
 	}
 
-	if err := manager.KillContainerInPod("", &pod.Spec.Containers[0], pod); err != nil {
+	if err := manager.KillContainerInPod(kubecontainer.ContainerID{}, &pod.Spec.Containers[0], pod); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 	// Assert the container has been stopped.
@@ -501,7 +501,7 @@ func TestKillContainerInPodWithError(t *testing.T) {
 	fakeDocker.ContainerList = containers
 	fakeDocker.Errors["stop"] = fmt.Errorf("sample error")
 
-	if err := manager.KillContainerInPod("", &pod.Spec.Containers[0], pod); err == nil {
+	if err := manager.KillContainerInPod(kubecontainer.ContainerID{}, &pod.Spec.Containers[0], pod); err == nil {
 		t.Errorf("expected error, found nil")
 	}
 }

--- a/pkg/kubelet/image_manager_test.go
+++ b/pkg/kubelet/image_manager_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/kubernetes/pkg/client/record"
 	"k8s.io/kubernetes/pkg/kubelet/cadvisor"
 	"k8s.io/kubernetes/pkg/kubelet/container"
-	"k8s.io/kubernetes/pkg/types"
 )
 
 var zero time.Time
@@ -74,7 +73,7 @@ func makeImage(id int, size int64) container.Image {
 // Make a container with the specified ID. It will use the image with the same ID.
 func makeContainer(id int) *container.Container {
 	return &container.Container{
-		ID:    types.UID(fmt.Sprintf("container-%d", id)),
+		ID:    container.ContainerID{"test", fmt.Sprintf("container-%d", id)},
 		Image: imageName(id),
 	}
 }
@@ -322,7 +321,7 @@ func TestFreeSpaceImagesAlsoDoesLookupByRepoTags(t *testing.T) {
 		{
 			Containers: []*container.Container{
 				{
-					ID:    "c5678",
+					ID:    container.ContainerID{"test", "c5678"},
 					Image: "salad",
 				},
 			},

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -586,7 +586,7 @@ func TestGetContainerInfo(t *testing.T) {
 			Containers: []*kubecontainer.Container{
 				{
 					Name: "foo",
-					ID:   types.UID(containerID),
+					ID:   kubecontainer.ContainerID{"test", containerID},
 				},
 			},
 		},
@@ -668,7 +668,7 @@ func TestGetContainerInfoWhenCadvisorFailed(t *testing.T) {
 			Namespace: "ns",
 			Containers: []*kubecontainer.Container{
 				{Name: "foo",
-					ID: types.UID(containerID),
+					ID: kubecontainer.ContainerID{"test", containerID},
 				},
 			},
 		},
@@ -752,7 +752,7 @@ func TestGetContainerInfoWithNoMatchingContainers(t *testing.T) {
 			Namespace: "ns",
 			Containers: []*kubecontainer.Container{
 				{Name: "bar",
-					ID: types.UID("fakeID"),
+					ID: kubecontainer.ContainerID{"test", "fakeID"},
 				},
 			}},
 	}
@@ -772,7 +772,7 @@ func TestGetContainerInfoWithNoMatchingContainers(t *testing.T) {
 
 type fakeContainerCommandRunner struct {
 	Cmd    []string
-	ID     string
+	ID     kubecontainer.ContainerID
 	PodID  types.UID
 	E      error
 	Stdin  io.Reader
@@ -783,13 +783,13 @@ type fakeContainerCommandRunner struct {
 	Stream io.ReadWriteCloser
 }
 
-func (f *fakeContainerCommandRunner) RunInContainer(id string, cmd []string) ([]byte, error) {
+func (f *fakeContainerCommandRunner) RunInContainer(id kubecontainer.ContainerID, cmd []string) ([]byte, error) {
 	f.Cmd = cmd
 	f.ID = id
 	return []byte{}, f.E
 }
 
-func (f *fakeContainerCommandRunner) ExecInContainer(id string, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool) error {
+func (f *fakeContainerCommandRunner) ExecInContainer(id kubecontainer.ContainerID, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool) error {
 	f.Cmd = cmd
 	f.ID = id
 	f.Stdin = in
@@ -835,7 +835,7 @@ func TestRunInContainer(t *testing.T) {
 	fakeCommandRunner := fakeContainerCommandRunner{}
 	kubelet.runner = &fakeCommandRunner
 
-	containerID := "abc1234"
+	containerID := kubecontainer.ContainerID{"test", "abc1234"}
 	fakeRuntime.PodList = []*kubecontainer.Pod{
 		{
 			ID:        "12345678",
@@ -843,7 +843,7 @@ func TestRunInContainer(t *testing.T) {
 			Namespace: "nsFoo",
 			Containers: []*kubecontainer.Container{
 				{Name: "containerFoo",
-					ID: types.UID(containerID),
+					ID: containerID,
 				},
 			},
 		},
@@ -1865,7 +1865,7 @@ func TestExecInContainerNoSuchPod(t *testing.T) {
 	if err == nil {
 		t.Fatal("unexpected non-error")
 	}
-	if fakeCommandRunner.ID != "" {
+	if !fakeCommandRunner.ID.IsEmpty() {
 		t.Fatal("unexpected invocation of runner.ExecInContainer")
 	}
 }
@@ -1887,7 +1887,7 @@ func TestExecInContainerNoSuchContainer(t *testing.T) {
 			Namespace: podNamespace,
 			Containers: []*kubecontainer.Container{
 				{Name: "bar",
-					ID: "barID"},
+					ID: kubecontainer.ContainerID{"test", "barID"}},
 			},
 		},
 	}
@@ -1909,7 +1909,7 @@ func TestExecInContainerNoSuchContainer(t *testing.T) {
 	if err == nil {
 		t.Fatal("unexpected non-error")
 	}
-	if fakeCommandRunner.ID != "" {
+	if !fakeCommandRunner.ID.IsEmpty() {
 		t.Fatal("unexpected invocation of runner.ExecInContainer")
 	}
 }
@@ -1950,7 +1950,7 @@ func TestExecInContainer(t *testing.T) {
 			Namespace: podNamespace,
 			Containers: []*kubecontainer.Container{
 				{Name: containerID,
-					ID: types.UID(containerID),
+					ID: kubecontainer.ContainerID{"test", containerID},
 				},
 			},
 		},
@@ -1973,7 +1973,7 @@ func TestExecInContainer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-	if e, a := containerID, fakeCommandRunner.ID; e != a {
+	if e, a := containerID, fakeCommandRunner.ID.ID; e != a {
 		t.Fatalf("container name: expected %q, got %q", e, a)
 	}
 	if e, a := command, fakeCommandRunner.Cmd; !reflect.DeepEqual(e, a) {
@@ -2014,7 +2014,7 @@ func TestPortForwardNoSuchPod(t *testing.T) {
 	if err == nil {
 		t.Fatal("unexpected non-error")
 	}
-	if fakeCommandRunner.ID != "" {
+	if !fakeCommandRunner.ID.IsEmpty() {
 		t.Fatal("unexpected invocation of runner.PortForward")
 	}
 }
@@ -2035,7 +2035,7 @@ func TestPortForward(t *testing.T) {
 			Containers: []*kubecontainer.Container{
 				{
 					Name: "foo",
-					ID:   "containerFoo",
+					ID:   kubecontainer.ContainerID{"test", "containerFoo"},
 				},
 			},
 		},
@@ -2847,7 +2847,7 @@ func TestGetContainerInfoForMirrorPods(t *testing.T) {
 			Containers: []*kubecontainer.Container{
 				{
 					Name: "foo",
-					ID:   types.UID(containerID),
+					ID:   kubecontainer.ContainerID{"test", containerID},
 				},
 			},
 		},

--- a/pkg/kubelet/lifecycle/handlers.go
+++ b/pkg/kubelet/lifecycle/handlers.go
@@ -46,8 +46,7 @@ func NewHandlerRunner(httpGetter kubeletTypes.HttpGetter, commandRunner kubecont
 	}
 }
 
-// TODO(yifan): Use a strong type for containerID.
-func (hr *HandlerRunner) Run(containerID string, pod *api.Pod, container *api.Container, handler *api.Handler) error {
+func (hr *HandlerRunner) Run(containerID kubecontainer.ContainerID, pod *api.Pod, container *api.Container, handler *api.Handler) error {
 	switch {
 	case handler.Exec != nil:
 		_, err := hr.commandRunner.RunInContainer(containerID, handler.Exec.Command)

--- a/pkg/kubelet/lifecycle/handlers_test.go
+++ b/pkg/kubelet/lifecycle/handlers_test.go
@@ -74,16 +74,16 @@ func TestResolvePortStringUnknown(t *testing.T) {
 
 type fakeContainerCommandRunner struct {
 	Cmd []string
-	ID  string
+	ID  kubecontainer.ContainerID
 }
 
-func (f *fakeContainerCommandRunner) RunInContainer(id string, cmd []string) ([]byte, error) {
+func (f *fakeContainerCommandRunner) RunInContainer(id kubecontainer.ContainerID, cmd []string) ([]byte, error) {
 	f.Cmd = cmd
 	f.ID = id
 	return []byte{}, nil
 }
 
-func (f *fakeContainerCommandRunner) ExecInContainer(id string, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool) error {
+func (f *fakeContainerCommandRunner) ExecInContainer(id kubecontainer.ContainerID, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool) error {
 	return nil
 }
 
@@ -95,7 +95,7 @@ func TestRunHandlerExec(t *testing.T) {
 	fakeCommandRunner := fakeContainerCommandRunner{}
 	handlerRunner := NewHandlerRunner(&fakeHTTP{}, &fakeCommandRunner, nil)
 
-	containerID := "abc1234"
+	containerID := kubecontainer.ContainerID{"test", "abc1234"}
 	containerName := "containerFoo"
 
 	container := api.Container{
@@ -137,7 +137,7 @@ func TestRunHandlerHttp(t *testing.T) {
 	fakeHttp := fakeHTTP{}
 	handlerRunner := NewHandlerRunner(&fakeHttp, &fakeContainerCommandRunner{}, nil)
 
-	containerID := "abc1234"
+	containerID := kubecontainer.ContainerID{"test", "abc1234"}
 	containerName := "containerFoo"
 
 	container := api.Container{
@@ -168,7 +168,7 @@ func TestRunHandlerHttp(t *testing.T) {
 
 func TestRunHandlerNil(t *testing.T) {
 	handlerRunner := NewHandlerRunner(&fakeHTTP{}, &fakeContainerCommandRunner{}, nil)
-	containerID := "abc1234"
+	containerID := kubecontainer.ContainerID{"test", "abc1234"}
 	podName := "podFoo"
 	podNamespace := "nsFoo"
 	containerName := "containerFoo"

--- a/pkg/kubelet/network/cni/cni.go
+++ b/pkg/kubelet/network/cni/cni.go
@@ -18,15 +18,17 @@ package cni
 
 import (
 	"fmt"
-	"github.com/appc/cni/libcni"
-	cniTypes "github.com/appc/cni/pkg/types"
-	"github.com/golang/glog"
-	"k8s.io/kubernetes/pkg/kubelet/dockertools"
-	"k8s.io/kubernetes/pkg/kubelet/network"
-	kubeletTypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"net"
 	"sort"
 	"strings"
+
+	"github.com/appc/cni/libcni"
+	cniTypes "github.com/appc/cni/pkg/types"
+	"github.com/golang/glog"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/kubelet/dockertools"
+	"k8s.io/kubernetes/pkg/kubelet/network"
+	kubeletTypes "k8s.io/kubernetes/pkg/kubelet/types"
 )
 
 const (
@@ -105,12 +107,12 @@ func (plugin *cniNetworkPlugin) SetUpPod(namespace string, name string, id kubel
 	if !ok {
 		return fmt.Errorf("CNI execution called on non-docker runtime")
 	}
-	netns, err := runtime.GetNetNs(string(id))
+	netns, err := runtime.GetNetNs(id.ContainerID())
 	if err != nil {
 		return err
 	}
 
-	_, err = plugin.defaultNetwork.addToNetwork(name, namespace, string(id), netns)
+	_, err = plugin.defaultNetwork.addToNetwork(name, namespace, id.ContainerID(), netns)
 	if err != nil {
 		glog.Errorf("Error while adding to cni network: %s", err)
 		return err
@@ -124,12 +126,12 @@ func (plugin *cniNetworkPlugin) TearDownPod(namespace string, name string, id ku
 	if !ok {
 		return fmt.Errorf("CNI execution called on non-docker runtime")
 	}
-	netns, err := runtime.GetNetNs(string(id))
+	netns, err := runtime.GetNetNs(id.ContainerID())
 	if err != nil {
 		return err
 	}
 
-	return plugin.defaultNetwork.deleteFromNetwork(name, namespace, string(id), netns)
+	return plugin.defaultNetwork.deleteFromNetwork(name, namespace, id.ContainerID(), netns)
 }
 
 // TODO: Use the addToNetwork function to obtain the IP of the Pod. That will assume idempotent ADD call to the plugin.
@@ -150,7 +152,7 @@ func (plugin *cniNetworkPlugin) Status(namespace string, name string, id kubelet
 	return &network.PodNetworkStatus{IP: ip}, nil
 }
 
-func (network *cniNetwork) addToNetwork(podName string, podNamespace string, podInfraContainerID string, podNetnsPath string) (*cniTypes.Result, error) {
+func (network *cniNetwork) addToNetwork(podName string, podNamespace string, podInfraContainerID kubecontainer.ContainerID, podNetnsPath string) (*cniTypes.Result, error) {
 	rt, err := buildCNIRuntimeConf(podName, podNamespace, podInfraContainerID, podNetnsPath)
 	if err != nil {
 		glog.Errorf("Error adding network: %v", err)
@@ -168,7 +170,7 @@ func (network *cniNetwork) addToNetwork(podName string, podNamespace string, pod
 	return res, nil
 }
 
-func (network *cniNetwork) deleteFromNetwork(podName string, podNamespace string, podInfraContainerID string, podNetnsPath string) error {
+func (network *cniNetwork) deleteFromNetwork(podName string, podNamespace string, podInfraContainerID kubecontainer.ContainerID, podNetnsPath string) error {
 	rt, err := buildCNIRuntimeConf(podName, podNamespace, podInfraContainerID, podNetnsPath)
 	if err != nil {
 		glog.Errorf("Error deleting network: %v", err)
@@ -185,18 +187,18 @@ func (network *cniNetwork) deleteFromNetwork(podName string, podNamespace string
 	return nil
 }
 
-func buildCNIRuntimeConf(podName string, podNs string, podInfraContainerID string, podNetnsPath string) (*libcni.RuntimeConf, error) {
+func buildCNIRuntimeConf(podName string, podNs string, podInfraContainerID kubecontainer.ContainerID, podNetnsPath string) (*libcni.RuntimeConf, error) {
 	glog.V(4).Infof("Got netns path %v", podNetnsPath)
 	glog.V(4).Infof("Using netns path %v", podNs)
 
 	rt := &libcni.RuntimeConf{
-		ContainerID: podInfraContainerID,
+		ContainerID: podInfraContainerID.ID,
 		NetNS:       podNetnsPath,
 		IfName:      DefaultInterfaceName,
 		Args: [][2]string{
 			{"K8S_POD_NAMESPACE", podNs},
 			{"K8S_POD_NAME", podName},
-			{"K8S_POD_INFRA_CONTAINER_ID", podInfraContainerID},
+			{"K8S_POD_INFRA_CONTAINER_ID", podInfraContainerID.ID},
 		},
 	}
 

--- a/pkg/kubelet/prober/fake_prober.go
+++ b/pkg/kubelet/prober/fake_prober.go
@@ -18,6 +18,7 @@ package prober
 
 import (
 	"k8s.io/kubernetes/pkg/api"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/probe"
 )
 
@@ -29,14 +30,14 @@ type FakeProber struct {
 	Error     error
 }
 
-func (f FakeProber) ProbeLiveness(_ *api.Pod, _ api.PodStatus, c api.Container, _ string, _ int64) (probe.Result, error) {
+func (f FakeProber) ProbeLiveness(_ *api.Pod, _ api.PodStatus, c api.Container, _ kubecontainer.ContainerID, _ int64) (probe.Result, error) {
 	if c.LivenessProbe == nil {
 		return probe.Success, nil
 	}
 	return f.Liveness, f.Error
 }
 
-func (f FakeProber) ProbeReadiness(_ *api.Pod, _ api.PodStatus, c api.Container, _ string) (probe.Result, error) {
+func (f FakeProber) ProbeReadiness(_ *api.Pod, _ api.PodStatus, c api.Container, _ kubecontainer.ContainerID) (probe.Result, error) {
 	if c.ReadinessProbe == nil {
 		return probe.Success, nil
 	}

--- a/pkg/kubelet/prober/manager.go
+++ b/pkg/kubelet/prober/manager.go
@@ -141,7 +141,8 @@ func (m *manager) UpdatePodStatus(podUID types.UID, podStatus *api.PodStatus) {
 		var ready bool
 		if c.State.Running == nil {
 			ready = false
-		} else if result, ok := m.readinessCache.getReadiness(kubecontainer.TrimRuntimePrefix(c.ContainerID)); ok {
+		} else if result, ok := m.readinessCache.getReadiness(
+			kubecontainer.ParseContainerID(c.ContainerID)); ok {
 			ready = result
 		} else {
 			// The check whether there is a probe which hasn't run yet.

--- a/pkg/kubelet/prober/manager_test.go
+++ b/pkg/kubelet/prober/manager_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/status"
 	"k8s.io/kubernetes/pkg/probe"
 	"k8s.io/kubernetes/pkg/util/wait"
@@ -151,35 +152,35 @@ func TestUpdatePodStatus(t *testing.T) {
 	const podUID = "pod_uid"
 	unprobed := api.ContainerStatus{
 		Name:        "unprobed_container",
-		ContainerID: "unprobed_container_id",
+		ContainerID: "test://unprobed_container_id",
 		State: api.ContainerState{
 			Running: &api.ContainerStateRunning{},
 		},
 	}
 	probedReady := api.ContainerStatus{
 		Name:        "probed_container_ready",
-		ContainerID: "probed_container_ready_id",
+		ContainerID: "test://probed_container_ready_id",
 		State: api.ContainerState{
 			Running: &api.ContainerStateRunning{},
 		},
 	}
 	probedPending := api.ContainerStatus{
 		Name:        "probed_container_pending",
-		ContainerID: "probed_container_pending_id",
+		ContainerID: "test://probed_container_pending_id",
 		State: api.ContainerState{
 			Running: &api.ContainerStateRunning{},
 		},
 	}
 	probedUnready := api.ContainerStatus{
 		Name:        "probed_container_unready",
-		ContainerID: "probed_container_unready_id",
+		ContainerID: "test://probed_container_unready_id",
 		State: api.ContainerState{
 			Running: &api.ContainerStateRunning{},
 		},
 	}
 	terminated := api.ContainerStatus{
 		Name:        "terminated_container",
-		ContainerID: "terminated_container_id",
+		ContainerID: "test://terminated_container_id",
 		State: api.ContainerState{
 			Terminated: &api.ContainerStateTerminated{},
 		},
@@ -199,9 +200,10 @@ func TestUpdatePodStatus(t *testing.T) {
 		containerPath{podUID, probedUnready.Name}: {},
 		containerPath{podUID, terminated.Name}:    {},
 	}
-	m.readinessCache.setReadiness(probedReady.ContainerID, true)
-	m.readinessCache.setReadiness(probedUnready.ContainerID, false)
-	m.readinessCache.setReadiness(terminated.ContainerID, true)
+
+	m.readinessCache.setReadiness(kubecontainer.ParseContainerID(probedReady.ContainerID), true)
+	m.readinessCache.setReadiness(kubecontainer.ParseContainerID(probedUnready.ContainerID), false)
+	m.readinessCache.setReadiness(kubecontainer.ParseContainerID(terminated.ContainerID), true)
 
 	m.UpdatePodStatus(podUID, &podStatus)
 

--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -41,8 +41,8 @@ const maxProbeRetries = 3
 
 // Prober checks the healthiness of a container.
 type Prober interface {
-	ProbeLiveness(pod *api.Pod, status api.PodStatus, container api.Container, containerID string, createdAt int64) (probe.Result, error)
-	ProbeReadiness(pod *api.Pod, status api.PodStatus, container api.Container, containerID string) (probe.Result, error)
+	ProbeLiveness(pod *api.Pod, status api.PodStatus, container api.Container, containerID kubecontainer.ContainerID, createdAt int64) (probe.Result, error)
+	ProbeReadiness(pod *api.Pod, status api.PodStatus, container api.Container, containerID kubecontainer.ContainerID) (probe.Result, error)
 }
 
 // Prober helps to check the liveness/readiness of a container.
@@ -75,7 +75,7 @@ func New(
 
 // ProbeLiveness probes the liveness of a container.
 // If the initalDelay since container creation on liveness probe has not passed the probe will return probe.Success.
-func (pb *prober) ProbeLiveness(pod *api.Pod, status api.PodStatus, container api.Container, containerID string, createdAt int64) (probe.Result, error) {
+func (pb *prober) ProbeLiveness(pod *api.Pod, status api.PodStatus, container api.Container, containerID kubecontainer.ContainerID, createdAt int64) (probe.Result, error) {
 	var live probe.Result
 	var output string
 	var err error
@@ -114,7 +114,7 @@ func (pb *prober) ProbeLiveness(pod *api.Pod, status api.PodStatus, container ap
 }
 
 // ProbeReadiness probes and sets the readiness of a container.
-func (pb *prober) ProbeReadiness(pod *api.Pod, status api.PodStatus, container api.Container, containerID string) (probe.Result, error) {
+func (pb *prober) ProbeReadiness(pod *api.Pod, status api.PodStatus, container api.Container, containerID kubecontainer.ContainerID) (probe.Result, error) {
 	var ready probe.Result
 	var output string
 	var err error
@@ -151,7 +151,7 @@ func (pb *prober) ProbeReadiness(pod *api.Pod, status api.PodStatus, container a
 
 // runProbeWithRetries tries to probe the container in a finite loop, it returns the last result
 // if it never succeeds.
-func (pb *prober) runProbeWithRetries(p *api.Probe, pod *api.Pod, status api.PodStatus, container api.Container, containerID string, retries int) (probe.Result, string, error) {
+func (pb *prober) runProbeWithRetries(p *api.Probe, pod *api.Pod, status api.PodStatus, container api.Container, containerID kubecontainer.ContainerID, retries int) (probe.Result, string, error) {
 	var err error
 	var result probe.Result
 	var output string
@@ -164,7 +164,7 @@ func (pb *prober) runProbeWithRetries(p *api.Probe, pod *api.Pod, status api.Pod
 	return result, output, err
 }
 
-func (pb *prober) runProbe(p *api.Probe, pod *api.Pod, status api.PodStatus, container api.Container, containerID string) (probe.Result, string, error) {
+func (pb *prober) runProbe(p *api.Probe, pod *api.Pod, status api.PodStatus, container api.Container, containerID kubecontainer.ContainerID) (probe.Result, string, error) {
 	timeout := time.Duration(p.TimeoutSeconds) * time.Second
 	if p.Exec != nil {
 		glog.V(4).Infof("Exec-Probe Pod: %v, Container: %v, Command: %v", pod, container, p.Exec.Command)
@@ -242,7 +242,7 @@ type execInContainer struct {
 	run func() ([]byte, error)
 }
 
-func (p *prober) newExecInContainer(pod *api.Pod, container api.Container, containerID string, cmd []string) exec.Cmd {
+func (p *prober) newExecInContainer(pod *api.Pod, container api.Container, containerID kubecontainer.ContainerID, cmd []string) exec.Cmd {
 	return execInContainer{func() ([]byte, error) {
 		return p.runner.RunInContainer(containerID, cmd)
 	}}

--- a/pkg/kubelet/prober/prober_test.go
+++ b/pkg/kubelet/prober/prober_test.go
@@ -183,7 +183,7 @@ func TestProbeContainer(t *testing.T) {
 		refManager: kubecontainer.NewRefManager(),
 		recorder:   &record.FakeRecorder{},
 	}
-	containerID := "foobar"
+	containerID := kubecontainer.ContainerID{"test", "foobar"}
 	createdAt := time.Now().Unix()
 
 	tests := []struct {

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -22,14 +22,16 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/probe"
 )
 
 const (
-	containerID   = "cOnTaInEr_Id"
 	containerName = "cOnTaInEr_NaMe"
 	podUID        = "pOd_UiD"
 )
+
+var containerID = kubecontainer.ContainerID{"test", "cOnTaInEr_Id"}
 
 func TestDoProbe(t *testing.T) {
 	m := newTestManager()
@@ -204,7 +206,7 @@ func newTestWorker(probeSpec api.Probe) *worker {
 func getRunningStatus() api.PodStatus {
 	containerStatus := api.ContainerStatus{
 		Name:        containerName,
-		ContainerID: containerID,
+		ContainerID: containerID.String(),
 	}
 	containerStatus.State.Running = &api.ContainerStateRunning{unversioned.Now()}
 	podStatus := api.PodStatus{
@@ -231,10 +233,10 @@ func getTestPod(probeSpec api.Probe) api.Pod {
 
 type CrashingProber struct{}
 
-func (f CrashingProber) ProbeLiveness(_ *api.Pod, _ api.PodStatus, c api.Container, _ string, _ int64) (probe.Result, error) {
+func (f CrashingProber) ProbeLiveness(_ *api.Pod, _ api.PodStatus, c api.Container, _ kubecontainer.ContainerID, _ int64) (probe.Result, error) {
 	panic("Intentional ProbeLiveness crash.")
 }
 
-func (f CrashingProber) ProbeReadiness(_ *api.Pod, _ api.PodStatus, c api.Container, _ string) (probe.Result, error) {
+func (f CrashingProber) ProbeReadiness(_ *api.Pod, _ api.PodStatus, c api.Container, _ kubecontainer.ContainerID) (probe.Result, error) {
 	panic("Intentional ProbeReadiness crash.")
 }

--- a/pkg/kubelet/rkt/container_id.go
+++ b/pkg/kubelet/rkt/container_id.go
@@ -19,6 +19,8 @@ package rkt
 import (
 	"fmt"
 	"strings"
+
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )
 
 // containerID defines the ID of rkt containers, it will
@@ -29,17 +31,22 @@ type containerID struct {
 	appName string // Name of the app in that pod.
 }
 
+const RktType = "rkt"
+
 // buildContainerID constructs the containers's ID using containerID,
 // which consists of the pod uuid and the container name.
 // The result can be used to uniquely identify a container.
-func buildContainerID(c *containerID) string {
-	return fmt.Sprintf("%s:%s", c.uuid, c.appName)
+func buildContainerID(c *containerID) kubecontainer.ContainerID {
+	return kubecontainer.ContainerID{
+		Type: RktType,
+		ID:   fmt.Sprintf("%s:%s", c.uuid, c.appName),
+	}
 }
 
 // parseContainerID parses the containerID into pod uuid and the container name. The
 // results can be used to get more information of the container.
-func parseContainerID(id string) (*containerID, error) {
-	tuples := strings.Split(id, ":")
+func parseContainerID(id kubecontainer.ContainerID) (*containerID, error) {
+	tuples := strings.Split(id.ID, ":")
 	if len(tuples) != 2 {
 		return nil, fmt.Errorf("rkt: cannot parse container ID for: %v", id)
 	}

--- a/pkg/kubelet/rkt/pod_info.go
+++ b/pkg/kubelet/rkt/pod_info.go
@@ -143,7 +143,7 @@ func makeContainerStatus(container *kubecontainer.Container, podInfo *podInfo) a
 	var status api.ContainerStatus
 	status.Name = container.Name
 	status.Image = container.Image
-	status.ContainerID = string(container.ID)
+	status.ContainerID = container.ID.String()
 	// TODO(yifan): Add image ID info.
 
 	switch podInfo.state {

--- a/pkg/kubelet/types/types.go
+++ b/pkg/kubelet/types/types.go
@@ -21,12 +21,20 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )
 
 // TODO: Reconcile custom types in kubelet/types and this subpackage
 
 // DockerID is an ID of docker container. It is a type to make it clear when we're working with docker container Ids
 type DockerID string
+
+func (id DockerID) ContainerID() kubecontainer.ContainerID {
+	return kubecontainer.ContainerID{
+		Type: "docker",
+		ID:   string(id),
+	}
+}
 
 type HttpGetter interface {
 	Get(url string) (*http.Response, error)


### PR DESCRIPTION
Change all references to the container ID in pkg/kubelet/... to the
strong type defined in pkg/kubelet/container: ContainerID

The motivation for this change is to make the format of the ID
unambiguous, specifically whether or not it includes the runtime
prefix (e.g. "docker://").

@yifan-gu 

cc/ @yujuhong @dchen1107 @vishh 
