### PR TITLE
jenkins/e2e: only run ./cluster/gce/list-resources.sh if it exists

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -955,9 +955,17 @@ cd kubernetes
 ARTIFACTS=${WORKSPACE}/_artifacts
 mkdir -p ${ARTIFACTS}
 export E2E_REPORT_DIR=${ARTIFACTS}
+declare -r gcp_list_resources_script="./cluster/gce/list-resources.sh"
 declare -r gcp_resources_before="${ARTIFACTS}/gcp-resources-before.txt"
 declare -r gcp_resources_cluster_up="${ARTIFACTS}/gcp-resources-cluster-up.txt"
 declare -r gcp_resources_after="${ARTIFACTS}/gcp-resources-after.txt"
+# TODO(15492): figure out some way to run this script even if it doesn't exist
+# in the Kubernetes tarball.
+if [[ ( ${KUBERNETES_PROVIDER} == "gce" || ${KUBERNETES_PROVIDER} == "gke" ) && -x "${gcp_list_resources_script}" ]]; then
+  gcp_list_resources="true"
+else
+  gcp_list_resources="false"
+fi
 
 ### Pre Set Up ###
 # Install gcloud from a custom path if provided. Used to test GKE with gcloud
@@ -977,13 +985,13 @@ fi
 ### Set up ###
 if [[ "${E2E_UP,,}" == "true" ]]; then
     go run ./hack/e2e.go ${E2E_OPT} -v --down
-    if [[ ${KUBERNETES_PROVIDER} == "gce" || ${KUBERNETES_PROVIDER} == "gke" ]]; then
-      ./cluster/gce/list-resources.sh > "${gcp_resources_before}"
+    if [[ "${gcp_list_resources}" == "true" ]]; then
+      ${gcp_list_resources_script} > "${gcp_resources_before}"
     fi
     go run ./hack/e2e.go ${E2E_OPT} -v --up
     go run ./hack/e2e.go -v --ctl="version --match-server-version=false"
-    if [[ ${KUBERNETES_PROVIDER} == "gce" || ${KUBERNETES_PROVIDER} == "gke" ]]; then
-      ./cluster/gce/list-resources.sh > "${gcp_resources_cluster_up}"
+    if [[ "${gcp_list_resources}" == "true" ]]; then
+      ${gcp_list_resources_script} > "${gcp_resources_cluster_up}"
     fi
 fi
 
@@ -1027,8 +1035,8 @@ if [[ "${E2E_DOWN,,}" == "true" ]]; then
     # for the wait between attempts.
     sleep 30
     go run ./hack/e2e.go ${E2E_OPT} -v --down
-    if [[ ${KUBERNETES_PROVIDER} == "gce" || ${KUBERNETES_PROVIDER} == "gke" ]]; then
-      ./cluster/gce/list-resources.sh > "${gcp_resources_after}"
+    if [[ "${gcp_list_resources}" == "true" ]]; then
+      ${gcp_list_resources_script} > "${gcp_resources_after}"
     fi
 fi
 


### PR DESCRIPTION
Some builds (such as GKE or upgrade jobs) use an older Kubernetes tarball which doesn't include this script. Only run it if it exists so we don't fail builds.

ref #15189

cc @roberthbailey @ihmccreery @kubernetes/goog-testing 
