### PR TITLE
kubelet: move PodManager and MirrorClient to a subpackage

### DIFF
--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/container"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/network"
+	kubepod "k8s.io/kubernetes/pkg/kubelet/pod"
 	"k8s.io/kubernetes/pkg/kubelet/prober"
 	"k8s.io/kubernetes/pkg/kubelet/status"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
@@ -80,7 +81,7 @@ type TestKubelet struct {
 	fakeRuntime      *kubecontainer.FakeRuntime
 	fakeCadvisor     *cadvisor.Mock
 	fakeKubeClient   *testclient.Fake
-	fakeMirrorClient *fakeMirrorClient
+	fakeMirrorClient *kubepod.FakeMirrorClient
 }
 
 func newTestKubelet(t *testing.T) *TestKubelet {
@@ -116,8 +117,8 @@ func newTestKubelet(t *testing.T) *TestKubelet {
 	kubelet.daemonEndpoints = &api.NodeDaemonEndpoints{}
 	mockCadvisor := &cadvisor.Mock{}
 	kubelet.cadvisor = mockCadvisor
-	podManager, fakeMirrorClient := newFakePodManager()
-	kubelet.podManager = podManager
+	fakeMirrorClient := kubepod.NewFakeMirrorClient()
+	kubelet.podManager = kubepod.NewBasicPodManager(fakeMirrorClient)
 	kubelet.containerRefManager = kubecontainer.NewRefManager()
 	diskSpaceManager, err := newDiskSpaceManager(mockCadvisor, DiskSpacePolicy{})
 	if err != nil {

--- a/pkg/kubelet/pod/manager_test.go
+++ b/pkg/kubelet/pod/manager_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubelet
+package pod
 
 import (
 	"reflect"
@@ -25,11 +25,10 @@ import (
 )
 
 // Stub out mirror client for testing purpose.
-func newFakePodManager() (*basicPodManager, *fakeMirrorClient) {
-	podManager := newBasicPodManager(nil)
-	fakeMirrorClient := newFakeMirrorClient()
-	podManager.mirrorClient = fakeMirrorClient
-	return podManager, fakeMirrorClient
+func newTestManager() (*basicManager, *FakeMirrorClient) {
+	fakeMirrorClient := NewFakeMirrorClient()
+	manager := NewBasicPodManager(fakeMirrorClient).(*basicManager)
+	return manager, fakeMirrorClient
 }
 
 // Tests that pods/maps are properly set after the pod update, and the basic
@@ -67,7 +66,7 @@ func TestGetSetPods(t *testing.T) {
 		staticPod,
 	}
 	updates := append(expectedPods, mirrorPod)
-	podManager, _ := newFakePodManager()
+	podManager, _ := newTestManager()
 	podManager.SetPods(updates)
 
 	// Tests that all regular pods are recorded corrrectly.

--- a/pkg/kubelet/pod/mirror_client_test.go
+++ b/pkg/kubelet/pod/mirror_client_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod
+
+import (
+	"testing"
+
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+)
+
+func TestParsePodFullName(t *testing.T) {
+	type nameTuple struct {
+		Name      string
+		Namespace string
+	}
+	successfulCases := map[string]nameTuple{
+		"bar_foo":         {Name: "bar", Namespace: "foo"},
+		"bar.org_foo.com": {Name: "bar.org", Namespace: "foo.com"},
+		"bar-bar_foo":     {Name: "bar-bar", Namespace: "foo"},
+	}
+	failedCases := []string{"barfoo", "bar_foo_foo", ""}
+
+	for podFullName, expected := range successfulCases {
+		name, namespace, err := kubecontainer.ParsePodFullName(podFullName)
+		if err != nil {
+			t.Errorf("unexpected error when parsing the full name: %v", err)
+			continue
+		}
+		if name != expected.Name || namespace != expected.Namespace {
+			t.Errorf("expected name %q, namespace %q; got name %q, namespace %q",
+				expected.Name, expected.Namespace, name, namespace)
+		}
+	}
+	for _, podFullName := range failedCases {
+		_, _, err := kubecontainer.ParsePodFullName(podFullName)
+		if err == nil {
+			t.Errorf("expected error when parsing the full name, got none")
+		}
+	}
+}

--- a/pkg/kubelet/runonce_test.go
+++ b/pkg/kubelet/runonce_test.go
@@ -26,14 +26,14 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cadvisor"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/network"
+	kubepod "k8s.io/kubernetes/pkg/kubelet/pod"
 	"k8s.io/kubernetes/pkg/kubelet/status"
 )
 
 func TestRunOnce(t *testing.T) {
 	cadvisor := &cadvisor.Mock{}
 	cadvisor.On("MachineInfo").Return(&cadvisorApi.MachineInfo{}, nil)
-
-	podManager, _ := newFakePodManager()
+	podManager := kubepod.NewBasicPodManager(kubepod.NewFakeMirrorClient())
 	diskSpaceManager, _ := newDiskSpaceManager(cadvisor, DiskSpacePolicy{})
 	fakeRuntime := &kubecontainer.FakeRuntime{}
 

--- a/pkg/kubelet/types/pod_update.go
+++ b/pkg/kubelet/types/pod_update.go
@@ -89,6 +89,16 @@ func GetValidatedSources(sources []string) ([]string, error) {
 	return validated, nil
 }
 
+// GetPodSource returns the source of the pod based on the annotation.
+func GetPodSource(pod *api.Pod) (string, error) {
+	if pod.Annotations != nil {
+		if source, ok := pod.Annotations[ConfigSourceAnnotationKey]; ok {
+			return source, nil
+		}
+	}
+	return "", fmt.Errorf("cannot get source of pod %q", pod.UID)
+}
+
 // SyncPodType classifies pod updates, eg: create, update.
 type SyncPodType int
 

--- a/pkg/kubelet/util.go
+++ b/pkg/kubelet/util.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/capabilities"
+	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/securitycontext"
 )
 
@@ -82,7 +83,7 @@ func canRunPod(pod *api.Pod) error {
 
 // Determined whether the specified pod is allowed to use host networking
 func allowHostNetwork(pod *api.Pod) (bool, error) {
-	podSource, err := getPodSource(pod)
+	podSource, err := kubetypes.GetPodSource(pod)
 	if err != nil {
 		return false, err
 	}
@@ -96,7 +97,7 @@ func allowHostNetwork(pod *api.Pod) (bool, error) {
 
 // Determined whether the specified pod is allowed to use host networking
 func allowHostPID(pod *api.Pod) (bool, error) {
-	podSource, err := getPodSource(pod)
+	podSource, err := kubetypes.GetPodSource(pod)
 	if err != nil {
 		return false, err
 	}
@@ -110,7 +111,7 @@ func allowHostPID(pod *api.Pod) (bool, error) {
 
 // Determined whether the specified pod is allowed to use host ipc
 func allowHostIPC(pod *api.Pod) (bool, error) {
-	podSource, err := getPodSource(pod)
+	podSource, err := kubetypes.GetPodSource(pod)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
This change moves pod_manager.go and mirror_client.go to a separate package.
Also made necessary, minor changes to facilitate testing.
