### PR TITLE
New SkyDNS build (Oct 13, 2015, 8c72f8c). 

### DIFF
--- a/cluster/addons/dns/skydns-rc.yaml.in
+++ b/cluster/addons/dns/skydns-rc.yaml.in
@@ -49,7 +49,7 @@ spec:
         # command = "/kube2sky"
         - -domain={{ pillar['dns_domain'] }}
       - name: skydns
-        image: gcr.io/google_containers/skydns:2015-03-11-001
+        image: gcr.io/google_containers/skydns:2015-10-13-8c72f8c
         resources:
           limits:
             cpu: 100m
@@ -58,7 +58,7 @@ spec:
         # command = "/skydns"
         - -machines=http://localhost:4001
         - -addr=0.0.0.0:53
-        - -rtimeout=1s
+        - -ns-rotate=false
         - -domain={{ pillar['dns_domain'] }}.
         ports:
         - containerPort: 53


### PR DESCRIPTION
New SkyDNS build (Oct 13, 2015, 8c72f8c).
1.Set ns-rotate to false. 
2. rtimeout is now defaulting to 2 seconds.
3. SkyDNS container includes its sources in /skydns_sources.tar.gz

Fixes:
https://github.com/kubernetes/kubernetes/issues/15303
https://github.com/kubernetes/kubernetes/issues/14807

@thockin 
