### PR TITLE
promote simple daemonset test out of flaky

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -109,7 +109,7 @@ GKE_REQUIRED_SKIP_TESTS=(
     "Nodes"
     "Etcd\sFailure"
     "MasterCerts"
-    "Daemon\sset"
+    "Daemon\sset\sshould\srun\sand\sstop\scomplex\sdaemon"
     "Deployment"
     "experimental\sresource\susage\stracking" # Expect --max-pods=100
     "Shell"


### PR DESCRIPTION
This unmatches 'Daemon set should run and stop simple daemon'
