### PR TITLE
Stop using `gcloud preview` - it is obsolete

### DIFF
--- a/contrib/for-tests/volumes-tester/ceph/Makefile
+++ b/contrib/for-tests/volumes-tester/ceph/Makefile
@@ -7,7 +7,7 @@ container:
 	docker tag gcr.io/google_containers/volume-ceph gcr.io/google_containers/volume-ceph:$(TAG)  # Add the version tag to the latest image 
 
 push: container
-	gcloud preview docker push gcr.io/google_containers/volume-ceph # Push image tagged as latest to repository
-	gcloud preview docker push gcr.io/google_containers/volume-ceph:$(TAG) # Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
+	gcloud docker push gcr.io/google_containers/volume-ceph # Push image tagged as latest to repository
+	gcloud docker push gcr.io/google_containers/volume-ceph:$(TAG) # Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
 
 clean:

--- a/docs/admin/cluster-management.md
+++ b/docs/admin/cluster-management.md
@@ -72,7 +72,7 @@ The node upgrade process is user-initiated and is described in the [GKE document
 
 ### Upgrading open source Google Compute Engine clusters
 
-Upgrades on open source Google Compute Engine (GCE) clusters are controlled by the ```cluster/gce/upgrade.sh``` script.
+Upgrades on open source Google Compute Engine (GCE) clusters are controlled by the `cluster/gce/upgrade.sh` script.
 
 Its usage is as follows:
 
@@ -108,7 +108,7 @@ If your cluster runs short on resources you can easily add more machines to it i
 If you're using GCE or GKE it's done by resizing Instance Group managing your Nodes. It can be accomplished by modifying number of instances on `Compute > Compute Engine > Instance groups > your group > Edit group` [Google Cloud Console page](https://console.developers.google.com) or using gcloud CLI:
 
 ```
-gcloud compute instance-groups managed --zone compute-zone resize my-cluster-minon-group --new-size 42
+gcloud compute instance-groups managed --zone $ZONE resize my-cluster-minon-group --new-size 42
 ```
 
 Instance Group will take care of putting appropriate image on new machines and start them, while Kubelet will register its Node with API server to make it available for scheduling. If you scale the instance group down, system will randomly choose Nodes to kill.
@@ -122,29 +122,29 @@ If you are using GCE, you can configure your cluster so that the number of nodes
  * CPU and memory utilization.
  * Amount of of CPU and memory requested by the pods (called also reservation).
 
-Before setting up the cluster by ```kube-up.sh```, you can set ```KUBE_ENABLE_NODE_AUTOSCALER``` environment variable to ```true``` and export it.
+Before setting up the cluster by `kube-up.sh`, you can set `KUBE_ENABLE_NODE_AUTOSCALER` environment variable to `true` and export it.
 The script will create an autoscaler for the instance group managing your nodes.
 
 The autoscaler will try to maintain the average CPU/memory utilization and reservation of nodes within the cluster close to the target value.
-The target value can be configured by ```KUBE_TARGET_NODE_UTILIZATION``` environment variable (default: 0.7) for ``kube-up.sh`` when creating the cluster.
+The target value can be configured by `KUBE_TARGET_NODE_UTILIZATION` environment variable (default: 0.7) for ``kube-up.sh`` when creating the cluster.
 Node utilization is the total node's CPU/memory usage (OS + k8s + user load) divided by the node's capacity.
 Node reservation is the total CPU/memory requested by pods that are running on the node divided by the node's capacity.
 If the desired numbers of nodes in the cluster resulting from CPU/memory utilization/reservation are different,
-the autoscaler will choose the bigger number. The number of nodes in the cluster set by the autoscaler will be limited from ```KUBE_AUTOSCALER_MIN_NODES``` (default: 1)
-to ```KUBE_AUTOSCALER_MAX_NODES``` (default: the initial number of nodes in the cluster).
+the autoscaler will choose the bigger number. The number of nodes in the cluster set by the autoscaler will be limited from `KUBE_AUTOSCALER_MIN_NODES` (default: 1)
+to `KUBE_AUTOSCALER_MAX_NODES` (default: the initial number of nodes in the cluster).
 
 The autoscaler is implemented as a Compute Engine Autoscaler.
-The initial values of the autoscaler parameters set by ``kube-up.sh`` and some more advanced options can be tweaked on
+The initial values of the autoscaler parameters set by `kube-up.sh` and some more advanced options can be tweaked on
 `Compute > Compute Engine > Instance groups > your group > Edit group`[Google Cloud Console page](https://console.developers.google.com)
 or using gcloud CLI:
 
 ```
-gcloud preview autoscaler --zone compute-zone <command>
+gcloud alpha compute autoscaler --zone $ZONE <command>
 ```
 
 Note that autoscaling will work properly only if node metrics are accessible in Google Cloud Monitoring.
-To make the metrics accessible, you need to create your cluster with ```KUBE_ENABLE_CLUSTER_MONITORING```
-equal to ```google``` or ```googleinfluxdb``` (```googleinfluxdb``` is the default value). Please also make sure
+To make the metrics accessible, you need to create your cluster with `KUBE_ENABLE_CLUSTER_MONITORING`
+equal to `google` or `googleinfluxdb` (`googleinfluxdb` is the default value). Please also make sure
 that you have Google Cloud Monitoring API enabled in Google Developer Console.
 
 ## Maintenance on a Node

--- a/docs/getting-started-guides/gce.md
+++ b/docs/getting-started-guides/gce.md
@@ -63,7 +63,7 @@ If you want to use custom binaries or pure open source Kubernetes, please contin
 
 1. You need a Google Cloud Platform account with billing enabled. Visit the [Google Developers Console](http://cloud.google.com/console) for more details.
 1. Install `gcloud` as necessary. `gcloud` can be installed as a part of the [Google Cloud SDK](https://cloud.google.com/sdk/).
-1. Then, make sure you have the `gcloud preview` command line component installed. Run `gcloud preview` at the command line - if it asks to install any components, go ahead and install them. If it simply shows help text, you're good to go. This is required as the cluster setup script uses GCE [Instance Groups](https://cloud.google.com/compute/docs/instance-groups/), which are in the gcloud preview namespace. You will also need to **enable [`Compute Engine Instance Group Manager API`](https://developers.google.com/console/help/new/#activatingapis)** in the developers console.
+1. Enable the [Compute Engine Instance Group Manager API](https://developers.google.com/console/help/new/#activatingapis) in the [Google Cloud developers console](https://console.developers.google.com).
 1. Make sure that gcloud is set to use the Google Cloud Platform project you want. You can check the current project using `gcloud config list project` and change it via `gcloud config set project <project-id>`.
 1. Make sure you have credentials for GCloud by running ` gcloud auth login`.
 1. Make sure you can start up a GCE VM from the command line.  At least make sure you can do the [Create an instance](https://cloud.google.com/compute/docs/instances/#startinstancegcloud) part of the GCE Quickstart.

--- a/test/e2e/restart.go
+++ b/test/e2e/restart.go
@@ -225,7 +225,7 @@ func restartNodes(provider string, nt time.Duration) error {
 // with the following bash, but needs to be written in Go:
 //
 //   # Step 1: Get instance names.
-//   list=$(gcloud preview instance-groups --project=${PROJECT} --zone=${ZONE} instances --group=${GROUP} list)
+//   list=$(gcloud compute instance-groups --project=${PROJECT} --zone=${ZONE} instances --group=${GROUP} list)
 //   i=""
 //   for l in $list; do
 // 	  i="${l##*/},${i}"


### PR DESCRIPTION
Switch to supported APIs. Update docs.

@RichieEscarez because mostly docs.  We should cherry pick this.
