### PR TITLE
upgrade flannel to 0.5.3 for ubuntu

### DIFF
--- a/cluster/ubuntu/build.sh
+++ b/cluster/ubuntu/build.sh
@@ -33,7 +33,7 @@ mkdir -p binaries/master
 mkdir -p binaries/minion
 
 # flannel
-FLANNEL_VERSION=${FLANNEL_VERSION:-"0.4.0"}
+FLANNEL_VERSION=${FLANNEL_VERSION:-"0.5.3"}
 echo "Prepare flannel ${FLANNEL_VERSION} release ..."
 if [ ! -f flannel.tar.gz ] ; then
   curl -L  https://github.com/coreos/flannel/releases/download/v${FLANNEL_VERSION}/flannel-${FLANNEL_VERSION}-linux-amd64.tar.gz -o flannel.tar.gz

--- a/cluster/ubuntu/util.sh
+++ b/cluster/ubuntu/util.sh
@@ -435,7 +435,7 @@ function kube-down {
       ssh -t $i 'sudo rm -f /opt/bin/kube* /opt/bin/flanneld;
       sudo rm -rf /etc/init/kube* /etc/init/flanneld.conf /etc/init.d/kube* /etc/init.d/flanneld;
       sudo rm -rf /etc/default/kube* /etc/default/flanneld; 
-      sudo rm -rf ~/kube /var/lib/kubelet'
+      sudo rm -rf ~/kube /var/lib/kubelet' || true
     }
     ((ii=ii+1))
   done

--- a/cluster/ubuntu/util.sh
+++ b/cluster/ubuntu/util.sh
@@ -435,7 +435,8 @@ function kube-down {
       ssh -t $i 'sudo rm -f /opt/bin/kube* /opt/bin/flanneld;
       sudo rm -rf /etc/init/kube* /etc/init/flanneld.conf /etc/init.d/kube* /etc/init.d/flanneld;
       sudo rm -rf /etc/default/kube* /etc/default/flanneld; 
-      sudo rm -rf ~/kube /var/lib/kubelet' || true
+      sudo rm -rf ~/kube /var/lib/kubelet;
+      sudo rm -rf /run/flannel/subnet.env' || true
     }
     ((ii=ii+1))
   done

--- a/docs/getting-started-guides/ubuntu.md
+++ b/docs/getting-started-guides/ubuntu.md
@@ -60,7 +60,7 @@ work, which has been merge into this document.
 Internet to download the necessary files, while worker nodes do not.
 3. These guide is tested OK on Ubuntu 14.04 LTS 64bit server, but it can not work with
 Ubuntu 15 which uses systemd instead of upstart.
-4. Dependencies of this guide: etcd-2.0.12, flannel-0.4.0, k8s-1.0.6, may work with higher versions.
+4. Dependencies of this guide: etcd-2.0.12, flannel-0.5.3, k8s-1.0.6, may work with higher versions.
 5. All the remote servers can be ssh logged in without a password by using key authentication.
 
 
@@ -77,13 +77,13 @@ $ git clone https://github.com/kubernetes/kubernetes.git
 #### Configure and start the Kubernetes cluster
 
 The startup process will first download all the required binaries automatically.
-By default etcd version is 2.0.12, flannel version is 0.4.0 and k8s version is 1.0.6.
+By default etcd version is 2.0.12, flannel version is 0.5.3 and k8s version is 1.0.6.
 You can customize your etcd version, flannel version, k8s version by changing corresponding variables
 `ETCD_VERSION` , `FLANNEL_VERSION` and `KUBE_VERSION` like following.
 
 ```console
 $ export KUBE_VERSION=1.0.5
-$ export FLANNEL_VERSION=0.5.3
+$ export FLANNEL_VERSION=0.5.0
 $ export ETCD_VERSION=2.2.0
 ```
 


### PR DESCRIPTION
- upgrade flannel to a higher release to get rid of potential bugs
- tear down cluster gracefully
