### PR TITLE
Automated cherry pick of #14766 #14994 #14823 #15068 upstream release 1.1

### DIFF
--- a/cluster/saltbase/salt/etcd/etcd.manifest
+++ b/cluster/saltbase/salt/etcd/etcd.manifest
@@ -13,10 +13,7 @@
     "image": "gcr.io/google_containers/etcd:2.0.12",
     "resources": {
       "limits": {
-        "cpu": "200m"
-      },
-      "requests": {
-        "cpu": "100m"
+        "cpu": {{ cpulimit }}
       }
     },
     "command": [

--- a/cluster/saltbase/salt/etcd/etcd.manifest
+++ b/cluster/saltbase/salt/etcd/etcd.manifest
@@ -22,7 +22,7 @@
     "command": [
               "/bin/sh",
               "-c",
-              "/usr/local/bin/etcd --listen-peer-urls=http://127.0.0.1:{{ server_port }} --addr 127.0.0.1:{{ port }} --bind-addr 127.0.0.1:{{ port }} --data-dir /var/etcd/data{{ suffix }} 1>>/var/log/etcd{{ suffix }}.log 2>&1"
+              "/usr/local/bin/etcd --listen-peer-urls http://127.0.0.1:{{ server_port }} --addr 127.0.0.1:{{ port }} --bind-addr 127.0.0.1:{{ port }} --data-dir /var/etcd/data{{ suffix }} 1>>/var/log/etcd{{ suffix }}.log 2>&1"
             ],
     "livenessProbe": {
       "httpGet": {

--- a/cluster/saltbase/salt/etcd/etcd.manifest
+++ b/cluster/saltbase/salt/etcd/etcd.manifest
@@ -2,7 +2,7 @@
 "apiVersion": "v1",
 "kind": "Pod",
 "metadata": {
-  "name":"etcd-server",
+  "name":"etcd-server{{ suffix }}",
   "namespace": "kube-system"
 },
 "spec":{
@@ -19,12 +19,12 @@
     "command": [
               "/bin/sh",
               "-c",
-              "/usr/local/bin/etcd --addr 127.0.0.1:4001 --bind-addr 127.0.0.1:4001 --data-dir /var/etcd/data 1>>/var/log/etcd.log 2>&1"
+              "/usr/local/bin/etcd --listen-peer-urls=http://127.0.0.1:{{ server_port }} --addr 127.0.0.1:{{ port }} --bind-addr 127.0.0.1:{{ port }} --data-dir /var/etcd/data{{ suffix }} 1>>/var/log/etcd{{ suffix }}.log 2>&1"
             ],
     "livenessProbe": {
       "httpGet": {
         "host": "127.0.0.1",
-        "port": 4001,
+        "port": {{ port }},
         "path": "/health"
       },
       "initialDelaySeconds": 15,
@@ -32,11 +32,13 @@
     },
     "ports":[
       { "name": "serverport",
-        "containerPort": 2380,
-        "hostPort": 2380},{
+        "containerPort": {{ server_port }},
+        "hostPort": {{ server_port }} 
+      },{
        "name": "clientport",
-        "containerPort": 4001,
-        "hostPort": 4001}
+        "containerPort": {{ port }},
+        "hostPort": {{ port }}
+      }
         ],
     "volumeMounts": [
       {"name": "varetcd",
@@ -44,7 +46,7 @@
        "readOnly": false
       },
       {"name": "varlogetcd",
-       "mountPath": "/var/log/etcd.log",
+       "mountPath": "/var/log/etcd{{ suffix }}.log",
        "readOnly": false
       }
      ]
@@ -57,7 +59,7 @@
   },
   { "name": "varlogetcd",
     "hostPath": {
-        "path": "/var/log/etcd.log"}
+        "path": "/var/log/etcd{{ suffix }}.log"}
   }
 ]
 }}

