### PR TITLE
Use PATCH instead of PUT when update events

### DIFF
--- a/pkg/client/unversioned/testclient/actions.go
+++ b/pkg/client/unversioned/testclient/actions.go
@@ -100,6 +100,25 @@ func NewUpdateAction(resource, namespace string, object runtime.Object) UpdateAc
 	return action
 }
 
+func NewRootPatchAction(resource string, object runtime.Object) PatchActionImpl {
+	action := PatchActionImpl{}
+	action.Verb = "patch"
+	action.Resource = resource
+	action.Object = object
+
+	return action
+}
+
+func NewPatchAction(resource, namespace string, object runtime.Object) PatchActionImpl {
+	action := PatchActionImpl{}
+	action.Verb = "patch"
+	action.Resource = resource
+	action.Namespace = namespace
+	action.Object = object
+
+	return action
+}
+
 func NewUpdateSubresourceAction(resource, subresource, namespace string, object runtime.Object) UpdateActionImpl {
 	action := UpdateActionImpl{}
 	action.Verb = "update"
@@ -286,6 +305,15 @@ type UpdateActionImpl struct {
 }
 
 func (a UpdateActionImpl) GetObject() runtime.Object {
+	return a.Object
+}
+
+type PatchActionImpl struct {
+	ActionImpl
+	Object runtime.Object
+}
+
+func (a PatchActionImpl) GetObject() runtime.Object {
 	return a.Object
 }
 

--- a/pkg/client/unversioned/testclient/fake_events.go
+++ b/pkg/client/unversioned/testclient/fake_events.go
@@ -87,6 +87,20 @@ func (c *FakeEvents) Update(event *api.Event) (*api.Event, error) {
 	return obj.(*api.Event), err
 }
 
+// Patch patches an existing event. Returns the copy of the event the server returns, or an error.
+func (c *FakeEvents) Patch(event *api.Event, data []byte) (*api.Event, error) {
+	action := NewRootPatchAction("events", event)
+	if c.Namespace != "" {
+		action = NewPatchAction("events", c.Namespace, event)
+	}
+	obj, err := c.Fake.Invokes(action, event)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*api.Event), err
+}
+
 func (c *FakeEvents) Delete(name string) error {
 	action := NewRootDeleteAction("events", name)
 	if c.Namespace != "" {


### PR DESCRIPTION
Fix #14126
#14126 identifies the problem that we accidentally wipe out the UID when update an Event. Update of an Event occurs when we compress events, so it requires updating the `Event.Count` and `Event.LastTimeStamp`. This PR uses "patch" instead of "update" when we need to modify an event, so fields other than the above two won't be changed.

Please ignore the first commit "increase the on-wire precision of time" which is in PR #15263. This PR needs this fix to pass the unit test.

@saad-ali @vishh @liggitt @jiangyaoguo @bgrant0607 @lavalamp 
