### PR TITLE
Fix client library for cluster with no SSL

### DIFF
--- a/cluster/images/hyperkube/master-multi.json
+++ b/cluster/images/hyperkube/master-multi.json
@@ -23,6 +23,7 @@
               "apiserver",
               "--portal-net=10.0.0.1/24",
               "--address=0.0.0.0",
+              "--read-write-port=8080",
               "--etcd-servers=http://127.0.0.1:4001",
               "--cluster-name=kubernetes",
               "--v=2"

--- a/cluster/images/hyperkube/master.json
+++ b/cluster/images/hyperkube/master.json
@@ -23,6 +23,7 @@
               "apiserver",
               "--portal-net=10.0.0.1/24",
               "--address=127.0.0.1",
+              "--read-write-port=8080",
               "--etcd-servers=http://127.0.0.1:4001",
               "--cluster-name=kubernetes",
               "--v=2"

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -68,6 +68,7 @@ type APIServer struct {
 	BindAddress                net.IP
 	AdvertiseAddress           net.IP
 	SecurePort                 int
+	ReadWritePort              int
 	ExternalHost               string
 	TLSCertFile                string
 	TLSPrivateKeyFile          string
@@ -177,6 +178,7 @@ func (s *APIServer) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&s.SecurePort, "secure-port", s.SecurePort, ""+
 		"The port on which to serve HTTPS with authentication and authorization. If 0, "+
 		"don't serve HTTPS at all.")
+	fs.IntVar(&s.ReadWritePort, "read-write-port", s.ReadWritePort, "The port for read and write operations; defaults to --secure-port.")
 	fs.StringVar(&s.TLSCertFile, "tls-cert-file", s.TLSCertFile, ""+
 		"File containing x509 Certificate for HTTPS.  (CA cert, if any, concatenated after server cert). "+
 		"If HTTPS serving is enabled, and --tls-cert-file and --tls-private-key-file are not provided, "+
@@ -514,6 +516,11 @@ func (s *APIServer) Run(_ []string) error {
 			installSSH = instances.AddSSHKeyToAllInstances
 		}
 	}
+
+	if s.ReadWritePort == 0 {
+		s.ReadWritePort = s.SecurePort
+	}
+
 	config := &master.Config{
 		StorageDestinations:       storageDestinations,
 		StorageVersions:           storageVersions,
@@ -530,7 +537,7 @@ func (s *APIServer) Run(_ []string) error {
 		APIPrefix:                 s.APIPrefix,
 		APIGroupPrefix:            s.APIGroupPrefix,
 		CorsAllowedOriginList:     s.CorsAllowedOriginList,
-		ReadWritePort:             s.SecurePort,
+		ReadWritePort:             s.ReadWritePort,
 		PublicAddress:             s.AdvertiseAddress,
 		Authenticator:             authenticator,
 		SupportsBasicAuth:         len(s.BasicAuthFile) > 0,

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -227,6 +227,7 @@ pv-recycler-pod-template-filepath-hostpath
 pv-recycler-minimum-timeout-hostpath
 pv-recycler-timeout-increment-hostpath
 read-only-port
+read-write-port
 really-crash-for-testing
 reconcile-cooldown
 reconcile-interval

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -450,8 +450,8 @@ func New(c *Config) *Master {
 		clusterIP:           c.PublicAddress,
 		publicReadWritePort: c.ReadWritePort,
 		serviceReadWriteIP:  c.ServiceReadWriteIP,
-		// TODO: serviceReadWritePort should be passed in as an argument, it may not always be 443
-		serviceReadWritePort: 443,
+		// TODO: serviceReadWritePort should be passed in as an argument, it may not always be the same as public read-write port.
+		serviceReadWritePort: c.ReadWritePort,
 
 		installSSHKey:             c.InstallSSHKey,
 		KubernetesServiceNodePort: c.KubernetesServiceNodePort,


### PR DESCRIPTION
Before this change k8s was:
- creating service that was always pointing to secured port, even if master did not expose one
- generating client config for pods which assumed HTTPS which was again incorrect in a setup without SSL

By default nothing changes and we use secure port. 

@mikedanese @roberthbailey @liggitt 

Fixes #15016 and #15017
