### PR TITLE
iscsi: if port is not provided, use default 3260 for target portal

### DIFF
--- a/pkg/volume/iscsi/iscsi.go
+++ b/pkg/volume/iscsi/iscsi.go
@@ -95,10 +95,7 @@ func (plugin *iscsiPlugin) newBuilderInternal(spec *volume.Spec, podUID types.UI
 	}
 
 	lun := strconv.Itoa(iscsi.Lun)
-	portal := iscsi.TargetPortal
-	if !strings.Contains(portal, ":") {
-		portal = iscsi.TargetPortal + ":3260"
-	}
+	portal := portalBuilder(iscsi.TargetPortal)
 
 	return &iscsiDiskBuilder{
 		iscsiDisk: &iscsiDisk{
@@ -192,4 +189,11 @@ func (c *iscsiDiskCleaner) TearDown() error {
 
 func (c *iscsiDiskCleaner) TearDownAt(dir string) error {
 	return diskTearDown(c.manager, *c, dir, c.mounter)
+}
+
+func portalBuilder(portal string) string {
+	if !strings.Contains(portal, ":") {
+		portal = portal + ":3260"
+	}
+	return portal
 }

--- a/pkg/volume/iscsi/iscsi.go
+++ b/pkg/volume/iscsi/iscsi.go
@@ -18,6 +18,7 @@ package iscsi
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
@@ -94,12 +95,16 @@ func (plugin *iscsiPlugin) newBuilderInternal(spec *volume.Spec, podUID types.UI
 	}
 
 	lun := strconv.Itoa(iscsi.Lun)
+	portal := iscsi.TargetPortal
+	if !strings.Contains(portal, ":") {
+		portal = iscsi.TargetPortal + ":3260"
+	}
 
 	return &iscsiDiskBuilder{
 		iscsiDisk: &iscsiDisk{
 			podUID:  podUID,
 			volName: spec.Name(),
-			portal:  iscsi.TargetPortal,
+			portal:  portal,
 			iqn:     iscsi.IQN,
 			lun:     lun,
 			manager: manager,

--- a/pkg/volume/iscsi/iscsi.go
+++ b/pkg/volume/iscsi/iscsi.go
@@ -108,7 +108,7 @@ func (plugin *iscsiPlugin) newBuilderInternal(spec *volume.Spec, podUID types.UI
 			iqn:     iscsi.IQN,
 			lun:     lun,
 			manager: manager,
-			mounter: mounter,
+			mounter: &mount.SafeFormatAndMount{mounter, exec.New()},
 			plugin:  plugin},
 		fsType:   iscsi.FSType,
 		readOnly: readOnly,

--- a/pkg/volume/iscsi/iscsi_test.go
+++ b/pkg/volume/iscsi/iscsi_test.go
@@ -250,3 +250,12 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 		t.Errorf("Expected true for builder.IsReadOnly")
 	}
 }
+
+func TestPortalBuilder(t *testing.T) {
+	if portal := portalBuilder("127.0.0.1"); portal != "127.0.0.1:3260" {
+		t.Errorf("wrong portal: %s", portal)
+	}
+	if portal := portalBuilder("127.0.0.1:3260"); portal != "127.0.0.1:3260" {
+		t.Errorf("wrong portal: %s", portal)
+	}
+}


### PR DESCRIPTION
this is to fix #15501 
