### PR TITLE
Removing explicit docker start

### DIFF
--- a/docs/getting-started-guides/coreos/cloud-configs/master.yaml
+++ b/docs/getting-started-guides/coreos/cloud-configs/master.yaml
@@ -69,8 +69,6 @@ coreos:
             Requires=etcd2.service
             [Service]
             ExecStartPre=/usr/bin/etcdctl set /coreos.com/network/config '{"Network":"10.244.0.0/16", "Backend": {"Type": "vxlan"}}'
-    - name: docker.service
-      command: start
     - name: kube-apiserver.service
       command: start
       content: |

--- a/docs/getting-started-guides/coreos/cloud-configs/node.yaml
+++ b/docs/getting-started-guides/coreos/cloud-configs/node.yaml
@@ -29,8 +29,6 @@ coreos:
             Requires=etcd2.service
             [Service]
             ExecStartPre=/usr/bin/etcdctl set /coreos.com/network/config '{"Network":"10.244.0.0/16", "Backend": {"Type": "vxlan"}}'
-    - name: docker.service
-      command: start
     - name: setup-network-environment.service
       command: start
       content: |


### PR DESCRIPTION
Fixing #15545. Explicit docker start was removed in getting started guides.
