### PR TITLE
Renaming experiments to extensions in release branch

### DIFF
--- a/pkg/controller/deployment/deployment_controller_test.go
+++ b/pkg/controller/deployment/deployment_controller_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
-	exp "k8s.io/kubernetes/pkg/apis/experimental"
+	exp "k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/client/record"
 	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
 	"k8s.io/kubernetes/pkg/runtime"


### PR DESCRIPTION
Fixing release branch breakage caused by merge conflict in merging https://github.com/kubernetes/kubernetes/pull/15388. That PR imported apis/experimental while https://github.com/kubernetes/kubernetes/pull/15503 changed it to apis/extensions in the meantime.

Note that this PR directly changes the release branch.

cc @caesarxuchao @lavalamp 
