### PR TITLE
Use beta.gcr.io for pause and fluentd-elasticsearch

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -102,7 +102,7 @@ readonly KUBE_DOCKER_WRAPPED_BINARIES=(
 
 # The set of addons images that should be prepopulated
 readonly KUBE_ADDON_PATHS=(
-  gcr.io/google_containers/pause:0.8.0
+  beta.gcr.io/google_containers/pause:2.0
   gcr.io/google_containers/kube-registry-proxy:0.3
 )
 

--- a/build/pause/Makefile
+++ b/build/pause/Makefile
@@ -1,13 +1,13 @@
 .PHONY:	build push
 
 IMAGE = pause
-TAG = 0.8.0
+TAG = 2.0
 
 build:
 	./prepare.sh
-	docker build -t gcr.io/google_containers/$(IMAGE):$(TAG) .
+	docker build -t beta.gcr.io/google_containers/$(IMAGE):$(TAG) .
 
 push:	build
-	gcloud docker push gcr.io/google_containers/$(IMAGE):$(TAG)
+	gcloud docker --server=beta.gcr.io push beta.gcr.io/google_containers/$(IMAGE):$(TAG)
 
 all:	push

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Makefile
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Makefile
@@ -1,10 +1,10 @@
 .PHONY:	build push
 
 IMAGE = fluentd-elasticsearch
-TAG = 1.11
+TAG = 1.12
 
 build:	
-	docker build -t gcr.io/google_containers/$(IMAGE):$(TAG) .
+	docker build -t beta.gcr.io/google_containers/$(IMAGE):$(TAG) .
 
 push:	
-	gcloud docker push gcr.io/google_containers/$(IMAGE):$(TAG)
+	gcloud docker --server=beta.gcr.io push beta.gcr.io/google_containers/$(IMAGE):$(TAG)

--- a/cluster/saltbase/salt/fluentd-es/fluentd-es.yaml
+++ b/cluster/saltbase/salt/fluentd-es/fluentd-es.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
   - name: fluentd-elasticsearch
-    image: gcr.io/google_containers/fluentd-elasticsearch:1.11
+    image: beta.gcr.io/google_containers/fluentd-elasticsearch:1.12
     resources:
       limits:
         cpu: 100m

--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -41,7 +41,7 @@ import (
 const (
 	PodInfraContainerName  = leaky.PodInfraContainerName
 	DockerPrefix           = "docker://"
-	PodInfraContainerImage = "gcr.io/google_containers/pause:0.8.0"
+	PodInfraContainerImage = "beta.gcr.io/google_containers/pause:2.0"
 	LogSuffix              = "log"
 )
 

--- a/test/e2e/autoscaling.go
+++ b/test/e2e/autoscaling.go
@@ -128,7 +128,7 @@ func ReserveCpu(f *Framework, id string, millicores int) {
 		Name:       id,
 		Namespace:  f.Namespace.Name,
 		Timeout:    10 * time.Minute,
-		Image:      "gcr.io/google_containers/pause",
+		Image:      "beta.gcr.io/google_containers/pause:2.0",
 		Replicas:   millicores / 100,
 		CpuRequest: 100,
 	}
@@ -142,7 +142,7 @@ func ReserveMemory(f *Framework, id string, megabytes int) {
 		Name:       id,
 		Namespace:  f.Namespace.Name,
 		Timeout:    10 * time.Minute,
-		Image:      "gcr.io/google_containers/pause",
+		Image:      "beta.gcr.io/google_containers/pause:2.0",
 		Replicas:   megabytes / 500,
 		MemRequest: 500 * 1024 * 1024,
 	}

--- a/test/e2e/density.go
+++ b/test/e2e/density.go
@@ -190,7 +190,7 @@ var _ = Describe("Density", func() {
 			expectNoError(err)
 			defer fileHndl.Close()
 			config := RCConfig{Client: c,
-				Image:                "gcr.io/google_containers/pause:go",
+				Image:                "beta.gcr.io/google_containers/pause:2.0",
 				Name:                 RCName,
 				Namespace:            ns,
 				PollInterval:         itArg.interval,
@@ -320,7 +320,7 @@ var _ = Describe("Density", func() {
 				}
 				for i := 1; i <= nodeCount; i++ {
 					name := additionalPodsPrefix + "-" + strconv.Itoa(i)
-					go createRunningPod(&wg, c, name, ns, "gcr.io/google_containers/pause:go", podLabels)
+					go createRunningPod(&wg, c, name, ns, "beta.gcr.io/google_containers/pause:2.0", podLabels)
 					time.Sleep(200 * time.Millisecond)
 				}
 				wg.Wait()

--- a/test/e2e/kubelet.go
+++ b/test/e2e/kubelet.go
@@ -130,7 +130,7 @@ var _ = Describe("kubelet", func() {
 					Client:    framework.Client,
 					Name:      rcName,
 					Namespace: framework.Namespace.Name,
-					Image:     "gcr.io/google_containers/pause:go",
+					Image:     "beta.gcr.io/google_containers/pause:2.0",
 					Replicas:  totalPods,
 				})).NotTo(HaveOccurred())
 				// Perform a sanity check so that we know all desired pods are

--- a/test/e2e/kubelet_perf.go
+++ b/test/e2e/kubelet_perf.go
@@ -61,7 +61,7 @@ func runResourceTrackingTest(framework *Framework, podsPerNode int, nodeNames se
 		Client:    framework.Client,
 		Name:      rcName,
 		Namespace: framework.Namespace.Name,
-		Image:     "gcr.io/google_containers/pause:go",
+		Image:     "beta.gcr.io/google_containers/pause:2.0",
 		Replicas:  totalPods,
 	})).NotTo(HaveOccurred())
 

--- a/test/e2e/pods.go
+++ b/test/e2e/pods.go
@@ -142,7 +142,7 @@ var _ = Describe("Pods", func() {
 				Containers: []api.Container{
 					{
 						Name:  "test",
-						Image: "gcr.io/google_containers/pause",
+						Image: "beta.gcr.io/google_containers/pause:2.0",
 					},
 				},
 			},
@@ -167,7 +167,7 @@ var _ = Describe("Pods", func() {
 				Containers: []api.Container{
 					{
 						Name:  "nginx",
-						Image: "gcr.io/google_containers/pause",
+						Image: "beta.gcr.io/google_containers/pause:2.0",
 						Resources: api.ResourceRequirements{
 							Limits: api.ResourceList{
 								api.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),

--- a/test/e2e/scheduler_predicates.go
+++ b/test/e2e/scheduler_predicates.go
@@ -208,7 +208,7 @@ var _ = Describe("SchedulerPredicates", func() {
 				Containers: []api.Container{
 					{
 						Name:  "",
-						Image: "gcr.io/google_containers/pause:go",
+						Image: "beta.gcr.io/google_containers/pause:2.0",
 					},
 				},
 			},
@@ -227,7 +227,7 @@ var _ = Describe("SchedulerPredicates", func() {
 				Containers: []api.Container{
 					{
 						Name:  podName,
-						Image: "gcr.io/google_containers/pause:go",
+						Image: "beta.gcr.io/google_containers/pause:2.0",
 					},
 				},
 			},
@@ -288,7 +288,7 @@ var _ = Describe("SchedulerPredicates", func() {
 				Containers: []api.Container{
 					{
 						Name:  "",
-						Image: "gcr.io/google_containers/pause:go",
+						Image: "beta.gcr.io/google_containers/pause:2.0",
 						Resources: api.ResourceRequirements{
 							Limits: api.ResourceList{
 								"cpu": *resource.NewMilliQuantity(milliCpuPerPod, "DecimalSI"),
@@ -312,7 +312,7 @@ var _ = Describe("SchedulerPredicates", func() {
 				Containers: []api.Container{
 					{
 						Name:  podName,
-						Image: "gcr.io/google_containers/pause:go",
+						Image: "beta.gcr.io/google_containers/pause:2.0",
 						Resources: api.ResourceRequirements{
 							Limits: api.ResourceList{
 								"cpu": *resource.NewMilliQuantity(milliCpuPerPod, "DecimalSI"),
@@ -354,7 +354,7 @@ var _ = Describe("SchedulerPredicates", func() {
 				Containers: []api.Container{
 					{
 						Name:  podName,
-						Image: "gcr.io/google_containers/pause:go",
+						Image: "beta.gcr.io/google_containers/pause:2.0",
 					},
 				},
 				NodeSelector: map[string]string{
@@ -390,7 +390,7 @@ var _ = Describe("SchedulerPredicates", func() {
 				Containers: []api.Container{
 					{
 						Name:  podName,
-						Image: "gcr.io/google_containers/pause:go",
+						Image: "beta.gcr.io/google_containers/pause:2.0",
 					},
 				},
 			},
@@ -428,7 +428,7 @@ var _ = Describe("SchedulerPredicates", func() {
 				Containers: []api.Container{
 					{
 						Name:  labelPodName,
-						Image: "gcr.io/google_containers/pause:go",
+						Image: "beta.gcr.io/google_containers/pause:2.0",
 					},
 				},
 				NodeSelector: map[string]string{

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -1225,7 +1225,7 @@ func addEndpointPodOrFail(c *client.Client, ns, name string, labels map[string]s
 			Containers: []api.Container{
 				{
 					Name:  "test",
-					Image: "gcr.io/google_containers/pause",
+					Image: "beta.gcr.io/google_containers/pause:2.0",
 					Ports: containerPorts,
 				},
 			},

--- a/test/e2e/service_latency.go
+++ b/test/e2e/service_latency.go
@@ -119,7 +119,7 @@ var _ = Describe("Service endpoints latency", func() {
 func runServiceLatencies(f *Framework, inParallel, total int) (output []time.Duration, err error) {
 	cfg := RCConfig{
 		Client:       f.Client,
-		Image:        "gcr.io/google_containers/pause:1.0",
+		Image:        "beta.gcr.io/google_containers/pause:2.0",
 		Name:         "svc-latency-rc",
 		Namespace:    f.Namespace.Name,
 		Replicas:     1,


### PR DESCRIPTION
This scopes down the initial PR: #14960 to replace just `pause` and `fluentd-elasticsearch` to come through `beta.gcr.io`.

I broke each replacement into a separate commit for clarity.

NOTE: `beta.gcr.io` will still serve images using v1 until they are pushed with v2.  Pulls through `gcr.io` will still work after pushing through `beta.gcr.io`, but will be served over v1 (via compat logic).
