### PR TITLE
Re-add Shell to gke required filter

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -112,6 +112,7 @@ GKE_REQUIRED_SKIP_TESTS=(
     "Daemon\sset"
     "Deployment"
     "experimental\sresource\susage\stracking" # Expect --max-pods=100
+    "Shell"
     )
 
 # Tests which cannot be run on AWS.


### PR DESCRIPTION
ref #14904. `shell.go` still exists on the 1.0 branch and must be skipped for gke. cc @wojtek-t 
