### PR TITLE
don't count nodes with 0 daemonpods running when 0 should be running as mischeduled.

### DIFF
--- a/pkg/controller/daemon/controller.go
+++ b/pkg/controller/daemon/controller.go
@@ -448,13 +448,18 @@ func (dsc *DaemonSetsController) updateDaemonSetStatus(ds *experimental.DaemonSe
 		shouldRun := nodeSelector.Matches(labels.Set(node.Labels))
 		numDaemonPods := len(nodeToDaemonPods[node.Name])
 
-		if numDaemonPods > 0 {
+		// TODO(mikedanese): this does not count nodes that should be running
+		// exactly one daemon pod but are running more than one daemon pods.
+
+		if shouldRun && numDaemonPods == 1 {
 			currentNumberScheduled++
 		}
 
 		if shouldRun {
 			desiredNumberScheduled++
-		} else if numDaemonPods >= 0 {
+		}
+
+		if !shouldRun && numDaemonPods > 0 {
 			numberMisscheduled++
 		}
 	}


### PR DESCRIPTION
and break of the if else for more code clarity. This uncovered a bug where we were using >= when we should have been using > (in the last if block) which was causing us to miscount number of nodes mischeduled.
