### PR TITLE
kubelet: move common types to kubelet/types

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -48,10 +48,10 @@ import (
 	"k8s.io/kubernetes/pkg/controller/node"
 	replicationControllerPkg "k8s.io/kubernetes/pkg/controller/replication"
 	"k8s.io/kubernetes/pkg/fields"
-	"k8s.io/kubernetes/pkg/kubelet"
 	"k8s.io/kubernetes/pkg/kubelet/cadvisor"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/dockertools"
+	kubeletTypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/master"
 	"k8s.io/kubernetes/pkg/tools/etcdtest"
@@ -415,7 +415,7 @@ containers:
 
 			// Wait for the mirror pod to be created.
 			podName := fmt.Sprintf("%s-localhost", desc)
-			namespace := kubelet.NamespaceDefault
+			namespace := kubeletTypes.NamespaceDefault
 			if err := wait.Poll(time.Second, longTestTimeout,
 				podRunning(c, namespace, podName)); err != nil {
 				if pods, err := c.Pods(namespace).List(labels.Everything(), fields.Everything()); err == nil {

--- a/contrib/mesos/pkg/executor/executor.go
+++ b/contrib/mesos/pkg/executor/executor.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet"
 	"k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/dockertools"
+	kubeletTypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/util"
 )
 
@@ -264,9 +265,9 @@ func (k *KubernetesExecutor) onInitialRegistration() {
 	defer close(k.initialRegComplete)
 
 	// emit an empty update to allow the mesos "source" to be marked as seen
-	k.updateChan <- kubelet.PodUpdate{
+	k.updateChan <- kubeletTypes.PodUpdate{
 		Pods:   []*api.Pod{},
-		Op:     kubelet.SET,
+		Op:     kubeletTypes.SET,
 		Source: k.sourcename,
 	}
 }
@@ -392,8 +393,8 @@ func (k *KubernetesExecutor) handleChangedApiserverPod(pod *api.Pod) {
 			oldPod.DeletionTimestamp = pod.DeletionTimestamp
 			oldPod.DeletionGracePeriodSeconds = pod.DeletionGracePeriodSeconds
 
-			update := kubelet.PodUpdate{
-				Op:   kubelet.UPDATE,
+			update := kubeletTypes.PodUpdate{
+				Op:   kubeletTypes.UPDATE,
 				Pods: []*api.Pod{oldPod},
 			}
 			k.updateChan <- update
@@ -565,8 +566,8 @@ func (k *KubernetesExecutor) launchTask(driver bindings.ExecutorDriver, taskId s
 	k.pods[podFullName] = pod
 
 	// send the new pod to the kubelet which will spin it up
-	update := kubelet.PodUpdate{
-		Op:   kubelet.ADD,
+	update := kubeletTypes.PodUpdate{
+		Op:   kubeletTypes.ADD,
 		Pods: []*api.Pod{pod},
 	}
 	k.updateChan <- update
@@ -770,8 +771,8 @@ func (k *KubernetesExecutor) removePodTask(driver bindings.ExecutorDriver, tid, 
 		delete(k.pods, pid)
 
 		// tell the kubelet to remove the pod
-		update := kubelet.PodUpdate{
-			Op:   kubelet.REMOVE,
+		update := kubeletTypes.PodUpdate{
+			Op:   kubeletTypes.REMOVE,
 			Pods: []*api.Pod{pod},
 		}
 		k.updateChan <- update

--- a/contrib/mesos/pkg/executor/executor_test.go
+++ b/contrib/mesos/pkg/executor/executor_test.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet"
 	kconfig "k8s.io/kubernetes/pkg/kubelet/config"
 	"k8s.io/kubernetes/pkg/kubelet/dockertools"
+	kubeletTypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/watch"
 
@@ -66,15 +67,15 @@ func TestExecutorRegister(t *testing.T) {
 	executor.Init(mockDriver)
 	executor.Registered(mockDriver, nil, nil, nil)
 
-	initialPodUpdate := kubelet.PodUpdate{
+	initialPodUpdate := kubeletTypes.PodUpdate{
 		Pods:   []*api.Pod{},
-		Op:     kubelet.SET,
+		Op:     kubeletTypes.SET,
 		Source: executor.sourcename,
 	}
 	receivedInitialPodUpdate := false
 	select {
 	case m := <-updates:
-		update, ok := m.(kubelet.PodUpdate)
+		update, ok := m.(kubeletTypes.PodUpdate)
 		if ok {
 			if reflect.DeepEqual(initialPodUpdate, update) {
 				receivedInitialPodUpdate = true
@@ -212,7 +213,7 @@ func TestExecutorLaunchAndKillTask(t *testing.T) {
 	gotPodUpdate := false
 	select {
 	case m := <-updates:
-		update, ok := m.(kubelet.PodUpdate)
+		update, ok := m.(kubeletTypes.PodUpdate)
 		if ok && len(update.Pods) == 1 {
 			gotPodUpdate = true
 		}
@@ -360,7 +361,7 @@ func TestExecutorStaticPods(t *testing.T) {
 			if !ok {
 				return
 			}
-			podUpdate, ok := update.(kubelet.PodUpdate)
+			podUpdate, ok := update.(kubeletTypes.PodUpdate)
 			if !ok {
 				continue
 			}

--- a/contrib/mesos/pkg/scheduler/scheduler.go
+++ b/contrib/mesos/pkg/scheduler/scheduler.go
@@ -46,8 +46,8 @@ import (
 	"k8s.io/kubernetes/pkg/api/errors"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
-	"k8s.io/kubernetes/pkg/kubelet"
 	"k8s.io/kubernetes/pkg/kubelet/container"
+	kubeletTypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/tools"
 	"k8s.io/kubernetes/pkg/util/sets"
@@ -897,7 +897,7 @@ func (ks *KubernetesScheduler) recoverTasks() error {
 		ks.slaveHostNames.Register(slaveId, t.Offer.Host())
 	}
 	for _, pod := range podList.Items {
-		if _, isMirrorPod := pod.Annotations[kubelet.ConfigMirrorAnnotationKey]; isMirrorPod {
+		if _, isMirrorPod := pod.Annotations[kubeletTypes.ConfigMirrorAnnotationKey]; isMirrorPod {
 			// mirrored pods are never reconciled because the scheduler isn't responsible for
 			// scheduling them; they're started by the executor/kubelet upon instantiation and
 			// reflected in the apiserver afterward. the scheduler has no knowledge of them.

--- a/pkg/kubelet/config/apiserver.go
+++ b/pkg/kubelet/config/apiserver.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/kubernetes/pkg/client/cache"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
-	"k8s.io/kubernetes/pkg/kubelet"
+	kubeletTypes "k8s.io/kubernetes/pkg/kubelet/types"
 )
 
 // NewSourceApiserver creates a config source that watches and pulls from the apiserver.
@@ -38,7 +38,7 @@ func newSourceApiserverFromLW(lw cache.ListerWatcher, updates chan<- interface{}
 		for _, o := range objs {
 			pods = append(pods, o.(*api.Pod))
 		}
-		updates <- kubelet.PodUpdate{Pods: pods, Op: kubelet.SET, Source: kubelet.ApiserverSource}
+		updates <- kubeletTypes.PodUpdate{Pods: pods, Op: kubeletTypes.SET, Source: kubeletTypes.ApiserverSource}
 	}
 	cache.NewReflector(lw, &api.Pod{}, cache.NewUndeltaStore(send, cache.MetaNamespaceKeyFunc), 0).Run()
 }

--- a/pkg/kubelet/config/apiserver_test.go
+++ b/pkg/kubelet/config/apiserver_test.go
@@ -21,7 +21,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/cache"
-	"k8s.io/kubernetes/pkg/kubelet"
+	kubeletTypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/watch"
 )
@@ -67,8 +67,8 @@ func TestNewSourceApiserver_UpdatesAndMultiplePods(t *testing.T) {
 	if !ok {
 		t.Errorf("Unable to read from channel when expected")
 	}
-	update := got.(kubelet.PodUpdate)
-	expected := CreatePodUpdate(kubelet.SET, kubelet.ApiserverSource, pod1v1)
+	update := got.(kubeletTypes.PodUpdate)
+	expected := CreatePodUpdate(kubeletTypes.SET, kubeletTypes.ApiserverSource, pod1v1)
 	if !api.Semantic.DeepEqual(expected, update) {
 		t.Errorf("Expected %#v; Got %#v", expected, update)
 	}
@@ -79,10 +79,10 @@ func TestNewSourceApiserver_UpdatesAndMultiplePods(t *testing.T) {
 	if !ok {
 		t.Errorf("Unable to read from channel when expected")
 	}
-	update = got.(kubelet.PodUpdate)
+	update = got.(kubeletTypes.PodUpdate)
 	// Could be sorted either of these two ways:
-	expectedA := CreatePodUpdate(kubelet.SET, kubelet.ApiserverSource, pod1v1, pod2)
-	expectedB := CreatePodUpdate(kubelet.SET, kubelet.ApiserverSource, pod2, pod1v1)
+	expectedA := CreatePodUpdate(kubeletTypes.SET, kubeletTypes.ApiserverSource, pod1v1, pod2)
+	expectedB := CreatePodUpdate(kubeletTypes.SET, kubeletTypes.ApiserverSource, pod2, pod1v1)
 
 	if !api.Semantic.DeepEqual(expectedA, update) && !api.Semantic.DeepEqual(expectedB, update) {
 		t.Errorf("Expected %#v or %#v, Got %#v", expectedA, expectedB, update)
@@ -94,9 +94,9 @@ func TestNewSourceApiserver_UpdatesAndMultiplePods(t *testing.T) {
 	if !ok {
 		t.Errorf("Unable to read from channel when expected")
 	}
-	update = got.(kubelet.PodUpdate)
-	expectedA = CreatePodUpdate(kubelet.SET, kubelet.ApiserverSource, pod1v2, pod2)
-	expectedB = CreatePodUpdate(kubelet.SET, kubelet.ApiserverSource, pod2, pod1v2)
+	update = got.(kubeletTypes.PodUpdate)
+	expectedA = CreatePodUpdate(kubeletTypes.SET, kubeletTypes.ApiserverSource, pod1v2, pod2)
+	expectedB = CreatePodUpdate(kubeletTypes.SET, kubeletTypes.ApiserverSource, pod2, pod1v2)
 
 	if !api.Semantic.DeepEqual(expectedA, update) && !api.Semantic.DeepEqual(expectedB, update) {
 		t.Errorf("Expected %#v or %#v, Got %#v", expectedA, expectedB, update)
@@ -108,8 +108,8 @@ func TestNewSourceApiserver_UpdatesAndMultiplePods(t *testing.T) {
 	if !ok {
 		t.Errorf("Unable to read from channel when expected")
 	}
-	update = got.(kubelet.PodUpdate)
-	expected = CreatePodUpdate(kubelet.SET, kubelet.ApiserverSource, pod2)
+	update = got.(kubeletTypes.PodUpdate)
+	expected = CreatePodUpdate(kubeletTypes.SET, kubeletTypes.ApiserverSource, pod2)
 	if !api.Semantic.DeepEqual(expected, update) {
 		t.Errorf("Expected %#v, Got %#v", expected, update)
 	}
@@ -120,8 +120,8 @@ func TestNewSourceApiserver_UpdatesAndMultiplePods(t *testing.T) {
 	if !ok {
 		t.Errorf("Unable to read from channel when expected")
 	}
-	update = got.(kubelet.PodUpdate)
-	expected = CreatePodUpdate(kubelet.SET, kubelet.ApiserverSource)
+	update = got.(kubeletTypes.PodUpdate)
+	expected = CreatePodUpdate(kubeletTypes.SET, kubeletTypes.ApiserverSource)
 	if !api.Semantic.DeepEqual(expected, update) {
 		t.Errorf("Expected %#v, Got %#v", expected, update)
 	}
@@ -150,7 +150,7 @@ func TestNewSourceApiserver_TwoNamespacesSameName(t *testing.T) {
 	if !ok {
 		t.Errorf("Unable to read from channel when expected")
 	}
-	update := got.(kubelet.PodUpdate)
+	update := got.(kubeletTypes.PodUpdate)
 	// Make sure that we get both pods.  Catches bug #2294.
 	if !(len(update.Pods) == 2) {
 		t.Errorf("Expected %d, Got %d", 2, len(update.Pods))
@@ -162,7 +162,7 @@ func TestNewSourceApiserver_TwoNamespacesSameName(t *testing.T) {
 	if !ok {
 		t.Errorf("Unable to read from channel when expected")
 	}
-	update = got.(kubelet.PodUpdate)
+	update = got.(kubeletTypes.PodUpdate)
 	if !(len(update.Pods) == 1) {
 		t.Errorf("Expected %d, Got %d", 1, len(update.Pods))
 	}
@@ -184,8 +184,8 @@ func TestNewSourceApiserverInitialEmptySendsEmptyPodUpdate(t *testing.T) {
 	if !ok {
 		t.Errorf("Unable to read from channel when expected")
 	}
-	update := got.(kubelet.PodUpdate)
-	expected := CreatePodUpdate(kubelet.SET, kubelet.ApiserverSource)
+	update := got.(kubeletTypes.PodUpdate)
+	expected := CreatePodUpdate(kubeletTypes.SET, kubeletTypes.ApiserverSource)
 	if !api.Semantic.DeepEqual(expected, update) {
 		t.Errorf("Expected %#v; Got %#v", expected, update)
 	}

--- a/pkg/kubelet/config/common.go
+++ b/pkg/kubelet/config/common.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/api/validation"
-	"k8s.io/kubernetes/pkg/kubelet"
+	kubeletTypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util"
 	utilyaml "k8s.io/kubernetes/pkg/util/yaml"
@@ -56,7 +56,7 @@ func applyDefaults(pod *api.Pod, source string, isFile bool, nodeName string) er
 	glog.V(5).Infof("Generated Name %q for UID %q from URL %s", pod.Name, pod.UID, source)
 
 	if pod.Namespace == "" {
-		pod.Namespace = kubelet.NamespaceDefault
+		pod.Namespace = kubeletTypes.NamespaceDefault
 	}
 	glog.V(5).Infof("Using namespace %q for pod %q from %s", pod.Namespace, pod.Name, source)
 

--- a/pkg/kubelet/config/config.go
+++ b/pkg/kubelet/config/config.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/validation"
 	"k8s.io/kubernetes/pkg/client/record"
-	"k8s.io/kubernetes/pkg/kubelet"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	kubeletTypes "k8s.io/kubernetes/pkg/kubelet/types"
 	kubeletUtil "k8s.io/kubernetes/pkg/kubelet/util"
@@ -60,7 +59,7 @@ type PodConfig struct {
 	mux  *config.Mux
 
 	// the channel of denormalized changes passed to listeners
-	updates chan kubelet.PodUpdate
+	updates chan kubeletTypes.PodUpdate
 
 	// contains the list of all configured sources
 	sourcesLock sync.Mutex
@@ -70,7 +69,7 @@ type PodConfig struct {
 // NewPodConfig creates an object that can merge many configuration sources into a stream
 // of normalized updates to a pod configuration.
 func NewPodConfig(mode PodConfigNotificationMode, recorder record.EventRecorder) *PodConfig {
-	updates := make(chan kubelet.PodUpdate, 50)
+	updates := make(chan kubeletTypes.PodUpdate, 50)
 	storage := newPodStorage(updates, mode, recorder)
 	podConfig := &PodConfig{
 		pods:    storage,
@@ -101,7 +100,7 @@ func (c *PodConfig) SeenAllSources() bool {
 }
 
 // Updates returns a channel of updates to the configuration, properly denormalized.
-func (c *PodConfig) Updates() <-chan kubelet.PodUpdate {
+func (c *PodConfig) Updates() <-chan kubeletTypes.PodUpdate {
 	return c.updates
 }
 
@@ -123,7 +122,7 @@ type podStorage struct {
 	// ensures that updates are delivered in strict order
 	// on the updates channel
 	updateLock sync.Mutex
-	updates    chan<- kubelet.PodUpdate
+	updates    chan<- kubeletTypes.PodUpdate
 
 	// contains the set of all sources that have sent at least one SET
 	sourcesSeenLock sync.Mutex
@@ -136,7 +135,7 @@ type podStorage struct {
 // TODO: PodConfigNotificationMode could be handled by a listener to the updates channel
 // in the future, especially with multiple listeners.
 // TODO: allow initialization of the current state of the store with snapshotted version.
-func newPodStorage(updates chan<- kubelet.PodUpdate, mode PodConfigNotificationMode, recorder record.EventRecorder) *podStorage {
+func newPodStorage(updates chan<- kubeletTypes.PodUpdate, mode PodConfigNotificationMode, recorder record.EventRecorder) *podStorage {
 	return &podStorage{
 		pods:        make(map[string]map[string]*api.Pod),
 		mode:        mode,
@@ -173,12 +172,12 @@ func (s *podStorage) Merge(source string, change interface{}) error {
 			s.updates <- *updates
 		}
 		if len(deletes.Pods) > 0 || len(adds.Pods) > 0 {
-			s.updates <- kubelet.PodUpdate{Pods: s.MergedState().([]*api.Pod), Op: kubelet.SET, Source: source}
+			s.updates <- kubeletTypes.PodUpdate{Pods: s.MergedState().([]*api.Pod), Op: kubeletTypes.SET, Source: source}
 		}
 
 	case PodConfigNotificationSnapshot:
 		if len(updates.Pods) > 0 || len(deletes.Pods) > 0 || len(adds.Pods) > 0 {
-			s.updates <- kubelet.PodUpdate{Pods: s.MergedState().([]*api.Pod), Op: kubelet.SET, Source: source}
+			s.updates <- kubeletTypes.PodUpdate{Pods: s.MergedState().([]*api.Pod), Op: kubeletTypes.SET, Source: source}
 		}
 
 	case PodConfigNotificationUnknown:
@@ -190,23 +189,23 @@ func (s *podStorage) Merge(source string, change interface{}) error {
 	return nil
 }
 
-func (s *podStorage) merge(source string, change interface{}) (adds, updates, deletes *kubelet.PodUpdate) {
+func (s *podStorage) merge(source string, change interface{}) (adds, updates, deletes *kubeletTypes.PodUpdate) {
 	s.podLock.Lock()
 	defer s.podLock.Unlock()
 
-	adds = &kubelet.PodUpdate{Op: kubelet.ADD, Source: source}
-	updates = &kubelet.PodUpdate{Op: kubelet.UPDATE, Source: source}
-	deletes = &kubelet.PodUpdate{Op: kubelet.REMOVE, Source: source}
+	adds = &kubeletTypes.PodUpdate{Op: kubeletTypes.ADD, Source: source}
+	updates = &kubeletTypes.PodUpdate{Op: kubeletTypes.UPDATE, Source: source}
+	deletes = &kubeletTypes.PodUpdate{Op: kubeletTypes.REMOVE, Source: source}
 
 	pods := s.pods[source]
 	if pods == nil {
 		pods = make(map[string]*api.Pod)
 	}
 
-	update := change.(kubelet.PodUpdate)
+	update := change.(kubeletTypes.PodUpdate)
 	switch update.Op {
-	case kubelet.ADD, kubelet.UPDATE:
-		if update.Op == kubelet.ADD {
+	case kubeletTypes.ADD, kubeletTypes.UPDATE:
+		if update.Op == kubeletTypes.ADD {
 			glog.V(4).Infof("Adding new pods from source %s : %v", source, update.Pods)
 		} else {
 			glog.V(4).Infof("Updating pods from source %s : %v", source, update.Pods)
@@ -219,7 +218,7 @@ func (s *podStorage) merge(source string, change interface{}) (adds, updates, de
 			if ref.Annotations == nil {
 				ref.Annotations = make(map[string]string)
 			}
-			ref.Annotations[kubelet.ConfigSourceAnnotationKey] = source
+			ref.Annotations[kubeletTypes.ConfigSourceAnnotationKey] = source
 			if existing, found := pods[name]; found {
 				if checkAndUpdatePod(existing, ref) {
 					// this is an update
@@ -235,7 +234,7 @@ func (s *podStorage) merge(source string, change interface{}) (adds, updates, de
 			adds.Pods = append(adds.Pods, ref)
 		}
 
-	case kubelet.REMOVE:
+	case kubeletTypes.REMOVE:
 		glog.V(4).Infof("Removing a pod %v", update)
 		for _, value := range update.Pods {
 			name := kubecontainer.GetPodFullName(value)
@@ -248,7 +247,7 @@ func (s *podStorage) merge(source string, change interface{}) (adds, updates, de
 			// this is a no-op
 		}
 
-	case kubelet.SET:
+	case kubeletTypes.SET:
 		glog.V(4).Infof("Setting pods for source %s", source)
 		s.markSourceSet(source)
 		// Clear the old map entries by just creating a new map
@@ -262,7 +261,7 @@ func (s *podStorage) merge(source string, change interface{}) (adds, updates, de
 			if ref.Annotations == nil {
 				ref.Annotations = make(map[string]string)
 			}
-			ref.Annotations[kubelet.ConfigSourceAnnotationKey] = source
+			ref.Annotations[kubeletTypes.ConfigSourceAnnotationKey] = source
 			if existing, found := oldPods[name]; found {
 				pods[name] = existing
 				if checkAndUpdatePod(existing, ref) {
@@ -336,9 +335,9 @@ func filterInvalidPods(pods []*api.Pod, source string, recorder record.EventReco
 
 // Annotations that the kubelet adds to the pod.
 var localAnnotations = []string{
-	kubelet.ConfigSourceAnnotationKey,
-	kubelet.ConfigMirrorAnnotationKey,
-	kubelet.ConfigFirstSeenAnnotationKey,
+	kubeletTypes.ConfigSourceAnnotationKey,
+	kubeletTypes.ConfigMirrorAnnotationKey,
+	kubeletTypes.ConfigFirstSeenAnnotationKey,
 }
 
 func isLocalAnnotationKey(key string) bool {
@@ -380,7 +379,7 @@ func isAnnotationMapEqual(existingMap, candidateMap map[string]string) bool {
 // recordFirstSeenTime records the first seen time of this pod.
 func recordFirstSeenTime(pod *api.Pod) {
 	glog.V(4).Infof("Receiving a new pod %q", kubeletUtil.FormatPodName(pod))
-	pod.Annotations[kubelet.ConfigFirstSeenAnnotationKey] = kubeletTypes.NewTimestamp().GetString()
+	pod.Annotations[kubeletTypes.ConfigFirstSeenAnnotationKey] = kubeletTypes.NewTimestamp().GetString()
 }
 
 // updateAnnotations returns an Annotation map containing the api annotation map plus
@@ -421,7 +420,7 @@ func checkAndUpdatePod(existing, ref *api.Pod) bool {
 
 	// Overwrite the first-seen time with the existing one. This is our own
 	// internal annotation, there is no need to update.
-	ref.Annotations[kubelet.ConfigFirstSeenAnnotationKey] = existing.Annotations[kubelet.ConfigFirstSeenAnnotationKey]
+	ref.Annotations[kubeletTypes.ConfigFirstSeenAnnotationKey] = existing.Annotations[kubeletTypes.ConfigFirstSeenAnnotationKey]
 
 	existing.Spec = ref.Spec
 	existing.Labels = ref.Labels
@@ -435,7 +434,7 @@ func checkAndUpdatePod(existing, ref *api.Pod) bool {
 func (s *podStorage) Sync() {
 	s.updateLock.Lock()
 	defer s.updateLock.Unlock()
-	s.updates <- kubelet.PodUpdate{Pods: s.MergedState().([]*api.Pod), Op: kubelet.SET, Source: kubelet.AllSource}
+	s.updates <- kubeletTypes.PodUpdate{Pods: s.MergedState().([]*api.Pod), Op: kubeletTypes.SET, Source: kubeletTypes.AllSource}
 }
 
 // Object implements config.Accessor

--- a/pkg/kubelet/config/config_test.go
+++ b/pkg/kubelet/config/config_test.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/record"
 	"k8s.io/kubernetes/pkg/conversion"
-	"k8s.io/kubernetes/pkg/kubelet"
+	kubeletTypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/securitycontext"
 	"k8s.io/kubernetes/pkg/types"
 )
@@ -74,11 +74,11 @@ func CreateValidPod(name, namespace string) *api.Pod {
 	}
 }
 
-func CreatePodUpdate(op kubelet.PodOperation, source string, pods ...*api.Pod) kubelet.PodUpdate {
-	return kubelet.PodUpdate{Pods: pods, Op: op, Source: source}
+func CreatePodUpdate(op kubeletTypes.PodOperation, source string, pods ...*api.Pod) kubeletTypes.PodUpdate {
+	return kubeletTypes.PodUpdate{Pods: pods, Op: op, Source: source}
 }
 
-func createPodConfigTester(mode PodConfigNotificationMode) (chan<- interface{}, <-chan kubelet.PodUpdate, *PodConfig) {
+func createPodConfigTester(mode PodConfigNotificationMode) (chan<- interface{}, <-chan kubeletTypes.PodUpdate, *PodConfig) {
 	eventBroadcaster := record.NewBroadcaster()
 	config := NewPodConfig(mode, eventBroadcaster.NewRecorder(api.EventSource{Component: "kubelet"}))
 	channel := config.Channel(TestSource)
@@ -86,7 +86,7 @@ func createPodConfigTester(mode PodConfigNotificationMode) (chan<- interface{}, 
 	return channel, ch, config
 }
 
-func expectPodUpdate(t *testing.T, ch <-chan kubelet.PodUpdate, expected ...kubelet.PodUpdate) {
+func expectPodUpdate(t *testing.T, ch <-chan kubeletTypes.PodUpdate, expected ...kubeletTypes.PodUpdate) {
 	for i := range expected {
 		update := <-ch
 		sort.Sort(sortedPods(update.Pods))
@@ -113,7 +113,7 @@ func expectPodUpdate(t *testing.T, ch <-chan kubelet.PodUpdate, expected ...kube
 	expectNoPodUpdate(t, ch)
 }
 
-func expectNoPodUpdate(t *testing.T, ch <-chan kubelet.PodUpdate) {
+func expectNoPodUpdate(t *testing.T, ch <-chan kubeletTypes.PodUpdate) {
 	select {
 	case update := <-ch:
 		t.Errorf("Expected no update in channel, Got %#v", update)
@@ -125,63 +125,63 @@ func TestNewPodAdded(t *testing.T) {
 	channel, ch, config := createPodConfigTester(PodConfigNotificationIncremental)
 
 	// see an update
-	podUpdate := CreatePodUpdate(kubelet.ADD, TestSource, CreateValidPod("foo", "new"))
+	podUpdate := CreatePodUpdate(kubeletTypes.ADD, TestSource, CreateValidPod("foo", "new"))
 	channel <- podUpdate
-	expectPodUpdate(t, ch, CreatePodUpdate(kubelet.ADD, TestSource, CreateValidPod("foo", "new")))
+	expectPodUpdate(t, ch, CreatePodUpdate(kubeletTypes.ADD, TestSource, CreateValidPod("foo", "new")))
 
 	config.Sync()
-	expectPodUpdate(t, ch, CreatePodUpdate(kubelet.SET, kubelet.AllSource, CreateValidPod("foo", "new")))
+	expectPodUpdate(t, ch, CreatePodUpdate(kubeletTypes.SET, kubeletTypes.AllSource, CreateValidPod("foo", "new")))
 }
 
 func TestNewPodAddedInvalidNamespace(t *testing.T) {
 	channel, ch, config := createPodConfigTester(PodConfigNotificationIncremental)
 
 	// see an update
-	podUpdate := CreatePodUpdate(kubelet.ADD, TestSource, CreateValidPod("foo", ""))
+	podUpdate := CreatePodUpdate(kubeletTypes.ADD, TestSource, CreateValidPod("foo", ""))
 	channel <- podUpdate
 	config.Sync()
-	expectPodUpdate(t, ch, CreatePodUpdate(kubelet.SET, kubelet.AllSource))
+	expectPodUpdate(t, ch, CreatePodUpdate(kubeletTypes.SET, kubeletTypes.AllSource))
 }
 
 func TestNewPodAddedDefaultNamespace(t *testing.T) {
 	channel, ch, config := createPodConfigTester(PodConfigNotificationIncremental)
 
 	// see an update
-	podUpdate := CreatePodUpdate(kubelet.ADD, TestSource, CreateValidPod("foo", "default"))
+	podUpdate := CreatePodUpdate(kubeletTypes.ADD, TestSource, CreateValidPod("foo", "default"))
 	channel <- podUpdate
-	expectPodUpdate(t, ch, CreatePodUpdate(kubelet.ADD, TestSource, CreateValidPod("foo", "default")))
+	expectPodUpdate(t, ch, CreatePodUpdate(kubeletTypes.ADD, TestSource, CreateValidPod("foo", "default")))
 
 	config.Sync()
-	expectPodUpdate(t, ch, CreatePodUpdate(kubelet.SET, kubelet.AllSource, CreateValidPod("foo", "default")))
+	expectPodUpdate(t, ch, CreatePodUpdate(kubeletTypes.SET, kubeletTypes.AllSource, CreateValidPod("foo", "default")))
 }
 
 func TestNewPodAddedDifferentNamespaces(t *testing.T) {
 	channel, ch, config := createPodConfigTester(PodConfigNotificationIncremental)
 
 	// see an update
-	podUpdate := CreatePodUpdate(kubelet.ADD, TestSource, CreateValidPod("foo", "default"))
+	podUpdate := CreatePodUpdate(kubeletTypes.ADD, TestSource, CreateValidPod("foo", "default"))
 	channel <- podUpdate
-	expectPodUpdate(t, ch, CreatePodUpdate(kubelet.ADD, TestSource, CreateValidPod("foo", "default")))
+	expectPodUpdate(t, ch, CreatePodUpdate(kubeletTypes.ADD, TestSource, CreateValidPod("foo", "default")))
 
 	// see an update in another namespace
-	podUpdate = CreatePodUpdate(kubelet.ADD, TestSource, CreateValidPod("foo", "new"))
+	podUpdate = CreatePodUpdate(kubeletTypes.ADD, TestSource, CreateValidPod("foo", "new"))
 	channel <- podUpdate
-	expectPodUpdate(t, ch, CreatePodUpdate(kubelet.ADD, TestSource, CreateValidPod("foo", "new")))
+	expectPodUpdate(t, ch, CreatePodUpdate(kubeletTypes.ADD, TestSource, CreateValidPod("foo", "new")))
 
 	config.Sync()
-	expectPodUpdate(t, ch, CreatePodUpdate(kubelet.SET, kubelet.AllSource, CreateValidPod("foo", "default"), CreateValidPod("foo", "new")))
+	expectPodUpdate(t, ch, CreatePodUpdate(kubeletTypes.SET, kubeletTypes.AllSource, CreateValidPod("foo", "default"), CreateValidPod("foo", "new")))
 }
 
 func TestInvalidPodFiltered(t *testing.T) {
 	channel, ch, _ := createPodConfigTester(PodConfigNotificationIncremental)
 
 	// see an update
-	podUpdate := CreatePodUpdate(kubelet.ADD, TestSource, CreateValidPod("foo", "new"))
+	podUpdate := CreatePodUpdate(kubeletTypes.ADD, TestSource, CreateValidPod("foo", "new"))
 	channel <- podUpdate
-	expectPodUpdate(t, ch, CreatePodUpdate(kubelet.ADD, TestSource, CreateValidPod("foo", "new")))
+	expectPodUpdate(t, ch, CreatePodUpdate(kubeletTypes.ADD, TestSource, CreateValidPod("foo", "new")))
 
 	// add an invalid update
-	podUpdate = CreatePodUpdate(kubelet.UPDATE, TestSource, &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}})
+	podUpdate = CreatePodUpdate(kubeletTypes.UPDATE, TestSource, &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}})
 	channel <- podUpdate
 	expectNoPodUpdate(t, ch)
 }
@@ -190,81 +190,81 @@ func TestNewPodAddedSnapshotAndUpdates(t *testing.T) {
 	channel, ch, config := createPodConfigTester(PodConfigNotificationSnapshotAndUpdates)
 
 	// see an set
-	podUpdate := CreatePodUpdate(kubelet.ADD, TestSource, CreateValidPod("foo", "new"))
+	podUpdate := CreatePodUpdate(kubeletTypes.ADD, TestSource, CreateValidPod("foo", "new"))
 	channel <- podUpdate
-	expectPodUpdate(t, ch, CreatePodUpdate(kubelet.SET, TestSource, CreateValidPod("foo", "new")))
+	expectPodUpdate(t, ch, CreatePodUpdate(kubeletTypes.SET, TestSource, CreateValidPod("foo", "new")))
 
 	config.Sync()
-	expectPodUpdate(t, ch, CreatePodUpdate(kubelet.SET, kubelet.AllSource, CreateValidPod("foo", "new")))
+	expectPodUpdate(t, ch, CreatePodUpdate(kubeletTypes.SET, kubeletTypes.AllSource, CreateValidPod("foo", "new")))
 
 	// container updates are separated as UPDATE
 	pod := *podUpdate.Pods[0]
 	pod.Spec.Containers = []api.Container{{Name: "bar", Image: "test", ImagePullPolicy: api.PullIfNotPresent}}
-	channel <- CreatePodUpdate(kubelet.ADD, TestSource, &pod)
-	expectPodUpdate(t, ch, CreatePodUpdate(kubelet.UPDATE, TestSource, &pod))
+	channel <- CreatePodUpdate(kubeletTypes.ADD, TestSource, &pod)
+	expectPodUpdate(t, ch, CreatePodUpdate(kubeletTypes.UPDATE, TestSource, &pod))
 }
 
 func TestNewPodAddedSnapshot(t *testing.T) {
 	channel, ch, config := createPodConfigTester(PodConfigNotificationSnapshot)
 
 	// see an set
-	podUpdate := CreatePodUpdate(kubelet.ADD, TestSource, CreateValidPod("foo", "new"))
+	podUpdate := CreatePodUpdate(kubeletTypes.ADD, TestSource, CreateValidPod("foo", "new"))
 	channel <- podUpdate
-	expectPodUpdate(t, ch, CreatePodUpdate(kubelet.SET, TestSource, CreateValidPod("foo", "new")))
+	expectPodUpdate(t, ch, CreatePodUpdate(kubeletTypes.SET, TestSource, CreateValidPod("foo", "new")))
 
 	config.Sync()
-	expectPodUpdate(t, ch, CreatePodUpdate(kubelet.SET, kubelet.AllSource, CreateValidPod("foo", "new")))
+	expectPodUpdate(t, ch, CreatePodUpdate(kubeletTypes.SET, kubeletTypes.AllSource, CreateValidPod("foo", "new")))
 
 	// container updates are separated as UPDATE
 	pod := *podUpdate.Pods[0]
 	pod.Spec.Containers = []api.Container{{Name: "bar", Image: "test", ImagePullPolicy: api.PullIfNotPresent}}
-	channel <- CreatePodUpdate(kubelet.ADD, TestSource, &pod)
-	expectPodUpdate(t, ch, CreatePodUpdate(kubelet.SET, TestSource, &pod))
+	channel <- CreatePodUpdate(kubeletTypes.ADD, TestSource, &pod)
+	expectPodUpdate(t, ch, CreatePodUpdate(kubeletTypes.SET, TestSource, &pod))
 }
 
 func TestNewPodAddedUpdatedRemoved(t *testing.T) {
 	channel, ch, _ := createPodConfigTester(PodConfigNotificationIncremental)
 
 	// should register an add
-	podUpdate := CreatePodUpdate(kubelet.ADD, TestSource, CreateValidPod("foo", "new"))
+	podUpdate := CreatePodUpdate(kubeletTypes.ADD, TestSource, CreateValidPod("foo", "new"))
 	channel <- podUpdate
-	expectPodUpdate(t, ch, CreatePodUpdate(kubelet.ADD, TestSource, CreateValidPod("foo", "new")))
+	expectPodUpdate(t, ch, CreatePodUpdate(kubeletTypes.ADD, TestSource, CreateValidPod("foo", "new")))
 
 	// should ignore ADDs that are identical
 	expectNoPodUpdate(t, ch)
 
-	// an kubelet.ADD should be converted to kubelet.UPDATE
+	// an kubeletTypes.ADD should be converted to kubeletTypes.UPDATE
 	pod := CreateValidPod("foo", "new")
 	pod.Spec.Containers = []api.Container{{Name: "bar", Image: "test", ImagePullPolicy: api.PullIfNotPresent}}
-	podUpdate = CreatePodUpdate(kubelet.ADD, TestSource, pod)
+	podUpdate = CreatePodUpdate(kubeletTypes.ADD, TestSource, pod)
 	channel <- podUpdate
-	expectPodUpdate(t, ch, CreatePodUpdate(kubelet.UPDATE, TestSource, pod))
+	expectPodUpdate(t, ch, CreatePodUpdate(kubeletTypes.UPDATE, TestSource, pod))
 
-	podUpdate = CreatePodUpdate(kubelet.REMOVE, TestSource, &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo", Namespace: "new"}})
+	podUpdate = CreatePodUpdate(kubeletTypes.REMOVE, TestSource, &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo", Namespace: "new"}})
 	channel <- podUpdate
-	expectPodUpdate(t, ch, CreatePodUpdate(kubelet.REMOVE, TestSource, pod))
+	expectPodUpdate(t, ch, CreatePodUpdate(kubeletTypes.REMOVE, TestSource, pod))
 }
 
 func TestNewPodAddedUpdatedSet(t *testing.T) {
 	channel, ch, _ := createPodConfigTester(PodConfigNotificationIncremental)
 
 	// should register an add
-	podUpdate := CreatePodUpdate(kubelet.ADD, TestSource, CreateValidPod("foo", "new"), CreateValidPod("foo2", "new"), CreateValidPod("foo3", "new"))
+	podUpdate := CreatePodUpdate(kubeletTypes.ADD, TestSource, CreateValidPod("foo", "new"), CreateValidPod("foo2", "new"), CreateValidPod("foo3", "new"))
 	channel <- podUpdate
-	expectPodUpdate(t, ch, CreatePodUpdate(kubelet.ADD, TestSource, CreateValidPod("foo", "new"), CreateValidPod("foo2", "new"), CreateValidPod("foo3", "new")))
+	expectPodUpdate(t, ch, CreatePodUpdate(kubeletTypes.ADD, TestSource, CreateValidPod("foo", "new"), CreateValidPod("foo2", "new"), CreateValidPod("foo3", "new")))
 
 	// should ignore ADDs that are identical
 	expectNoPodUpdate(t, ch)
 
-	// should be converted to an kubelet.ADD, kubelet.REMOVE, and kubelet.UPDATE
+	// should be converted to an kubeletTypes.ADD, kubeletTypes.REMOVE, and kubeletTypes.UPDATE
 	pod := CreateValidPod("foo2", "new")
 	pod.Spec.Containers = []api.Container{{Name: "bar", Image: "test", ImagePullPolicy: api.PullIfNotPresent}}
-	podUpdate = CreatePodUpdate(kubelet.SET, TestSource, pod, CreateValidPod("foo3", "new"), CreateValidPod("foo4", "new"))
+	podUpdate = CreatePodUpdate(kubeletTypes.SET, TestSource, pod, CreateValidPod("foo3", "new"), CreateValidPod("foo4", "new"))
 	channel <- podUpdate
 	expectPodUpdate(t, ch,
-		CreatePodUpdate(kubelet.REMOVE, TestSource, CreateValidPod("foo", "new")),
-		CreatePodUpdate(kubelet.ADD, TestSource, CreateValidPod("foo4", "new")),
-		CreatePodUpdate(kubelet.UPDATE, TestSource, pod))
+		CreatePodUpdate(kubeletTypes.REMOVE, TestSource, CreateValidPod("foo", "new")),
+		CreatePodUpdate(kubeletTypes.ADD, TestSource, CreateValidPod("foo4", "new")),
+		CreatePodUpdate(kubeletTypes.UPDATE, TestSource, pod))
 }
 
 func TestPodUpdateAnnotations(t *testing.T) {
@@ -279,24 +279,24 @@ func TestPodUpdateAnnotations(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 
-	podUpdate := CreatePodUpdate(kubelet.SET, TestSource, CreateValidPod("foo1", "new"), clone.(*api.Pod), CreateValidPod("foo3", "new"))
+	podUpdate := CreatePodUpdate(kubeletTypes.SET, TestSource, CreateValidPod("foo1", "new"), clone.(*api.Pod), CreateValidPod("foo3", "new"))
 	channel <- podUpdate
-	expectPodUpdate(t, ch, CreatePodUpdate(kubelet.ADD, TestSource, CreateValidPod("foo1", "new"), pod, CreateValidPod("foo3", "new")))
+	expectPodUpdate(t, ch, CreatePodUpdate(kubeletTypes.ADD, TestSource, CreateValidPod("foo1", "new"), pod, CreateValidPod("foo3", "new")))
 
 	pod.Annotations["kubenetes.io/blah"] = "superblah"
-	podUpdate = CreatePodUpdate(kubelet.SET, TestSource, CreateValidPod("foo1", "new"), pod, CreateValidPod("foo3", "new"))
+	podUpdate = CreatePodUpdate(kubeletTypes.SET, TestSource, CreateValidPod("foo1", "new"), pod, CreateValidPod("foo3", "new"))
 	channel <- podUpdate
-	expectPodUpdate(t, ch, CreatePodUpdate(kubelet.UPDATE, TestSource, pod))
+	expectPodUpdate(t, ch, CreatePodUpdate(kubeletTypes.UPDATE, TestSource, pod))
 
 	pod.Annotations["kubernetes.io/otherblah"] = "doh"
-	podUpdate = CreatePodUpdate(kubelet.SET, TestSource, CreateValidPod("foo1", "new"), pod, CreateValidPod("foo3", "new"))
+	podUpdate = CreatePodUpdate(kubeletTypes.SET, TestSource, CreateValidPod("foo1", "new"), pod, CreateValidPod("foo3", "new"))
 	channel <- podUpdate
-	expectPodUpdate(t, ch, CreatePodUpdate(kubelet.UPDATE, TestSource, pod))
+	expectPodUpdate(t, ch, CreatePodUpdate(kubeletTypes.UPDATE, TestSource, pod))
 
 	delete(pod.Annotations, "kubernetes.io/blah")
-	podUpdate = CreatePodUpdate(kubelet.SET, TestSource, CreateValidPod("foo1", "new"), pod, CreateValidPod("foo3", "new"))
+	podUpdate = CreatePodUpdate(kubeletTypes.SET, TestSource, CreateValidPod("foo1", "new"), pod, CreateValidPod("foo3", "new"))
 	channel <- podUpdate
-	expectPodUpdate(t, ch, CreatePodUpdate(kubelet.UPDATE, TestSource, pod))
+	expectPodUpdate(t, ch, CreatePodUpdate(kubeletTypes.UPDATE, TestSource, pod))
 }
 
 func TestPodUpdateLables(t *testing.T) {
@@ -311,13 +311,13 @@ func TestPodUpdateLables(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 
-	podUpdate := CreatePodUpdate(kubelet.SET, TestSource, clone.(*api.Pod))
+	podUpdate := CreatePodUpdate(kubeletTypes.SET, TestSource, clone.(*api.Pod))
 	channel <- podUpdate
-	expectPodUpdate(t, ch, CreatePodUpdate(kubelet.ADD, TestSource, pod))
+	expectPodUpdate(t, ch, CreatePodUpdate(kubeletTypes.ADD, TestSource, pod))
 
 	pod.Labels["key"] = "newValue"
-	podUpdate = CreatePodUpdate(kubelet.SET, TestSource, pod)
+	podUpdate = CreatePodUpdate(kubeletTypes.SET, TestSource, pod)
 	channel <- podUpdate
-	expectPodUpdate(t, ch, CreatePodUpdate(kubelet.UPDATE, TestSource, pod))
+	expectPodUpdate(t, ch, CreatePodUpdate(kubeletTypes.UPDATE, TestSource, pod))
 
 }

--- a/pkg/kubelet/config/file.go
+++ b/pkg/kubelet/config/file.go
@@ -26,7 +26,7 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/kubelet"
+	kubeletTypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/util"
 
 	"github.com/golang/glog"
@@ -66,7 +66,7 @@ func (s *sourceFile) extractFromPath() error {
 			return err
 		}
 		// Emit an update with an empty PodList to allow FileSource to be marked as seen
-		s.updates <- kubelet.PodUpdate{Pods: []*api.Pod{}, Op: kubelet.SET, Source: kubelet.FileSource}
+		s.updates <- kubeletTypes.PodUpdate{Pods: []*api.Pod{}, Op: kubeletTypes.SET, Source: kubeletTypes.FileSource}
 		return fmt.Errorf("path does not exist, ignoring")
 	}
 
@@ -76,14 +76,14 @@ func (s *sourceFile) extractFromPath() error {
 		if err != nil {
 			return err
 		}
-		s.updates <- kubelet.PodUpdate{Pods: pods, Op: kubelet.SET, Source: kubelet.FileSource}
+		s.updates <- kubeletTypes.PodUpdate{Pods: pods, Op: kubeletTypes.SET, Source: kubeletTypes.FileSource}
 
 	case statInfo.Mode().IsRegular():
 		pod, err := s.extractFromFile(path)
 		if err != nil {
 			return err
 		}
-		s.updates <- kubelet.PodUpdate{Pods: []*api.Pod{pod}, Op: kubelet.SET, Source: kubelet.FileSource}
+		s.updates <- kubeletTypes.PodUpdate{Pods: []*api.Pod{pod}, Op: kubeletTypes.SET, Source: kubeletTypes.FileSource}
 
 	default:
 		return fmt.Errorf("path is not a directory or file")

--- a/pkg/kubelet/config/file_test.go
+++ b/pkg/kubelet/config/file_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/api/validation"
-	"k8s.io/kubernetes/pkg/kubelet"
+	kubeletTypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/securitycontext"
 	"k8s.io/kubernetes/pkg/util"
@@ -46,8 +46,8 @@ func TestUpdateOnNonExistentFile(t *testing.T) {
 	NewSourceFile("random_non_existent_path", "localhost", time.Millisecond, ch)
 	select {
 	case got := <-ch:
-		update := got.(kubelet.PodUpdate)
-		expected := CreatePodUpdate(kubelet.SET, kubelet.FileSource)
+		update := got.(kubeletTypes.PodUpdate)
+		expected := CreatePodUpdate(kubeletTypes.SET, kubeletTypes.FileSource)
 		if !api.Semantic.DeepDerivative(expected, update) {
 			t.Fatalf("Expected %#v, Got %#v", expected, update)
 		}
@@ -75,7 +75,7 @@ func TestReadPodsFromFile(t *testing.T) {
 	var testCases = []struct {
 		desc     string
 		pod      runtime.Object
-		expected kubelet.PodUpdate
+		expected kubeletTypes.PodUpdate
 	}{
 		{
 			desc: "Simple pod",
@@ -94,7 +94,7 @@ func TestReadPodsFromFile(t *testing.T) {
 					SecurityContext: &api.PodSecurityContext{},
 				},
 			},
-			expected: CreatePodUpdate(kubelet.SET, kubelet.FileSource, &api.Pod{
+			expected: CreatePodUpdate(kubeletTypes.SET, kubeletTypes.FileSource, &api.Pod{
 				ObjectMeta: api.ObjectMeta{
 					Name:      "test-" + hostname,
 					UID:       "12345",
@@ -137,7 +137,7 @@ func TestReadPodsFromFile(t *testing.T) {
 			NewSourceFile(file.Name(), hostname, time.Millisecond, ch)
 			select {
 			case got := <-ch:
-				update := got.(kubelet.PodUpdate)
+				update := got.(kubeletTypes.PodUpdate)
 				for _, pod := range update.Pods {
 					if errs := validation.ValidatePod(pod); len(errs) > 0 {
 						t.Errorf("%s: Invalid pod %#v, %#v", testCase.desc, pod, errs)
@@ -180,8 +180,8 @@ func TestExtractFromEmptyDir(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	update := (<-ch).(kubelet.PodUpdate)
-	expected := CreatePodUpdate(kubelet.SET, kubelet.FileSource)
+	update := (<-ch).(kubeletTypes.PodUpdate)
+	expected := CreatePodUpdate(kubeletTypes.SET, kubeletTypes.FileSource)
 	if !api.Semantic.DeepEqual(expected, update) {
 		t.Errorf("Expected %#v, Got %#v", expected, update)
 	}

--- a/pkg/kubelet/config/http.go
+++ b/pkg/kubelet/config/http.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/kubelet"
+	kubeletTypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/util"
 
 	"github.com/golang/glog"
@@ -95,7 +95,7 @@ func (s *sourceURL) extractFromURL() error {
 	}
 	if len(data) == 0 {
 		// Emit an update with an empty PodList to allow HTTPSource to be marked as seen
-		s.updates <- kubelet.PodUpdate{Pods: []*api.Pod{}, Op: kubelet.SET, Source: kubelet.HTTPSource}
+		s.updates <- kubeletTypes.PodUpdate{Pods: []*api.Pod{}, Op: kubeletTypes.SET, Source: kubeletTypes.HTTPSource}
 		return fmt.Errorf("zero-length data received from %v", s.url)
 	}
 	// Short circuit if the data has not changed since the last time it was read.
@@ -111,7 +111,7 @@ func (s *sourceURL) extractFromURL() error {
 			// It parsed but could not be used.
 			return singlePodErr
 		}
-		s.updates <- kubelet.PodUpdate{Pods: []*api.Pod{pod}, Op: kubelet.SET, Source: kubelet.HTTPSource}
+		s.updates <- kubeletTypes.PodUpdate{Pods: []*api.Pod{pod}, Op: kubeletTypes.SET, Source: kubeletTypes.HTTPSource}
 		return nil
 	}
 
@@ -126,7 +126,7 @@ func (s *sourceURL) extractFromURL() error {
 		for i := range podList.Items {
 			pods = append(pods, &podList.Items[i])
 		}
-		s.updates <- kubelet.PodUpdate{Pods: pods, Op: kubelet.SET, Source: kubelet.HTTPSource}
+		s.updates <- kubeletTypes.PodUpdate{Pods: pods, Op: kubeletTypes.SET, Source: kubeletTypes.HTTPSource}
 		return nil
 	}
 

--- a/pkg/kubelet/config/http_test.go
+++ b/pkg/kubelet/config/http_test.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/api/validation"
-	"k8s.io/kubernetes/pkg/kubelet"
+	kubeletTypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/errors"
@@ -128,7 +128,7 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 	var testCases = []struct {
 		desc     string
 		pods     runtime.Object
-		expected kubelet.PodUpdate
+		expected kubeletTypes.PodUpdate
 	}{
 		{
 			desc: "Single pod",
@@ -148,8 +148,8 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 					SecurityContext: &api.PodSecurityContext{},
 				},
 			},
-			expected: CreatePodUpdate(kubelet.SET,
-				kubelet.HTTPSource,
+			expected: CreatePodUpdate(kubeletTypes.SET,
+				kubeletTypes.HTTPSource,
 				&api.Pod{
 					ObjectMeta: api.ObjectMeta{
 						UID:       "111",
@@ -206,15 +206,15 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 					},
 				},
 			},
-			expected: CreatePodUpdate(kubelet.SET,
-				kubelet.HTTPSource,
+			expected: CreatePodUpdate(kubeletTypes.SET,
+				kubeletTypes.HTTPSource,
 				&api.Pod{
 					ObjectMeta: api.ObjectMeta{
 						UID:       "111",
 						Name:      "foo" + "-" + hostname,
 						Namespace: "default",
 
-						SelfLink: getSelfLink("foo-"+hostname, kubelet.NamespaceDefault),
+						SelfLink: getSelfLink("foo-"+hostname, kubeletTypes.NamespaceDefault),
 					},
 					Spec: api.PodSpec{
 						NodeName:                      hostname,
@@ -237,7 +237,7 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 						Name:      "bar" + "-" + hostname,
 						Namespace: "default",
 
-						SelfLink: getSelfLink("bar-"+hostname, kubelet.NamespaceDefault),
+						SelfLink: getSelfLink("bar-"+hostname, kubeletTypes.NamespaceDefault),
 					},
 					Spec: api.PodSpec{
 						NodeName:                      hostname,
@@ -279,7 +279,7 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 			t.Errorf("%s: Unexpected error: %v", testCase.desc, err)
 			continue
 		}
-		update := (<-ch).(kubelet.PodUpdate)
+		update := (<-ch).(kubeletTypes.PodUpdate)
 
 		if !api.Semantic.DeepEqual(testCase.expected, update) {
 			t.Errorf("%s: Expected: %#v, Got: %#v", testCase.desc, testCase.expected, update)
@@ -325,7 +325,7 @@ func TestURLWithHeader(t *testing.T) {
 	if err := c.extractFromURL(); err != nil {
 		t.Fatalf("Unexpected error extracting from URL: %v", err)
 	}
-	update := (<-ch).(kubelet.PodUpdate)
+	update := (<-ch).(kubeletTypes.PodUpdate)
 
 	headerVal := fakeHandler.RequestReceived.Header["Metadata-Flavor"]
 	if len(headerVal) != 1 || headerVal[0] != "Google" {

--- a/pkg/kubelet/fake_pod_workers.go
+++ b/pkg/kubelet/fake_pod_workers.go
@@ -19,6 +19,7 @@ package kubelet
 import (
 	"k8s.io/kubernetes/pkg/api"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	kubeletTypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/types"
 )
 
@@ -30,12 +31,12 @@ type fakePodWorkers struct {
 	t            TestingInterface
 }
 
-func (f *fakePodWorkers) UpdatePod(pod *api.Pod, mirrorPod *api.Pod, updateType SyncPodType, updateComplete func()) {
+func (f *fakePodWorkers) UpdatePod(pod *api.Pod, mirrorPod *api.Pod, updateType kubeletTypes.SyncPodType, updateComplete func()) {
 	pods, err := f.runtimeCache.GetPods()
 	if err != nil {
 		f.t.Errorf("Unexpected error: %v", err)
 	}
-	if err := f.syncPodFn(pod, mirrorPod, kubecontainer.Pods(pods).FindPodByID(pod.UID), SyncPodUpdate); err != nil {
+	if err := f.syncPodFn(pod, mirrorPod, kubecontainer.Pods(pods).FindPodByID(pod.UID), kubeletTypes.SyncPodUpdate); err != nil {
 		f.t.Errorf("Unexpected error: %v", err)
 	}
 }

--- a/pkg/kubelet/mirror_client.go
+++ b/pkg/kubelet/mirror_client.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	kubeletTypes "k8s.io/kubernetes/pkg/kubelet/types"
 )
 
 // Mirror client is used to create/delete a mirror pod.
@@ -54,7 +55,7 @@ func (mc *basicMirrorClient) CreateMirrorPod(pod *api.Pod) error {
 	for k, v := range pod.Annotations {
 		copyPod.Annotations[k] = v
 	}
-	copyPod.Annotations[ConfigMirrorAnnotationKey] = MirrorType
+	copyPod.Annotations[kubeletTypes.ConfigMirrorAnnotationKey] = kubeletTypes.MirrorType
 
 	_, err := mc.apiserverClient.Pods(copyPod.Namespace).Create(&copyPod)
 	return err
@@ -80,7 +81,7 @@ func (mc *basicMirrorClient) DeleteMirrorPod(podFullName string) error {
 // Helper functions.
 func getPodSource(pod *api.Pod) (string, error) {
 	if pod.Annotations != nil {
-		if source, ok := pod.Annotations[ConfigSourceAnnotationKey]; ok {
+		if source, ok := pod.Annotations[kubeletTypes.ConfigSourceAnnotationKey]; ok {
 			return source, nil
 		}
 	}
@@ -89,13 +90,13 @@ func getPodSource(pod *api.Pod) (string, error) {
 
 func isStaticPod(pod *api.Pod) bool {
 	source, err := getPodSource(pod)
-	return err == nil && source != ApiserverSource
+	return err == nil && source != kubeletTypes.ApiserverSource
 }
 
 func isMirrorPod(pod *api.Pod) bool {
-	if value, ok := pod.Annotations[ConfigMirrorAnnotationKey]; !ok {
+	if value, ok := pod.Annotations[kubeletTypes.ConfigMirrorAnnotationKey]; !ok {
 		return false
 	} else {
-		return value == MirrorType
+		return value == kubeletTypes.MirrorType
 	}
 }

--- a/pkg/kubelet/pod_manager_test.go
+++ b/pkg/kubelet/pod_manager_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
+	kubeletTypes "k8s.io/kubernetes/pkg/kubelet/types"
 )
 
 // Stub out mirror client for testing purpose.
@@ -40,8 +41,8 @@ func TestGetSetPods(t *testing.T) {
 			Name:      "bar",
 			Namespace: "default",
 			Annotations: map[string]string{
-				ConfigSourceAnnotationKey: "api",
-				ConfigMirrorAnnotationKey: "mirror",
+				kubeletTypes.ConfigSourceAnnotationKey: "api",
+				kubeletTypes.ConfigMirrorAnnotationKey: "mirror",
 			},
 		},
 	}
@@ -50,7 +51,7 @@ func TestGetSetPods(t *testing.T) {
 			UID:         "123456789",
 			Name:        "bar",
 			Namespace:   "default",
-			Annotations: map[string]string{ConfigSourceAnnotationKey: "file"},
+			Annotations: map[string]string{kubeletTypes.ConfigSourceAnnotationKey: "file"},
 		},
 	}
 
@@ -60,7 +61,7 @@ func TestGetSetPods(t *testing.T) {
 				UID:         "999999999",
 				Name:        "taco",
 				Namespace:   "default",
-				Annotations: map[string]string{ConfigSourceAnnotationKey: "api"},
+				Annotations: map[string]string{kubeletTypes.ConfigSourceAnnotationKey: "api"},
 			},
 		},
 		staticPod,

--- a/pkg/kubelet/pod_workers.go
+++ b/pkg/kubelet/pod_workers.go
@@ -24,18 +24,19 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/record"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	kubeletTypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util"
 )
 
 // PodWorkers is an abstract interface for testability.
 type PodWorkers interface {
-	UpdatePod(pod *api.Pod, mirrorPod *api.Pod, updateType SyncPodType, updateComplete func())
+	UpdatePod(pod *api.Pod, mirrorPod *api.Pod, updateType kubeletTypes.SyncPodType, updateComplete func())
 	ForgetNonExistingPodWorkers(desiredPods map[types.UID]empty)
 	ForgetWorker(uid types.UID)
 }
 
-type syncPodFnType func(*api.Pod, *api.Pod, kubecontainer.Pod, SyncPodType) error
+type syncPodFnType func(*api.Pod, *api.Pod, kubecontainer.Pod, kubeletTypes.SyncPodType) error
 
 type podWorkers struct {
 	// Protects all per worker fields.
@@ -74,7 +75,7 @@ type workUpdate struct {
 	updateCompleteFn func()
 
 	// A string describing the type of this update, eg: create
-	updateType SyncPodType
+	updateType kubeletTypes.SyncPodType
 }
 
 func newPodWorkers(runtimeCache kubecontainer.RuntimeCache, syncPodFn syncPodFnType,
@@ -121,7 +122,7 @@ func (p *podWorkers) managePodLoop(podUpdates <-chan workUpdate) {
 }
 
 // Apply the new setting to the specified pod. updateComplete is called when the update is completed.
-func (p *podWorkers) UpdatePod(pod *api.Pod, mirrorPod *api.Pod, updateType SyncPodType, updateComplete func()) {
+func (p *podWorkers) UpdatePod(pod *api.Pod, mirrorPod *api.Pod, updateType kubeletTypes.SyncPodType, updateComplete func()) {
 	uid := pod.UID
 	var podUpdates chan workUpdate
 	var exists bool

--- a/pkg/kubelet/runonce.go
+++ b/pkg/kubelet/runonce.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/kubelet/container"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	kubeletTypes "k8s.io/kubernetes/pkg/kubelet/types"
 )
 
 const (
@@ -39,7 +40,7 @@ type RunPodResult struct {
 }
 
 // RunOnce polls from one configuration update and run the associated pods.
-func (kl *Kubelet) RunOnce(updates <-chan PodUpdate) ([]RunPodResult, error) {
+func (kl *Kubelet) RunOnce(updates <-chan kubeletTypes.PodUpdate) ([]RunPodResult, error) {
 	select {
 	case u := <-updates:
 		glog.Infof("processing manifest with %d pods", len(u.Pods))
@@ -109,7 +110,7 @@ func (kl *Kubelet) runPod(pod *api.Pod, retryDelay time.Duration) error {
 		glog.Infof("pod %q containers not running: syncing", pod.Name)
 		// We don't create mirror pods in this mode; pass a dummy boolean value
 		// to sycnPod.
-		if err = kl.syncPod(pod, nil, p, SyncPodUpdate); err != nil {
+		if err = kl.syncPod(pod, nil, p, kubeletTypes.SyncPodUpdate); err != nil {
 			return fmt.Errorf("error syncing pod: %v", err)
 		}
 		if retry >= RunOnceMaxRetries {

--- a/pkg/kubelet/server_test.go
+++ b/pkg/kubelet/server_test.go
@@ -37,6 +37,7 @@ import (
 	apierrs "k8s.io/kubernetes/pkg/api/errors"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/dockertools"
+	kubeletTypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util/httpstream"
 	"k8s.io/kubernetes/pkg/util/httpstream/spdy"
@@ -172,7 +173,7 @@ func readResp(resp *http.Response) (string, error) {
 // A helper function to return the correct pod name.
 func getPodName(name, namespace string) string {
 	if namespace == "" {
-		namespace = NamespaceDefault
+		namespace = kubeletTypes.NamespaceDefault
 	}
 	return name + "_" + namespace
 }

--- a/pkg/kubelet/types/pod_update.go
+++ b/pkg/kubelet/types/pod_update.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubelet
+package types
 
 import (
 	"fmt"

--- a/pkg/kubelet/types/pod_update_test.go
+++ b/pkg/kubelet/types/pod_update_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubelet
+package types
 
 import (
 	"testing"

--- a/plugin/pkg/admission/serviceaccount/admission.go
+++ b/plugin/pkg/admission/serviceaccount/admission.go
@@ -29,7 +29,7 @@ import (
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/controller/serviceaccount"
 	"k8s.io/kubernetes/pkg/fields"
-	"k8s.io/kubernetes/pkg/kubelet"
+	kubelet "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/sets"

--- a/plugin/pkg/admission/serviceaccount/admission_test.go
+++ b/plugin/pkg/admission/serviceaccount/admission_test.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/admission"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
-	"k8s.io/kubernetes/pkg/kubelet"
+	kubelet "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/types"
 )
 


### PR DESCRIPTION
This would faciliate tasks such as moving code in pkg/kubelet to sub packages.
