### PR TITLE
simplify DaemonSetReaper by using NodeSelector

### DIFF
--- a/docs/design/daemon.md
+++ b/docs/design/daemon.md
@@ -97,7 +97,7 @@ The DaemonSet supports standard API features:
     - get (e.g. kubectl get daemonsets)
     - describe
   - Modifiers
-    - delete (if --cascade=true, then first the client turns down all the pods controlled by the DaemonSet (by setting the nodeName to a non-existant name); then it deletes the DaemonSet; then it deletes the pods)
+    - delete (if --cascade=true, then first the client turns down all the pods controlled by the DaemonSet (by setting the nodeSelector to a uuid pair that is unlikely to be set on any node); then it deletes the DaemonSet; then it deletes the pods)
     - label
 	- annotate
     - update operations like patch and replace (only allowed to selector and to nodeSelector and nodeName of pod template)


### PR DESCRIPTION
cc @erictune 

This also fixes another particularly insidious flake. One in 20 strings produced by the fuzz has lenght 0.

https://github.com/google/gofuzz/blob/master/fuzz.go#L434

This would cause the Reaper to set NodeName to "" which is usually a noop, then it times out.
