### PR TITLE
enhance upstart param for containerized kubelet

### DIFF
--- a/docs/getting-started-guides/docker-multinode/master.md
+++ b/docs/getting-started-guides/docker-multinode/master.md
@@ -164,7 +164,7 @@ sudo docker run \
     --volume=/:/rootfs:ro \
     --volume=/sys:/sys:ro \
     --volume=/dev:/dev \
-    --volume=/var/lib/docker/:/var/lib/docker:ro \
+    --volume=/var/lib/docker/:/var/lib/docker:rw \
     --volume=/var/lib/kubelet/:/var/lib/kubelet:rw \
     --volume=/var/run:/var/run:rw \
     --net=host \

--- a/docs/getting-started-guides/docker-multinode/master.md
+++ b/docs/getting-started-guides/docker-multinode/master.md
@@ -160,7 +160,18 @@ systemctl start docker
 Ok, now that your networking is set up, you can startup Kubernetes, this is the same as the single-node case, we will use the "main" instance of the Docker daemon for the Kubernetes components.
 
 ```sh
-sudo docker run --net=host -d -v /var/run/docker.sock:/var/run/docker.sock  gcr.io/google_containers/hyperkube:v1.0.1 /hyperkube kubelet --api-servers=http://localhost:8080 --v=2 --address=0.0.0.0 --enable-server --hostname-override=127.0.0.1 --config=/etc/kubernetes/manifests-multi --cluster-dns=10.0.0.10 --cluster-domain=cluster.local
+sudo docker run \
+    --volume=/:/rootfs:ro \
+    --volume=/sys:/sys:ro \
+    --volume=/dev:/dev \
+    --volume=/var/lib/docker/:/var/lib/docker:ro \
+    --volume=/var/lib/kubelet/:/var/lib/kubelet:rw \
+    --volume=/var/run:/var/run:rw \
+    --net=host \
+    --privileged=true \
+    --pid=host \ 
+    -d \
+    gcr.io/google_containers/hyperkube:v1.0.1 /hyperkube kubelet --api-servers=http://localhost:8080 --v=2 --address=0.0.0.0 --enable-server --hostname-override=127.0.0.1 --config=/etc/kubernetes/manifests-multi --cluster-dns=10.0.0.10 --cluster-domain=cluster.local
 ```
 
 > Note that `--cluster-dns` and `--cluster-domain` is used to deploy dns, feel free to discard them if dns is not needed.

--- a/docs/getting-started-guides/docker-multinode/master.sh
+++ b/docs/getting-started-guides/docker-multinode/master.sh
@@ -149,6 +149,7 @@ start_k8s(){
     # Start kubelet & proxy, then start master components as pods
     docker run \
         --net=host \
+        --pid=host \
         --privileged \
         --restart=always \
         -d \

--- a/docs/getting-started-guides/docker-multinode/worker.md
+++ b/docs/getting-started-guides/docker-multinode/worker.md
@@ -150,7 +150,7 @@ sudo docker run \
     --volume=/:/rootfs:ro \
     --volume=/sys:/sys:ro \
     --volume=/dev:/dev \
-    --volume=/var/lib/docker/:/var/lib/docker:ro \
+    --volume=/var/lib/docker/:/var/lib/docker:rw \
     --volume=/var/lib/kubelet/:/var/lib/kubelet:rw \
     --volume=/var/run:/var/run:rw \
     --net=host \

--- a/docs/getting-started-guides/docker-multinode/worker.md
+++ b/docs/getting-started-guides/docker-multinode/worker.md
@@ -146,7 +146,18 @@ systemctl start docker
 Again this is similar to the above, but the `--api-servers` now points to the master we set up in the beginning.
 
 ```sh
-sudo docker run --net=host -d -v /var/run/docker.sock:/var/run/docker.sock  gcr.io/google_containers/hyperkube:v1.0.1 /hyperkube kubelet --api-servers=http://${MASTER_IP}:8080 --v=2 --address=0.0.0.0 --enable-server --hostname-override=$(hostname -i) --cluster-dns=10.0.0.10 --cluster-domain=cluster.local
+sudo docker run \
+    --volume=/:/rootfs:ro \
+    --volume=/sys:/sys:ro \
+    --volume=/dev:/dev \
+    --volume=/var/lib/docker/:/var/lib/docker:ro \
+    --volume=/var/lib/kubelet/:/var/lib/kubelet:rw \
+    --volume=/var/run:/var/run:rw \
+    --net=host \
+    --privileged=true \
+    --pid=host \ 
+    -d \
+    gcr.io/google_containers/hyperkube:v1.0.1 /hyperkube kubelet --api-servers=http://${MASTER_IP}:8080 --v=2 --address=0.0.0.0 --enable-server --hostname-override=$(hostname -i) --cluster-dns=10.0.0.10 --cluster-domain=cluster.local
 ```
 
 #### Run the service proxy

--- a/docs/getting-started-guides/docker-multinode/worker.sh
+++ b/docs/getting-started-guides/docker-multinode/worker.sh
@@ -151,6 +151,7 @@ start_k8s() {
     # Start kubelet & proxy in container
     docker run \
         --net=host \
+        --pid=host \
         --privileged \
         --restart=always \
         -d \

--- a/docs/getting-started-guides/docker.md
+++ b/docs/getting-started-guides/docker.md
@@ -100,6 +100,7 @@ docker run \
     --volume=/var/lib/kubelet/:/var/lib/kubelet:rw \
     --volume=/var/run:/var/run:rw \
     --net=host \
+    --pid=host \ 
     --privileged=true \
     -d \
     gcr.io/google_containers/hyperkube:v1.0.6 \


### PR DESCRIPTION
- It was @fgrzadkowski 's idea to add a param `pid=host`, which aims to access namespace of other process on the host for kubelet. Fix #14269 and #14402. 
- Keep consistent among the documents and scripts
