### PR TITLE
 kubelet: independent pod syncs and backoff on error

### DIFF
--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -50,6 +50,7 @@ import (
 	proberesults "k8s.io/kubernetes/pkg/kubelet/prober/results"
 	"k8s.io/kubernetes/pkg/kubelet/status"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
+	"k8s.io/kubernetes/pkg/kubelet/util/queue"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util"
@@ -145,6 +146,7 @@ func newTestKubelet(t *testing.T) *TestKubelet {
 	kubelet.backOff.Clock = fakeClock
 	kubelet.podKillingCh = make(chan *kubecontainer.Pod, 20)
 	kubelet.resyncInterval = 10 * time.Second
+	kubelet.workQueue = queue.NewBasicWorkQueue()
 	return &TestKubelet{kubelet, fakeRuntime, mockCadvisor, fakeKubeClient, fakeMirrorClient}
 }
 

--- a/pkg/kubelet/pod/manager.go
+++ b/pkg/kubelet/pod/manager.go
@@ -43,6 +43,7 @@ type Manager interface {
 	GetPods() []*api.Pod
 	GetPodByFullName(podFullName string) (*api.Pod, bool)
 	GetPodByName(namespace, name string) (*api.Pod, bool)
+	GetPodByUID(types.UID) (*api.Pod, bool)
 	GetPodByMirrorPod(*api.Pod) (*api.Pod, bool)
 	GetMirrorPodByPod(*api.Pod) (*api.Pod, bool)
 	GetPodsAndMirrorPods() ([]*api.Pod, []*api.Pod)
@@ -175,6 +176,15 @@ func (pm *basicManager) getAllPods() []*api.Pod {
 func (pm *basicManager) GetPodByName(namespace, name string) (*api.Pod, bool) {
 	podFullName := kubecontainer.BuildPodFullName(name, namespace)
 	return pm.GetPodByFullName(podFullName)
+}
+
+// GetPodByUID provides the (non-mirror) pod that matches pod UID as well as
+// whether the pod was found.
+func (pm *basicManager) GetPodByUID(uid types.UID) (*api.Pod, bool) {
+	pm.lock.RLock()
+	defer pm.lock.RUnlock()
+	pod, ok := pm.podByUID[uid]
+	return pod, ok
 }
 
 // GetPodByName returns the (non-mirror) pod that matches full name, as well as

--- a/pkg/kubelet/pod_workers_test.go
+++ b/pkg/kubelet/pod_workers_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/dockertools"
 	"k8s.io/kubernetes/pkg/kubelet/network"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
+	"k8s.io/kubernetes/pkg/kubelet/util/queue"
 	"k8s.io/kubernetes/pkg/types"
 )
 
@@ -66,6 +67,9 @@ func createPodWorkers() (*podWorkers, map[types.UID][]string) {
 			return nil
 		},
 		fakeRecorder,
+		queue.NewBasicWorkQueue(),
+		time.Second,
+		time.Second,
 	)
 	return podWorkers, processed
 }
