### PR TITLE
Fix race condition for consuming podIP via downward API.

### DIFF
--- a/pkg/kubelet/dockertools/manager_test.go
+++ b/pkg/kubelet/dockertools/manager_test.go
@@ -2059,3 +2059,61 @@ func TestGetIPCMode(t *testing.T) {
 		t.Errorf("expected host ipc mode for pod but got %v", ipcMode)
 	}
 }
+
+func TestPodDependsOnPodIP(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected bool
+		env      api.EnvVar
+	}{
+		{
+			name:     "depends on pod IP",
+			expected: true,
+			env: api.EnvVar{
+				Name: "POD_IP",
+				ValueFrom: &api.EnvVarSource{
+					FieldRef: &api.ObjectFieldSelector{
+						APIVersion: testapi.Default.Version(),
+						FieldPath:  "status.podIP",
+					},
+				},
+			},
+		},
+		{
+			name:     "literal value",
+			expected: false,
+			env: api.EnvVar{
+				Name:  "SOME_VAR",
+				Value: "foo",
+			},
+		},
+		{
+			name:     "other downward api field",
+			expected: false,
+			env: api.EnvVar{
+				Name: "POD_NAME",
+				ValueFrom: &api.EnvVarSource{
+					FieldRef: &api.ObjectFieldSelector{
+						APIVersion: testapi.Default.Version(),
+						FieldPath:  "metadata.name",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		pod := &api.Pod{
+			Spec: api.PodSpec{
+				Containers: []api.Container{
+					{Env: []api.EnvVar{tc.env}},
+				},
+			},
+		}
+
+		result := podDependsOnPodIP(pod)
+		if e, a := tc.expected, result; e != a {
+			t.Errorf("%v: Unexpected result; expected %v, got %v", tc.name, e, a)
+		}
+	}
+}

--- a/test/e2e/docker_containers.go
+++ b/test/e2e/docker_containers.go
@@ -47,7 +47,7 @@ var _ = Describe("Docker Containers", func() {
 	})
 
 	It("should use the image defaults if command and args are blank [Conformance]", func() {
-		testContainerOutputInNamespace("use defaults", c, entrypointTestPod(), 0, []string{
+		testContainerOutput("use defaults", c, entrypointTestPod(), 0, []string{
 			"[/ep default arguments]",
 		}, ns)
 	})
@@ -56,7 +56,7 @@ var _ = Describe("Docker Containers", func() {
 		pod := entrypointTestPod()
 		pod.Spec.Containers[0].Args = []string{"override", "arguments"}
 
-		testContainerOutputInNamespace("override arguments", c, pod, 0, []string{
+		testContainerOutput("override arguments", c, pod, 0, []string{
 			"[/ep override arguments]",
 		}, ns)
 	})
@@ -67,7 +67,7 @@ var _ = Describe("Docker Containers", func() {
 		pod := entrypointTestPod()
 		pod.Spec.Containers[0].Command = []string{"/ep-2"}
 
-		testContainerOutputInNamespace("override command", c, pod, 0, []string{
+		testContainerOutput("override command", c, pod, 0, []string{
 			"[/ep-2]",
 		}, ns)
 	})
@@ -77,7 +77,7 @@ var _ = Describe("Docker Containers", func() {
 		pod.Spec.Containers[0].Command = []string{"/ep-2"}
 		pod.Spec.Containers[0].Args = []string{"override", "arguments"}
 
-		testContainerOutputInNamespace("override all", c, pod, 0, []string{
+		testContainerOutput("override all", c, pod, 0, []string{
 			"[/ep-2 override arguments]",
 		}, ns)
 	})

--- a/test/e2e/downward_api.go
+++ b/test/e2e/downward_api.go
@@ -30,46 +30,75 @@ var _ = Describe("Downward API", func() {
 
 	It("should provide pod name and namespace as env vars [Conformance]", func() {
 		podName := "downward-api-" + string(util.NewUUID())
-		pod := &api.Pod{
-			ObjectMeta: api.ObjectMeta{
-				Name:   podName,
-				Labels: map[string]string{"name": podName},
-			},
-			Spec: api.PodSpec{
-				Containers: []api.Container{
-					{
-						Name:    "dapi-container",
-						Image:   "gcr.io/google_containers/busybox",
-						Command: []string{"sh", "-c", "env"},
-						Env: []api.EnvVar{
-							{
-								Name: "POD_NAME",
-								ValueFrom: &api.EnvVarSource{
-									FieldRef: &api.ObjectFieldSelector{
-										APIVersion: "v1",
-										FieldPath:  "metadata.name",
-									},
-								},
-							},
-							{
-								Name: "POD_NAMESPACE",
-								ValueFrom: &api.EnvVarSource{
-									FieldRef: &api.ObjectFieldSelector{
-										APIVersion: "v1",
-										FieldPath:  "metadata.namespace",
-									},
-								},
-							},
-						},
+		env := []api.EnvVar{
+			{
+				Name: "POD_NAME",
+				ValueFrom: &api.EnvVarSource{
+					FieldRef: &api.ObjectFieldSelector{
+						APIVersion: "v1",
+						FieldPath:  "metadata.name",
 					},
 				},
-				RestartPolicy: api.RestartPolicyNever,
+			},
+			{
+				Name: "POD_NAMESPACE",
+				ValueFrom: &api.EnvVarSource{
+					FieldRef: &api.ObjectFieldSelector{
+						APIVersion: "v1",
+						FieldPath:  "metadata.namespace",
+					},
+				},
 			},
 		}
 
-		framework.TestContainerOutput("downward api env vars", pod, 0, []string{
+		expectations := []string{
 			fmt.Sprintf("POD_NAME=%v", podName),
 			fmt.Sprintf("POD_NAMESPACE=%v", framework.Namespace.Name),
-		})
+		}
+
+		testDownwardAPI(framework, podName, env, expectations)
+	})
+
+	It("should provide pod IP as an env var", func() {
+		podName := "downward-api-" + string(util.NewUUID())
+		env := []api.EnvVar{
+			{
+				Name: "POD_IP",
+				ValueFrom: &api.EnvVarSource{
+					FieldRef: &api.ObjectFieldSelector{
+						APIVersion: "v1",
+						FieldPath:  "status.podIP",
+					},
+				},
+			},
+		}
+
+		expectations := []string{
+			"POD_IP=(?:\\d+)\\.(?:\\d+)\\.(?:\\d+)\\.(?:\\d+)",
+		}
+
+		testDownwardAPI(framework, podName, env, expectations)
 	})
 })
+
+func testDownwardAPI(framework *Framework, podName string, env []api.EnvVar, expectations []string) {
+	pod := &api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Name:   podName,
+			Labels: map[string]string{"name": podName},
+		},
+		Spec: api.PodSpec{
+			Containers: []api.Container{
+				{
+					Name:    "dapi-container",
+					Image:   "gcr.io/google_containers/busybox",
+					Command: []string{"sh", "-c", "env"},
+					Env:     env,
+				},
+			},
+			RestartPolicy: api.RestartPolicyNever,
+		},
+	}
+
+	framework.TestContainerOutputRegexp("downward api env vars", pod, 0, expectations)
+}

--- a/test/e2e/downwardapi_volume.go
+++ b/test/e2e/downwardapi_volume.go
@@ -86,7 +86,7 @@ var _ = Describe("Downward API volume", func() {
 				RestartPolicy: api.RestartPolicyNever,
 			},
 		}
-		testContainerOutputInNamespace("downward API volume plugin", f.Client, pod, 0, []string{
+		testContainerOutput("downward API volume plugin", f.Client, pod, 0, []string{
 			fmt.Sprintf("cluster=\"rack10\"\n"),
 			fmt.Sprintf("builder=\"john-doe\"\n"),
 			fmt.Sprintf("%s\n", podName),

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -121,7 +121,12 @@ func (f *Framework) WaitForPodRunning(podName string) error {
 
 // Runs the given pod and verifies that the output of exact container matches the desired output.
 func (f *Framework) TestContainerOutput(scenarioName string, pod *api.Pod, containerIndex int, expectedOutput []string) {
-	testContainerOutputInNamespace(scenarioName, f.Client, pod, containerIndex, expectedOutput, f.Namespace.Name)
+	testContainerOutput(scenarioName, f.Client, pod, containerIndex, expectedOutput, f.Namespace.Name)
+}
+
+// Runs the given pod and verifies that the output of exact container matches the desired regexps.
+func (f *Framework) TestContainerOutputRegexp(scenarioName string, pod *api.Pod, containerIndex int, expectedOutput []string) {
+	testContainerOutputRegexp(scenarioName, f.Client, pod, containerIndex, expectedOutput, f.Namespace.Name)
 }
 
 // WaitForAnEndpoint waits for at least one endpoint to become available in the

--- a/test/e2e/host_path.go
+++ b/test/e2e/host_path.go
@@ -70,7 +70,7 @@ var _ = Describe("hostPath", func() {
 			fmt.Sprintf("--fs_type=%v", volumePath),
 			fmt.Sprintf("--file_mode=%v", volumePath),
 		}
-		testContainerOutputInNamespace("hostPath mode", c, pod, 0, []string{
+		testContainerOutput("hostPath mode", c, pod, 0, []string{
 			"mode of file \"/test-volume\": dtrwxrwxrwx", // we expect the sticky bit (mode flag t) to be set for the dir
 		},
 			namespace.Name)
@@ -96,7 +96,7 @@ var _ = Describe("hostPath", func() {
 		}
 		//Read the content of the file with the second container to
 		//verify volumes  being shared properly among continers within the pod.
-		testContainerOutputInNamespace("hostPath r/w", c, pod, 1, []string{
+		testContainerOutput("hostPath r/w", c, pod, 1, []string{
 			"content of file \"/test-volume/test-file\": mount-tester new file",
 		}, namespace.Name,
 		)

--- a/test/e2e/secrets.go
+++ b/test/e2e/secrets.go
@@ -92,7 +92,7 @@ var _ = Describe("Secrets", func() {
 			},
 		}
 
-		testContainerOutputInNamespace("consume secrets", f.Client, pod, 0, []string{
+		testContainerOutput("consume secrets", f.Client, pod, 0, []string{
 			"content of file \"/etc/secret-volume/data-1\": value-1",
 			"mode of file \"/etc/secret-volume/data-1\": -r--r--r--",
 		}, f.Namespace.Name)


### PR DESCRIPTION
Replaces #13052, which was reverted. In researching the slowdowns that occurred after that PR was merged, it turns out that podInfraContainerIP was being shadowed and lost, resulting in every container (other than the infra container) to fail to start with e.g. `Cannot start container dcb2eaeffadf7298dc3e8e77aee7ea2432e8a3bd978e68cb6c4f638b58822d26: Prefix can't be empty`. This is because the call to start the container with `--net=container:<infra container ID>` ended up getting `--net=container:` (no container ID). The next time the Kubelet's sync loop happened (i.e. by default every 10 seconds), it was able to find the infra container's ID, and use that when starting the other containers in the pod. The net result was an ~ 10 second delay before a pod could transition to Running and Ready.

@thockin @smarterclayton @pmorie @ashcrow @wojtek-t @mwielgus 
