### PR TITLE
Cherry-pick of #15228

### DIFF
--- a/hack/conformance-test.sh
+++ b/hack/conformance-test.sh
@@ -74,38 +74,14 @@ git show-ref | grep $HEAD_SHA | grep refs/tags
 echo
 echo "Conformance test checking conformance with Kubernetes version 1.0"
 
-# It runs a whitelist of tests.  This whitelist was assembled at commit
-# b70b7084c93d4ce80b7463f48c23d5ac04edb2b1 starting from this list of tests:
-#   grep -h 'It(\|Describe(' -R test
+# It runs a whitelist of tests: all tests which are flagged with [Conformance]
+# somewhere in the description (i.e. either in the Describe part or the It part).
+# The list of tagged conformance tests can be retrieved by:
 #
-# List of test name patterns not included and why not included:
-#  Cadvisor: impl detail how stats gotten from containers.
-#  MasterCerts: GKE/GCE specific
-#  Density: performance
-#  Cluster level logging...: optional feature
-#  Etcd failure: reliability
-#  Load Capacity: performance
-#  Monitoring: optional feature.
-#  Namespaces.*seconds: performance.
-#  Pod disks: uses GCE specific feature.
-#  Reboot: node management
-#  Nodes: node management.
-#  Restart: node management.
-#  Scale: performance
-#  Services.*load balancer: not all cloud providers have a load balancer.
-#  Services.*NodePort: requires you to open the firewall yourself, so not covered.
-#  Services.*nodeport: requires you to open the firewall yourself, so not covered.
-#  Shell: replies on optional ssh access to nodes.
-#  SSH: optional feature.
-#  Addon\supdate: requires SSH
-#  Volumes: contained only skipped tests.
-#  Clean\sup\spods\son\snode: performance
-#  MaxPods\slimit\snumber\sof\spods: not sure why this wasn't working on GCE but it wasn't.
-#  Kubectl\sclient\sSimple\spod: not sure why this wasn't working on GCE but it wasn't
-#  DNS: not sure why this wasn't working on GCE but it wasn't
-export CONFORMANCE_TEST_SKIP_REGEX="Cadvisor|MasterCerts|Density|Cluster\slevel\slogging|Etcd\sfailure|Load\sCapacity|Monitoring|Namespaces.*seconds|Pod\sdisks|Reboot|Restart|Nodes|Scale|Services.*load\sbalancer|Services.*NodePort|Services.*nodeport|Shell|SSH|Addon\supdate|Volumes|Clean\sup\spods\son\snode|Skipped|skipped|MaxPods\slimit\snumber\sof\spods|Kubectl\sclient\sSimple\spod|DNS|Resource\susage\sof\ssystem\scontainers"
+# NUM_MINIONS=4 KUBERNETES_CONFORMANCE_TEST="y" \
+# hack/ginkgo-e2e.sh -ginkgo.focus='\[Conformance\]' -ginkgo.dryRun=true
 
 declare -x KUBERNETES_CONFORMANCE_TEST="y"
 declare -x NUM_MINIONS=4
-hack/ginkgo-e2e.sh
+hack/ginkgo-e2e.sh -ginkgo.focus='\[Conformance\]'
 exit $?

