### PR TITLE
Connect should be passed a Responder interface

### DIFF
--- a/pkg/api/rest/rest.go
+++ b/pkg/api/rest/rest.go
@@ -202,20 +202,24 @@ type Redirector interface {
 	ResourceLocation(ctx api.Context, id string) (remoteLocation *url.URL, transport http.RoundTripper, err error)
 }
 
-// ConnectHandler is a handler for HTTP connection requests. It extends the standard
-// http.Handler interface by adding a method that returns an error object if an error
-// occurred during the handling of the request.
-type ConnectHandler interface {
-	http.Handler
-
-	// RequestError returns an error if one occurred during handling of an HTTP request
-	RequestError() error
+// Responder abstracts the normal response behavior for a REST method and is passed to callers that
+// may wish to handle the response directly in some cases, but delegate to the normal error or object
+// behavior in other cases.
+type Responder interface {
+	// Object writes the provided object to the response. Invoking this method multiple times is undefined.
+	Object(statusCode int, obj runtime.Object)
+	// Error writes the provided error to the response. This method may only be invoked once.
+	Error(err error)
 }
 
-// Connecter is a storage object that responds to a connection request
+// Connecter is a storage object that responds to a connection request.
 type Connecter interface {
-	// Connect returns a ConnectHandler that will handle the request/response for a request
-	Connect(ctx api.Context, id string, options runtime.Object) (ConnectHandler, error)
+	// Connect returns an http.Handler that will handle the request/response for a given API invocation.
+	// The provided responder may be used for common API responses. The responder will write both status
+	// code and body, so the ServeHTTP method should exit after invoking the responder. The Handler will
+	// be used for a single API request and then discarded. The Responder is guaranteed to write to the
+	// same http.ResponseWriter passed to ServeHTTP.
+	Connect(ctx api.Context, id string, options runtime.Object, r Responder) (http.Handler, error)
 
 	// NewConnectOptions returns an empty options object that will be used to pass
 	// options to the Connect method. If nil, then a nil options object is passed to

--- a/pkg/registry/generic/rest/proxy.go
+++ b/pkg/registry/generic/rest/proxy.go
@@ -44,30 +44,32 @@ type UpgradeAwareProxyHandler struct {
 	WrapTransport  bool
 	FlushInterval  time.Duration
 	MaxBytesPerSec int64
-	err            error
+	Responder      ErrorResponder
 }
 
 const defaultFlushInterval = 200 * time.Millisecond
 
-// NewUpgradeAwareProxyHandler creates a new proxy handler with a default flush interval
-func NewUpgradeAwareProxyHandler(location *url.URL, transport http.RoundTripper, wrapTransport, upgradeRequired bool) *UpgradeAwareProxyHandler {
+// ErrorResponder abstracts error reporting to the proxy handler to remove the need to hardcode a particular
+// error format.
+type ErrorResponder interface {
+	Error(err error)
+}
+
+// NewUpgradeAwareProxyHandler creates a new proxy handler with a default flush interval. Responder is required for returning
+// errors to the caller.
+func NewUpgradeAwareProxyHandler(location *url.URL, transport http.RoundTripper, wrapTransport, upgradeRequired bool, responder ErrorResponder) *UpgradeAwareProxyHandler {
 	return &UpgradeAwareProxyHandler{
 		Location:        location,
 		Transport:       transport,
 		WrapTransport:   wrapTransport,
 		UpgradeRequired: upgradeRequired,
 		FlushInterval:   defaultFlushInterval,
+		Responder:       responder,
 	}
-}
-
-// RequestError returns an error that occurred while handling request
-func (h *UpgradeAwareProxyHandler) RequestError() error {
-	return h.err
 }
 
 // ServeHTTP handles the proxy request
 func (h *UpgradeAwareProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	h.err = nil
 	if len(h.Location.Scheme) == 0 {
 		h.Location.Scheme = "http"
 	}
@@ -75,7 +77,7 @@ func (h *UpgradeAwareProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Re
 		return
 	}
 	if h.UpgradeRequired {
-		h.err = errors.NewBadRequest("Upgrade request required")
+		h.Responder.Error(errors.NewBadRequest("Upgrade request required"))
 		return
 	}
 
@@ -108,7 +110,7 @@ func (h *UpgradeAwareProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Re
 
 	newReq, err := http.NewRequest(req.Method, loc.String(), req.Body)
 	if err != nil {
-		h.err = err
+		h.Responder.Error(err)
 		return
 	}
 	newReq.Header = req.Header
@@ -127,27 +129,27 @@ func (h *UpgradeAwareProxyHandler) tryUpgrade(w http.ResponseWriter, req *http.R
 
 	backendConn, err := proxy.DialURL(h.Location, h.Transport)
 	if err != nil {
-		h.err = err
+		h.Responder.Error(err)
 		return true
 	}
 	defer backendConn.Close()
 
 	requestHijackedConn, _, err := w.(http.Hijacker).Hijack()
 	if err != nil {
-		h.err = err
+		h.Responder.Error(err)
 		return true
 	}
 	defer requestHijackedConn.Close()
 
 	newReq, err := http.NewRequest(req.Method, h.Location.String(), req.Body)
 	if err != nil {
-		h.err = err
+		h.Responder.Error(err)
 		return true
 	}
 	newReq.Header = req.Header
 
 	if err = newReq.Write(backendConn); err != nil {
-		h.err = err
+		h.Responder.Error(err)
 		return true
 	}
 


### PR DESCRIPTION
For connect handlers that need to respond with a structured error or structured object, pass an interface that hides the details of writing an object to the response (error or runtime.Object).  Pure refactor, no API changes.

Example use case:

Connect handler that accepts a body input stream, which it streams to a
pod, and then returns a structured object with info about the pod it
just created.

@csrwng because this was your code originally