--- a/cluster/saltbase/salt/etcd/etcd.manifest
+++ b/cluster/saltbase/salt/etcd/etcd.manifest
@@ -14,6 +14,9 @@
     "resources": {
       "limits": {
         "cpu": "200m"
+      },
+      "requests": {
+        "cpu": "100m"
       }
     },
     "command": [

--- a/cluster/saltbase/salt/etcd/init.sls
+++ b/cluster/saltbase/salt/etcd/init.sls
@@ -65,6 +65,7 @@ touch /var/log/etcd-events.log:
         suffix: ""
         port: 4001
         server_port: 2380
+        cpulimit: '"200m"'
 
 /etc/kubernetes/manifests/etcd-events.manifest:
   file.managed:
@@ -79,3 +80,4 @@ touch /var/log/etcd-events.log:
         suffix: "-events"
         port: 4002
         server_port: 2381
+        cpulimit: '"100m"'

--- a/cluster/saltbase/salt/etcd/init.sls
+++ b/cluster/saltbase/salt/etcd/init.sls
@@ -38,6 +38,10 @@ touch /var/log/etcd.log:
   cmd.run:
     - creates: /var/log/etcd.log
 
+touch /var/log/etcd-events.log:
+  cmd.run:
+    - creates: /var/log/etcd-events.log
+
 /var/etcd:
   file.directory:
     - user: root
@@ -57,3 +61,21 @@ touch /var/log/etcd.log:
     - mode: 644
     - makedirs: true
     - dir_mode: 755
+    - context:
+        suffix: ""
+        port: 4001
+        server_port: 2380
+
+/etc/kubernetes/manifests/etcd-events.manifest:
+  file.managed:
+    - source: salt://etcd/etcd.manifest
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: true
+    - dir_mode: 755
+    - context:
+        suffix: "-events"
+        port: 4002
+        server_port: 2381

--- a/cluster/saltbase/salt/kube-apiserver/kube-apiserver.manifest
+++ b/cluster/saltbase/salt/kube-apiserver/kube-apiserver.manifest
@@ -44,6 +44,7 @@
 {% endif -%}
 
 {% set etcd_servers = "--etcd-servers=http://127.0.0.1:4001" -%}
+{% set etcd_servers_overrides = "--etcd-servers-overrides=/events#http://127.0.0.1:4002" -%}
 
 {% set service_cluster_ip_range = "" -%}
 {% if pillar['service_cluster_ip_range'] is defined -%}
@@ -88,7 +89,7 @@
  {% set runtime_config = "--runtime-config=" + grains.runtime_config -%}
 {% endif -%}
 
-{% set params = address + " " + etcd_servers + " " + cloud_provider + " " + cloud_config + " " + runtime_config + " " + admission_control + " " + service_cluster_ip_range + " " + client_ca_file + " " + basic_auth_file + " " + min_request_timeout -%}
+{% set params = address + " " + etcd_servers + " " + etcd_servers_overrides + " " + cloud_provider + " " + cloud_config + " " + runtime_config + " " + admission_control + " " + service_cluster_ip_range + " " + client_ca_file + " " + basic_auth_file + " " + min_request_timeout -%}
 {% set params = params + " " + cluster_name + " " + cert_file + " " + key_file + " --secure-port=" + secure_port + " " + token_auth_file + " " + bind_address + " " + pillar['log_level'] + " " + advertise_address  + " " + proxy_ssh_options -%}
 
 # test_args has to be kept at the end, so they'll overwrite any prior configuration

--- a/cluster/saltbase/salt/kube-apiserver/kube-apiserver.manifest
+++ b/cluster/saltbase/salt/kube-apiserver/kube-apiserver.manifest
@@ -112,7 +112,7 @@
     "image": "gcr.io/google_containers/kube-apiserver:{{pillar['kube-apiserver_docker_tag']}}",
     "resources": {
       "limits": {
-        "cpu": "200m"
+        "cpu": "250m"
       }
     },
     "command": [

--- a/cluster/saltbase/salt/kube-scheduler/kube-scheduler.manifest
+++ b/cluster/saltbase/salt/kube-scheduler/kube-scheduler.manifest
@@ -24,7 +24,7 @@
     "image": "gcr.io/google_containers/kube-scheduler:{{pillar['kube-scheduler_docker_tag']}}",
     "resources": {
       "limits": {
-        "cpu": "200m"
+        "cpu": "100m"
       }
     },
     "command": [

--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -140,10 +140,12 @@ func startComponents(firstManifestURL, secondManifestURL string) (string, string
 	}
 	expEtcdStorage, err := master.NewEtcdStorage(etcdClient, latest.GroupOrDie("experimental").InterfacesFor, testapi.Experimental.GroupAndVersion(), etcdtest.PathPrefix())
 	storageVersions["experimental"] = testapi.Experimental.GroupAndVersion()
-
 	if err != nil {
 		glog.Fatalf("Unable to get etcd storage for experimental: %v", err)
 	}
+	storageDestinations := master.NewStorageDestinations()
+	storageDestinations.AddAPIGroup("", etcdStorage)
+	storageDestinations.AddAPIGroup("experimental", expEtcdStorage)
 
 	// Master
 	host, port, err := net.SplitHostPort(strings.TrimLeft(apiServer.URL, "http://"))
@@ -162,8 +164,7 @@ func startComponents(firstManifestURL, secondManifestURL string) (string, string
 
 	// Create a master and install handlers into mux.
 	m := master.New(&master.Config{
-		DatabaseStorage:       etcdStorage,
-		ExpDatabaseStorage:    expEtcdStorage,
+		StorageDestinations:   storageDestinations,
 		KubeletClient:         fakeKubeletClient{},
 		EnableCoreControllers: true,
 		EnableLogsSupport:     false,

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -76,6 +76,7 @@ etcd-config
 etcd-prefix
 etcd-server
 etcd-servers
+etcd-servers-overrides
 event-burst
 event-qps
 event-ttl

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -98,10 +98,78 @@ const (
 	DefaultEtcdPathPrefix = "/registry"
 )
 
+// StorageDestinations is a mapping from API group & resource to
+// the underlying storage interfaces.
+type StorageDestinations struct {
+	APIGroups map[string]*StorageDestinationsForAPIGroup
+}
+
+type StorageDestinationsForAPIGroup struct {
+	Default   storage.Interface
+	Overrides map[string]storage.Interface
+}
+
+func NewStorageDestinations() StorageDestinations {
+	return StorageDestinations{
+		APIGroups: map[string]*StorageDestinationsForAPIGroup{},
+	}
+}
+
+func (s *StorageDestinations) AddAPIGroup(group string, defaultStorage storage.Interface) {
+	s.APIGroups[group] = &StorageDestinationsForAPIGroup{
+		Default:   defaultStorage,
+		Overrides: map[string]storage.Interface{},
+	}
+}
+
+func (s *StorageDestinations) AddStorageOverride(group, resource string, override storage.Interface) {
+	if _, ok := s.APIGroups[group]; !ok {
+		s.AddAPIGroup(group, nil)
+	}
+	if s.APIGroups[group].Overrides == nil {
+		s.APIGroups[group].Overrides = map[string]storage.Interface{}
+	}
+	s.APIGroups[group].Overrides[resource] = override
+}
+
+func (s *StorageDestinations) get(group, resource string) storage.Interface {
+	apigroup, ok := s.APIGroups[group]
+	if !ok {
+		glog.Errorf("No storage defined for API group: '%s'", apigroup)
+		return nil
+	}
+	if apigroup.Overrides != nil {
+		if client, exists := apigroup.Overrides[resource]; exists {
+			return client
+		}
+	}
+	return apigroup.Default
+}
+
+// Get all backends for all registered storage destinations.
+// Used for getting all instances for health validations.
+func (s *StorageDestinations) backends() []string {
+	backends := sets.String{}
+	for _, group := range s.APIGroups {
+		if group.Default != nil {
+			for _, backend := range group.Default.Backends() {
+				backends.Insert(backend)
+			}
+		}
+		if group.Overrides != nil {
+			for _, storage := range group.Overrides {
+				for _, backend := range storage.Backends() {
+					backends.Insert(backend)
+				}
+			}
+		}
+	}
+	return backends.List()
+}
+
 // Config is a structure used to configure a Master.
 type Config struct {
-	DatabaseStorage    storage.Interface
-	ExpDatabaseStorage storage.Interface
+	StorageDestinations StorageDestinations
 	// StorageVersions is a map between groups and their storage versions
 	StorageVersions map[string]string
 	EventTTL        time.Duration
@@ -435,35 +503,36 @@ func NewHandlerContainer(mux *http.ServeMux) *restful.Container {
 func (m *Master) init(c *Config) {
 	healthzChecks := []healthz.HealthzChecker{}
 	m.clock = util.RealClock{}
-	podStorage := podetcd.NewStorage(c.DatabaseStorage, c.EnableWatchCache, c.KubeletClient)
+	dbClient := func(resource string) storage.Interface { return c.StorageDestinations.get("", resource) }
+	podStorage := podetcd.NewStorage(dbClient("pods"), c.EnableWatchCache, c.KubeletClient)
 
-	podTemplateStorage := podtemplateetcd.NewREST(c.DatabaseStorage)
+	podTemplateStorage := podtemplateetcd.NewREST(dbClient("podTemplates"))
 
-	eventStorage := eventetcd.NewREST(c.DatabaseStorage, uint64(c.EventTTL.Seconds()))
-	limitRangeStorage := limitrangeetcd.NewREST(c.DatabaseStorage)
+	eventStorage := eventetcd.NewREST(dbClient("events"), uint64(c.EventTTL.Seconds()))
+	limitRangeStorage := limitrangeetcd.NewREST(dbClient("limitRanges"))
 
-	resourceQuotaStorage, resourceQuotaStatusStorage := resourcequotaetcd.NewREST(c.DatabaseStorage)
-	secretStorage := secretetcd.NewREST(c.DatabaseStorage)
-	serviceAccountStorage := serviceaccountetcd.NewREST(c.DatabaseStorage)
-	persistentVolumeStorage, persistentVolumeStatusStorage := pvetcd.NewREST(c.DatabaseStorage)
-	persistentVolumeClaimStorage, persistentVolumeClaimStatusStorage := pvcetcd.NewREST(c.DatabaseStorage)
+	resourceQuotaStorage, resourceQuotaStatusStorage := resourcequotaetcd.NewREST(dbClient("resourceQuotas"))
+	secretStorage := secretetcd.NewREST(dbClient("secrets"))
+	serviceAccountStorage := serviceaccountetcd.NewREST(dbClient("serviceAccounts"))
+	persistentVolumeStorage, persistentVolumeStatusStorage := pvetcd.NewREST(dbClient("persistentVolumes"))
+	persistentVolumeClaimStorage, persistentVolumeClaimStatusStorage := pvcetcd.NewREST(dbClient("persistentVolumeClaims"))
 
-	namespaceStorage, namespaceStatusStorage, namespaceFinalizeStorage := namespaceetcd.NewREST(c.DatabaseStorage)
+	namespaceStorage, namespaceStatusStorage, namespaceFinalizeStorage := namespaceetcd.NewREST(dbClient("namespaces"))
 	m.namespaceRegistry = namespace.NewRegistry(namespaceStorage)
 
-	endpointsStorage := endpointsetcd.NewREST(c.DatabaseStorage, c.EnableWatchCache)
+	endpointsStorage := endpointsetcd.NewREST(dbClient("endpoints"), c.EnableWatchCache)
 	m.endpointRegistry = endpoint.NewRegistry(endpointsStorage)
 
-	nodeStorage, nodeStatusStorage := nodeetcd.NewREST(c.DatabaseStorage, c.EnableWatchCache, c.KubeletClient)
+	nodeStorage, nodeStatusStorage := nodeetcd.NewREST(dbClient("nodes"), c.EnableWatchCache, c.KubeletClient)
 	m.nodeRegistry = node.NewRegistry(nodeStorage)
 
-	serviceStorage := serviceetcd.NewREST(c.DatabaseStorage)
+	serviceStorage := serviceetcd.NewREST(dbClient("services"))
 	m.serviceRegistry = service.NewRegistry(serviceStorage)
 
 	var serviceClusterIPRegistry service.RangeRegistry
 	serviceClusterIPAllocator := ipallocator.NewAllocatorCIDRRange(m.serviceClusterIPRange, func(max int, rangeSpec string) allocator.Interface {
 		mem := allocator.NewAllocationMap(max, rangeSpec)
-		etcd := etcdallocator.NewEtcd(mem, "/ranges/serviceips", "serviceipallocation", c.DatabaseStorage)
+		etcd := etcdallocator.NewEtcd(mem, "/ranges/serviceips", "serviceipallocation", dbClient("services"))
 		serviceClusterIPRegistry = etcd
 		return etcd
 	})
@@ -472,13 +541,13 @@ func (m *Master) init(c *Config) {
 	var serviceNodePortRegistry service.RangeRegistry
 	serviceNodePortAllocator := portallocator.NewPortAllocatorCustom(m.serviceNodePortRange, func(max int, rangeSpec string) allocator.Interface {
 		mem := allocator.NewAllocationMap(max, rangeSpec)
-		etcd := etcdallocator.NewEtcd(mem, "/ranges/servicenodeports", "servicenodeportallocation", c.DatabaseStorage)
+		etcd := etcdallocator.NewEtcd(mem, "/ranges/servicenodeports", "servicenodeportallocation", dbClient("services"))
 		serviceNodePortRegistry = etcd
 		return etcd
 	})
 	m.serviceNodePortAllocator = serviceNodePortRegistry
 
-	controllerStorage := controlleretcd.NewREST(c.DatabaseStorage)
+	controllerStorage := controlleretcd.NewREST(dbClient("replicationControllers"))
 
 	// TODO: Factor out the core API registration
 	m.storage = map[string]rest.Storage{
@@ -581,7 +650,7 @@ func (m *Master) init(c *Config) {
 	// allGroups records all supported groups at /apis
 	allGroups := []api.APIGroup{}
 	if m.exp {
-		m.thirdPartyStorage = c.ExpDatabaseStorage
+		m.thirdPartyStorage = c.StorageDestinations.APIGroups["experimental"].Default
 		m.thirdPartyResources = map[string]*thirdpartyresourcedataetcd.REST{}
 
 		expVersion := m.experimental(c)
@@ -755,7 +824,8 @@ func (m *Master) getServersToValidate(c *Config) map[string]apiserver.Server {
 		"controller-manager": {Addr: "127.0.0.1", Port: ports.ControllerManagerPort, Path: "/healthz"},
 		"scheduler":          {Addr: "127.0.0.1", Port: ports.SchedulerPort, Path: "/healthz"},
 	}
-	for ix, machine := range c.DatabaseStorage.Backends() {
+
+	for ix, machine := range c.StorageDestinations.backends() {
 		etcdUrl, err := url.Parse(machine)
 		if err != nil {
 			glog.Errorf("Failed to parse etcd url for validation: %v", err)
@@ -957,13 +1027,16 @@ func (m *Master) thirdpartyapi(group, kind, version string) *apiserver.APIGroupV
 
 // experimental returns the resources and codec for the experimental api
 func (m *Master) experimental(c *Config) *apiserver.APIGroupVersion {
-	controllerStorage := expcontrolleretcd.NewStorage(c.DatabaseStorage)
-	autoscalerStorage := horizontalpodautoscaleretcd.NewREST(c.ExpDatabaseStorage)
-	thirdPartyResourceStorage := thirdpartyresourceetcd.NewREST(c.ExpDatabaseStorage)
-	daemonSetStorage, daemonSetStatusStorage := daemonetcd.NewREST(c.ExpDatabaseStorage)
-	deploymentStorage := deploymentetcd.NewStorage(c.ExpDatabaseStorage)
-	jobStorage, jobStatusStorage := jobetcd.NewREST(c.ExpDatabaseStorage)
-	ingressStorage := ingressetcd.NewREST(c.ExpDatabaseStorage)
+	controllerStorage := expcontrolleretcd.NewStorage(c.StorageDestinations.get("", "replicationControllers"))
+	dbClient := func(resource string) storage.Interface {
+		return c.StorageDestinations.get("experimental", resource)
+	}
+	autoscalerStorage := horizontalpodautoscaleretcd.NewREST(dbClient("horizonalpodautoscalers"))
+	thirdPartyResourceStorage := thirdpartyresourceetcd.NewREST(dbClient("thirdpartyresources"))
+	daemonSetStorage, daemonSetStatusStorage := daemonetcd.NewREST(dbClient("daemonsets"))
+	deploymentStorage := deploymentetcd.NewStorage(dbClient("deployments"))
+	jobStorage, jobStatusStorage := jobetcd.NewREST(dbClient("jobs"))
+	ingressStorage := ingressetcd.NewREST(dbClient("ingress"))
 
 	thirdPartyControl := ThirdPartyController{
 		master: m,

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -65,9 +65,11 @@ func setUp(t *testing.T) (Master, Config, *assert.Assertions) {
 	fakeClient := tools.NewFakeEtcdClient(t)
 	fakeClient.Machines = []string{"http://machine1:4001", "http://machine2", "http://machine3:4003"}
 	storageVersions := make(map[string]string)
-	config.DatabaseStorage = etcdstorage.NewEtcdStorage(fakeClient, testapi.Default.Codec(), etcdtest.PathPrefix())
+	storageDestinations := NewStorageDestinations()
+	storageDestinations.AddAPIGroup("", etcdstorage.NewEtcdStorage(fakeClient, testapi.Default.Codec(), etcdtest.PathPrefix()))
+	storageDestinations.AddAPIGroup("experimental", etcdstorage.NewEtcdStorage(fakeClient, testapi.Experimental.Codec(), etcdtest.PathPrefix()))
+	config.StorageDestinations = storageDestinations
 	storageVersions[""] = testapi.Default.Version()
-	config.ExpDatabaseStorage = etcdstorage.NewEtcdStorage(fakeClient, testapi.Experimental.Codec(), etcdtest.PathPrefix())
 	storageVersions["experimental"] = testapi.Experimental.GroupAndVersion()
 	config.StorageVersions = storageVersions
 	master.nodeRegistry = registrytest.NewNodeRegistry([]string{"node1", "node2"}, api.NodeResources{})

--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -390,6 +390,8 @@ func TestAuthModeAlwaysAllow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	storageDestinations := master.NewStorageDestinations()
+	storageDestinations.AddAPIGroup("", etcdStorage)
 	var m *master.Master
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		m.Handler.ServeHTTP(w, req)
@@ -397,7 +399,7 @@ func TestAuthModeAlwaysAllow(t *testing.T) {
 	defer s.Close()
 
 	m = master.New(&master.Config{
-		DatabaseStorage:       etcdStorage,
+		StorageDestinations:   storageDestinations,
 		KubeletClient:         client.FakeKubeletClient{},
 		EnableCoreControllers: true,
 		EnableLogsSupport:     false,
@@ -506,6 +508,8 @@ func TestAuthModeAlwaysDeny(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	storageDestinations := master.NewStorageDestinations()
+	storageDestinations.AddAPIGroup("", etcdStorage)
 
 	var m *master.Master
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -514,7 +518,7 @@ func TestAuthModeAlwaysDeny(t *testing.T) {
 	defer s.Close()
 
 	m = master.New(&master.Config{
-		DatabaseStorage:       etcdStorage,
+		StorageDestinations:   storageDestinations,
 		KubeletClient:         client.FakeKubeletClient{},
 		EnableCoreControllers: true,
 		EnableLogsSupport:     false,
@@ -574,6 +578,8 @@ func TestAliceNotForbiddenOrUnauthorized(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	storageDestinations := master.NewStorageDestinations()
+	storageDestinations.AddAPIGroup("", etcdStorage)
 
 	var m *master.Master
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -582,7 +588,7 @@ func TestAliceNotForbiddenOrUnauthorized(t *testing.T) {
 	defer s.Close()
 
 	m = master.New(&master.Config{
-		DatabaseStorage:       etcdStorage,
+		StorageDestinations:   storageDestinations,
 		KubeletClient:         client.FakeKubeletClient{},
 		EnableCoreControllers: true,
 		EnableLogsSupport:     false,
@@ -662,6 +668,8 @@ func TestBobIsForbidden(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	storageDestinations := master.NewStorageDestinations()
+	storageDestinations.AddAPIGroup("", etcdStorage)
 
 	var m *master.Master
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -670,7 +678,7 @@ func TestBobIsForbidden(t *testing.T) {
 	defer s.Close()
 
 	m = master.New(&master.Config{
-		DatabaseStorage:       etcdStorage,
+		StorageDestinations:   storageDestinations,
 		KubeletClient:         client.FakeKubeletClient{},
 		EnableCoreControllers: true,
 		EnableLogsSupport:     false,
@@ -724,6 +732,8 @@ func TestUnknownUserIsUnauthorized(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	storageDestinations := master.NewStorageDestinations()
+	storageDestinations.AddAPIGroup("", etcdStorage)
 
 	var m *master.Master
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -732,7 +742,7 @@ func TestUnknownUserIsUnauthorized(t *testing.T) {
 	defer s.Close()
 
 	m = master.New(&master.Config{
-		DatabaseStorage:       etcdStorage,
+		StorageDestinations:   storageDestinations,
 		KubeletClient:         client.FakeKubeletClient{},
 		EnableCoreControllers: true,
 		EnableLogsSupport:     false,
@@ -802,6 +812,8 @@ func TestNamespaceAuthorization(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	storageDestinations := master.NewStorageDestinations()
+	storageDestinations.AddAPIGroup("", etcdStorage)
 
 	a := newAuthorizerWithContents(t, `{"namespace": "foo"}
 `)
@@ -813,7 +825,7 @@ func TestNamespaceAuthorization(t *testing.T) {
 	defer s.Close()
 
 	m = master.New(&master.Config{
-		DatabaseStorage:       etcdStorage,
+		StorageDestinations:   storageDestinations,
 		KubeletClient:         client.FakeKubeletClient{},
 		EnableCoreControllers: true,
 		EnableLogsSupport:     false,
@@ -918,6 +930,8 @@ func TestKindAuthorization(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	storageDestinations := master.NewStorageDestinations()
+	storageDestinations.AddAPIGroup("", etcdStorage)
 
 	a := newAuthorizerWithContents(t, `{"resource": "services"}
 `)
@@ -929,7 +943,7 @@ func TestKindAuthorization(t *testing.T) {
 	defer s.Close()
 
 	m = master.New(&master.Config{
-		DatabaseStorage:       etcdStorage,
+		StorageDestinations:   storageDestinations,
 		KubeletClient:         client.FakeKubeletClient{},
 		EnableCoreControllers: true,
 		EnableLogsSupport:     false,
@@ -1022,6 +1036,8 @@ func TestReadOnlyAuthorization(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	storageDestinations := master.NewStorageDestinations()
+	storageDestinations.AddAPIGroup("", etcdStorage)
 
 	a := newAuthorizerWithContents(t, `{"readonly": true}`)
 
@@ -1032,7 +1048,7 @@ func TestReadOnlyAuthorization(t *testing.T) {
 	defer s.Close()
 
 	m = master.New(&master.Config{
-		DatabaseStorage:       etcdStorage,
+		StorageDestinations:   storageDestinations,
 		KubeletClient:         client.FakeKubeletClient{},
 		EnableCoreControllers: true,
 		EnableLogsSupport:     false,

--- a/test/integration/scheduler_test.go
+++ b/test/integration/scheduler_test.go
@@ -58,6 +58,8 @@ func TestUnschedulableNodes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't create etcd storage: %v", err)
 	}
+	storageDestinations := master.NewStorageDestinations()
+	storageDestinations.AddAPIGroup("", etcdStorage)
 	framework.DeleteAllEtcdKeys()
 
 	var m *master.Master
@@ -67,7 +69,7 @@ func TestUnschedulableNodes(t *testing.T) {
 	defer s.Close()
 
 	m = master.New(&master.Config{
-		DatabaseStorage:       etcdStorage,
+		StorageDestinations:   storageDestinations,
 		KubeletClient:         client.FakeKubeletClient{},
 		EnableCoreControllers: true,
 		EnableLogsSupport:     false,

--- a/test/integration/secret_test.go
+++ b/test/integration/secret_test.go
@@ -51,6 +51,8 @@ func TestSecrets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	storageDestinations := master.NewStorageDestinations()
+	storageDestinations.AddAPIGroup("", etcdStorage)
 
 	var m *master.Master
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -59,7 +61,7 @@ func TestSecrets(t *testing.T) {
 	defer s.Close()
 
 	m = master.New(&master.Config{
-		DatabaseStorage:       etcdStorage,
+		StorageDestinations:   storageDestinations,
 		KubeletClient:         client.FakeKubeletClient{},
 		EnableCoreControllers: true,
 		EnableLogsSupport:     false,

--- a/test/integration/service_account_test.go
+++ b/test/integration/service_account_test.go
@@ -345,6 +345,8 @@ func startServiceAccountTestServer(t *testing.T) (*client.Client, client.Config,
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	storageDestinations := master.NewStorageDestinations()
+	storageDestinations.AddAPIGroup("", etcdStorage)
 
 	// Listener
 	var m *master.Master
@@ -411,16 +413,16 @@ func startServiceAccountTestServer(t *testing.T) (*client.Client, client.Config,
 
 	// Create a master and install handlers into mux.
 	m = master.New(&master.Config{
-		DatabaseStorage:   etcdStorage,
-		KubeletClient:     client.FakeKubeletClient{},
-		EnableLogsSupport: false,
-		EnableUISupport:   false,
-		EnableIndex:       true,
-		APIPrefix:         "/api",
-		Authenticator:     authenticator,
-		Authorizer:        authorizer,
-		AdmissionControl:  serviceAccountAdmission,
-		StorageVersions:   map[string]string{"": testapi.Default.Version()},
+		StorageDestinations: storageDestinations,
+		KubeletClient:       client.FakeKubeletClient{},
+		EnableLogsSupport:   false,
+		EnableUISupport:     false,
+		EnableIndex:         true,
+		APIPrefix:           "/api",
+		Authenticator:       authenticator,
+		Authorizer:          authorizer,
+		AdmissionControl:    serviceAccountAdmission,
+		StorageVersions:     map[string]string{"": testapi.Default.Version()},
 	})
 
 	// Start the service account and service account token controllers

--- a/test/integration/utils.go
+++ b/test/integration/utils.go
@@ -70,9 +70,11 @@ func runAMaster(t *testing.T) (*master.Master, *httptest.Server) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	storageDestinations := master.NewStorageDestinations()
+	storageDestinations.AddAPIGroup("", etcdStorage)
 
 	m := master.New(&master.Config{
-		DatabaseStorage:       etcdStorage,
+		StorageDestinations:   storageDestinations,
 		KubeletClient:         client.FakeKubeletClient{},
 		EnableCoreControllers: true,
 		EnableLogsSupport:     false,


### PR DESCRIPTION
This moved events to a separate etcd instance.

@brendandburns @lavalamp @dchen1107 
