### PR TITLE
Users have to explicitly specify group for in-development resource when kubectl 

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -136,7 +136,7 @@ KUBE_API_VERSIONS="v1,extensions/v1beta1" "${KUBE_OUTPUT_HOSTBIN}/kube-apiserver
   --kubelet-port=${KUBELET_PORT} \
   --runtime-config=api/v1 \
   --cert-dir="${TMPDIR:-/tmp/}" \
-  --runtime_config="experimental/v1alpha1=true" \
+  --runtime_config="extensions/v1beta1=true" \
   --service-cluster-ip-range="10.0.0.0/24" 1>&2 &
 APISERVER_PID=$!
 
@@ -924,31 +924,23 @@ __EOF__
   kube::test::get_object_assert "nodes 127.0.0.1" "{{.spec.unschedulable}}" '<no value>'
 
 
-  #########################
-  # Experimental resource #
-  #########################
+  ###########################
+  # In-development resource #
+  ###########################
 
-  ### Create and delete an experimental deployment example
-  # Pre-condition: no persistent experimental deployment currently exist
-  kube::test::get_object_assert experimental/deployment "{{range.items}}{{$id_field}}:{{end}}" ''
+  ### Create and delete a deployment example
+  # Pre-condition: no persistent deployment currently exist
+  kube::test::get_object_assert extensions/deployment "{{range.items}}{{$id_field}}:{{end}}" ''
   # Command
   kubectl create -f examples/experimental/deployment.yaml
   # Post-condition: deployment "nginx-deployment" is created
-  kube::test::get_object_assert experimental/deployment "{{range.items}}{{$id_field}}:{{end}}" 'nginx-deployment:'
+  kube::test::get_object_assert extensions/deployment "{{range.items}}{{$id_field}}:{{end}}" 'nginx-deployment:'
   # Clean up
-  kubectl delete experimental/deployment nginx-deployment
-  ### Get experimental resource via shortname
-  kubectl get experimental/hpa
-  ### Get experimental resource via shortname implicitly should fail
-  ERROR_FILE="${KUBE_TEMP}/should-error"
-  kubectl get hpa 1>&2 2> "${ERROR_FILE}" || true
-  if grep -q "error" "${ERROR_FILE}" && grep -q "should be specified explicitly" "${ERROR_FILE}"; then
-    echo "\"kubectl get hpa\" returns error as expected: $(cat ${ERROR_FILE})"
-  else
-    echo "\"kubectl get hpa\" returns unexpected error or non-error: $(cat ${ERROR_FILE})"
-    exit 1
-  fi
-  rm "${ERROR_FILE}"
+  kubectl delete extensions/deployment nginx-deployment
+  ### Get in-development resource via shortname
+  kubectl get extensions/hpa
+  ### Get in-development resource via shortname implicitly should fail
+  ! kubectl get hpa
 
 
   #####################

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -940,7 +940,7 @@ __EOF__
   ### Get experimental resource via shortname
   kubectl get experimental/hpa
   ### Get experimental resource via shortname implicitly should fail
-  ERROR_FILE="/tmp/should-error"
+  ERROR_FILE="${KUBE_TEMP}/should-error"
   kubectl get hpa 1>&2 2> "${ERROR_FILE}" || true
   if grep -q "error" "${ERROR_FILE}" && grep -q "should be specified explicitly" "${ERROR_FILE}"; then
     echo "\"kubectl get hpa\" returns error as expected: $(cat ${ERROR_FILE})"

--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -939,13 +939,13 @@ __EOF__
   kubectl delete experimental/deployment nginx-deployment
   ### Get experimental resource via shortname
   kubectl get experimental/hpa
-  ### Get experimental resource via shortname implicitly
+  ### Get experimental resource via shortname implicitly should fail
   ERROR_FILE="/tmp/should-error"
   kubectl get hpa 1>&2 2> "${ERROR_FILE}" || true
   if grep -q "error" "${ERROR_FILE}" && grep -q "should be specified explicitly" "${ERROR_FILE}"; then
     echo "\"kubectl get hpa\" returns error as expected: $(cat ${ERROR_FILE})"
   else
