### PR TITLE
Fix api proxy handling of encoded slashes

### DIFF
--- a/pkg/registry/pod/etcd/etcd.go
+++ b/pkg/registry/pod/etcd/etcd.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"path"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
@@ -289,8 +288,7 @@ func (r *ProxyREST) Connect(ctx api.Context, id string, opts runtime.Object) (re
 	if err != nil {
 		return nil, err
 	}
-	location.Path = path.Join(location.Path, proxyOpts.Path)
-	return newUpgradeAwareProxyHandler(location, nil, false), nil
+	return newUpgradeAwareProxyHandler(location, proxyOpts.Path, nil, false), nil
 }
 
 // Support both GET and POST methods. Over time, we want to move all clients to start using POST and then stop supporting GET.
@@ -321,7 +319,7 @@ func (r *AttachREST) Connect(ctx api.Context, name string, opts runtime.Object) 
 	if err != nil {
 		return nil, err
 	}
-	return genericrest.NewUpgradeAwareProxyHandler(location, transport, true), nil
+	return genericrest.NewUpgradeAwareProxyHandler(location, "", transport, true), nil
 }
 
 // NewConnectOptions returns the versioned object that represents exec parameters
@@ -359,7 +357,7 @@ func (r *ExecREST) Connect(ctx api.Context, name string, opts runtime.Object) (r
 	if err != nil {
 		return nil, err
 	}
-	return newUpgradeAwareProxyHandler(location, transport, true), nil
+	return newUpgradeAwareProxyHandler(location, "", transport, true), nil
 }
 
 // NewConnectOptions returns the versioned object that represents exec parameters
@@ -403,11 +401,11 @@ func (r *PortForwardREST) Connect(ctx api.Context, name string, opts runtime.Obj
 	if err != nil {
 		return nil, err
 	}
-	return newUpgradeAwareProxyHandler(location, transport, true), nil
+	return newUpgradeAwareProxyHandler(location, "", transport, true), nil
 }
 
-func newUpgradeAwareProxyHandler(location *url.URL, transport http.RoundTripper, upgradeRequired bool) *genericrest.UpgradeAwareProxyHandler {
-	handler := genericrest.NewUpgradeAwareProxyHandler(location, transport, upgradeRequired)
+func newUpgradeAwareProxyHandler(location *url.URL, path string, transport http.RoundTripper, upgradeRequired bool) *genericrest.UpgradeAwareProxyHandler {
+	handler := genericrest.NewUpgradeAwareProxyHandler(location, path, transport, upgradeRequired)
 	handler.MaxBytesPerSec = capabilities.Get().PerConnectionBandwidthLimitBytesPerSec
 	return handler
 }

--- a/pkg/util/proxy/transport.go
+++ b/pkg/util/proxy/transport.go
@@ -31,6 +31,7 @@ import (
 	"golang.org/x/net/html"
 	"golang.org/x/net/html/atom"
 
+	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/sets"
 )
 
@@ -140,7 +141,7 @@ func (t *Transport) rewriteURL(targetURL string, sourceURL *url.URL) string {
 	if strings.HasPrefix(url.Path, t.PathPrepend) {
 		return url.String()
 	}
-	url.Path = path.Join(t.PathPrepend, url.Path)
+	url.Path = util.SingleJoiningSlash(t.PathPrepend, url.Path)
 	if strings.HasSuffix(origPath, "/") {
 		// Add back the trailing slash, which was stripped by path.Join().
 		url.Path += "/"

--- a/pkg/util/single_slash.go
+++ b/pkg/util/single_slash.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"strings"
+)
+
+// SingleJoiningSlash will join two strings with a single slash,
+// avoiding a double slash if there's a suffix slash on the first string
+// or a prefix slash on the second string.
+func SingleJoiningSlash(a, b string) string {
+	aslash := strings.HasSuffix(a, "/")
+	bslash := strings.HasPrefix(b, "/")
+	switch {
+	case aslash && bslash:
+		return a + b[1:]
+	case !aslash && !bslash:
+		return a + "/" + b
+	}
+	return a + b
+}

--- a/pkg/util/single_slash_test.go
+++ b/pkg/util/single_slash_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+)
+
+func TestSingleJoiningSlash(t *testing.T) {
+	tests := []struct {
+		a, b, expected string
+	}{
+		{
+			a:        "one",
+			b:        "two",
+			expected: "one/two",
+		},
+		{
+			a:        "one/",
+			b:        "two",
+			expected: "one/two",
+		},
+		{
+			a:        "one",
+			b:        "/two",
+			expected: "one/two",
+		},
+		{
+			a:        "one/",
+			b:        "/two",
+			expected: "one/two",
+		},
+		{
+			a:        "one",
+			b:        "",
+			expected: "one/",
+		},
+		{
+			a:        "",
+			b:        "two",
+			expected: "/two",
+		},
+		{
+			a:        "",
+			b:        "",
+			expected: "/",
+		},
+	}
+
+	for _, tc := range tests {
+		if a, e := SingleJoiningSlash(tc.a, tc.b), tc.expected; a != e {
+			t.Errorf("Expected %s for inputs %s and %s. Got: %s", e, tc.a, tc.b, a)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #14193 up to a point. 
If the path to proxy includes double-slashes or a path segment consisting of a "." or "..", the golang ServeMux handler will return a 301 with a normalized and decoded URL before it gets to the k8s handler. Thanks to @burmanm for providing an initial fix in openshift. 
