### PR TITLE
return api.DaemonSetList, instead of an array

### DIFF
--- a/pkg/client/cache/listers.go
+++ b/pkg/client/cache/listers.go
@@ -242,9 +242,9 @@ func (s *StoreToDaemonSetLister) Exists(ds *extensions.DaemonSet) (bool, error) 
 
 // List lists all daemon sets in the store.
 // TODO: converge on the interface in pkg/client
-func (s *StoreToDaemonSetLister) List() (dss []extensions.DaemonSet, err error) {
+func (s *StoreToDaemonSetLister) List() (dss extensions.DaemonSetList, err error) {
 	for _, c := range s.Store.List() {
-		dss = append(dss, *(c.(*extensions.DaemonSet)))
+		dss.Items = append(dss.Items, *(c.(*extensions.DaemonSet)))
 	}
 	return dss, nil
 }

--- a/pkg/client/cache/listers_test.go
+++ b/pkg/client/cache/listers_test.go
@@ -171,7 +171,8 @@ func TestStoreToDaemonSetLister(t *testing.T) {
 				{ObjectMeta: api.ObjectMeta{Name: "basic"}},
 			},
 			list: func() ([]extensions.DaemonSet, error) {
-				return lister.List()
+				list, err := lister.List()
+				return list.Items, err
 			},
 			outDaemonSetNames: sets.NewString("basic"),
 		},
@@ -183,7 +184,8 @@ func TestStoreToDaemonSetLister(t *testing.T) {
 				{ObjectMeta: api.ObjectMeta{Name: "complex2"}},
 			},
 			list: func() ([]extensions.DaemonSet, error) {
-				return lister.List()
+				list, err := lister.List()
+				return list.Items, err
 			},
 			outDaemonSetNames: sets.NewString("basic", "complex", "complex2"),
 		},

--- a/pkg/controller/daemon/controller.go
+++ b/pkg/controller/daemon/controller.go
@@ -202,8 +202,8 @@ func (dsc *DaemonSetsController) enqueueAllDaemonSets() {
 		glog.Errorf("Error enqueueing daemon sets: %v", err)
 		return
 	}
-	for i := range ds {
-		dsc.enqueueDaemonSet(&ds[i])
+	for i := range ds.Items {
+		dsc.enqueueDaemonSet(&ds.Items[i])
 	}
 }
 


### PR DESCRIPTION
`StoreToDaemonSetLister.List()` should return `api.DaemonSetList`, instead of `[]api.DeamonSet`
