### PR TITLE
Add option to save the verbose output from unit tests

### DIFF
--- a/hack/jenkins/gotest.sh
+++ b/hack/jenkins/gotest.sh
@@ -38,6 +38,8 @@ go get -u github.com/jstemmer/go-junit-report
 export KUBE_RACE=-race
 # Produce a JUnit-style XML test report for Jenkins.
 export KUBE_JUNIT_REPORT_DIR=${WORKSPACE}/_artifacts
+# Save the verbose stdout as well.
+export KUBE_KEEP_VERBOSE_TEST_OUTPUT=y
 
 ./hack/test-go.sh
 ./hack/test-integration.sh

--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -65,6 +65,9 @@ KUBE_TEST_API_VERSIONS=${KUBE_TEST_API_VERSIONS:-"v1,experimental/v1alpha1"}
 KUBE_TEST_ETCD_PREFIXES=${KUBE_TEST_ETCD_PREFIXES:-"registry,kubernetes.io/registry"}
 # Create a junit-style XML test report in this directory if set.
 KUBE_JUNIT_REPORT_DIR=${KUBE_JUNIT_REPORT_DIR:-}
+# Set to 'y' to keep the verbose stdout from tests when KUBE_JUNIT_REPORT_DIR is
+# set.
+KUBE_KEEP_VERBOSE_TEST_OUTPUT=${KUBE_KEEP_VERBOSE_TEST_OUTPUT:-n}
 
 kube::test::usage() {
   kube::log::usage_from_stdin <<EOF
@@ -162,7 +165,9 @@ produceJUnitXMLReport() {
     return
   fi
   cat ${test_stdout_filenames} | go-junit-report > "${junit_xml_filename}"
-  rm ${test_stdout_filenames}
+  if [[ ! ${KUBE_KEEP_VERBOSE_TEST_OUTPUT} =~ ^[yY]$ ]]; then
+    rm ${test_stdout_filenames}
+  fi
   kube::log::status "Saved JUnit XML test report to ${junit_xml_filename}"
 }
 


### PR DESCRIPTION
Also enable this option in our Jenkins runs.

ref #15125

@kubernetes/goog-testing 
