### PR TITLE
handling extension api in libvirt_coreos

### DIFF
--- a/cluster/libvirt-coreos/user_data_master.yml
+++ b/cluster/libvirt-coreos/user_data_master.yml
@@ -18,6 +18,7 @@ coreos:
         --insecure-port=8080 \
         --etcd-servers=http://127.0.0.1:2379 \
         --kubelet-port=10250 \
+        --runtime-config=${API_VERSION} \
         --service-cluster-ip-range=${SERVICE_CLUSTER_IP_RANGE}
         Restart=always
         RestartSec=2

--- a/cluster/libvirt-coreos/util.sh
+++ b/cluster/libvirt-coreos/util.sh
@@ -51,6 +51,16 @@ function detect-minions {
   KUBE_MINION_IP_ADDRESSES=("${MINION_IPS[@]}")
 }
 
+# Creates apiserver parameter for apis extension support.
+# If RUNTIME_CONFIG contains extensions/v1beta1 modify parameter for api-server
+RUNTIME_CONFIG=${RUNTIME_CONFIG:-""}
+function detect-api-extension {
+    API_VERSION="api/v1"
+    if [[ $RUNTIME_CONFIG = *extensions/v1beta1* ]]; then
+        API_VERSION="extensions/v1beta1"
+    fi
+}
+
 # Verify prereqs on host machine
 function verify-prereqs {
   if ! which virsh >/dev/null; then
@@ -181,6 +191,7 @@ function wait-cluster-readiness {
 
 # Instantiate a kubernetes cluster
 function kube-up {
+  detect-api-extension
   detect-master
   detect-minions
   gen-kube-bearertoken

--- a/docs/user-guide/jobs.md
+++ b/docs/user-guide/jobs.md
@@ -243,7 +243,7 @@ value is `Always`.)
 
 Job is part of the experimental API group, so it is not subject to the same compatibility
 guarantees as objects in the main API.  It may not be enabled.  Enable by setting
-`--runtime-config=experimental/v1alpha1` on the apiserver.
+`--runtime-config=extensions/v1beta1` on the apiserver.
 
 ## Future work
 


### PR DESCRIPTION
goal of this PR is to add support for api extensions in libvirt_coreos cluster.
`runtime-config` support is added to `kube-server`.
Controller doesn't need `--enable-experimental` since https://github.com/kubernetes/kubernetes/pull/15427 is landing as reported by @mikedanese  in https://github.com/kubernetes/kubernetes/pull/15544.
@lhuard1A thanksk to have a look 
@zmerlynn 