--- a/test/e2e/container_probe.go
+++ b/test/e2e/container_probe.go
@@ -40,7 +40,7 @@ var _ = Describe("Probing container", func() {
 
 	AfterEach(framework.afterEach)
 
-	It("with readiness probe should not be ready before initial delay and never restart", func() {
+	It("with readiness probe should not be ready before initial delay and never restart [Conformance]", func() {
 		p, err := podClient.Create(makePodSpec(probe.withInitialDelay().build(), nil))
 		expectNoError(err)
 		startTime := time.Now()
@@ -73,7 +73,7 @@ var _ = Describe("Probing container", func() {
 		Expect(restartCount == 0).To(BeTrue(), "pod should have a restart count of 0 but got %v", restartCount)
 	})
 
-	It("with readiness probe that fails should never be ready and never restart", func() {
+	It("with readiness probe that fails should never be ready and never restart [Conformance]", func() {
 		p, err := podClient.Create(makePodSpec(probe.withFailing().build(), nil))
 		expectNoError(err)
 

--- a/test/e2e/docker_containers.go
+++ b/test/e2e/docker_containers.go
@@ -46,13 +46,13 @@ var _ = Describe("Docker Containers", func() {
 		}
 	})
 
-	It("should use the image defaults if command and args are blank", func() {
+	It("should use the image defaults if command and args are blank [Conformance]", func() {
 		testContainerOutputInNamespace("use defaults", c, entrypointTestPod(), 0, []string{
 			"[/ep default arguments]",
 		}, ns)
 	})
 
-	It("should be able to override the image's default arguments (docker cmd)", func() {
+	It("should be able to override the image's default arguments (docker cmd) [Conformance]", func() {
 		pod := entrypointTestPod()
 		pod.Spec.Containers[0].Args = []string{"override", "arguments"}
 
@@ -63,7 +63,7 @@ var _ = Describe("Docker Containers", func() {
 
 	// Note: when you override the entrypoint, the image's arguments (docker cmd)
 	// are ignored.
-	It("should be able to override the image's default commmand (docker entrypoint)", func() {
+	It("should be able to override the image's default commmand (docker entrypoint) [Conformance]", func() {
 		pod := entrypointTestPod()
 		pod.Spec.Containers[0].Command = []string{"/ep-2"}
 
@@ -72,7 +72,7 @@ var _ = Describe("Docker Containers", func() {
 		}, ns)
 	})
 
-	It("should be able to override the image's default command and arguments", func() {
+	It("should be able to override the image's default command and arguments [Conformance]", func() {
 		pod := entrypointTestPod()
 		pod.Spec.Containers[0].Command = []string{"/ep-2"}
 		pod.Spec.Containers[0].Args = []string{"override", "arguments"}

--- a/test/e2e/downward_api.go
+++ b/test/e2e/downward_api.go
@@ -28,7 +28,7 @@ import (
 var _ = Describe("Downward API", func() {
 	framework := NewFramework("downward-api")
 
-	It("should provide pod name and namespace as env vars", func() {
+	It("should provide pod name and namespace as env vars [Conformance]", func() {
 		podName := "downward-api-" + string(util.NewUUID())
 		pod := &api.Pod{
 			ObjectMeta: api.ObjectMeta{

--- a/test/e2e/downwardapi_volume.go
+++ b/test/e2e/downwardapi_volume.go
@@ -28,7 +28,7 @@ import (
 var _ = Describe("Downward API volume", func() {
 	f := NewFramework("downward-api")
 
-	It("should provide labels and annotations files", func() {
+	It("should provide labels and annotations files [Conformance]", func() {
 		podName := "metadata-volume-" + string(util.NewUUID())
 		pod := &api.Pod{
 			ObjectMeta: api.ObjectMeta{

--- a/test/e2e/empty_dir.go
+++ b/test/e2e/empty_dir.go
@@ -37,59 +37,59 @@ var _ = Describe("EmptyDir volumes", func() {
 
 	f := NewFramework("emptydir")
 
-	It("volume on tmpfs should have the correct mode", func() {
+	It("volume on tmpfs should have the correct mode [Conformance]", func() {
 		doTestVolumeMode(f, testImageRootUid, api.StorageMediumMemory)
 	})
 
-	It("should support (root,0644,tmpfs)", func() {
+	It("should support (root,0644,tmpfs) [Conformance]", func() {
 		doTest0644(f, testImageRootUid, api.StorageMediumMemory)
 	})
 
-	It("should support (root,0666,tmpfs)", func() {
+	It("should support (root,0666,tmpfs) [Conformance]", func() {
 		doTest0666(f, testImageRootUid, api.StorageMediumMemory)
 	})
 
-	It("should support (root,0777,tmpfs)", func() {
+	It("should support (root,0777,tmpfs) [Conformance]", func() {
 		doTest0777(f, testImageRootUid, api.StorageMediumMemory)
 	})
 
-	It("should support (non-root,0644,tmpfs)", func() {
+	It("should support (non-root,0644,tmpfs) [Conformance]", func() {
 		doTest0644(f, testImageNonRootUid, api.StorageMediumMemory)
 	})
 
-	It("should support (non-root,0666,tmpfs)", func() {
+	It("should support (non-root,0666,tmpfs) [Conformance]", func() {
 		doTest0666(f, testImageNonRootUid, api.StorageMediumMemory)
 	})
 
-	It("should support (non-root,0777,tmpfs)", func() {
+	It("should support (non-root,0777,tmpfs) [Conformance]", func() {
 		doTest0777(f, testImageNonRootUid, api.StorageMediumMemory)
 	})
 
-	It("volume on default medium should have the correct mode", func() {
+	It("volume on default medium should have the correct mode [Conformance]", func() {
 		doTestVolumeMode(f, testImageRootUid, api.StorageMediumDefault)
 	})
 
-	It("should support (root,0644,default)", func() {
+	It("should support (root,0644,default) [Conformance]", func() {
 		doTest0644(f, testImageRootUid, api.StorageMediumDefault)
 	})
 
-	It("should support (root,0666,default)", func() {
+	It("should support (root,0666,default) [Conformance]", func() {
 		doTest0666(f, testImageRootUid, api.StorageMediumDefault)
 	})
 
-	It("should support (root,0777,default)", func() {
+	It("should support (root,0777,default) [Conformance]", func() {
 		doTest0777(f, testImageRootUid, api.StorageMediumDefault)
 	})
 
-	It("should support (non-root,0644,default)", func() {
+	It("should support (non-root,0644,default) [Conformance]", func() {
 		doTest0644(f, testImageNonRootUid, api.StorageMediumDefault)
 	})
 
-	It("should support (non-root,0666,default)", func() {
+	It("should support (non-root,0666,default) [Conformance]", func() {
 		doTest0666(f, testImageNonRootUid, api.StorageMediumDefault)
 	})
 
-	It("should support (non-root,0777,default)", func() {
+	It("should support (non-root,0777,default) [Conformance]", func() {
 		doTest0777(f, testImageNonRootUid, api.StorageMediumDefault)
 	})
 })

--- a/test/e2e/events.go
+++ b/test/e2e/events.go
@@ -34,7 +34,7 @@ import (
 var _ = Describe("Events", func() {
 	framework := NewFramework("events")
 
-	It("should be sent by kubelets and the scheduler about pods scheduling and running", func() {
+	It("should be sent by kubelets and the scheduler about pods scheduling and running [Conformance]", func() {
 
 		podClient := framework.Client.Pods(framework.Namespace.Name)
 

--- a/test/e2e/examples.go
+++ b/test/e2e/examples.go
@@ -430,7 +430,7 @@ var _ = Describe("Examples e2e", func() {
 	})
 
 	Describe("[Example]ClusterDns", func() {
-		It("should create pod that uses dns", func() {
+		It("should create pod that uses dns [Conformance]", func() {
 			mkpath := func(file string) string {
 				return filepath.Join(testContext.RepoRoot, "examples/cluster-dns", file)
 			}

--- a/test/e2e/expansion.go
+++ b/test/e2e/expansion.go
@@ -26,7 +26,7 @@ import (
 var _ = Describe("Variable Expansion", func() {
 	framework := NewFramework("var-expansion")
 
-	It("should allow composing env vars into new env vars", func() {
+	It("should allow composing env vars into new env vars [Conformance]", func() {
 		podName := "var-expansion-" + string(util.NewUUID())
 		pod := &api.Pod{
 			ObjectMeta: api.ObjectMeta{
@@ -66,7 +66,7 @@ var _ = Describe("Variable Expansion", func() {
 		})
 	})
 
-	It("should allow substituting values in a container's command", func() {
+	It("should allow substituting values in a container's command [Conformance]", func() {
 		podName := "var-expansion-" + string(util.NewUUID())
 		pod := &api.Pod{
 			ObjectMeta: api.ObjectMeta{
@@ -96,7 +96,7 @@ var _ = Describe("Variable Expansion", func() {
 		})
 	})
 
-	It("should allow substituting values in a container's args", func() {
+	It("should allow substituting values in a container's args [Conformance]", func() {
 		podName := "var-expansion-" + string(util.NewUUID())
 		pod := &api.Pod{
 			ObjectMeta: api.ObjectMeta{

--- a/test/e2e/host_path.go
+++ b/test/e2e/host_path.go
@@ -59,7 +59,7 @@ var _ = Describe("hostPath", func() {
 		}
 	})
 
-	It("should give a volume the correct mode", func() {
+	It("should give a volume the correct mode [Conformance]", func() {
 		volumePath := "/test-volume"
 		source := &api.HostPathVolumeSource{
 			Path: "/tmp",
@@ -76,7 +76,7 @@ var _ = Describe("hostPath", func() {
 			namespace.Name)
 	})
 
-	It("should support r/w", func() {
+	It("should support r/w [Conformance]", func() {
 		volumePath := "/test-volume"
 		filePath := path.Join(volumePath, "test-file")
 		retryDuration := 180

--- a/test/e2e/kube-ui.go
+++ b/test/e2e/kube-ui.go
@@ -38,7 +38,7 @@ var _ = Describe("kube-ui", func() {
 
 	f := NewFramework("kube-ui")
 
-	It("should check that the kube-ui instance is alive", func() {
+	It("should check that the kube-ui instance is alive [Conformance]", func() {
 		By("Checking the kube-ui service exists.")
 		err := waitForService(f.Client, uiNamespace, uiServiceName, true, poll, serviceStartTimeout)
 		Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -93,7 +93,7 @@ var _ = Describe("Kubectl client", func() {
 			nautilusPath = filepath.Join(updateDemoRoot, "nautilus-rc.yaml")
 			kittenPath = filepath.Join(updateDemoRoot, "kitten-rc.yaml")
 		})
-		It("should create and stop a replication controller", func() {
+		It("should create and stop a replication controller [Conformance]", func() {
 			defer cleanup(nautilusPath, ns, updateDemoSelector)
 
 			By("creating a replication controller")
@@ -101,7 +101,7 @@ var _ = Describe("Kubectl client", func() {
 			validateController(c, nautilusImage, 2, "update-demo", updateDemoSelector, getUDData("nautilus.jpg", ns), ns)
 		})
 
-		It("should scale a replication controller", func() {
+		It("should scale a replication controller [Conformance]", func() {
 			defer cleanup(nautilusPath, ns, updateDemoSelector)
 
 			By("creating a replication controller")
@@ -115,7 +115,7 @@ var _ = Describe("Kubectl client", func() {
 			validateController(c, nautilusImage, 2, "update-demo", updateDemoSelector, getUDData("nautilus.jpg", ns), ns)
 		})
 
-		It("should do a rolling update of a replication controller", func() {
+		It("should do a rolling update of a replication controller [Conformance]", func() {
 			By("creating the initial replication controller")
 			runKubectl("create", "-f", nautilusPath, fmt.Sprintf("--namespace=%v", ns))
 			validateController(c, nautilusImage, 2, "update-demo", updateDemoSelector, getUDData("nautilus.jpg", ns), ns)
@@ -133,7 +133,7 @@ var _ = Describe("Kubectl client", func() {
 			guestbookPath = filepath.Join(testContext.RepoRoot, "examples/guestbook")
 		})
 
-		It("should create and stop a working application", func() {
+		It("should create and stop a working application [Conformance]", func() {
 			defer cleanup(guestbookPath, ns, frontendSelector, redisMasterSelector, redisSlaveSelector)
 
 			By("creating all guestbook components")
@@ -238,7 +238,7 @@ var _ = Describe("Kubectl client", func() {
 	})
 
 	Describe("Kubectl api-versions", func() {
-		It("should check if v1 is in available api versions", func() {
+		It("should check if v1 is in available api versions [Conformance]", func() {
 			By("validating api verions")
 			output := runKubectl("api-versions")
 			if !strings.Contains(output, "Available Server Api Versions:") {
@@ -251,7 +251,7 @@ var _ = Describe("Kubectl client", func() {
 	})
 
 	Describe("Kubectl cluster-info", func() {
-		It("should check if Kubernetes master services is included in cluster-info", func() {
+		It("should check if Kubernetes master services is included in cluster-info [Conformance]", func() {
 			By("validating cluster-info")
 			output := runKubectl("cluster-info")
 			// Can't check exact strings due to terminal control commands (colors)
@@ -268,7 +268,7 @@ var _ = Describe("Kubectl client", func() {
 	})
 
 	Describe("Kubectl describe", func() {
-		It("should check if kubectl describe prints relevant information for rc and pods", func() {
+		It("should check if kubectl describe prints relevant information for rc and pods [Conformance]", func() {
 			mkpath := func(file string) string {
 				return filepath.Join(testContext.RepoRoot, "examples/guestbook-go", file)
 			}
@@ -358,7 +358,7 @@ var _ = Describe("Kubectl client", func() {
 	})
 
 	Describe("Kubectl expose", func() {
-		It("should create services for rc", func() {
+		It("should create services for rc [Conformance]", func() {
 			mkpath := func(file string) string {
 				return filepath.Join(testContext.RepoRoot, "examples/guestbook-go", file)
 			}
@@ -441,7 +441,7 @@ var _ = Describe("Kubectl client", func() {
 			cleanup(podPath, ns, simplePodSelector)
 		})
 
-		It("should update the label on a resource", func() {
+		It("should update the label on a resource [Conformance]", func() {
 			labelName := "testing-label"
 			labelValue := "testing-label-value"
 
@@ -480,7 +480,7 @@ var _ = Describe("Kubectl client", func() {
 			cleanup(rcPath, ns, simplePodSelector)
 		})
 
-		It("should be able to retrieve and filter logs", func() {
+		It("should be able to retrieve and filter logs [Conformance]", func() {
 			forEachPod(c, ns, "app", "redis", func(pod api.Pod) {
 				By("checking for a matching strings")
 				_, err := lookForStringInLog(ns, pod.Name, containerName, "The server is now ready to accept connections", podStartTimeout)
@@ -520,7 +520,7 @@ var _ = Describe("Kubectl client", func() {
 	})
 
 	Describe("Kubectl patch", func() {
-		It("should add annotations for pods in rc", func() {
+		It("should add annotations for pods in rc [Conformance]", func() {
 			mkpath := func(file string) string {
 				return filepath.Join(testContext.RepoRoot, "examples/guestbook-go", file)
 			}
@@ -549,7 +549,7 @@ var _ = Describe("Kubectl client", func() {
 	})
 
 	Describe("Kubectl version", func() {
-		It("should check is all data is printed", func() {
+		It("should check is all data is printed [Conformance]", func() {
 			version := runKubectl("version")
 			requiredItems := []string{"Client Version:", "Server Version:", "Major:", "Minor:", "GitCommit:"}
 			for _, item := range requiredItems {
@@ -573,7 +573,7 @@ var _ = Describe("Kubectl client", func() {
 			runKubectl("stop", "rc", rcName, nsFlag)
 		})
 
-		It("should create an rc from an image", func() {
+		It("should create an rc from an image [Conformance]", func() {
 			image := "nginx"
 
 			By("running the image " + image)
@@ -616,7 +616,7 @@ var _ = Describe("Kubectl client", func() {
 			runKubectl("stop", "pods", podName, nsFlag)
 		})
 
-		It("should create a pod from an image when restart is OnFailure", func() {
+		It("should create a pod from an image when restart is OnFailure [Conformance]", func() {
 			image := "nginx"
 
 			By("running the image " + image)
@@ -635,7 +635,7 @@ var _ = Describe("Kubectl client", func() {
 			}
 		})
 
-		It("should create a pod from an image when restart is Never", func() {
+		It("should create a pod from an image when restart is Never [Conformance]", func() {
 			image := "nginx"
 
 			By("running the image " + image)
@@ -658,7 +658,7 @@ var _ = Describe("Kubectl client", func() {
 
 	Describe("Proxy server", func() {
 		// TODO: test proxy options (static, prefix, etc)
-		It("should support proxy with --port 0", func() {
+		It("should support proxy with --port 0 [Conformance]", func() {
 			By("starting the proxy server")
 			port, cmd, err := startProxyServer()
 			if cmd != nil {
@@ -675,7 +675,7 @@ var _ = Describe("Kubectl client", func() {
 			}
 		})
 
-		It("should support --unix-socket=/path", func() {
+		It("should support --unix-socket=/path [Conformance]", func() {
 			By("Starting the proxy")
 			tmpdir, err := ioutil.TempDir("", "kubectl-proxy-unix")
 			if err != nil {

--- a/test/e2e/networking.go
+++ b/test/e2e/networking.go
@@ -51,7 +51,7 @@ var _ = Describe("Networking", func() {
 		}
 	})
 
-	It("should provide Internet connection for containers", func() {
+	It("should provide Internet connection for containers [Conformance]", func() {
 		By("Running container which tries to wget google.com")
 		podName := "wget-test"
 		contName := "wget-test-container"
@@ -82,7 +82,7 @@ var _ = Describe("Networking", func() {
 	})
 
 	// First test because it has no dependencies on variables created later on.
-	It("should provide unchanging, static URL paths for kubernetes api services.", func() {
+	It("should provide unchanging, static URL paths for kubernetes api services [Conformance]", func() {
 		tests := []struct {
 			path string
 		}{
@@ -103,7 +103,7 @@ var _ = Describe("Networking", func() {
 	})
 
 	//Now we can proceed with the test.
-	It("should function for intra-pod communication", func() {
+	It("should function for intra-pod communication [Conformance]", func() {
 
 		By(fmt.Sprintf("Creating a service named %q in namespace %q", svcname, f.Namespace.Name))
 		svc, err := f.Client.Services(f.Namespace.Name).Create(&api.Service{

--- a/test/e2e/pods.go
+++ b/test/e2e/pods.go
@@ -128,7 +128,7 @@ func testHostIP(c *client.Client, ns string, pod *api.Pod) {
 var _ = Describe("Pods", func() {
 	framework := NewFramework("pods")
 
-	PIt("should get a host IP", func() {
+	PIt("should get a host IP [Conformance]", func() {
 		name := "pod-hostip-" + string(util.NewUUID())
 		testHostIP(framework.Client, framework.Namespace.Name, &api.Pod{
 			ObjectMeta: api.ObjectMeta{
@@ -145,7 +145,7 @@ var _ = Describe("Pods", func() {
 		})
 	})
 
-	It("should be schedule with cpu and memory limits", func() {
+	It("should be schedule with cpu and memory limits [Conformance]", func() {
 		podClient := framework.Client.Pods(framework.Namespace.Name)
 
 		By("creating the pod")
@@ -182,7 +182,7 @@ var _ = Describe("Pods", func() {
 		expectNoError(framework.WaitForPodRunning(pod.Name))
 	})
 
-	It("should be submitted and removed", func() {
+	It("should be submitted and removed [Conformance]", func() {
 		podClient := framework.Client.Pods(framework.Namespace.Name)
 
 		By("creating the pod")
@@ -290,7 +290,7 @@ var _ = Describe("Pods", func() {
 		Expect(len(pods.Items)).To(Equal(0))
 	})
 
-	It("should be updated", func() {
+	It("should be updated [Conformance]", func() {
 		podClient := framework.Client.Pods(framework.Namespace.Name)
 
 		By("creating the pod")
@@ -372,7 +372,7 @@ var _ = Describe("Pods", func() {
 		Logf("Pod update OK")
 	})
 
-	It("should contain environment variables for services", func() {
+	It("should contain environment variables for services [Conformance]", func() {
 		// Make a pod that will be a service.
 		// This pod serves its hostname via HTTP.
 		serverName := "server-envvars-" + string(util.NewUUID())
@@ -459,7 +459,7 @@ var _ = Describe("Pods", func() {
 		})
 	})
 
-	It("should be restarted with a docker exec \"cat /tmp/health\" liveness probe", func() {
+	It("should be restarted with a docker exec \"cat /tmp/health\" liveness probe [Conformance]", func() {
 		runLivenessTest(framework.Client, framework.Namespace.Name, &api.Pod{
 			ObjectMeta: api.ObjectMeta{
 				Name:   "liveness-exec",
@@ -485,7 +485,7 @@ var _ = Describe("Pods", func() {
 		}, 1)
 	})
 
-	It("should *not* be restarted with a docker exec \"cat /tmp/health\" liveness probe", func() {
+	It("should *not* be restarted with a docker exec \"cat /tmp/health\" liveness probe [Conformance]", func() {
 		runLivenessTest(framework.Client, framework.Namespace.Name, &api.Pod{
 			ObjectMeta: api.ObjectMeta{
 				Name:   "liveness-exec",
@@ -511,7 +511,7 @@ var _ = Describe("Pods", func() {
 		}, 0)
 	})
 
-	It("should be restarted with a /healthz http liveness probe", func() {
+	It("should be restarted with a /healthz http liveness probe [Conformance]", func() {
 		runLivenessTest(framework.Client, framework.Namespace.Name, &api.Pod{
 			ObjectMeta: api.ObjectMeta{
 				Name:   "liveness-http",
@@ -538,7 +538,7 @@ var _ = Describe("Pods", func() {
 		}, 1)
 	})
 
-	PIt("should have monotonically increasing restart count", func() {
+	PIt("should have monotonically increasing restart count [Conformance]", func() {
 		runLivenessTest(framework.Client, framework.Namespace.Name, &api.Pod{
 			ObjectMeta: api.ObjectMeta{
 				Name:   "liveness-http",
@@ -565,7 +565,7 @@ var _ = Describe("Pods", func() {
 		}, 8)
 	})
 
-	It("should *not* be restarted with a /healthz http liveness probe", func() {
+	It("should *not* be restarted with a /healthz http liveness probe [Conformance]", func() {
 		runLivenessTest(framework.Client, framework.Namespace.Name, &api.Pod{
 			ObjectMeta: api.ObjectMeta{
 				Name:   "liveness-http",

--- a/test/e2e/pre_stop.go
+++ b/test/e2e/pre_stop.go
@@ -144,7 +144,7 @@ func testPreStop(c *client.Client, ns string) {
 var _ = Describe("PreStop", func() {
 	f := NewFramework("prestop")
 
-	It("should call prestop when killing a pod", func() {
+	It("should call prestop when killing a pod [Conformance]", func() {
 		testPreStop(f.Client, f.Namespace.Name)
 	})
 })

--- a/test/e2e/proxy.go
+++ b/test/e2e/proxy.go
@@ -53,13 +53,13 @@ func proxyContext(version string) {
 	prefix := "/api/" + version
 
 	// Port here has to be kept in sync with default kubelet port.
-	It("should proxy logs on node with explicit kubelet port", func() { nodeProxyTest(f, version, ":10250/logs/") })
+	It("should proxy logs on node with explicit kubelet port [Conformance]", func() { nodeProxyTest(f, version, ":10250/logs/") })
 
-	It("should proxy logs on node", func() { nodeProxyTest(f, version, "/logs/") })
+	It("should proxy logs on node [Conformance]", func() { nodeProxyTest(f, version, "/logs/") })
 
-	It("should proxy to cadvisor", func() { nodeProxyTest(f, version, ":4194/containers/") })
+	It("should proxy to cadvisor [Conformance]", func() { nodeProxyTest(f, version, ":4194/containers/") })
 
-	It("should proxy through a service and a pod", func() {
+	It("should proxy through a service and a pod [Conformance]", func() {
 		labels := map[string]string{"proxy-service-target": "true"}
 		service, err := f.Client.Services(f.Namespace.Name).Create(&api.Service{
 			ObjectMeta: api.ObjectMeta{

--- a/test/e2e/rc.go
+++ b/test/e2e/rc.go
@@ -33,7 +33,7 @@ import (
 var _ = Describe("ReplicationController", func() {
 	framework := NewFramework("replication-controller")
 
-	It("should serve a basic image on each replica with a public image", func() {
+	It("should serve a basic image on each replica with a public image [Conformance]", func() {
 		ServeImageOrFail(framework, "basic", "gcr.io/google_containers/serve_hostname:1.1")
 	})
 

--- a/test/e2e/scheduler_predicates.go
+++ b/test/e2e/scheduler_predicates.go
@@ -179,7 +179,7 @@ var _ = Describe("SchedulerPredicates", func() {
 	// This test verifies that max-pods flag works as advertised. It assumes that cluster add-on pods stay stable
 	// and cannot be run in parallel with any other test that touches Nodes or Pods. It is so because to check
 	// if max-pods is working we need to fully saturate the cluster and keep it in this state for few seconds.
-	It("validates MaxPods limit number of pods that are allowed to run.", func() {
+	It("validates MaxPods limit number of pods that are allowed to run", func() {
 		totalPodCapacity = 0
 
 		for _, node := range nodeList.Items {
@@ -245,7 +245,7 @@ var _ = Describe("SchedulerPredicates", func() {
 	// This test verifies we don't allow scheduling of pods in a way that sum of limits of pods is greater than machines capacity.
 	// It assumes that cluster add-on pods stay stable and cannot be run in parallel with any other test that touches Nodes or Pods.
 	// It is so because we need to have precise control on what's running in the cluster.
-	It("validates resource limits of pods that are allowed to run.", func() {
+	It("validates resource limits of pods that are allowed to run [Conformance]", func() {
 		nodeToCapacityMap := make(map[string]int64)
 		for _, node := range nodeList.Items {
 			capacity, found := node.Status.Capacity["cpu"]
@@ -334,7 +334,7 @@ var _ = Describe("SchedulerPredicates", func() {
 
 	// Test Nodes does not have any label, hence it should be impossible to schedule Pod with
 	// nonempty Selector set.
-	It("validates that NodeSelector is respected.", func() {
+	It("validates that NodeSelector is respected [Conformance]", func() {
 		By("Trying to schedule Pod with nonempty NodeSelector.")
 		podName := "restricted-pod"
 

--- a/test/e2e/secrets.go
+++ b/test/e2e/secrets.go
@@ -28,7 +28,7 @@ import (
 var _ = Describe("Secrets", func() {
 	f := NewFramework("secrets")
 
-	It("should be consumable from pods", func() {
+	It("should be consumable from pods [Conformance]", func() {
 		name := "secret-test-" + string(util.NewUUID())
 		volumeName := "secret-volume"
 		volumeMountPath := "/etc/secret-volume"

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -72,12 +72,12 @@ var _ = Describe("Services", func() {
 	})
 
 	// TODO: We get coverage of TCP/UDP and multi-port services through the DNS test. We should have a simpler test for multi-port TCP here.
-	It("should provide secure master service", func() {
+	It("should provide secure master service [Conformance]", func() {
 		_, err := c.Services(api.NamespaceDefault).Get("kubernetes")
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("should serve a basic endpoint from pods", func() {
+	It("should serve a basic endpoint from pods [Conformance]", func() {
 		serviceName := "endpoint-test2"
 		ns := namespaces[0]
 		labels := map[string]string{
@@ -140,7 +140,7 @@ var _ = Describe("Services", func() {
 		validateEndpointsOrFail(c, ns, serviceName, PortsByPodName{})
 	})
 
-	It("should serve multiport endpoints from pods", func() {
+	It("should serve multiport endpoints from pods [Conformance]", func() {
 		// repacking functionality is intentionally not tested here - it's better to test it in an integration test.
 		serviceName := "multi-endpoint-test"
 		ns := namespaces[0]

--- a/test/e2e/service_accounts.go
+++ b/test/e2e/service_accounts.go
@@ -34,7 +34,7 @@ import (
 var _ = Describe("ServiceAccounts", func() {
 	f := NewFramework("svcaccounts")
 
-	It("should mount an API token into pods", func() {
+	It("should mount an API token into pods [Conformance]", func() {
 		var tokenName string
 		var tokenContent string
 		var rootCAContent string

--- a/test/e2e/service_latency.go
+++ b/test/e2e/service_latency.go
@@ -44,7 +44,7 @@ func (d durations) Swap(i, j int)      { d[i], d[j] = d[j], d[i] }
 var _ = Describe("Service endpoints latency", func() {
 	f := NewFramework("svc-latency")
 
-	It("should not be very high", func() {
+	It("should not be very high [Conformance]", func() {
 		const (
 			// These are very generous criteria. Ideally we will
 			// get this much lower in the future. See issue


### PR DESCRIPTION
This PR cherry-picks #15228 for release-v1.1, with little changes for not-yet-existing tests in that branch.

Difference between **master** and **this PR**:

``` diff
--- sorted-conformance-tag.txt  2015-10-08 15:39:19.000000000 +0200
+++ sorted-conformance-v1.1.txt 2015-10-10 12:24:17.000000000 +0200
@@ -50,9 +50,6 @@
 Pods should contain environment variables for services
 Pods should get a host IP
 Pods should have monotonically increasing restart count
-Port forwarding With a server that expects a client request should support a client that connects, sends data, and disconnects
-Port forwarding With a server that expects a client request should support a client that connects, sends no data, and disconnects
-Port forwarding With a server that expects no client request should support a client that connects, sends no data, and disconnects
 PreStop should call prestop when killing a pod
 Probing container with readiness probe should not be ready before initial delay and never restart
 Probing container with readiness probe that fails should never be ready and never restart
@@ -62,8 +59,7 @@
 Proxy version v1 should proxy to cadvisor
 ReplicationController should serve a basic image on each replica with a public image
 SchedulerPredicates validates resource limits of pods that are allowed to run
-SchedulerPredicates validates that NodeSelector is respected if matching
-SchedulerPredicates validates that NodeSelector is respected if not matching
+SchedulerPredicates validates that NodeSelector is respected
 Secrets should be consumable from pods
 Service endpoints latency should not be very high
 ServiceAccounts should mount an API token into pods
```

The port-forward test do not exist yet, the same for the negative NodeSelector test.
