### PR TITLE
Replace default ginkgo reporter with simpler reporter

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -51,10 +51,10 @@ var (
 
 func init() {
 	// Turn on verbose by default to get spec names
-	config.DefaultReporterConfig.Verbose = true
+	config.DefaultReporterConfig.Verbose = false
 
 	// Turn on EmitSpecProgress to get spec progress (especially on interrupt)
-	config.GinkgoConfig.EmitSpecProgress = true
+	config.GinkgoConfig.EmitSpecProgress = false
 
 	// Randomize specs as well as suites
 	config.GinkgoConfig.RandomizeAllSpecs = true
@@ -137,5 +137,7 @@ func TestE2E(t *testing.T) {
 	if *reportDir != "" {
 		r = append(r, reporters.NewJUnitReporter(path.Join(*reportDir, fmt.Sprintf("junit_%02d.xml", config.GinkgoConfig.ParallelNode))))
 	}
-	ginkgo.RunSpecsWithDefaultAndCustomReporters(t, "Kubernetes e2e suite", r)
+
+	r = append(r, NewSimpleReporter())
+	ginkgo.RunSpecsWithCustomReporters(t, "Kubernetes e2e suite", r)
 }

--- a/test/e2e/reporter.go
+++ b/test/e2e/reporter.go
@@ -1,0 +1,137 @@
+package e2e
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/onsi/ginkgo/config"
+	"github.com/onsi/ginkgo/reporters/stenographer"
+	"github.com/onsi/ginkgo/types"
+)
+
+// maxDescriptionLength define the maximum number of characters showed for the
+// spec description in console. After this number, the description will be
+// trimmed and suffixed by ' ...'
+const maxDescriptionLength = 100
+
+// TrimCodeLocationOn trims the code location (file path) to left after last
+// occurence of this string. This helps copy&paste of broken test files and also
+// improves readability
+var TrimCodeLocationOn = "/k8s.io/kubernetes/"
+
+type SimpleReporter struct {
+	stenographer stenographer.Stenographer
+
+	// Output defines a writer where to send the test output (eg. os.Stdout)
+	Output io.Writer
+}
+
+// NewSimpleReporter initializes the simple Ginkgo reporter
+func NewSimpleReporter() *SimpleReporter {
+	return &SimpleReporter{
+		Output:       os.Stdout,
+		stenographer: stenographer.New(!config.DefaultReporterConfig.NoColor),
+	}
+}
+
+func (r *SimpleReporter) SpecSuiteWillBegin(config config.GinkgoConfigType, summary *types.SuiteSummary) {
+	fmt.Fprintf(r.Output, "=== SUITE %s (%d total specs, %d will run):\n",
+		summary.SuiteDescription, summary.NumberOfTotalSpecs, summary.NumberOfSpecsThatWillBeRun)
+}
+
+func (r *SimpleReporter) BeforeSuiteDidRun(*types.SetupSummary) {
+}
+
+func (r *SimpleReporter) SpecWillRun(spec *types.SpecSummary) {
+	r.printRunLine(spec)
+}
+
+func (r *SimpleReporter) SpecDidComplete(spec *types.SpecSummary) {
+	r.handleSpecFailure(spec)
+	r.printStatusLine(spec)
+}
+
+func (r *SimpleReporter) AfterSuiteDidRun(setupSummary *types.SetupSummary) {
+}
+
+func (r *SimpleReporter) SpecSuiteDidEnd(summary *types.SuiteSummary) {
+}
+
+func (r *SimpleReporter) handleSpecFailure(spec *types.SpecSummary) {
+	switch spec.State {
+	case types.SpecStateFailed:
+		r.stenographer.AnnounceSpecFailed(spec, true, false)
+	case types.SpecStatePanicked:
+		r.stenographer.AnnounceSpecPanicked(spec, true, false)
+	case types.SpecStateTimedOut:
+		r.stenographer.AnnounceSpecTimedOut(spec, true, false)
+	}
+}
+
+func (r *SimpleReporter) printStatusLine(spec *types.SpecSummary) {
+	runTime := ""
+	if runTime = fmt.Sprintf(" (%v)", spec.RunTime); runTime == " (0)" {
+		runTime = ""
+	}
+	fmt.Fprintf(r.Output, "%4s%-16s %s%s\n", " ", convertGinkgoState(spec.State), specDescription(spec), runTime)
+}
+
+func (r *SimpleReporter) printRunLine(spec *types.SpecSummary) {
+	fmt.Fprintf(r.Output, "=== RUN %s:\n", trimCodeLocation(spec.ComponentCodeLocations[1]))
+}
+
+func specDescription(spec *types.SpecSummary) string {
+	name := ""
+	for _, t := range spec.ComponentTexts[1:len(spec.ComponentTexts)] {
+		name += strings.TrimSpace(t) + " "
+	}
+	if len(name) == 0 {
+		name = fmt.Sprintf("FIXME: Invalid name for %q", spec.ComponentTexts)
+	}
+	return shorten(strings.TrimSpace(name))
+}
+
+func shorten(s string) string {
+	runes := []rune(s)
+	if len(runes) > maxDescriptionLength {
+		return string(runes[:maxDescriptionLength]) + " ..."
+	}
+	return s
+}
+
+func bold(v string) string {
+	return "\033[1m" + v + "\033[0m"
+}
+
+func red(v string) string {
+	return "\033[31m" + v + "\033[0m"
+}
+
+func magenta(v string) string {
+	return "\033[35m" + v + "\033[0m"
+}
+
+func convertGinkgoState(s types.SpecState) string {
+	switch s {
+	case types.SpecStatePassed:
+		return bold("ok")
+	case types.SpecStateSkipped:
+		return magenta("skip")
+	case types.SpecStateFailed:
+		return red("fail")
+	case types.SpecStateTimedOut:
+		return red("timed")
+	case types.SpecStatePanicked:
+		return red("panic")
+	case types.SpecStatePending:
+		return magenta("pending")
+	default:
+		return bold(fmt.Sprintf("%v", s))
+	}
+}
+
+func trimCodeLocation(l types.CodeLocation) string {
+	return fmt.Sprintf("%q", l.FileName[strings.LastIndex(l.FileName, TrimCodeLocationOn)+len(TrimCodeLocationOn):])
+}


### PR DESCRIPTION
This will replace the default, noisy Ginkgo reporter with much simpler reporter that just prints what test is running and its status (without STEP, etc..).  In case of failure, it falls back to original default Ginkgo reporter. As a result, you will get much cleaner logs when no failure is recorded.

OpenShift PR: https://github.com/openshift/origin/pull/4984
