### PR TITLE
Support passing args to cluster/test-smoke.sh

### DIFF
--- a/cluster/test-smoke.sh
+++ b/cluster/test-smoke.sh
@@ -25,6 +25,8 @@ set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
+TEST_ARGS="$@"
+
 SMOKE_TEST_FOCUS_REGEX="Guestbook.application"
 
-exec "${KUBE_ROOT}/cluster/test-e2e.sh" -ginkgo.focus="${SMOKE_TEST_FOCUS_REGEX}"
+exec "${KUBE_ROOT}/cluster/test-e2e.sh" -ginkgo.focus="${SMOKE_TEST_FOCUS_REGEX}" ${TEST_ARGS}


### PR DESCRIPTION
For things like `./cluster/test-smoke.sh -v=2`