-    echo "\"kubectl get hpa\" returns unexpected non-error: $(cat ${ERROR_FILE})"
+    echo "\"kubectl get hpa\" returns unexpected error or non-error: $(cat ${ERROR_FILE})"
     exit 1
   fi
   rm "${ERROR_FILE}"

--- a/pkg/api/meta/restmapper.go
+++ b/pkg/api/meta/restmapper.go
@@ -311,9 +311,9 @@ func (m MultiRESTMapper) ResourceSingularizer(resource string) (singular string,
 func (m MultiRESTMapper) VersionAndKindForResource(resource string) (defaultVersion, kind string, err error) {
 	for _, t := range m {
 		defaultVersion, kind, err = t.VersionAndKindForResource(resource)
-		// If "resource" is an experimental resource without specifying "experimental/",
+		// If "resource" is an in-development resource without specifying "extensions/",
 		// version, kind, and error will all be returned.
-		// (We need to stop here otherwise mapper will try to find experimental resource in other groups.)
+		// (We need to stop here otherwise mapper will try to find in-development resource in other groups.)
 		if len(defaultVersion) > 0 && len(kind) > 0 {
 			return
 		}

--- a/pkg/api/meta/restmapper.go
+++ b/pkg/api/meta/restmapper.go
@@ -309,7 +309,10 @@ func (m MultiRESTMapper) ResourceSingularizer(resource string) (singular string,
 func (m MultiRESTMapper) VersionAndKindForResource(resource string) (defaultVersion, kind string, err error) {
 	for _, t := range m {
 		defaultVersion, kind, err = t.VersionAndKindForResource(resource)
-		if err == nil {
+		// If "resource" is an experimental resource without specifying "experimental/",
+		// version, kind, and error will all be returned.
+		// (We need to stop here otherwise mapper will try to find experimental resource in other groups.)
+		if len(defaultVersion) > 0 && len(kind) > 0 {
 			return
 		}
 	}

--- a/pkg/api/meta/restmapper.go
+++ b/pkg/api/meta/restmapper.go
@@ -185,6 +185,8 @@ func (m *DefaultRESTMapper) VersionAndKindForResource(resource string) (defaultV
 	return meta.APIVersion, meta.Kind, nil
 }
 
+// GroupForResource takes a string (resource) and returns its group.
+// Note that the input string should not include group information; "group/resource" will result in an error.
 func (m *DefaultRESTMapper) GroupForResource(resource string) (string, error) {
 	if _, ok := m.mapping[strings.ToLower(resource)]; !ok {
 		return "", fmt.Errorf("no resource %q has been defined", resource)
@@ -321,6 +323,7 @@ func (m MultiRESTMapper) VersionAndKindForResource(resource string) (defaultVers
 
 // GroupForResource provides the Group mappings for the REST resources. This
 // implementation supports multiple REST schemas and returns the first match.
+// Note that the input string should not include group information; "group/resource" will result in an error.
 func (m MultiRESTMapper) GroupForResource(resource string) (group string, err error) {
 	for _, t := range m {
 		group, err = t.GroupForResource(resource)

--- a/pkg/apis/extensions/install/install_test.go
+++ b/pkg/apis/extensions/install/install_test.go
@@ -75,7 +75,7 @@ func TestInterfacesFor(t *testing.T) {
 }
 
 func TestRESTMapper(t *testing.T) {
-	if v, k, err := latest.GroupOrDie("extensions").RESTMapper.VersionAndKindForResource("horizontalpodautoscalers"); err != nil || v != "extensions/v1beta1" || k != "HorizontalPodAutoscaler" {
+	if v, k, err := latest.GroupOrDie("extensions").RESTMapper.VersionAndKindForResource("extensions/horizontalpodautoscalers"); err != nil || v != "extensions/v1beta1" || k != "HorizontalPodAutoscaler" {
 		t.Errorf("unexpected version mapping: %s %s %v", v, k, err)
 	}
 

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -103,6 +103,8 @@ func (e ShortcutExpander) ResourceIsValid(resource string) bool {
 	return e.RESTMapper.ResourceIsValid(expandResourceShortcut(resource))
 }
 
+// GroupForResource takes a string (resource) and returns its group.
+// Note that the input string should not include group information; "group/resource" will result in an error.
 func (e ShortcutExpander) GroupForResource(resource string) (group string, err error) {
 	return e.RESTMapper.GroupForResource(expandResourceShortcut(resource))
 }

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -78,7 +78,7 @@ type ShortcutExpander struct {
 // VersionAndKindForResource implements meta.RESTMapper. It expands the resource first, then invokes the wrapped
 // mapper.
 func (e ShortcutExpander) VersionAndKindForResource(resource string) (defaultVersion, kind string, err error) {
-	exp := "experimental"
+	ext := "extensions"
 	parts := strings.Split(resource, "/")
 	// group/kind or group/kind-shortcut
 	if len(parts) > 1 {
@@ -90,8 +90,8 @@ func (e ShortcutExpander) VersionAndKindForResource(resource string) (defaultVer
 			return
 		}
 		// kind that should be experimental/kind
-		if group, err2 := e.GroupForResource(resource); err2 == nil && group == exp {
-			err = fmt.Errorf("%s resource %q should be specified explicitly; use %s/%s instead", exp, resource, exp, resource)
+		if group, err2 := e.GroupForResource(resource); err2 == nil && group == ext {
+			err = fmt.Errorf("in-development resource %q should be specified explicitly; use %s/%s instead", resource, ext, resource)
 		}
 	}
 	return

--- a/pkg/kubectl/resource/builder.go
+++ b/pkg/kubectl/resource/builder.go
@@ -347,9 +347,6 @@ func (b *Builder) ResourceTypeOrNameArgs(allowEmptySelector bool, args ...string
 				b.resourceTuples = append(b.resourceTuples, tuple)
 			}
 		}
-		if err = b.checkImplicitExpResource(); err != nil {
-			b.errs = append(b.errs, err)
-		}
 		return b
 	}
 	if len(args) > 0 {
@@ -372,34 +369,7 @@ func (b *Builder) ResourceTypeOrNameArgs(allowEmptySelector bool, args ...string
 	default:
 		b.errs = append(b.errs, fmt.Errorf("when passing arguments, must be resource or resource and name"))
 	}
-	if err := b.checkImplicitExpResource(); err != nil {
-		b.errs = append(b.errs, err)
-	}
 	return b
-}
-
-func (b *Builder) checkImplicitExpResource() error {
-	for _, tuple := range b.resourceTuples {
-		if err := b.errorOnImplicitExpResource(tuple.Resource); err != nil {
-			return err
-		}
-	}
-	for _, resource := range b.resources {
-		if err := b.errorOnImplicitExpResource(resource); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (b *Builder) errorOnImplicitExpResource(resource string) error {
-	exp := "experimental"
-	if !strings.Contains(resource, "/") {
-		if group, err := b.mapper.GroupForResource(resource); err == nil && group == exp {
-			return fmt.Errorf("%s resource %q should be specified explicitly; use %s/%s instead", exp, resource, exp, resource)
-		}
-	}
-	return nil
 }
 
 // replaceAliases accepts an argument and tries to expand any existing


### PR DESCRIPTION
Partially fixes - #13929
Follow up #14461. 

`kubectl <operation> deployments` gives you error `experimental resource "deployments" should be specified explicitly; use experimental/deployments instead`

cc @lavalamp @caesarxuchao @bgrant0607 
