### PR TITLE
Add an environment variable override for AWS ssh keys

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1784,6 +1784,12 @@ func getSigner(provider string) (ssh.Signer, error) {
 	case "gce", "gke":
 		keyfile = "google_compute_engine"
 	case "aws":
+		// If there is an env. variable override, use that.
+		aws_keyfile := os.Getenv("AWS_SSH_KEY")
+		if len(aws_keyfile) != 0 {
+			return util.MakePrivateKeySignerFromFile(aws_keyfile)
+		}
+		// Otherwise revert to home dir
 		keyfile = "kube_aws_rsa"
 	default:
 		return nil, fmt.Errorf("getSigner(...) not implemented for %s", provider)


### PR DESCRIPTION
@quinton-hoole @ixdy 

Jenkins appears to override the `$HOME` directory which means that key loading fails.  Enable an environment variable override (`AWS_SSH_KEY`) that is matches what is set in other scripts.
