### PR TITLE
MESOS: Take default limits for cpu and mem into account in FitPredicate

### DIFF
--- a/contrib/mesos/pkg/scheduler/plugin_test.go
+++ b/contrib/mesos/pkg/scheduler/plugin_test.go
@@ -450,7 +450,10 @@ func newLifecycleTest(t *testing.T) lifecycleTest {
 
 	// create scheduler
 	strategy := NewAllocationStrategy(
-		podtask.DefaultPredicate,
+		podtask.NewDefaultPredicate(
+			mresource.DefaultDefaultContainerCPULimit,
+			mresource.DefaultDefaultContainerMemLimit,
+		),
 		podtask.NewDefaultProcurement(
 			mresource.DefaultDefaultContainerCPULimit,
 			mresource.DefaultDefaultContainerMemLimit,

--- a/contrib/mesos/pkg/scheduler/service/service.go
+++ b/contrib/mesos/pkg/scheduler/service/service.go
@@ -678,8 +678,15 @@ func (s *SchedulerServer) bootstrap(hks hyperkube.Interface, sc *schedcfg.Config
 	}
 
 	as := scheduler.NewAllocationStrategy(
-		podtask.DefaultPredicate,
-		podtask.NewDefaultProcurement(s.DefaultContainerCPULimit, s.DefaultContainerMemLimit))
+		podtask.NewDefaultPredicate(
+			s.DefaultContainerCPULimit,
+			s.DefaultContainerMemLimit,
+		),
+		podtask.NewDefaultProcurement(
+			s.DefaultContainerCPULimit,
+			s.DefaultContainerMemLimit,
+		),
+	)
 
 	// downgrade allocation strategy if user disables "account-for-pod-resources"
 	if !s.AccountForPodResources {


### PR DESCRIPTION
The FitPredicate did not consider the default cpu and mem limits for pod which do not set them. This could lead to a successful fit and and a non-successful procurement.

The unit tests only tested pods with limits. Hence, nobody noticed the bug.
