### PR TITLE
Fix service-loadbalancer e2e tests

### DIFF
--- a/test/e2e/testing-manifests/haproxyrc.yaml
+++ b/test/e2e/testing-manifests/haproxyrc.yaml
@@ -16,8 +16,6 @@ spec:
         app: service-loadbalancer
         version: v1
     spec:
-      nodeSelector:
-        role: loadbalancer
       containers:
       - image: gcr.io/google_containers/servicelb:0.1
         imagePullPolicy: Always

--- a/test/e2e/testing-manifests/netexecrc.yaml
+++ b/test/e2e/testing-manifests/netexecrc.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: netexec
+spec:
+  # Assumes you have 3 nodes in your cluster.
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: netexec
+    spec:
+      containers:
+      - name: netexec
+        image: gcr.io/google_containers/netexec:1.0
+        ports:
+        - containerPort: 8080
+          # This is to force these pods to land on different hosts.
+          # TODO: use the downward api and get podname instead.
+          hostPort: 81

--- a/test/e2e/testing-manifests/netexecsvc.yaml
+++ b/test/e2e/testing-manifests/netexecsvc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: netexec
+  labels:
+    app: netexec
+spec:
+  Type: NodePort
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  selector:
+    app: netexec


### PR DESCRIPTION
```
old-mbp:kubernetes aledbf$ ./hack/ginkgo-e2e.sh --ginkgo.focus=ServiceLoadBalancer.*
Setting up for KUBERNETES_PROVIDER="gce".
Project: supple-lattice-109620
Zone: us-central1-b
>>> testContext.KubeConfig: /Users/aledbf/.kube/config
Oct 12 21:25:01.621: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
Oct 12 21:25:02.816: INFO: 10 / 10 pods in namespace 'kube-system' are running and ready (1 seconds elapsed)
Oct 12 21:25:02.816: INFO: expected 7 pod replicas in namespace 'kube-system', 7 are Running and Ready.
Running Suite: Kubernetes e2e suite
===================================
Random Seed: 1444695901 - Will randomize all specs
Will run 1 of 190 specs

SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
ServiceLoadBalancer
  should support simple GET on Ingress ips
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/serviceloadbalancers.go:244
[BeforeEach] ServiceLoadBalancer
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/serviceloadbalancers.go:220
STEP: Creating a kubernetes client
>>> testContext.KubeConfig: /Users/aledbf/.kube/config
STEP: Building a namespace api object
Oct 12 21:25:03.042: INFO: Waiting up to 2m0s for service account default to be provisioned in ns e2e-tests-servicelb-u4pw5
Oct 12 21:25:03.854: INFO: Service account default in ns e2e-tests-servicelb-u4pw5 with secrets found. (812.272384ms)
STEP: Waiting for a default service account to be provisioned in namespace
Oct 12 21:25:03.854: INFO: Waiting up to 2m0s for service account default to be provisioned in ns e2e-tests-servicelb-u4pw5
Oct 12 21:25:04.029: INFO: Service account default in ns e2e-tests-servicelb-u4pw5 with secrets found. (175.151631ms)
[It] should support simple GET on Ingress ips
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/serviceloadbalancers.go:244
STEP: Starting loadbalancer controller haproxy in namespace e2e-tests-servicelb-u4pw5
Oct 12 21:25:04.029: INFO: Parsing rc from /Users/aledbf/go/src/k8s.io/kubernetes/test/e2e/testing-manifests/haproxyrc.yaml
Oct 12 21:25:04.030: INFO: Container args [--tcp-services=mysql:3306,nginxsvc:443 --namespace=e2e-tests-servicelb-u4pw5]
STEP: Starting ingress manager netexec in namespace e2e-tests-servicelb-u4pw5
Oct 12 21:25:06.129: INFO: Parsing rc from /Users/aledbf/go/src/k8s.io/kubernetes/test/e2e/testing-manifests/netexecrc.yaml
Oct 12 21:25:06.312: INFO: Parsing service from /Users/aledbf/go/src/k8s.io/kubernetes/test/e2e/testing-manifests/netexecsvc.yaml
Oct 12 21:25:07.057: INFO: Testing path http://104.197.37.74/netexec
[AfterEach] ServiceLoadBalancer
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/serviceloadbalancers.go:224
Oct 12 21:25:09.168: INFO: Waiting up to 1m0s for all nodes to be ready
Oct 12 21:25:09.357: INFO: Node e2e-test-aledbf-minion-81hn condition 1/1: type: Ready, status: True, reason: "KubeletReady", message: "kubelet is posting ready status", last transition time: 2015-10-12 21:16:16 -0300 CLT
Oct 12 21:25:09.357: INFO: Successfully found node e2e-test-aledbf-minion-81hn readiness to be true
Oct 12 21:25:09.357: INFO: Node e2e-test-aledbf-minion-9hbg condition 1/1: type: Ready, status: True, reason: "KubeletReady", message: "kubelet is posting ready status", last transition time: 2015-10-12 21:16:04 -0300 CLT
Oct 12 21:25:09.357: INFO: Successfully found node e2e-test-aledbf-minion-9hbg readiness to be true
Oct 12 21:25:09.357: INFO: Node e2e-test-aledbf-minion-zccd condition 1/1: type: Ready, status: True, reason: "KubeletReady", message: "kubelet is posting ready status", last transition time: 2015-10-12 21:16:06 -0300 CLT
Oct 12 21:25:09.357: INFO: Successfully found node e2e-test-aledbf-minion-zccd readiness to be true
STEP: Destroying namespace "e2e-tests-servicelb-u4pw5" for this suite.

• [SLOW TEST:12.284 seconds]
ServiceLoadBalancer
/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/serviceloadbalancers.go:245
  should support simple GET on Ingress ips
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/serviceloadbalancers.go:244
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
Ran 1 of 190 Specs in 12.285 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 189 Skipped PASS

Ginkgo ran 1 suite in 13.660391625s
Test Suite Passed
```
