### PR TITLE
fix jobname for kubernetes-e2e-gce-release-1.1

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -401,7 +401,7 @@ case ${JOB_NAME} in
   # sequentially. As a reminder, if you need to change the skip list
   # or flaky test list on the release branch, you'll need to propose a
   # pull request directly to the release branch itself.
-  kubernetes-e2e-gce-rc)
+  kubernetes-e2e-gce-release-1.1)
     : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-release-1.1"}
     : ${E2E_DOWN:="false"}
     : ${E2E_NETWORK:="gce-e2e-1-1"}


### PR DESCRIPTION
Of course, I would forget the most important thing to fix in the rename... the job name itself.

Verified this time, the job is currently running the script from this pr branch.

@k8s-oncall please merge on green.
