### PR TITLE
Expose kube-api burst/qps settings for kube components

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -64,6 +64,8 @@ type ProxyServerConfig struct {
 	nodeRef            *api.ObjectReference // Reference to this node.
 	MasqueradeAll      bool
 	CleanupAndExit     bool
+	KubeApiQps         float32
+	KubeApiBurst       int
 }
 
 type ProxyServer struct {
@@ -93,6 +95,8 @@ func (s *ProxyServerConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&s.SyncPeriod, "iptables-sync-period", s.SyncPeriod, "How often iptables rules are refreshed (e.g. '5s', '1m', '2h22m').  Must be greater than 0.")
 	fs.BoolVar(&s.MasqueradeAll, "masquerade-all", false, "If using the pure iptables proxy, SNAT everything")
 	fs.BoolVar(&s.CleanupAndExit, "cleanup-iptables", false, "If true cleanup iptables rules and exit.")
+	fs.Float32Var(&s.KubeApiQps, "kube-api-qps", s.KubeApiQps, "QPS to use while talking with kubernetes apiserver")
+	fs.IntVar(&s.KubeApiBurst, "kube-api-burst", s.KubeApiBurst, "Burst to use while talking with kubernetes apiserver")
 }
 
 const (
@@ -117,6 +121,8 @@ func NewProxyConfig() *ProxyServerConfig {
 		OOMScoreAdj:        qos.KubeProxyOOMScoreAdj,
 		ResourceContainer:  "/kube-proxy",
 		SyncPeriod:         30 * time.Second,
+		KubeApiQps:         5.0,
+		KubeApiBurst:       10,
 	}
 }
 
@@ -195,6 +201,11 @@ func NewProxyServerDefault(config *ProxyServerConfig) (*ProxyServer, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Override kubeconfig qps/burst settings from flags
+	kubeconfig.QPS = config.KubeApiQps
+	kubeconfig.Burst = config.KubeApiBurst
+
 	client, err := kubeclient.New(kubeconfig)
 	if err != nil {
 		glog.Fatalf("Invalid API configuration: %v", err)

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -129,6 +129,8 @@ ir-user
 jenkins-host
 jenkins-jobs
 km-path
+kube-api-burst
+kube-api-qps
 kubectl-path
 kubelet-cadvisor-port
 kubelet-certificate-authority

--- a/plugin/cmd/kube-scheduler/app/server.go
+++ b/plugin/cmd/kube-scheduler/app/server.go
@@ -56,6 +56,8 @@ type SchedulerServer struct {
 	Kubeconfig        string
 	BindPodsQPS       float32
 	BindPodsBurst     int
+	KubeApiQps        float32
+	KubeApiBurst      int
 }
 
 // NewSchedulerServer creates a new SchedulerServer with default parameters
@@ -64,6 +66,10 @@ func NewSchedulerServer() *SchedulerServer {
 		Port:              ports.SchedulerPort,
 		Address:           net.ParseIP("127.0.0.1"),
 		AlgorithmProvider: factory.DefaultProvider,
+		BindPodsQPS:       50.0,
+		BindPodsBurst:     100,
+		KubeApiQps:        50.0,
+		KubeApiBurst:      100,
 	}
 	return &s
 }
@@ -77,8 +83,10 @@ func (s *SchedulerServer) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&s.EnableProfiling, "profiling", true, "Enable profiling via web interface host:port/debug/pprof/")
 	fs.StringVar(&s.Master, "master", s.Master, "The address of the Kubernetes API server (overrides any value in kubeconfig)")
 	fs.StringVar(&s.Kubeconfig, "kubeconfig", s.Kubeconfig, "Path to kubeconfig file with authorization and master location information.")
-	fs.Float32Var(&s.BindPodsQPS, "bind-pods-qps", 50.0, "Number of bindings per second scheduler is allowed to continuously make")
-	fs.IntVar(&s.BindPodsBurst, "bind-pods-burst", 100, "Number of bindings per second scheduler is allowed to make during bursts")
+	fs.Float32Var(&s.BindPodsQPS, "bind-pods-qps", s.BindPodsQPS, "Number of bindings per second scheduler is allowed to continuously make")
+	fs.IntVar(&s.BindPodsBurst, "bind-pods-burst", s.BindPodsBurst, "Number of bindings per second scheduler is allowed to make during bursts")
+	fs.Float32Var(&s.KubeApiQps, "kube-api-qps", s.KubeApiQps, "QPS to use while talking with kubernetes apiserver")
+	fs.IntVar(&s.KubeApiBurst, "kube-api-burst", s.KubeApiBurst, "Burst to use while talking with kubernetes apiserver")
 }
 
 // Run runs the specified SchedulerServer.  This should never exit.
@@ -95,8 +103,10 @@ func (s *SchedulerServer) Run(_ []string) error {
 	if err != nil {
 		return err
 	}
-	kubeconfig.QPS = 50.0
-	kubeconfig.Burst = 100
+
+	// Override kubeconfig qps/burst settings from flags
+	kubeconfig.QPS = s.KubeApiQps
+	kubeconfig.Burst = s.KubeApiBurst
 
 	kubeClient, err := client.New(kubeconfig)
 	if err != nil {


### PR DESCRIPTION
Trying to remove API limits to assist with tracking down the cause of #14216

Default to 20.0 qps, 30 burst since that's what I saw hardcoded in at
least some of the components

Unclear if maybe it'd be better to just assume these are set as part of
the incoming kubeconfig.  For now just exposing them as flags since it's
easier for me to manually tweak.
