### PR TITLE
Move hack/travis/install-etcd.sh to hack/, and update etcd version to 2.0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
 
 install:
   - go get github.com/tools/godep
-  - ./hack/travis/install-etcd.sh
+  - ./hack/install-etcd.sh
   - ./hack/build-go.sh
   - export PATH=$GOPATH/bin:./third_party/etcd:$PATH
 

--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -35,11 +35,12 @@ RUN rm -rf /var/lib/apt/lists/
 RUN apt-get -o Acquire::Check-Valid-Until=false update && apt-get install -y rsync
 
 # Download and symlink etcd.  We need this for our integration tests.
+ENV ETCD_VERSION v2.0.12
 RUN mkdir -p /usr/local/src/etcd &&\
     cd /usr/local/src/etcd &&\
-    curl -L -O -s https://github.com/coreos/etcd/releases/download/v2.0.0/etcd-v2.0.0-linux-amd64.tar.gz &&\
-    tar xzf etcd-v2.0.0-linux-amd64.tar.gz &&\
-    ln -s ../src/etcd/etcd-v2.0.0-linux-amd64/etcd /usr/local/bin/
+    curl -fsSLO https://github.com/coreos/etcd/releases/download/$ETCD_VERSION/etcd-$ETCD_VERSION-linux-amd64.tar.gz &&\
+    tar xzf etcd-$ETCD_VERSION-linux-amd64.tar.gz &&\
+    ln -s ../src/etcd/etcd-$ETCD_VERSION-linux-amd64/etcd /usr/local/bin/
 
 # Mark this as a kube-build container
 RUN touch /kube-build-image

--- a/cluster/mesos/docker/test/bin/install-etcd.sh
+++ b/cluster/mesos/docker/test/bin/install-etcd.sh
@@ -20,7 +20,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-ETCD_VERSION=${ETCD_VERSION:-v2.0.11}
+ETCD_VERSION=${ETCD_VERSION:-v2.0.12}
 
 full_name=etcd-${ETCD_VERSION}-linux-amd64
 archive_url=https://github.com/coreos/etcd/releases/download/${ETCD_VERSION}/${full_name}.tar.gz

--- a/docs/devel/development.md
+++ b/docs/devel/development.md
@@ -264,7 +264,9 @@ Coverage results for the project can also be viewed on [Coveralls](https://cover
 
 ## Integration tests
 
-You need an [etcd](https://github.com/coreos/etcd/releases/tag/v2.0.12) in your path, please make sure it is installed and in your ``$PATH``.
+You need an [etcd](https://github.com/coreos/etcd/releases) in your path. To download a copy of the latest version used by Kubernetes, either
+ * run `hack/install-etcd.sh`, which will download etcd to `third_party/etcd`, and then set your `PATH` to include `third_party/etcd`.
+ * inspect `cluster/saltbase/salt/etcd/etcd.manifest` for the correct version, and then manually download and install it to some place in your `PATH`.
 
 ```sh
 cd kubernetes

--- a/docs/devel/development.md
+++ b/docs/devel/development.md
@@ -264,7 +264,7 @@ Coverage results for the project can also be viewed on [Coveralls](https://cover
 
 ## Integration tests
 
-You need an [etcd](https://github.com/coreos/etcd/releases/tag/v2.0.0) in your path, please make sure it is installed and in your ``$PATH``.
+You need an [etcd](https://github.com/coreos/etcd/releases/tag/v2.0.12) in your path, please make sure it is installed and in your ``$PATH``.
 
 ```sh
 cd kubernetes

--- a/hack/install-etcd.sh
+++ b/hack/install-etcd.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 ETCD_VERSION=${ETCD_VERSION:-v2.0.0}
 

--- a/hack/install-etcd.sh
+++ b/hack/install-etcd.sh
@@ -20,9 +20,9 @@ set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
-ETCD_VERSION=${ETCD_VERSION:-v2.0.0}
+ETCD_VERSION=${ETCD_VERSION:-v2.0.12}
 
 cd "${KUBE_ROOT}/third_party"
-curl -sL https://github.com/coreos/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz \
+curl -fsSL https://github.com/coreos/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz \
   | tar xzf -
-ln -sF etcd-${ETCD_VERSION}-linux-amd64 etcd
+ln -fns etcd-${ETCD_VERSION}-linux-amd64 etcd

--- a/hack/jenkins/gotest.sh
+++ b/hack/jenkins/gotest.sh
@@ -32,7 +32,7 @@ export PATH=${GOPATH}/bin:${HOME}/third_party/etcd:/usr/local/go/bin:$PATH
 
 # Install a few things needed by unit and /integration tests.
 go get -u github.com/jstemmer/go-junit-report
-./hack/travis/install-etcd.sh
+./hack/install-etcd.sh
 
 # Enable the Go race detector.
 export KUBE_RACE=-race

--- a/shippable.yml
+++ b/shippable.yml
@@ -32,7 +32,7 @@ before_install:
   - if [[ $SHIPPABLE_GO_VERSION == "tip" ]]; then gvm install tip; gvm use tip; fi
   - if [[ $SHIPPABLE_GO_VERSION == *release* ]]; then gvm install release; gvm use release; fi
   - if [[ $SHIPPABLE_GO_VERSION =~ [0-9].[0-9] ]]; then gvm install go$SHIPPABLE_GO_VERSION; gvm use go$SHIPPABLE_GO_VERSION; fi
-  - ./hack/travis/install-etcd.sh
+  - ./hack/install-etcd.sh
   - export GOPATH=$SHIPPABLE_GOPATH
   - mkdir -p /root/workspace/src/k8s.io; mv /root/workspace/src/github.com/kubernetes/kubernetes /root/workspace/src/k8s.io/kubernetes
   - export PATH=$GOPATH/bin:./third_party/etcd:$PATH
@@ -44,7 +44,7 @@ install:
   - go get github.com/jstemmer/go-junit-report
   - ./hack/build-go.sh
   - godep go install ./...
-  - ./hack/travis/install-etcd.sh
+  - ./hack/install-etcd.sh
   - ./hack/verify-gofmt.sh
   - ./hack/verify-boilerplate.sh
   - ./hack/verify-description.sh


### PR DESCRIPTION
First part is a cleanup from https://github.com/kubernetes/kubernetes/pull/13951#discussion_r39546179, since both Jenkins + Shippable are using this script (and not just Travis).

Second part is catching up our local testing to match what we really use in clusters as of June (ec1e308ae268c58e5912604e8e267c94ad651558).

@kubernetes/goog-testing 
