### PR TITLE
Cherry pick of #15367 #15255 upstream release 1.1 - mesos 0.24

### DIFF
--- a/cluster/mesos/docker/docker-compose.yml
+++ b/cluster/mesos/docker/docker-compose.yml
@@ -29,7 +29,7 @@ mesosmaster1:
 mesosslave:
   hostname: mesosslave
   privileged: true
-  image: mesosphere/mesos-slave-dind:0.23.0-1.0.ubuntu1404.docker181
+  image: mesosphere/mesos-slave-dind:mesos-0.24.0_dind-0.2_docker-1.8.2_ubuntu-14.04.3
   entrypoint:
   - bash
   - -xc

--- a/cluster/mesos/docker/docker-compose.yml
+++ b/cluster/mesos/docker/docker-compose.yml
@@ -13,7 +13,7 @@ etcd:
     --initial-cluster-state new
 mesosmaster1:
   hostname: mesosmaster1
-  image: mesosphere/mesos:0.23.0-1.0.ubuntu1404
+  image: mesosphere/mesos:0.24.0-1.0.27.ubuntu1404
   entrypoint: [ "mesos-master" ]
   ports: [ "5050:5050" ]
   environment:

--- a/cluster/mesos/docker/keygen/Dockerfile
+++ b/cluster/mesos/docker/keygen/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04.2
+FROM ubuntu:14.04.3
 MAINTAINER Mesosphere <support@mesosphere.io>
 
 RUN locale-gen en_US.UTF-8

--- a/cluster/mesos/docker/km/Dockerfile
+++ b/cluster/mesos/docker/km/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04.2
+FROM ubuntu:14.04.3
 MAINTAINER Mesosphere <support@mesosphere.io>
 
 RUN locale-gen en_US.UTF-8

--- a/cluster/mesos/docker/test/Dockerfile
+++ b/cluster/mesos/docker/test/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.4.2
+FROM golang:1.4.3
 MAINTAINER Mesosphere <support@mesosphere.io>
 
 # docker.io is suppossed to be in backports, but it's not there yet.


### PR DESCRIPTION
This cherry-pick updates the docker base images used by the mesos/docker cluster to ones that actually work (the dind wrapper was broken by a recent kernel bug with overlay-on-overlay filesystems). This also bumps the Mesos version to 0.24 (which fixes some other miscellaneous bugs).

This is required for the release-1.1 branch (and cherry-pick PRs to that branch) to pass mesos/docker smoke tests.

xref: #15367 #15255
