### PR TITLE
Simplify and fix the e2e logic for checking an external load balancer.

### DIFF
--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -532,20 +532,12 @@ var _ = Describe("Services", func() {
 		testNotReachable(ip, nodePort1)
 
 		By("hitting the pod through the service's LoadBalancer")
-		i := 1
-		for start := time.Now(); time.Since(start) < podStartTimeout; time.Sleep(3 * time.Second) {
-			service, err = waitForLoadBalancerIngress(f.Client, serviceName, f.Namespace.Name)
-			Expect(err).NotTo(HaveOccurred())
+		service, err = waitForLoadBalancerIngress(f.Client, serviceName, f.Namespace.Name)
+		Expect(err).NotTo(HaveOccurred())
 
-			ingress2 := service.Status.LoadBalancer.Ingress[0]
-			if testLoadBalancerReachableInTime(ingress2, 80, 5*time.Second) {
-				break
-			}
-
-			if i%5 == 0 {
-				Logf("Waiting for load-balancer changes (%v elapsed, will retry)", time.Since(start))
-			}
-			i++
+		ingress2 := service.Status.LoadBalancer.Ingress[0]
+		if !testLoadBalancerReachable(ingress2, 80) {
+			Failf("Failed to reach load balancer at ingress: %+v", service)
 		}
 
 		By("changing service " + serviceName + " back to type=ClusterIP")


### PR DESCRIPTION
@thockin - you updated this a couple weeks ago, and it looks funny to me. Maybe I'm crazy though, so take a second look for me.

It looks like the old looping code:
1. Polls for up to podStartTimeout (5 minutes), even though waitForLoadBalancerIngress waits for up to 20 minutes, meaning it's likely to only ever loop once
2. Never actually fails if testLoadBalancerReachableInTime never succeeds. The loop just exits and goes on its merry way, never failing the test.

The simplified version simply waits for the load balancer IP to appear, failing if it doesn't, then waits for the load balancer to be reachable, failing if it doesn't.