@@ -200,7 +204,7 @@ func TestFakePodWorkers(t *testing.T) {
 	kubeletForRealWorkers := &simpleFakeKubelet{}
 	kubeletForFakeWorkers := &simpleFakeKubelet{}
 
-	realPodWorkers := newPodWorkers(fakeRuntimeCache, kubeletForRealWorkers.syncPodWithWaitGroup, fakeRecorder)
+	realPodWorkers := newPodWorkers(fakeRuntimeCache, kubeletForRealWorkers.syncPodWithWaitGroup, fakeRecorder, queue.NewBasicWorkQueue(), time.Second, time.Second)
 	fakePodWorkers := &fakePodWorkers{kubeletForFakeWorkers.syncPod, fakeRuntimeCache, t}
 
 	tests := []struct {

--- a/pkg/kubelet/util/queue/work_queue.go
+++ b/pkg/kubelet/util/queue/work_queue.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queue
+
+import (
+	"sync"
+	"time"
+
+	"k8s.io/kubernetes/pkg/types"
+	"k8s.io/kubernetes/pkg/util"
+)
+
+// WorkQueue allows queueing items with a timestamp. An item is
+// considered ready to process if the timestamp has expired.
+type WorkQueue interface {
+	// GetWork dequeues and returns all ready items.
+	GetWork() []types.UID
+	// Enqueue inserts a new item or overwrites an existing item with the
+	// new timestamp (time.Now() + delay) if it is greater.
+	Enqueue(item types.UID, delay time.Duration)
+}
+
+type basicWorkQueue struct {
+	clock util.Clock
+	lock  sync.Mutex
+	queue map[types.UID]time.Time
+}
+
+var _ WorkQueue = &basicWorkQueue{}
+
+func NewBasicWorkQueue() WorkQueue {
+	queue := make(map[types.UID]time.Time)
+	return &basicWorkQueue{queue: queue, clock: util.RealClock{}}
+}
+
+func (q *basicWorkQueue) GetWork() []types.UID {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	now := q.clock.Now()
+	var items []types.UID
+	for k, v := range q.queue {
+		if v.Before(now) {
+			items = append(items, k)
+			delete(q.queue, k)
+		}
+	}
+	return items
+}
+
+func (q *basicWorkQueue) Enqueue(item types.UID, delay time.Duration) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+	now := q.clock.Now()
+	timestamp := now.Add(delay)
+	existing, ok := q.queue[item]
+	if !ok || (ok && existing.Before(timestamp)) {
+		q.queue[item] = timestamp
+	}
+}

--- a/pkg/kubelet/util/queue/work_queue_test.go
+++ b/pkg/kubelet/util/queue/work_queue_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queue
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/kubernetes/pkg/types"
+	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/sets"
+)
+
+func newTestBasicWorkQueue() (*basicWorkQueue, *util.FakeClock) {
+	fakeClock := &util.FakeClock{Time: time.Now()}
+	wq := &basicWorkQueue{
+		clock: fakeClock,
+		queue: make(map[types.UID]time.Time),
+	}
+	return wq, fakeClock
+}
+
+func compareResults(t *testing.T, expected, actual []types.UID) {
+	expectedSet := sets.NewString()
+	for _, u := range expected {
+		expectedSet.Insert(string(u))
+	}
+	actualSet := sets.NewString()
+	for _, u := range actual {
+		actualSet.Insert(string(u))
+	}
+	if !expectedSet.Equal(actualSet) {
+		t.Errorf("Expected %#v, got %#v", expectedSet.List(), actualSet.List())
+	}
+}
+
+func TestGetWork(t *testing.T) {
+	q, clock := newTestBasicWorkQueue()
+	q.Enqueue(types.UID("foo1"), -1*time.Minute)
+	q.Enqueue(types.UID("foo2"), -1*time.Minute)
+	q.Enqueue(types.UID("foo3"), 1*time.Minute)
+	q.Enqueue(types.UID("foo4"), 1*time.Minute)
+	expected := []types.UID{types.UID("foo1"), types.UID("foo2")}
+	compareResults(t, expected, q.GetWork())
+	compareResults(t, []types.UID{}, q.GetWork())
+	// Dial the time to 1 hour ahead.
+	clock.Step(time.Hour)
+	expected = []types.UID{types.UID("foo3"), types.UID("foo4")}
+	compareResults(t, expected, q.GetWork())
+	compareResults(t, []types.UID{}, q.GetWork())
+}
+
+func TestEnqueueKeepGreaterTimestamp(t *testing.T) {
+	q, _ := newTestBasicWorkQueue()
+	item := types.UID("foo")
+	q.Enqueue(item, -7*time.Hour)
+	q.Enqueue(item, 3*time.Hour)
+	compareResults(t, []types.UID{}, q.GetWork())
+
+	q.Enqueue(item, 3*time.Hour)
+	q.Enqueue(item, -7*time.Hour)
+	compareResults(t, []types.UID{}, q.GetWork())
+}


### PR DESCRIPTION
If a pod worker is unable to finish a sync without any error, it should ensure
that it would be woken up again to retry in the near future.
Note that we do not need this right now because we sync/resync every 10s, but
the change would become necesssary when we add the pod event generator and
disable or increase the resync period.

This change adds a simple queue to communicate between kubelet and the pod
workers. Upon a sync error, the worker can requeue itself with a future
timestamp indicating when it should be woken up. If there is no error, worker
would also requeue itself for a (further) future timestamp for a resync. This
replaces the global periodic syncing across all pods, i.e., we no longer have
to trigger periodiac syncs for all pods at the same time.

This change also makes sure that if a sync does not succeed (either due to
real error or the per-container backoff mechanism), an error would be propagated
back to the pod worker, which is responsible for requeuing.
