### PR TITLE
Disable explicit AWS availability zone config.

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -191,11 +191,13 @@ type AWSCloud struct {
 
 type AWSCloudConfig struct {
 	Global struct {
-		// TODO: Is there any use for this?  We can get it from the instance metadata service
-		// Maybe if we're not running on AWS, e.g. bootstrap; for now it is not very useful
-		Zone string
-
 		KubernetesClusterTag string
+
+		// DEPRECATED
+		//
+		// A cluster can only be tied to a single region (e.g. eu-west-1, us-east-1, us-west-2).
+		// The region and availability zones are fetched using the EC2 metadata service.
+		Zone string
 	}
 }
 
@@ -450,83 +452,19 @@ func init() {
 	})
 }
 
-// readAWSCloudConfig reads an instance of AWSCloudConfig from config reader.
-func readAWSCloudConfig(config io.Reader, metadata EC2Metadata) (*AWSCloudConfig, error) {
-	var cfg AWSCloudConfig
-	var err error
-
-	if config != nil {
-		err = gcfg.ReadInto(&cfg, config)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if cfg.Global.Zone == "" {
-		if metadata != nil {
-			glog.Info("Zone not specified in configuration file; querying AWS metadata service")
-			cfg.Global.Zone, err = getAvailabilityZone(metadata)
-			if err != nil {
-				return nil, err
-			}
-		}
-		if cfg.Global.Zone == "" {
-			return nil, fmt.Errorf("no zone specified in configuration file")
-		}
-	}
-
-	return &cfg, nil
-}
-
-func getAvailabilityZone(metadata EC2Metadata) (string, error) {
-	return metadata.GetMetadata("placement/availability-zone")
-}
-
-func isRegionValid(region string) bool {
-	regions := [...]string{
-		"us-east-1",
-		"us-west-1",
-		"us-west-2",
-		"eu-west-1",
-		"eu-central-1",
-		"ap-southeast-1",
-		"ap-southeast-2",
-		"ap-northeast-1",
-		"cn-north-1",
-		"us-gov-west-1",
-		"sa-east-1",
-	}
-	for _, r := range regions {
-		if r == region {
-			return true
-		}
-	}
-	return false
-}
-
 // newAWSCloud creates a new instance of AWSCloud.
 // AWSProvider and instanceId are primarily for tests
 func newAWSCloud(config io.Reader, awsServices AWSServices) (*AWSCloud, error) {
 	metadata, err := awsServices.Metadata()
 	if err != nil {
-		return nil, fmt.Errorf("error creating AWS metadata client: %v", err)
+		return nil, fmt.Errorf("error creating EC2 metadata client: %v", err)
 	}
 
-	cfg, err := readAWSCloudConfig(config, metadata)
-	if err != nil {
-		return nil, fmt.Errorf("unable to read AWS cloud provider config file: %v", err)
-	}
-
-	zone := cfg.Global.Zone
-	if len(zone) <= 1 {
-		return nil, fmt.Errorf("invalid AWS zone in config file: %s", zone)
+	zone, err := metadata.GetMetadata("placement/availability-zone")
+	if err != nil || len(zone) < 1 {
+		return nil, fmt.Errorf("cannot query EC2 metadata service for availability zone: %v", err)
 	}
 	regionName := zone[:len(zone)-1]
-
-	valid := isRegionValid(regionName)
-	if !valid {
-		return nil, fmt.Errorf("not a valid AWS zone (unknown region): %s", zone)
-	}
 
 	ec2, err := awsServices.Compute(regionName)
 	if err != nil {
@@ -543,13 +481,19 @@ func newAWSCloud(config io.Reader, awsServices AWSServices) (*AWSCloud, error) {
 		return nil, fmt.Errorf("error creating AWS autoscaling client: %v", err)
 	}
 
+	var cfg AWSCloudConfig
+	err = gcfg.ReadInto(&cfg, config)
+	if err != nil {
+		return nil, err
+	}
+
 	awsCloud := &AWSCloud{
 		awsServices:      awsServices,
 		ec2:              ec2,
 		elb:              elb,
 		asg:              asg,
 		metadata:         metadata,
-		cfg:              cfg,
+		cfg:              &cfg,
 		region:           regionName,
 		availabilityZone: zone,
 	}
@@ -571,6 +515,10 @@ func newAWSCloud(config io.Reader, awsServices AWSServices) (*AWSCloud, error) {
 				filterTags[TagNameKubernetesCluster] = orEmpty(tag.Value)
 			}
 		}
+	}
+
+	if cfg.Global.Zone != "" {
+		glog.Warningf("Zone cannot be manually configured. Using '%s' from EC2 metadata instead of '%s'", regionName, cfg.Global.Zone)
 	}
 
 	awsCloud.filterTags = filterTags

--- a/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_test.go
@@ -34,76 +34,6 @@ import (
 
 const TestClusterId = "clusterid.test"
 
-func TestReadAWSCloudConfig(t *testing.T) {
-	tests := []struct {
-		name string
-
-		reader io.Reader
-		aws    AWSServices
-
-		expectError bool
-		zone        string
-	}{
-		{
-			"No config reader",
-			nil, nil,
-			true, "",
-		},
-		{
-			"Empty config, no metadata",
-			strings.NewReader(""), nil,
-			true, "",
-		},
-		{
-			"No zone in config, no metadata",
-			strings.NewReader("[global]\n"), nil,
-			true, "",
-		},
-		{
-			"Zone in config, no metadata",
-			strings.NewReader("[global]\nzone = eu-west-1a"), nil,
-			false, "eu-west-1a",
-		},
-		{
-			"No zone in config, metadata does not have zone",
-			strings.NewReader("[global]\n"), NewFakeAWSServices().withAz(""),
-			true, "",
-		},
-		{
-			"No zone in config, metadata has zone",
-			strings.NewReader("[global]\n"), NewFakeAWSServices(),
-			false, "us-east-1a",
-		},
-		{
-			"Zone in config should take precedence over metadata",
-			strings.NewReader("[global]\nzone = eu-west-1a"), NewFakeAWSServices(),
-			false, "eu-west-1a",
-		},
-	}
-
-	for _, test := range tests {
-		t.Logf("Running test case %s", test.name)
-		var metadata EC2Metadata
-		if test.aws != nil {
-			metadata, _ = test.aws.Metadata()
-		}
-		cfg, err := readAWSCloudConfig(test.reader, metadata)
-		if test.expectError {
-			if err == nil {
-				t.Errorf("Should error for case %s (cfg=%v)", test.name, cfg)
-			}
-		} else {
-			if err != nil {
-				t.Errorf("Should succeed for case: %s", test.name)
-			}
-			if cfg.Global.Zone != test.zone {
-				t.Errorf("Incorrect zone value (%s vs %s) for case: %s",
-					cfg.Global.Zone, test.zone, test.name)
-			}
-		}
-	}
-}
-
 type FakeAWSServices struct {
 	availabilityZone        string
 	instances               []*ec2.Instance
@@ -205,20 +135,21 @@ func TestNewAWSCloud(t *testing.T) {
 		},
 		{
 			"Config specified invalid zone",
-			strings.NewReader("[global]\nzone = blahonga"), NewFakeAWSServices(),
-			true, "",
+			strings.NewReader("[global]\nzone = blahonga"),
+			NewFakeAWSServices(),
+			false, "us-east-1a",
 		},
 		{
 			"Config specifies valid zone",
-			strings.NewReader("[global]\nzone = eu-west-1a"), NewFakeAWSServices(),
-			false, "eu-west-1a",
+			strings.NewReader("[global]\nzone = eu-west-1a"),
+			NewFakeAWSServices(),
+			false, "us-east-1a",
 		},
 		{
 			"Gets zone from metadata when not in config",
-
 			strings.NewReader("[global]\n"),
-			NewFakeAWSServices(),
-			false, "us-east-1a",
+			NewFakeAWSServices().withAz("us-west-2a"),
+			false, "us-west-2a",
 		},
 		{
 			"No zone in config or metadata",


### PR DESCRIPTION
This removes the ability to configure the AWS availability zone globally since it can authoritatively be retrieved from the EC2 metadata service.
