### PR TITLE
Stop using the deprecated --portal-net flag

### DIFF
--- a/cluster/images/hyperkube/master-multi.json
+++ b/cluster/images/hyperkube/master-multi.json
@@ -21,7 +21,7 @@
       "command": [
               "/hyperkube",
               "apiserver",
-              "--portal-net=10.0.0.1/24",
+              "--service-cluster-ip-range=10.0.0.1/24",
               "--address=0.0.0.0",
               "--etcd-servers=http://127.0.0.1:4001",
               "--cluster-name=kubernetes",

--- a/cluster/images/hyperkube/master.json
+++ b/cluster/images/hyperkube/master.json
@@ -21,7 +21,7 @@
       "command": [
               "/hyperkube",
               "apiserver",
-              "--portal-net=10.0.0.1/24",
+              "--service-cluster-ip-range=10.0.0.1/24",
               "--address=127.0.0.1",
               "--etcd-servers=http://127.0.0.1:4001",
               "--cluster-name=kubernetes",


### PR DESCRIPTION
In the docker single/multi-node examples. 
