### PR TITLE
Branched CI builds for building release candidates

### DIFF
--- a/build/mark-new-version.sh
+++ b/build/mark-new-version.sh
@@ -20,6 +20,11 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+if [ "$#" -ne 1 ]; then
+  echo "Usage: ${0} <version>"
+  exit 1
+fi
+
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 NEW_VERSION=${1-}

--- a/build/mark-new-version.sh
+++ b/build/mark-new-version.sh
@@ -110,28 +110,31 @@ gofmt -s -w "${VERSION_FILE}"
 
 echo "+++ Committing version change"
 git add "${VERSION_FILE}"
-git commit -m "Kubernetes version $NEW_VERSION"
+git commit -m "Kubernetes version ${NEW_VERSION}"
 
 echo "+++ Tagging version"
-git tag -a -m "Kubernetes version $NEW_VERSION" "${NEW_VERSION}"
+git tag -a -m "Kubernetes version ${NEW_VERSION}" "${NEW_VERSION}"
 # We have to sleep for a bit so that the timestamp of the beta tag is after the
 # timestamp of the release version, so that future commits are described as
 # beta, and not release versions.
+echo "+++ Waiting for 5 seconds to ensure timestamps are different before continuing"
 sleep 5
+echo "+++ Tagging beta tag"
 declare -r beta_ver="v${VERSION_MAJOR}.${VERSION_MINOR}.$((${VERSION_PATCH}+1))-beta"
-git tag -a -m "Kubernetes version $beta_ver" "${beta_ver}"
+git tag -a -m "Kubernetes version ${beta_ver}" "${beta_ver}"
 newtag=$(git rev-parse --short HEAD)
 
 if [[ "${VERSION_PATCH}" == "0" ]]; then
   declare -r alpha_ver="v${VERSION_MAJOR}.$((${VERSION_MINOR}+1)).0-alpha.0"
-  git tag -a -m "Kubernetes pre-release branch ${alpha-ver}" "${alpha_ver}" "${head_commit}"
+  git tag -a -m "Kubernetes pre-release branch ${alpha_ver}" "${alpha_ver}" "${head_commit}"
 fi
 
 echo ""
 echo "Success you must now:"
 echo ""
-echo "- Push the tag:"
-echo "   git push ${push_url} v${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}"
+echo "- Push the tags:"
+echo "   git push ${push_url} ${NEW_VERSION}"
+echo "   git push ${push_url} ${beta_ver}"
 
 if [[ "${VERSION_PATCH}" == "0" ]]; then
   echo "- Push the alpha tag:"

--- a/build/mark-new-version.sh
+++ b/build/mark-new-version.sh
@@ -114,6 +114,12 @@ git commit -m "Kubernetes version $NEW_VERSION"
 
 echo "+++ Tagging version"
 git tag -a -m "Kubernetes version $NEW_VERSION" "${NEW_VERSION}"
+# We have to sleep for a bit so that the timestamp of the beta tag is after the
+# timestamp of the release version, so that future commits are described as
+# beta, and not release versions.
+sleep 5
+declare -r beta_ver="v${VERSION_MAJOR}.${VERSION_MINOR}.$((${VERSION_PATCH}+1))-beta"
+git tag -a -m "Kubernetes version $beta_ver" "${beta_ver}"
 newtag=$(git rev-parse --short HEAD)
 
 if [[ "${VERSION_PATCH}" == "0" ]]; then

--- a/build/versionize-docs.sh
+++ b/build/versionize-docs.sh
@@ -72,4 +72,4 @@ done
 $SED -ri -e "s|(releases.k8s.io)/[^/]+|\1/${NEW_VERSION}|" pkg/api/v[0-9]*/types.go
 
 ${KUBE_ROOT}/hack/update-generated-docs.sh
-${KUBE_ROOT}/hack/update-swagger-spec.sh
+${KUBE_ROOT}/hack/update-generated-swagger-docs.sh

--- a/hack/update-generated-swagger-docs.sh
+++ b/hack/update-generated-swagger-docs.sh
@@ -66,3 +66,4 @@ for group_version in "${GROUP_VERSIONS[@]}"; do
 done
 
 "${KUBE_ROOT}/hack/update-swagger-spec.sh"
+"${KUBE_ROOT}/hack/gen-swagger-doc/run-gen-swagger-docs.sh"


### PR DESCRIPTION
This enacts (some of the) changes in versioning.md, and allows us to push builds from different release branches to CI, (e.g. we can have HEAD building and pushing to latest, latest-1, and latest-1.2, and also have release-1.1 pushing to latest-1.1).  This is necessary for #14771.

This also updates swagger scripts, (this supplants #14596), which was necessary to test this.

Once this is in, we need to manually tag the release-1.1 branch with a `v1.1.0-beta` tag, and then we can start a Jenkins release-candidate builder similar to the one we have against HEAD.

It's a bit insane to have all this semver parsing and comparison logic in bash, but I needed it so that release-candidate CI builds didn't clobber `latest.txt` (HEAD CI builds).  Perhaps I/we can clean it up when addressing #13339.  I'm also definitely open to suggestions for better ways to do this.
