### PR TITLE
Enable controllers based on which APIs the master is serving.

### DIFF
--- a/cluster/saltbase/salt/kube-controller-manager/kube-controller-manager.manifest
+++ b/cluster/saltbase/salt/kube-controller-manager/kube-controller-manager.manifest
@@ -1,7 +1,6 @@
 {% set cluster_name = "" -%}
 {% set cluster_cidr = "" -%}
 {% set allocate_node_cidrs = "" -%}
-{% set enable_experimental = "" -%}
 
 {% if pillar['instance_prefix'] is defined -%}
   {% set cluster_name = "--cluster-name=" + pillar['instance_prefix'] -%}
@@ -11,9 +10,6 @@
 {% endif -%}
 {% if pillar['allocate_node_cidrs'] is defined -%}
   {% set allocate_node_cidrs = "--allocate-node-cidrs=" + pillar['allocate_node_cidrs'] -%}
-{% endif -%}
-{% if pillar['enable_experimental_api'] is defined -%}
-  {% set enable_experimental = "--enable-experimental=" + pillar['enable_experimental_api'] -%}
 {% endif -%}
 
 {% set cloud_provider = "" -%}
@@ -38,7 +34,7 @@
    {% set root_ca_file = "--root-ca-file=/srv/kubernetes/ca.crt" -%}
 {% endif -%}
 
