### PR TITLE
Ensure panic_on_oom disabled

### DIFF
--- a/pkg/util/sysctl/sysctl.go
+++ b/pkg/util/sysctl/sysctl.go
@@ -23,7 +23,14 @@ import (
 	"strings"
 )
 
-const sysctlBase = "/proc/sys"
+const (
+	sysctlBase         = "/proc/sys"
+	VmOvercommitMemory = "vm/overcommit_memory"
+	VmPanicOnOOM       = "vm/panic_on_oom"
+
+	VmOvercommitMemoryAlways    = 1 // kernel performs no memory over-commit handling
+	VmPanicOnOOMInvokeOOMKiller = 0 // kernel calls the oom_killer function when OOM occurs
+)
 
 // GetSysctl returns the value for the specified sysctl setting
 func GetSysctl(sysctl string) (int, error) {


### PR DESCRIPTION
Fixes #15091 

In process, cleaned up code structure some.

I spoke with our operations folks, and they requested that the node have options to error/warn/modify when setting kernel flags.  Structured the code to allow that future setup, will plumb an argument in the Kubelet in a future PR.

For now, we default to modify kernel flags if not set as desired.

/cc @vishh 
