### PR TITLE
Correct compatibility test to include kind/apiVersion for scheduler json

### DIFF
--- a/plugin/pkg/scheduler/algorithmprovider/defaults/compatibility_test.go
+++ b/plugin/pkg/scheduler/algorithmprovider/defaults/compatibility_test.go
@@ -34,6 +34,8 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 		// Do not change this JSON. A failure indicates backwards compatibility with 1.0 was broken.
 		"1.0": {
 			JSON: `{
+  "kind": "Policy",
+  "apiVersion": "v1",
   "predicates": [
     {"name": "MatchNodeSelector"},
     {"name": "PodFitsResources"},
@@ -69,6 +71,8 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 		// Do not change this JSON after 1.1 is tagged. A failure indicates backwards compatibility with 1.1 was broken.
 		"1.1": {
 			JSON: `{
+		  "kind": "Policy",
+		  "apiVersion": "v1",
 		  "predicates": [
 		    {"name": "PodFitsHostPorts"}
 		  ],"priorities": [


### PR DESCRIPTION
The test was incorrectly deserializing to the internal version (which happened to work, because all field names were the same as their JSON fields).

This fixes the test JSON to correctly detect defaulting or conversion errors if the scheduler API ever changes