-{% set params = "--master=127.0.0.1:8080" + " " + cluster_name + " " + cluster_cidr + " " + allocate_node_cidrs + " " + enable_experimental + " " + cloud_provider  + " " + cloud_config + service_account_key + pillar['log_level'] + " " + root_ca_file -%}
+{% set params = "--master=127.0.0.1:8080" + " " + cluster_name + " " + cluster_cidr + " " + allocate_node_cidrs + " " + cloud_provider  + " " + cloud_config + service_account_key + pillar['log_level'] + " " + root_ca_file -%}
 
 # test_args has to be kept at the end, so they'll overwrite any prior configuration
 {% if pillar['controller_manager_test_args'] is defined -%}

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -32,7 +32,7 @@ import (
 	"strconv"
 	"time"
 
-	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
@@ -290,9 +290,9 @@ func (s *CMServer) Run(_ []string) error {
 	if err != nil {
 		glog.Fatalf("Failed to get api versions from server: %v", err)
 	}
-	versions := &api.APIVersions{Versions: versionStrings}
+	versions := &unversioned.APIVersions{Versions: versionStrings}
 
-	resourceMap, err := kubeClient.SupportedResources()
+	resourceMap, err := client.SupportedResources(kubeClient, kubeconfig)
 	if err != nil {
 		glog.Fatalf("Failed to get supported resources from server: %v", err)
 	}
@@ -375,7 +375,7 @@ func (s *CMServer) Run(_ []string) error {
 	select {}
 }
 
-func containsVersion(versions *api.APIVersions, version string) bool {
+func containsVersion(versions *unversioned.APIVersions, version string) bool {
 	for ix := range versions.Versions {
 		if versions.Versions[ix] == version {
 			return true
@@ -384,7 +384,7 @@ func containsVersion(versions *api.APIVersions, version string) bool {
 	return false
 }
 
-func containsResource(resources *api.APIResourceList, resourceName string) bool {
+func containsResource(resources *unversioned.APIResourceList, resourceName string) bool {
 	for ix := range resources.APIResources {
 		resource := resources.APIResources[ix]
 		if resource.Name == resourceName {

--- a/contrib/mesos/pkg/controllermanager/controllermanager.go
+++ b/contrib/mesos/pkg/controllermanager/controllermanager.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/cmd/kube-controller-manager/app"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
@@ -156,7 +157,7 @@ func (s *CMServer) Run(_ []string) error {
 	resourceQuotaController := resourcequotacontroller.NewResourceQuotaController(kubeClient)
 	resourceQuotaController.Run(s.ResourceQuotaSyncPeriod)
 
-	namespaceController := namespacecontroller.NewNamespaceController(kubeClient, false, s.NamespaceSyncPeriod)
+	namespaceController := namespacecontroller.NewNamespaceController(kubeClient, &unversioned.APIVersions{}, s.NamespaceSyncPeriod)
 	namespaceController.Run()
 
 	pvclaimBinder := persistentvolumecontroller.NewPersistentVolumeClaimBinder(kubeClient, s.PVClaimBinderSyncPeriod)

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -71,7 +71,6 @@ duration-sec
 e2e-verify-service-account
 e2e-output-dir
 enable-debugging-handlers
-enable-experimental
 enable-server
 etcd-config
 etcd-prefix

--- a/pkg/client/unversioned/client.go
+++ b/pkg/client/unversioned/client.go
@@ -52,6 +52,7 @@ type Interface interface {
 	ComponentStatusesInterface
 	SwaggerSchemaInterface
 	Extensions() ExtensionsInterface
+	ResourcesInterface
 }
 
 func (c *Client) ReplicationControllers(namespace string) ReplicationControllerInterface {
@@ -119,6 +120,12 @@ type VersionInterface interface {
 	ServerAPIVersions() (*unversioned.APIVersions, error)
 }
 
+// ResourcesInterface has methods for obtaining supported resources on the API server
+type ResourcesInterface interface {
+	SupportedResourcesForGroupVersion(groupVersion string) (*api.APIResourceList, error)
+	SupportedResources() (map[string]*api.APIResourceList, error)
+}
+
 // APIStatus is exposed by errors that can be converted to an api.Status object
 // for finer grained details.
 type APIStatus interface {
@@ -143,6 +150,42 @@ func (c *Client) ServerVersion() (*version.Info, error) {
 		return nil, fmt.Errorf("got '%s': %v", string(body), err)
 	}
 	return &info, nil
+}
+
+// SupportedResourcesForGroupVersion retrieves the list of resources supported by the API server for a group version.
+func (c *Client) SupportedResourcesForGroupVersion(groupVersion string) (*api.APIResourceList, error) {
+	var prefix string
+	if groupVersion == "v1" {
+		prefix = "/api"
+	} else {
+		prefix = "/apis"
+	}
+	body, err := c.Get().AbsPath(prefix, groupVersion).Do().Raw()
+	if err != nil {
+		return nil, err
+	}
+	resources := api.APIResourceList{}
+	if err := json.Unmarshal(body, &resources); err != nil {
+		return nil, err
+	}
+	return &resources, nil
+}
+
+// SupportedResources gets all supported resources for all group versions.  The key in the map is an API groupVersion.
+func (c *Client) SupportedResources() (map[string]*api.APIResourceList, error) {
+	apis, err := c.ServerAPIVersions()
+	if err != nil {
+		return nil, err
+	}
+	result := map[string]*api.APIResourceList{}
+	for _, groupVersion := range apis.Versions {
+		resources, err := c.SupportedResourcesForGroupVersion(groupVersion)
+		if err != nil {
+			return nil, err
+		}
+		result[groupVersion] = resources
+	}
+	return result, nil
 }
 
 // ServerAPIVersions retrieves and parses the list of API versions the server supports.

--- a/pkg/client/unversioned/client.go
+++ b/pkg/client/unversioned/client.go
@@ -122,8 +122,7 @@ type VersionInterface interface {
 
 // ResourcesInterface has methods for obtaining supported resources on the API server
 type ResourcesInterface interface {
-	SupportedResourcesForGroupVersion(groupVersion string) (*api.APIResourceList, error)
-	SupportedResources() (map[string]*api.APIResourceList, error)
+	SupportedResourcesForGroupVersion(groupVersion string) (*unversioned.APIResourceList, error)
 }
 
 // APIStatus is exposed by errors that can be converted to an api.Status object
@@ -153,7 +152,7 @@ func (c *Client) ServerVersion() (*version.Info, error) {
 }
 
 // SupportedResourcesForGroupVersion retrieves the list of resources supported by the API server for a group version.
-func (c *Client) SupportedResourcesForGroupVersion(groupVersion string) (*api.APIResourceList, error) {
+func (c *Client) SupportedResourcesForGroupVersion(groupVersion string) (*unversioned.APIResourceList, error) {
 	var prefix string
 	if groupVersion == "v1" {
 		prefix = "/api"
@@ -164,7 +163,7 @@ func (c *Client) SupportedResourcesForGroupVersion(groupVersion string) (*api.AP
 	if err != nil {
 		return nil, err
 	}
-	resources := api.APIResourceList{}
+	resources := unversioned.APIResourceList{}
 	if err := json.Unmarshal(body, &resources); err != nil {
 		return nil, err
 	}
@@ -172,13 +171,13 @@ func (c *Client) SupportedResourcesForGroupVersion(groupVersion string) (*api.AP
 }
 
 // SupportedResources gets all supported resources for all group versions.  The key in the map is an API groupVersion.
-func (c *Client) SupportedResources() (map[string]*api.APIResourceList, error) {
-	apis, err := c.ServerAPIVersions()
+func SupportedResources(c Interface, cfg *Config) (map[string]*unversioned.APIResourceList, error) {
+	apis, err := ServerAPIVersions(cfg)
 	if err != nil {
 		return nil, err
 	}
-	result := map[string]*api.APIResourceList{}
-	for _, groupVersion := range apis.Versions {
+	result := map[string]*unversioned.APIResourceList{}
+	for _, groupVersion := range apis {
 		resources, err := c.SupportedResourcesForGroupVersion(groupVersion)
 		if err != nil {
 			return nil, err

--- a/pkg/client/unversioned/client_test.go
+++ b/pkg/client/unversioned/client_test.go
@@ -271,6 +271,105 @@ func TestGetServerVersion(t *testing.T) {
 	}
 }
 
+func TestGetServerResources(t *testing.T) {
+	stable := api.APIResourceList{
+		GroupVersion: "v1",
+		APIResources: []api.APIResource{
+			{"pods", true},
+			{"services", true},
+			{"namespaces", false},
+		},
+	}
+	beta := api.APIResourceList{
+		GroupVersion: "extensions/v1",
+		APIResources: []api.APIResource{
+			{"deployments", true},
+			{"ingress", true},
+			{"jobs", true},
+		},
+	}
+	tests := []struct {
+		resourcesList *api.APIResourceList
+		path          string
+		request       string
+		expectErr     bool
+	}{
+		{
+			resourcesList: &stable,
+			path:          "/api/v1",
+			request:       "v1",
+			expectErr:     false,
+		},
+		{
+			resourcesList: &beta,
+			path:          "/apis/extensions/v1beta1",
+			request:       "extensions/v1beta1",
+			expectErr:     false,
+		},
+		{
+			resourcesList: &stable,
+			path:          "/api/v1",
+			request:       "foobar",
+			expectErr:     true,
+		},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		var list interface{}
+		switch req.URL.Path {
+		case "/api/v1":
+			list = &stable
+		case "/apis/extensions/v1beta1":
+			list = &beta
+		case "/api":
+			list = &api.APIVersions{
+				Versions: []string{
+					"v1",
+					"extensions/v1beta1",
+				},
+			}
+		default:
+			t.Logf("unexpected request: %s", req.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		output, err := json.Marshal(list)
+		if err != nil {
+			t.Errorf("unexpected encoding error: %v", err)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(output)
+	}))
+	client := NewOrDie(&Config{Host: server.URL})
+	for _, test := range tests {
+		got, err := client.SupportedResourcesForGroupVersion(test.request)
+		if test.expectErr {
+			if err == nil {
+				t.Error("unexpected non-error")
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+			continue
+		}
+		if !reflect.DeepEqual(got, test.resourcesList) {
+			t.Errorf("expected:\n%v\ngot:\n%v\n", test.resourcesList, got)
+		}
+	}
+
+	resourceMap, err := client.SupportedResources()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	for _, api := range []string{"v1", "extensions/v1beta1"} {
+		if _, found := resourceMap[api]; !found {
+			t.Errorf("missing expected api: %s", api)
+		}
+	}
+}
+
 func TestGetServerAPIVersions(t *testing.T) {
 	versions := []string{"v1", "v2", "v3"}
 	expect := unversioned.APIVersions{Versions: versions}

--- a/pkg/client/unversioned/client_test.go
+++ b/pkg/client/unversioned/client_test.go
@@ -272,24 +272,24 @@ func TestGetServerVersion(t *testing.T) {
 }
 
 func TestGetServerResources(t *testing.T) {
-	stable := api.APIResourceList{
+	stable := unversioned.APIResourceList{
 		GroupVersion: "v1",
-		APIResources: []api.APIResource{
+		APIResources: []unversioned.APIResource{
 			{"pods", true},
 			{"services", true},
 			{"namespaces", false},
 		},
 	}
-	beta := api.APIResourceList{
+	beta := unversioned.APIResourceList{
 		GroupVersion: "extensions/v1",
-		APIResources: []api.APIResource{
+		APIResources: []unversioned.APIResource{
 			{"deployments", true},
 			{"ingress", true},
 			{"jobs", true},
 		},
 	}
 	tests := []struct {
-		resourcesList *api.APIResourceList
+		resourcesList *unversioned.APIResourceList
 		path          string
 		request       string
 		expectErr     bool
@@ -321,10 +321,19 @@ func TestGetServerResources(t *testing.T) {
 		case "/apis/extensions/v1beta1":
 			list = &beta
 		case "/api":
-			list = &api.APIVersions{
+			list = &unversioned.APIVersions{
 				Versions: []string{
 					"v1",
-					"extensions/v1beta1",
+				},
+			}
+		case "/apis":
+			list = &unversioned.APIGroupList{
+				Groups: []unversioned.APIGroup{
+					{
+						Versions: []unversioned.GroupVersion{
+							{GroupVersion: "extensions/v1beta1"},
+						},
+					},
 				},
 			}
 		default:
@@ -359,7 +368,7 @@ func TestGetServerResources(t *testing.T) {
 		}
 	}
 
-	resourceMap, err := client.SupportedResources()
+	resourceMap, err := SupportedResources(client, &Config{Host: server.URL})
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/pkg/client/unversioned/testclient/testclient.go
+++ b/pkg/client/unversioned/testclient/testclient.go
@@ -61,7 +61,7 @@ type Fake struct {
 	// ProxyReactionChain is the list of proxy reactors that will be attempted for every request in the order they are tried
 	ProxyReactionChain []ProxyReactor
 
-	Resources []api.APIResourceList
+	Resources []unversioned.APIResourceList
 }
 
 // Reactor is an interface to allow the composition of reaction functions.
@@ -274,22 +274,7 @@ func (c *Fake) Extensions() client.ExtensionsInterface {
 	return &FakeExperimental{c}
 }
 
-func (c *Fake) SupportedResources() (map[string]*api.APIResourceList, error) {
-	action := ActionImpl{
-		Verb:     "get",
-		Resource: "resources",
-	}
-	c.Invokes(action, nil)
-	result := map[string]*api.APIResourceList{}
-	for _, resource := range c.Resources {
-		result[resource.GroupVersion] = &api.APIResourceList{
-			APIResources: resource.APIResources,
-		}
-	}
-	return result, nil
-}
-
-func (c *Fake) SupportedResourcesForGroupVersion(version string) (*api.APIResourceList, error) {
+func (c *Fake) SupportedResourcesForGroupVersion(version string) (*unversioned.APIResourceList, error) {
 	action := ActionImpl{
 		Verb:     "get",
 		Resource: "resource",

--- a/pkg/client/unversioned/testclient/testclient.go
+++ b/pkg/client/unversioned/testclient/testclient.go
@@ -60,6 +60,8 @@ type Fake struct {
 	WatchReactionChain []WatchReactor
 	// ProxyReactionChain is the list of proxy reactors that will be attempted for every request in the order they are tried
 	ProxyReactionChain []ProxyReactor
+
+	Resources []api.APIResourceList
 }
 
 // Reactor is an interface to allow the composition of reaction functions.
@@ -270,6 +272,35 @@ func (c *Fake) Namespaces() client.NamespaceInterface {
 
 func (c *Fake) Extensions() client.ExtensionsInterface {
 	return &FakeExperimental{c}
+}
+
+func (c *Fake) SupportedResources() (map[string]*api.APIResourceList, error) {
+	action := ActionImpl{
+		Verb:     "get",
+		Resource: "resources",
+	}
+	c.Invokes(action, nil)
+	result := map[string]*api.APIResourceList{}
+	for _, resource := range c.Resources {
+		result[resource.GroupVersion] = &api.APIResourceList{
+			APIResources: resource.APIResources,
+		}
+	}
+	return result, nil
+}
+
+func (c *Fake) SupportedResourcesForGroupVersion(version string) (*api.APIResourceList, error) {
+	action := ActionImpl{
+		Verb:     "get",
+		Resource: "resource",
+	}
+	c.Invokes(action, nil)
+	for _, resource := range c.Resources {
+		if resource.GroupVersion == version {
+			return &resource, nil
+		}
+	}
+	return nil, nil
 }
 
 func (c *Fake) ServerVersion() (*version.Info, error) {

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -43,7 +43,7 @@ type NamespaceController struct {
 }
 
 // NewNamespaceController creates a new NamespaceController
-func NewNamespaceController(kubeClient client.Interface, experimentalMode bool, resyncPeriod time.Duration) *NamespaceController {
+func NewNamespaceController(kubeClient client.Interface, versions *api.APIVersions, resyncPeriod time.Duration) *NamespaceController {
 	var controller *framework.Controller
 	_, controller = framework.NewInformer(
 		&cache.ListWatch{
@@ -60,7 +60,7 @@ func NewNamespaceController(kubeClient client.Interface, experimentalMode bool, 
 		framework.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				namespace := obj.(*api.Namespace)
-				if err := syncNamespace(kubeClient, experimentalMode, namespace); err != nil {
+				if err := syncNamespace(kubeClient, versions, namespace); err != nil {
 					if estimate, ok := err.(*contentRemainingError); ok {
 						go func() {
 							// Estimate is the aggregate total of TerminationGracePeriodSeconds, which defaults to 30s
@@ -82,7 +82,7 @@ func NewNamespaceController(kubeClient client.Interface, experimentalMode bool, 
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				namespace := newObj.(*api.Namespace)
-				if err := syncNamespace(kubeClient, experimentalMode, namespace); err != nil {
+				if err := syncNamespace(kubeClient, versions, namespace); err != nil {
 					if estimate, ok := err.(*contentRemainingError); ok {
 						go func() {
 							t := estimate.Estimate/2 + 1
@@ -155,7 +155,7 @@ func (e *contentRemainingError) Error() string {
 // deleteAllContent will delete all content known to the system in a namespace. It returns an estimate
 // of the time remaining before the remaining resources are deleted. If estimate > 0 not all resources
 // are guaranteed to be gone.
-func deleteAllContent(kubeClient client.Interface, experimentalMode bool, namespace string, before unversioned.Time) (estimate int64, err error) {
+func deleteAllContent(kubeClient client.Interface, versions *api.APIVersions, namespace string, before unversioned.Time) (estimate int64, err error) {
 	err = deleteServiceAccounts(kubeClient, namespace)
 	if err != nil {
 		return estimate, err
@@ -193,26 +193,41 @@ func deleteAllContent(kubeClient client.Interface, experimentalMode bool, namesp
 		return estimate, err
 	}
 	// If experimental mode, delete all experimental resources for the namespace.
-	if experimentalMode {
-		err = deleteHorizontalPodAutoscalers(kubeClient.Extensions(), namespace)
+	if containsVersion(versions, "extensions/v1beta1") {
+		resources, err := kubeClient.SupportedResourcesForGroupVersion("extensions/v1beta1")
+		glog.Errorf("%v", resources)
 		if err != nil {
 			return estimate, err
 		}
-		err = deleteDaemonSets(kubeClient.Extensions(), namespace)
-		if err != nil {
-			return estimate, err
+		if containsResource(resources, "horizontalpodautoscalers") {
+			err = deleteHorizontalPodAutoscalers(kubeClient.Extensions(), namespace)
+			if err != nil {
+				return estimate, err
+			}
 		}
-		err = deleteJobs(kubeClient.Extensions(), namespace)
-		if err != nil {
-			return estimate, err
+		if containsResource(resources, "ingress") {
+			err = deleteIngress(kubeClient.Extensions(), namespace)
+			if err != nil {
+				return estimate, err
+			}
 		}
-		err = deleteDeployments(kubeClient.Extensions(), namespace)
-		if err != nil {
-			return estimate, err
+		if containsResource(resources, "daemonsets") {
+			err = deleteDaemonSets(kubeClient.Extensions(), namespace)
+			if err != nil {
+				return estimate, err
+			}
 		}
-		err = deleteIngress(kubeClient.Extensions(), namespace)
-		if err != nil {
-			return estimate, err
+		if containsResource(resources, "jobs") {
+			err = deleteJobs(kubeClient.Extensions(), namespace)
+			if err != nil {
+				return estimate, err
+			}
+		}
+		if containsResource(resources, "deployments") {
+			err = deleteDeployments(kubeClient.Extensions(), namespace)
+			if err != nil {
+				return estimate, err
+			}
 		}
 	}
 	return estimate, nil
@@ -254,7 +269,7 @@ func updateNamespaceStatusFunc(kubeClient client.Interface, namespace *api.Names
 }
 
 // syncNamespace orchestrates deletion of a Namespace and its associated content.
-func syncNamespace(kubeClient client.Interface, experimentalMode bool, namespace *api.Namespace) (err error) {
+func syncNamespace(kubeClient client.Interface, versions *api.APIVersions, namespace *api.Namespace) (err error) {
 	if namespace.DeletionTimestamp == nil {
 		return nil
 	}
@@ -280,7 +295,7 @@ func syncNamespace(kubeClient client.Interface, experimentalMode bool, namespace
 	}
 
 	// there may still be content for us to remove
-	estimate, err := deleteAllContent(kubeClient, experimentalMode, namespace.Name, *namespace.DeletionTimestamp)
+	estimate, err := deleteAllContent(kubeClient, versions, namespace.Name, *namespace.DeletionTimestamp)
 	if err != nil {
 		return err
 	}
@@ -514,4 +529,28 @@ func deleteIngress(expClient client.ExtensionsInterface, ns string) error {
 		}
 	}
 	return nil
+}
+
+// TODO: this is duplicated logic.  Move it somewhere central?
+func containsVersion(versions *api.APIVersions, version string) bool {
+	for ix := range versions.Versions {
+		if versions.Versions[ix] == version {
+			return true
+		}
+	}
+	return false
+}
+
+// TODO: this is duplicated logic.  Move it somewhere central?
+func containsResource(resources *api.APIResourceList, resourceName string) bool {
+	if resources == nil {
+		return false
+	}
+	for ix := range resources.APIResources {
+		resource := resources.APIResources[ix]
+		if resource.Name == resourceName {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -43,7 +43,7 @@ type NamespaceController struct {
 }
 
 // NewNamespaceController creates a new NamespaceController
-func NewNamespaceController(kubeClient client.Interface, versions *api.APIVersions, resyncPeriod time.Duration) *NamespaceController {
+func NewNamespaceController(kubeClient client.Interface, versions *unversioned.APIVersions, resyncPeriod time.Duration) *NamespaceController {
 	var controller *framework.Controller
 	_, controller = framework.NewInformer(
 		&cache.ListWatch{
@@ -155,7 +155,7 @@ func (e *contentRemainingError) Error() string {
 // deleteAllContent will delete all content known to the system in a namespace. It returns an estimate
 // of the time remaining before the remaining resources are deleted. If estimate > 0 not all resources
 // are guaranteed to be gone.
-func deleteAllContent(kubeClient client.Interface, versions *api.APIVersions, namespace string, before unversioned.Time) (estimate int64, err error) {
+func deleteAllContent(kubeClient client.Interface, versions *unversioned.APIVersions, namespace string, before unversioned.Time) (estimate int64, err error) {
 	err = deleteServiceAccounts(kubeClient, namespace)
 	if err != nil {
 		return estimate, err
@@ -195,7 +195,6 @@ func deleteAllContent(kubeClient client.Interface, versions *api.APIVersions, na
 	// If experimental mode, delete all experimental resources for the namespace.
 	if containsVersion(versions, "extensions/v1beta1") {
 		resources, err := kubeClient.SupportedResourcesForGroupVersion("extensions/v1beta1")
-		glog.Errorf("%v", resources)
 		if err != nil {
 			return estimate, err
 		}
@@ -269,7 +268,7 @@ func updateNamespaceStatusFunc(kubeClient client.Interface, namespace *api.Names
 }
 
 // syncNamespace orchestrates deletion of a Namespace and its associated content.
-func syncNamespace(kubeClient client.Interface, versions *api.APIVersions, namespace *api.Namespace) (err error) {
+func syncNamespace(kubeClient client.Interface, versions *unversioned.APIVersions, namespace *api.Namespace) (err error) {
 	if namespace.DeletionTimestamp == nil {
 		return nil
 	}
@@ -532,7 +531,7 @@ func deleteIngress(expClient client.ExtensionsInterface, ns string) error {
 }
 
 // TODO: this is duplicated logic.  Move it somewhere central?
-func containsVersion(versions *api.APIVersions, version string) bool {
+func containsVersion(versions *unversioned.APIVersions, version string) bool {
 	for ix := range versions.Versions {
 		if versions.Versions[ix] == version {
 			return true
@@ -542,7 +541,7 @@ func containsVersion(versions *api.APIVersions, version string) bool {
 }
 
 // TODO: this is duplicated logic.  Move it somewhere central?
-func containsResource(resources *api.APIResourceList, resourceName string) bool {
+func containsResource(resources *unversioned.APIResourceList, resourceName string) bool {
 	if resources == nil {
 		return false
 	}

--- a/pkg/controller/namespace/namespace_controller_test.go
+++ b/pkg/controller/namespace/namespace_controller_test.go
@@ -73,7 +73,7 @@ func TestFinalizeNamespaceFunc(t *testing.T) {
 	}
 }
 
-func testSyncNamespaceThatIsTerminating(t *testing.T, versions *api.APIVersions) {
+func testSyncNamespaceThatIsTerminating(t *testing.T, versions *unversioned.APIVersions) {
 	mockClient := &testclient.Fake{}
 	now := unversioned.Now()
 	testNamespace := &api.Namespace{
@@ -91,11 +91,11 @@ func testSyncNamespaceThatIsTerminating(t *testing.T, versions *api.APIVersions)
 	}
 
 	if containsVersion(versions, "extensions/v1beta1") {
-		resources := []api.APIResource{}
+		resources := []unversioned.APIResource{}
 		for _, resource := range []string{"daemonsets", "deployments", "jobs", "horizontalpodautoscalers", "ingress"} {
-			resources = append(resources, api.APIResource{Name: resource})
+			resources = append(resources, unversioned.APIResource{Name: resource})
 		}
-		mockClient.Resources = []api.APIResourceList{
+		mockClient.Resources = []unversioned.APIResourceList{
 			{
 				GroupVersion: "extensions/v1beta1",
 				APIResources: resources,
@@ -166,11 +166,11 @@ func TestRetryOnConflictError(t *testing.T) {
 }
 
 func TestSyncNamespaceThatIsTerminatingNonExperimental(t *testing.T) {
-	testSyncNamespaceThatIsTerminating(t, &api.APIVersions{})
+	testSyncNamespaceThatIsTerminating(t, &unversioned.APIVersions{})
 }
 
 func TestSyncNamespaceThatIsTerminatingV1Beta1(t *testing.T) {
-	testSyncNamespaceThatIsTerminating(t, &api.APIVersions{Versions: []string{"extensions/v1beta1"}})
+	testSyncNamespaceThatIsTerminating(t, &unversioned.APIVersions{Versions: []string{"extensions/v1beta1"}})
 }
 
 func TestSyncNamespaceThatIsActive(t *testing.T) {
@@ -187,7 +187,7 @@ func TestSyncNamespaceThatIsActive(t *testing.T) {
 			Phase: api.NamespaceActive,
 		},
 	}
-	err := syncNamespace(mockClient, &api.APIVersions{}, testNamespace)
+	err := syncNamespace(mockClient, &unversioned.APIVersions{}, testNamespace)
 	if err != nil {
 		t.Errorf("Unexpected error when synching namespace %v", err)
 	}
@@ -199,7 +199,7 @@ func TestSyncNamespaceThatIsActive(t *testing.T) {
 func TestRunStop(t *testing.T) {
 	mockClient := &testclient.Fake{}
 
-	nsController := NewNamespaceController(mockClient, &api.APIVersions{}, 1*time.Second)
+	nsController := NewNamespaceController(mockClient, &unversioned.APIVersions{}, 1*time.Second)
 
 	if nsController.StopEverything != nil {
 		t.Errorf("Non-running manager should not have a stop channel.  Got %v", nsController.StopEverything)


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kubernetes/issues/15402

@lavalamp @kubernetes/goog-control-plane @davidopp 
