### PR TITLE
Addresses issue #6596.

### DIFF
--- a/pkg/api/ref.go
+++ b/pkg/api/ref.go
@@ -32,10 +32,6 @@ var (
 	ErrNoSelfLink = errors.New("selfLink was empty, can't make reference")
 )
 
-// ForTesting_ReferencesAllowBlankSelfLinks can be set to true in tests to avoid
-// "ErrNoSelfLink" errors.
-var ForTesting_ReferencesAllowBlankSelfLinks = false
-
 // GetReference returns an ObjectReference which refers to the given
 // object, or an error if the object doesn't follow the conventions
 // that would allow this.
@@ -68,11 +64,7 @@ func GetReference(obj runtime.Object) (*ObjectReference, error) {
 	if version == "" {
 		selfLink := meta.SelfLink()
 		if selfLink == "" {
-			if ForTesting_ReferencesAllowBlankSelfLinks {
-				version = "testing"
-			} else {
-				return nil, ErrNoSelfLink
-			}
+			return nil, ErrNoSelfLink
 		} else {
 			selfLinkUrl, err := url.Parse(selfLink)
 			if err != nil {

--- a/pkg/controller/daemon/controller_test.go
+++ b/pkg/controller/daemon/controller_test.go
@@ -38,10 +38,6 @@ var (
 	alwaysReady           = func() bool { return true }
 )
 
-func init() {
-	api.ForTesting_ReferencesAllowBlankSelfLinks = true
-}
-
 func getKey(ds *extensions.DaemonSet, t *testing.T) string {
 	if key, err := controller.KeyFunc(ds); err != nil {
 		t.Errorf("Unexpected error getting key for ds %v: %v", ds.Name, err)

--- a/pkg/controller/persistentvolume/persistentvolume_claim_binder_controller_test.go
+++ b/pkg/controller/persistentvolume/persistentvolume_claim_binder_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/host_path"
@@ -169,7 +170,6 @@ func TestExampleObjects(t *testing.T) {
 }
 
 func TestBindingWithExamples(t *testing.T) {
-	api.ForTesting_ReferencesAllowBlankSelfLinks = true
 	o := testclient.NewObjects(api.Scheme, api.Scheme)
 	if err := testclient.AddObjectsFromPath("../../../docs/user-guide/persistent-volumes/claims/claim-01.yaml", o, api.Scheme); err != nil {
 		t.Fatal(err)
@@ -186,11 +186,13 @@ func TestBindingWithExamples(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error getting PV from client: %v", err)
 	}
+	pv.ObjectMeta.SelfLink = testapi.Default.SelfLink("pv", "")
 
 	claim, error := client.PersistentVolumeClaims("ns").Get("any")
 	if error != nil {
 		t.Errorf("Unexpected error getting PVC from client: %v", err)
 	}
+	claim.ObjectMeta.SelfLink = testapi.Default.SelfLink("pvc", "")
 
 	volumeIndex := NewPersistentVolumeOrderedIndex()
 	mockClient := &mockBinderClient{
@@ -273,7 +275,6 @@ func TestBindingWithExamples(t *testing.T) {
 }
 
 func TestMissingFromIndex(t *testing.T) {
-	api.ForTesting_ReferencesAllowBlankSelfLinks = true
 	o := testclient.NewObjects(api.Scheme, api.Scheme)
 	if err := testclient.AddObjectsFromPath("../../../docs/user-guide/persistent-volumes/claims/claim-01.yaml", o, api.Scheme); err != nil {
 		t.Fatal(err)
@@ -289,11 +290,13 @@ func TestMissingFromIndex(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error getting PV from client: %v", err)
 	}
+	pv.ObjectMeta.SelfLink = testapi.Default.SelfLink("pv", "")
 
 	claim, error := client.PersistentVolumeClaims("ns").Get("any")
 	if error != nil {
 		t.Errorf("Unexpected error getting PVC from client: %v", err)
 	}
+	claim.ObjectMeta.SelfLink = testapi.Default.SelfLink("pvc", "")
 
 	volumeIndex := NewPersistentVolumeOrderedIndex()
 	mockClient := &mockBinderClient{

--- a/pkg/controller/replication/replication_controller_test.go
+++ b/pkg/controller/replication/replication_controller_test.go
@@ -39,10 +39,6 @@ import (
 
 var alwaysReady = func() bool { return true }
 
-func init() {
-	api.ForTesting_ReferencesAllowBlankSelfLinks = true
-}
-
 func getKey(rc *api.ReplicationController, t *testing.T) string {
 	if key, err := controller.KeyFunc(rc); err != nil {
 		t.Errorf("Unexpected error getting key for rc %v: %v", rc.Name, err)

--- a/pkg/kubectl/describe_test.go
+++ b/pkg/kubectl/describe_test.go
@@ -39,10 +39,6 @@ type describeClient struct {
 	client.Interface
 }
 
-func init() {
-	api.ForTesting_ReferencesAllowBlankSelfLinks = true
-}
-
 func TestDescribePod(t *testing.T) {
 	fake := testclient.NewSimpleFake(&api.Pod{
 		ObjectMeta: api.ObjectMeta{

--- a/pkg/kubelet/dockertools/manager_test.go
+++ b/pkg/kubelet/dockertools/manager_test.go
@@ -963,7 +963,6 @@ func TestSyncPodsDoesNothing(t *testing.T) {
 }
 
 func TestSyncPodWithPullPolicy(t *testing.T) {
-	api.ForTesting_ReferencesAllowBlankSelfLinks = true
 	dm, fakeDocker := newTestDockerManager()
 	puller := dm.dockerPuller.(*FakeDockerPuller)
 	puller.HasImages = []string{"existing_one", "want:latest"}

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -59,7 +59,6 @@ import (
 )
 
 func init() {
-	api.ForTesting_ReferencesAllowBlankSelfLinks = true
 	util.ReallyCrash = true
 }
 


### PR DESCRIPTION
Addresses issue #6596.
Removes ForTesting_ReferencesAllowBlankSelfLinks.
Fixes controller's persistentvolumes unit tests.
