### PR TITLE
EXPERIMENTAL/MESOS: Revert back to mesos-slave 0.23 because of instability with 0.24

### DIFF
--- a/cluster/mesos/docker/docker-compose.yml
+++ b/cluster/mesos/docker/docker-compose.yml
@@ -29,7 +29,7 @@ mesosmaster1:
 mesosslave:
   hostname: mesosslave
   privileged: true
-  image: mesosphere/mesos-slave-dind:mesos-0.24.0_dind-0.2_docker-1.8.2_ubuntu-14.04.3
+  image: mesosphere/mesos-slave-dind:mesos-0.23.0-1.0.ubuntu1404-docker-1.8.2-0-trusty
   entrypoint:
   - bash
   - -xc


### PR DESCRIPTION
Temporarily fixes https://github.com/mesosphere/kubernetes-mesos/issues/554

This PR depends on
- https://github.com/mesosphere/docker-containers/pull/30
- the docker image being pushed:

```
make images MESOS_VERSION=0.23.0-1.0.ubuntu1404 DOCKER_VERSION=1.8.2-0~trusty
make push MESOS_VERSION=0.23.0-1.0.ubuntu1404 DOCKER_VERSION=1.8.2-0~trusty
```

The master is not downgraded intentionally because running a 0.24 master with 0.23 is a supported setup.
