### PR TITLE
Deployment: Fixing the selector for new RC created by deployment

### DIFF
--- a/pkg/apis/extensions/v1beta1/defaults.go
+++ b/pkg/apis/extensions/v1beta1/defaults.go
@@ -44,6 +44,19 @@ func addDefaultingFuncs() {
 			}
 		},
 		func(obj *Deployment) {
+			// Default labels and selector to labels from pod template spec.
+			var labels map[string]string
+			if obj.Spec.Template != nil {
+				labels = obj.Spec.Template.Labels
+			}
+			if labels != nil {
+				if len(obj.Spec.Selector) == 0 {
+					obj.Spec.Selector = labels
+				}
+				if len(obj.Labels) == 0 {
+					obj.Labels = labels
+				}
+			}
 			// Set DeploymentSpec.Replicas to 1 if it is not set.
 			if obj.Spec.Replicas == nil {
 				obj.Spec.Replicas = new(int)

--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -140,6 +140,9 @@ func (d *DeploymentController) getNewRC(deployment extensions.Deployment) (*api.
 	podTemplateSpecHash := deploymentUtil.GetPodTemplateSpecHash(deployment.Spec.Template)
 	rcName := fmt.Sprintf("deploymentrc-%d", podTemplateSpecHash)
 	newRCTemplate := deploymentUtil.GetNewRCTemplate(deployment)
+	// Add podTemplateHash label to selector.
+	newRCSelector := deploymentUtil.CloneAndAddLabel(deployment.Spec.Selector, deployment.Spec.UniqueLabelKey, podTemplateSpecHash)
+
 	newRC := api.ReplicationController{
 		ObjectMeta: api.ObjectMeta{
 			Name:      rcName,
@@ -147,7 +150,7 @@ func (d *DeploymentController) getNewRC(deployment extensions.Deployment) (*api.
 		},
 		Spec: api.ReplicationControllerSpec{
 			Replicas: 0,
-			Selector: newRCTemplate.ObjectMeta.Labels,
+			Selector: newRCSelector,
 			Template: newRCTemplate,
 		},
 	}

--- a/pkg/util/deployment/deployment.go
+++ b/pkg/util/deployment/deployment.go
@@ -90,16 +90,27 @@ func GetNewRCTemplate(deployment extensions.Deployment) *api.PodTemplateSpec {
 		ObjectMeta: deployment.Spec.Template.ObjectMeta,
 		Spec:       deployment.Spec.Template.Spec,
 	}
-	podTemplateSpecHash := GetPodTemplateSpecHash(newRCTemplate)
-	if deployment.Spec.UniqueLabelKey != "" {
-		newLabels := map[string]string{}
-		for key, value := range deployment.Spec.Template.ObjectMeta.Labels {
-			newLabels[key] = value
-		}
-		newLabels[deployment.Spec.UniqueLabelKey] = fmt.Sprintf("%d", podTemplateSpecHash)
-		newRCTemplate.ObjectMeta.Labels = newLabels
-	}
+	newRCTemplate.ObjectMeta.Labels = CloneAndAddLabel(
+		deployment.Spec.Template.ObjectMeta.Labels,
+		deployment.Spec.UniqueLabelKey,
+		GetPodTemplateSpecHash(newRCTemplate))
 	return newRCTemplate
+}
+
+// Clones the given map and returns a new map with the given key and value added.
+// Returns the given map, if labelKey is empty.
+func CloneAndAddLabel(labels map[string]string, labelKey string, labelValue uint32) map[string]string {
+	if labelKey == "" {
+		// Dont need to add a label.
+		return labels
+	}
+	// Clone.
+	newLabels := map[string]string{}
+	for key, value := range labels {
+		newLabels[key] = value
+	}
+	newLabels[labelKey] = fmt.Sprintf("%d", labelValue)
+	return newLabels
 }
 
 func GetPodTemplateSpecHash(template *api.PodTemplateSpec) uint32 {


### PR DESCRIPTION
As per discussion with Brian, the selector for new RC should be derived from the deployment selector, rather than from the labels in podTemplate.

cc @ironcladlou @bgrant0607 @ghodss 
