### PR TITLE
Refactor test objects to a separate package

### DIFF
--- a/pkg/apiserver/testing/types.go
+++ b/pkg/apiserver/testing/types.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+)
+
+type Simple struct {
+	unversioned.TypeMeta `json:",inline"`
+	api.ObjectMeta       `json:"metadata"`
+	Other                string            `json:"other,omitempty"`
+	Labels               map[string]string `json:"labels,omitempty"`
+}
+
+func (*Simple) IsAnAPIObject() {}
+
+type SimpleRoot struct {
+	unversioned.TypeMeta `json:",inline"`
+	api.ObjectMeta       `json:"metadata"`
+	Other                string            `json:"other,omitempty"`
+	Labels               map[string]string `json:"labels,omitempty"`
+}
+
+func (*SimpleRoot) IsAnAPIObject() {}
+
+type SimpleGetOptions struct {
+	unversioned.TypeMeta `json:",inline"`
+	Param1               string `json:"param1"`
+	Param2               string `json:"param2"`
+	Path                 string `json:"atAPath"`
+}
+
+func (SimpleGetOptions) SwaggerDoc() map[string]string {
+	return map[string]string{
+		"param1": "description for param1",
+		"param2": "description for param2",
+	}
+}
+
+func (*SimpleGetOptions) IsAnAPIObject() {}
+
+type SimpleList struct {
+	unversioned.TypeMeta `json:",inline"`
+	unversioned.ListMeta `json:"metadata,inline"`
+	Items                []Simple `json:"items,omitempty"`
+}
+
+func (*SimpleList) IsAnAPIObject() {}

--- a/pkg/apiserver/watch_test.go
+++ b/pkg/apiserver/watch_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/rest"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	apiservertesting "k8s.io/kubernetes/pkg/apiserver/testing"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
@@ -47,9 +48,9 @@ var watchTestTable = []struct {
 	t   watch.EventType
 	obj runtime.Object
 }{
-	{watch.Added, &Simple{ObjectMeta: api.ObjectMeta{Name: "foo"}}},
-	{watch.Modified, &Simple{ObjectMeta: api.ObjectMeta{Name: "bar"}}},
-	{watch.Deleted, &Simple{ObjectMeta: api.ObjectMeta{Name: "bar"}}},
+	{watch.Added, &apiservertesting.Simple{ObjectMeta: api.ObjectMeta{Name: "foo"}}},
+	{watch.Modified, &apiservertesting.Simple{ObjectMeta: api.ObjectMeta{Name: "bar"}}},
+	{watch.Deleted, &apiservertesting.Simple{ObjectMeta: api.ObjectMeta{Name: "bar"}}},
 }
 
 func TestWatchWebsocket(t *testing.T) {
@@ -363,7 +364,7 @@ func TestWatchHTTPTimeout(t *testing.T) {
 	req, _ := http.NewRequest("GET", dest.String(), nil)
 	client := http.Client{}
 	resp, err := client.Do(req)
-	watcher.Add(&Simple{TypeMeta: unversioned.TypeMeta{APIVersion: newVersion}})
+	watcher.Add(&apiservertesting.Simple{TypeMeta: unversioned.TypeMeta{APIVersion: newVersion}})
 
 	// Make sure we can actually watch an endpoint
 	decoder := json.NewDecoder(resp.Body)

--- a/pkg/kubectl/testing/types.go
+++ b/pkg/kubectl/testing/types.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+)
+
+type TestStruct struct {
+	unversioned.TypeMeta `json:",inline"`
+	api.ObjectMeta       `json:"metadata,omitempty"`
+	Key                  string         `json:"Key"`
+	Map                  map[string]int `json:"Map"`
+	StringList           []string       `json:"StringList"`
+	IntList              []int          `json:"IntList"`
+}
+
+func (ts *TestStruct) IsAnAPIObject() {}

--- a/pkg/storage/etcd/api_object_versioner_test.go
+++ b/pkg/storage/etcd/api_object_versioner_test.go
@@ -22,17 +22,18 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	storagetesting "k8s.io/kubernetes/pkg/storage/testing"
 )
 
 func TestObjectVersioner(t *testing.T) {
 	v := APIObjectVersioner{}
-	if ver, err := v.ObjectResourceVersion(&TestResource{ObjectMeta: api.ObjectMeta{ResourceVersion: "5"}}); err != nil || ver != 5 {
+	if ver, err := v.ObjectResourceVersion(&storagetesting.TestResource{ObjectMeta: api.ObjectMeta{ResourceVersion: "5"}}); err != nil || ver != 5 {
 		t.Errorf("unexpected version: %d %v", ver, err)
 	}
-	if ver, err := v.ObjectResourceVersion(&TestResource{ObjectMeta: api.ObjectMeta{ResourceVersion: "a"}}); err == nil || ver != 0 {
+	if ver, err := v.ObjectResourceVersion(&storagetesting.TestResource{ObjectMeta: api.ObjectMeta{ResourceVersion: "a"}}); err == nil || ver != 0 {
 		t.Errorf("unexpected version: %d %v", ver, err)
 	}
-	obj := &TestResource{ObjectMeta: api.ObjectMeta{ResourceVersion: "a"}}
+	obj := &storagetesting.TestResource{ObjectMeta: api.ObjectMeta{ResourceVersion: "a"}}
 	if err := v.UpdateObject(obj, nil, 5); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -40,7 +41,7 @@ func TestObjectVersioner(t *testing.T) {
 		t.Errorf("unexpected resource version: %#v", obj)
 	}
 	now := unversioned.Time{Time: time.Now()}
-	obj = &TestResource{ObjectMeta: api.ObjectMeta{ResourceVersion: "a"}}
+	obj = &storagetesting.TestResource{ObjectMeta: api.ObjectMeta{ResourceVersion: "a"}}
 	if err := v.UpdateObject(obj, &now.Time, 5); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/storage/testing/types.go
+++ b/pkg/storage/testing/types.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+)
+
+type TestResource struct {
+	unversioned.TypeMeta `json:",inline"`
+	api.ObjectMeta       `json:"metadata"`
+	Value                int `json:"value"`
+}
+
+func (*TestResource) IsAnAPIObject() {}


### PR DESCRIPTION
This is a prerequisite for migrating to ugorji codec instead of using standard go json parser.
I'm moving test types to a separate package and then we will be able to easily generate code for those.

The rationale why it is necessary:

"The problem was that you ran codecgen on a value (e.g. api.TypeMeta) which you then embedded,
causing the value to be a codec.Selfer. 
This effectively made the "wrapping" type (ie api.Policy) a codec.Selfer also. 
This is how go works.

To fix, you MUST also run codecgen on the containing types, so that they have their own 
implementation of codec.Selfer, and that gets used.

Note: You will have the same issue if you embed anything that is a 
encoding.(Binary|Text)(M|Unm)arshaler, json.(M|Unm)arshaler, codec.Selfer . 
The "wrapping/containing" type will then have that implementation, and that will be delegated to.

The key thing to note here is that, when using anonymous fields, the methods are inherited.
So you have to manage that by ensuring all "containing" types have the methods specified or they
will delegate to the child which may be a problem."

Ref #15072
cc @lavalamp 
