### PR TITLE
MESOS: Use mesos-slave-dind docker image with overlay-over-overlay smoketest

### DIFF
--- a/cluster/mesos/docker/docker-compose.yml
+++ b/cluster/mesos/docker/docker-compose.yml
@@ -29,7 +29,7 @@ mesosmaster1:
 mesosslave:
   hostname: mesosslave
   privileged: true
-  image: mesosphere/mesos-slave-dind:0.23.0-1.0.ubuntu1404.docker181
+  image: mesosphere/mesos-slave-dind:mesos-0.24.0_dind-0.2_docker-1.8.2_ubuntu-14.04.3
   entrypoint:
   - bash
   - -xc


### PR DESCRIPTION
Actually use mesosphere/mesos-slave-dind:mesos-0.24.0_dind-0.2_docker-1.8.2_ubuntu-14.04.3 docker image for mesos slaves in mesos/docker cluster. This fixes docker-in-docker on Kernel 4.20 and 3.19.

This unbreaks Mesos e2e tests due to recent AWS kernel updates.
