### PR TITLE
Simplify TLSConfigFor, honor Insecure with client certs

### DIFF
--- a/pkg/client/unversioned/transport.go
+++ b/pkg/client/unversioned/transport.go
@@ -90,28 +90,32 @@ func TLSConfigFor(config *Config) (*tls.Config, error) {
 	hasCA := len(config.CAFile) > 0 || len(config.CAData) > 0
 	hasCert := len(config.CertFile) > 0 || len(config.CertData) > 0
 
+	if !hasCA && !hasCert && !config.Insecure {
+		return nil, nil
+	}
 	if hasCA && config.Insecure {
 		return nil, fmt.Errorf("specifying a root certificates file with the insecure flag is not allowed")
 	}
 	if err := LoadTLSFiles(config); err != nil {
 		return nil, err
 	}
-	var tlsConfig *tls.Config
-	switch {
-	case hasCert:
-		cfg, err := NewClientCertTLSConfig(config.CertData, config.KeyData, config.CAData)
+
+	tlsConfig := &tls.Config{
+		// Change default from SSLv3 to TLSv1.0 (because of POODLE vulnerability)
+		MinVersion:         tls.VersionTLS10,
+		InsecureSkipVerify: config.Insecure,
+	}
+
+	if hasCA {
+		tlsConfig.RootCAs = rootCertPool(config.CAData)
+	}
+
+	if hasCert {
+		cert, err := tls.X509KeyPair(config.CertData, config.KeyData)
 		if err != nil {
 			return nil, err
 		}
-		tlsConfig = cfg
-	case hasCA:
-		cfg, err := NewTLSConfig(config.CAData)
-		if err != nil {
-			return nil, err
-		}
-		tlsConfig = cfg
-	case config.Insecure:
-		tlsConfig = NewUnsafeTLSConfig()
+		tlsConfig.Certificates = []tls.Certificate{cert}
 	}
 
 	return tlsConfig, nil
@@ -166,30 +170,6 @@ func dataFromSliceOrFile(data []byte, file string) ([]byte, error) {
 	return nil, nil
 }
 
-func NewClientCertTLSConfig(certData, keyData, caData []byte) (*tls.Config, error) {
-	cert, err := tls.X509KeyPair(certData, keyData)
-	if err != nil {
-		return nil, err
-	}
-
-	return &tls.Config{
-		// Change default from SSLv3 to TLSv1.0 (because of POODLE vulnerability)
-		MinVersion: tls.VersionTLS10,
-		Certificates: []tls.Certificate{
-			cert,
-		},
-		RootCAs: rootCertPool(caData),
-	}, nil
-}
-
-func NewTLSConfig(caData []byte) (*tls.Config, error) {
-	return &tls.Config{
-		// Change default from SSLv3 to TLSv1.0 (because of POODLE vulnerability)
-		MinVersion: tls.VersionTLS10,
-		RootCAs:    rootCertPool(caData),
-	}, nil
-}
-
 // rootCertPool returns nil if caData is empty.  When passed along, this will mean "use system CAs".
 // When caData is not empty, it will be the ONLY information used in the CertPool.
 func rootCertPool(caData []byte) *x509.CertPool {
@@ -204,12 +184,6 @@ func rootCertPool(caData []byte) *x509.CertPool {
 	certPool := x509.NewCertPool()
 	certPool.AppendCertsFromPEM(caData)
 	return certPool
-}
-
-func NewUnsafeTLSConfig() *tls.Config {
-	return &tls.Config{
-		InsecureSkipVerify: true,
-	}
 }
 
 // cloneRequest returns a clone of the provided *http.Request.

--- a/pkg/client/unversioned/transport_test.go
+++ b/pkg/client/unversioned/transport_test.go
@@ -24,13 +24,6 @@ import (
 	"k8s.io/kubernetes/pkg/api/testapi"
 )
 
-func TestUnsecuredTLSTransport(t *testing.T) {
-	cfg := NewUnsafeTLSConfig()
-	if !cfg.InsecureSkipVerify {
-		t.Errorf("expected config to be insecure")
-	}
-}
-
 type testRoundTripper struct {
 	Request  *http.Request
 	Response *http.Response


### PR DESCRIPTION
Fixes #13830 by honoring the Insecure flag, even if a client cert/key is used
