### PR TITLE
Deployment e2e flake: Wait for events to be generated before verifying them

### DIFF
--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -255,6 +255,7 @@ func testRollingUpdateDeploymentEvents(f *Framework) {
 	// Verify that the pods were scaled up and down as expected. We use events to verify that.
 	deployment, err := c.Deployments(ns).Get(deploymentName)
 	Expect(err).NotTo(HaveOccurred())
+	waitForEvents(c, ns, deployment, 2)
 	events, err := c.Events(ns).Search(deployment)
 	if err != nil {
 		Logf("error in listing events: %s", err)

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1631,6 +1631,25 @@ func waitForDeploymentStatus(c *client.Client, ns, deploymentName string, desire
 	})
 }
 
+// Waits for the number of events on the given object to reach a desired count.
+func waitForEvents(c *client.Client, ns string, objOrRef runtime.Object, desiredEventsCount int) error {
+	return wait.Poll(poll, 5*time.Minute, func() (bool, error) {
+		events, err := c.Events(ns).Search(objOrRef)
+		if err != nil {
+			return false, fmt.Errorf("error in listing events: %s", err)
+		}
+		eventsCount := len(events.Items)
+		if eventsCount == desiredEventsCount {
+			return true, nil
+		}
+		if eventsCount < desiredEventsCount {
+			return false, nil
+		}
+		// Number of events has exceeded the desired count.
+		return false, fmt.Errorf("number of events has exceeded the desired count, eventsCount: %d, desiredCount: %d", eventsCount, desiredEventsCount)
+	})
+}
+
 // Convenient wrapper around listing nodes supporting retries.
 func listNodes(c *client.Client, label labels.Selector, field fields.Selector) (*api.NodeList, error) {
 	var nodes *api.NodeList


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/15369

Fixing the code to wait for the desired number of events to be generated, before starting to verify them.
Previously, we started verifying events as soon as the number of replicas reached the desired numbers. 
This resulted in a race condition where we could start verifying the events when the controller has set the desired replica size but hasnt generated an event for it yet.

cc @ironcladlou 
