### PR TITLE
Alias local packagename for pkg/util/errors

### DIFF
--- a/pkg/admission/errors.go
+++ b/pkg/admission/errors.go
@@ -19,7 +19,7 @@ package admission
 import (
 	"k8s.io/kubernetes/pkg/api"
 	apierrors "k8s.io/kubernetes/pkg/api/errors"
-	errs "k8s.io/kubernetes/pkg/util/errors"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 )
 
 func extractKindName(a Attributes) (name, kind string, err error) {
@@ -50,7 +50,7 @@ func NewForbidden(a Attributes, internalError error) error {
 	}
 	name, kind, err := extractKindName(a)
 	if err != nil {
-		return apierrors.NewInternalError(errs.NewAggregate([]error{internalError, err}))
+		return apierrors.NewInternalError(utilerrors.NewAggregate([]error{internalError, err}))
 	}
 	return apierrors.NewForbidden(kind, name, internalError)
 }

--- a/pkg/api/errors/errors.go
+++ b/pkg/api/errors/errors.go
@@ -24,7 +24,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/util/errors"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/util/fielderrors"
 )
 
@@ -179,7 +179,7 @@ func NewInvalid(kind, name string, errs fielderrors.ValidationErrorList) error {
 			Name:   name,
 			Causes: causes,
 		},
-		Message: fmt.Sprintf("%s %q is invalid: %v", kind, name, errors.NewAggregate(errs)),
+		Message: fmt.Sprintf("%s %q is invalid: %v", kind, name, utilerrors.NewAggregate(errs)),
 	}}
 }
 

--- a/pkg/api/validation/schema.go
+++ b/pkg/api/validation/schema.go
@@ -26,7 +26,7 @@ import (
 	"github.com/emicklei/go-restful/swagger"
 	"github.com/golang/glog"
 	apiutil "k8s.io/kubernetes/pkg/api/util"
-	"k8s.io/kubernetes/pkg/util/errors"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	errs "k8s.io/kubernetes/pkg/util/fielderrors"
 	"k8s.io/kubernetes/pkg/util/yaml"
 )
@@ -150,14 +150,14 @@ func (s *SwaggerSchema) ValidateBytes(data []byte) error {
 		return fmt.Errorf("kind isn't string type")
 	}
 	if strings.HasSuffix(kind.(string), "List") {
-		return errors.NewAggregate(s.validateList(fields))
+		return utilerrors.NewAggregate(s.validateList(fields))
 	}
 	version := apiutil.GetVersion(groupVersion.(string))
 	allErrs := s.ValidateObject(obj, "", version+"."+kind.(string))
 	if len(allErrs) == 1 {
 		return allErrs[0]
 	}
-	return errors.NewAggregate(allErrs)
+	return utilerrors.NewAggregate(allErrs)
 }
 
 func (s *SwaggerSchema) ValidateObject(obj interface{}, fieldName, typeName string) errs.ValidationErrorList {

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -41,7 +41,7 @@ import (
 	"k8s.io/kubernetes/pkg/healthz"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
-	"k8s.io/kubernetes/pkg/util/errors"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/util/flushwriter"
 	"k8s.io/kubernetes/pkg/util/wsstream"
 	"k8s.io/kubernetes/pkg/version"
@@ -129,7 +129,7 @@ func (g *APIGroupVersion) InstallREST(container *restful.Container) error {
 	// TODO: g.Version only contains "version" now, it will contain "group/version" in the near future.
 	AddSupportedResourcesWebService(ws, g.Version, apiResources)
 	container.Add(ws)
-	return errors.NewAggregate(registrationErrors)
+	return utilerrors.NewAggregate(registrationErrors)
 }
 
 // UpdateREST registers the REST handlers for this APIGroupVersion to an existing web service
@@ -153,7 +153,7 @@ func (g *APIGroupVersion) UpdateREST(container *restful.Container) error {
 	apiResources, registrationErrors := installer.Install(ws)
 	// TODO: g.Version only contains "version" now, it will contain "group/version" in the near future.
 	AddSupportedResourcesWebService(ws, g.Version, apiResources)
-	return errors.NewAggregate(registrationErrors)
+	return utilerrors.NewAggregate(registrationErrors)
 }
 
 // newInstaller is a helper to create the installer.  Used by InstallREST and UpdateREST.

--- a/pkg/auth/authorizer/union/union.go
+++ b/pkg/auth/authorizer/union/union.go
@@ -18,7 +18,7 @@ package union
 
 import (
 	"k8s.io/kubernetes/pkg/auth/authorizer"
-	"k8s.io/kubernetes/pkg/util/errors"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 )
 
 // unionAuthzHandler authorizer against a chain of authorizer.Authorizer
@@ -41,5 +41,5 @@ func (authzHandler unionAuthzHandler) Authorize(a authorizer.Attributes) error {
 		return nil
 	}
 
-	return errors.NewAggregate(errlist)
+	return utilerrors.NewAggregate(errlist)
 }

--- a/pkg/client/unversioned/clientcmd/loader.go
+++ b/pkg/client/unversioned/clientcmd/loader.go
@@ -30,7 +30,7 @@ import (
 
 	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
 	clientcmdlatest "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api/latest"
-	"k8s.io/kubernetes/pkg/util/errors"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 )
 
 const (
@@ -146,7 +146,7 @@ func (rules *ClientConfigLoadingRules) Load() (*clientcmdapi.Config, error) {
 		}
 	}
 
-	return config, errors.NewAggregate(errlist)
+	return config, utilerrors.NewAggregate(errlist)
 }
 
 // Migrate uses the MigrationRules map.  If a destination file is not present, then the source file is checked.

--- a/pkg/client/unversioned/clientcmd/validation_test.go
+++ b/pkg/client/unversioned/clientcmd/validation_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 
 	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
-	"k8s.io/kubernetes/pkg/util/errors"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 )
 
 func TestConfirmUsableBadInfoButOkConfig(t *testing.T) {
@@ -326,14 +326,14 @@ func (c configValidationTest) testContext(contextName string, t *testing.T) {
 			t.Errorf("Expected error containing: %v", c.expectedErrorSubstring)
 		}
 		for _, curr := range c.expectedErrorSubstring {
-			if len(errs) != 0 && !strings.Contains(errors.NewAggregate(errs).Error(), curr) {
-				t.Errorf("Expected error containing: %v, but got %v", c.expectedErrorSubstring, errors.NewAggregate(errs))
+			if len(errs) != 0 && !strings.Contains(utilerrors.NewAggregate(errs).Error(), curr) {
+				t.Errorf("Expected error containing: %v, but got %v", c.expectedErrorSubstring, utilerrors.NewAggregate(errs))
 			}
 		}
 
 	} else {
 		if len(errs) != 0 {
-			t.Errorf("Unexpected error: %v", errors.NewAggregate(errs))
+			t.Errorf("Unexpected error: %v", utilerrors.NewAggregate(errs))
 		}
 	}
 }
@@ -386,14 +386,14 @@ func (c configValidationTest) testCluster(clusterName string, t *testing.T) {
 			t.Errorf("Expected error containing: %v", c.expectedErrorSubstring)
 		}
 		for _, curr := range c.expectedErrorSubstring {
-			if len(errs) != 0 && !strings.Contains(errors.NewAggregate(errs).Error(), curr) {
-				t.Errorf("Expected error containing: %v, but got %v", c.expectedErrorSubstring, errors.NewAggregate(errs))
+			if len(errs) != 0 && !strings.Contains(utilerrors.NewAggregate(errs).Error(), curr) {
+				t.Errorf("Expected error containing: %v, but got %v", c.expectedErrorSubstring, utilerrors.NewAggregate(errs))
 			}
 		}
 
 	} else {
 		if len(errs) != 0 {
-			t.Errorf("Unexpected error: %v", errors.NewAggregate(errs))
+			t.Errorf("Unexpected error: %v", utilerrors.NewAggregate(errs))
 		}
 	}
 }
@@ -406,14 +406,14 @@ func (c configValidationTest) testAuthInfo(authInfoName string, t *testing.T) {
 			t.Errorf("Expected error containing: %v", c.expectedErrorSubstring)
 		}
 		for _, curr := range c.expectedErrorSubstring {
-			if len(errs) != 0 && !strings.Contains(errors.NewAggregate(errs).Error(), curr) {
-				t.Errorf("Expected error containing: %v, but got %v", c.expectedErrorSubstring, errors.NewAggregate(errs))
+			if len(errs) != 0 && !strings.Contains(utilerrors.NewAggregate(errs).Error(), curr) {
+				t.Errorf("Expected error containing: %v, but got %v", c.expectedErrorSubstring, utilerrors.NewAggregate(errs))
 			}
 		}
 
 	} else {
 		if len(errs) != 0 {
-			t.Errorf("Unexpected error: %v", errors.NewAggregate(errs))
+			t.Errorf("Unexpected error: %v", utilerrors.NewAggregate(errs))
 		}
 	}
 }

--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -29,7 +29,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/cloudprovider"
-	"k8s.io/kubernetes/pkg/util/errors"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/util/wait"
 
@@ -805,7 +805,7 @@ func (gce *GCECloud) UpdateTCPLoadBalancer(name, region string, hosts []string) 
 
 // EnsureTCPLoadBalancerDeleted is an implementation of TCPLoadBalancer.EnsureTCPLoadBalancerDeleted.
 func (gce *GCECloud) EnsureTCPLoadBalancerDeleted(name, region string) error {
-	err := errors.AggregateGoroutines(
+	err := utilerrors.AggregateGoroutines(
 		func() error { return gce.deleteFirewall(name, region) },
 		// Even though we don't hold on to static IPs for load balancers, it's
 		// possible that EnsureTCPLoadBalancer left one around in a failed
@@ -824,7 +824,7 @@ func (gce *GCECloud) EnsureTCPLoadBalancerDeleted(name, region string) error {
 		},
 	)
 	if err != nil {
-		return errors.Flatten(err)
+		return utilerrors.Flatten(err)
 	}
 	return nil
 }

--- a/pkg/kubectl/cmd/describe.go
+++ b/pkg/kubectl/cmd/describe.go
@@ -29,7 +29,7 @@ import (
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/util/errors"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 )
 
 // DescribeOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
@@ -142,7 +142,7 @@ func RunDescribe(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []s
 		fmt.Fprintf(out, "%s\n\n", s)
 	}
 
-	return errors.NewAggregate(allErrs)
+	return utilerrors.NewAggregate(allErrs)
 }
 
 func DescribeMatchingResources(mapper meta.RESTMapper, typer runtime.ObjectTyper, f *cmdutil.Factory, namespace, rsrc, prefix string, out io.Writer, originalError error) error {

--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -28,7 +28,7 @@ import (
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/util/errors"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/util/strategicpatch"
 	"k8s.io/kubernetes/pkg/util/validation"
 )
@@ -106,7 +106,7 @@ func validateNoOverwrites(meta *api.ObjectMeta, labels map[string]string) error 
 			allErrs = append(allErrs, fmt.Errorf("'%s' already has a value (%s), and --overwrite is false", key, value))
 		}
 	}
-	return errors.NewAggregate(allErrs)
+	return utilerrors.NewAggregate(allErrs)
 }
 
 func parseLabels(spec []string) (map[string]string, []string, error) {

--- a/pkg/kubectl/cmd/scale.go
+++ b/pkg/kubectl/cmd/scale.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
-	"k8s.io/kubernetes/pkg/util/errors"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 )
 
 // ScaleOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
@@ -149,5 +149,5 @@ func RunScale(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []stri
 		cmdutil.PrintSuccess(mapper, shortOutput, out, info.Mapping.Resource, info.Name, "scaled")
 	}
 
-	return errors.NewAggregate(errs)
+	return utilerrors.NewAggregate(errs)
 }

--- a/pkg/kubectl/generate.go
+++ b/pkg/kubectl/generate.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/util/errors"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 )
 
 // GeneratorParam is a parameter for a generator
@@ -60,7 +60,7 @@ func ValidateParams(paramSpec []GeneratorParam, params map[string]interface{}) e
 			}
 		}
 	}
-	return errors.NewAggregate(allErrs)
+	return utilerrors.NewAggregate(allErrs)
 }
 
 // MakeParams is a utility that creates generator parameters from a command line

--- a/pkg/kubectl/resource/builder.go
+++ b/pkg/kubectl/resource/builder.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/validation"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/util/errors"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/util/sets"
 )
 
@@ -520,7 +520,7 @@ func (b *Builder) resourceTupleMappings() (map[string]*meta.RESTMapping, error) 
 
 func (b *Builder) visitorResult() *Result {
 	if len(b.errs) > 0 {
-		return &Result{err: errors.NewAggregate(b.errs)}
+		return &Result{err: utilerrors.NewAggregate(b.errs)}
 	}
 
 	if b.selectAll {

--- a/pkg/kubectl/resource/builder_test.go
+++ b/pkg/kubectl/resource/builder_test.go
@@ -36,7 +36,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/util/errors"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/watch"
 	watchjson "k8s.io/kubernetes/pkg/watch/json"
 )
@@ -829,7 +829,7 @@ func TestContinueOnErrorVisitor(t *testing.T) {
 	if count != 3 {
 		t.Fatalf("did not visit all infos: %d", count)
 	}
-	agg, ok := err.(errors.Aggregate)
+	agg, ok := err.(utilerrors.Aggregate)
 	if !ok {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1068,7 +1068,7 @@ func TestReceiveMultipleErrors(t *testing.T) {
 		t.Fatalf("unexpected response: %v %t %#v", err, singular, test.Infos)
 	}
 
-	errs, ok := err.(errors.Aggregate)
+	errs, ok := err.(utilerrors.Aggregate)
 	if !ok {
 		t.Fatalf("unexpected error: %v", reflect.TypeOf(err))
 	}

--- a/pkg/kubectl/resource/result.go
+++ b/pkg/kubectl/resource/result.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/util/errors"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/watch"
 )
@@ -41,7 +41,7 @@ type Result struct {
 	sources  []Visitor
 	singular bool
 
-	ignoreErrors []errors.Matcher
+	ignoreErrors []utilerrors.Matcher
 
 	// populated by a call to Infos
 	info []*Info
@@ -56,7 +56,7 @@ type Result struct {
 // err.
 func (r *Result) IgnoreErrors(fns ...ErrMatchFunc) *Result {
 	for _, fn := range fns {
-		r.ignoreErrors = append(r.ignoreErrors, errors.Matcher(fn))
+		r.ignoreErrors = append(r.ignoreErrors, utilerrors.Matcher(fn))
 	}
 	return r
 }
@@ -77,7 +77,7 @@ func (r *Result) Visit(fn VisitorFunc) error {
 		return r.err
 	}
 	err := r.visitor.Visit(fn)
-	return errors.FilterOut(err, r.ignoreErrors...)
+	return utilerrors.FilterOut(err, r.ignoreErrors...)
 }
 
 // IntoSingular sets the provided boolean pointer to true if the Builder input
@@ -106,7 +106,7 @@ func (r *Result) Infos() ([]*Info, error) {
 		infos = append(infos, info)
 		return nil
 	})
-	err = errors.FilterOut(err, r.ignoreErrors...)
+	err = utilerrors.FilterOut(err, r.ignoreErrors...)
 
 	r.info, r.err = infos, err
 	return infos, err

--- a/pkg/kubectl/resource/visitor.go
+++ b/pkg/kubectl/resource/visitor.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/validation"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/util/errors"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/util/yaml"
 	"k8s.io/kubernetes/pkg/watch"
 )
@@ -196,7 +196,7 @@ func (l EagerVisitorList) Visit(fn VisitorFunc) error {
 			errs = append(errs, err)
 		}
 	}
-	return errors.NewAggregate(errs)
+	return utilerrors.NewAggregate(errs)
 }
 
 func ValidateSchema(data []byte, schema validation.Schema) error {
@@ -307,7 +307,7 @@ func (v ContinueOnErrorVisitor) Visit(fn VisitorFunc) error {
 	if len(errs) == 1 {
 		return errs[0]
 	}
-	return errors.NewAggregate(errs)
+	return utilerrors.NewAggregate(errs)
 }
 
 // FlattenListVisitor flattens any objects that runtime.ExtractList recognizes as a list
@@ -343,7 +343,7 @@ func (v FlattenListVisitor) Visit(fn VisitorFunc) error {
 			runtime.ObjectTyper
 			runtime.Decoder
 		}{v.Mapper, info.Mapping.Codec}); len(errs) > 0 {
-			return errors.NewAggregate(errs)
+			return utilerrors.NewAggregate(errs)
 		}
 		for i := range items {
 			item, err := v.InfoForObject(items[i])

--- a/pkg/kubelet/config/http_test.go
+++ b/pkg/kubelet/config/http_test.go
@@ -30,7 +30,7 @@ import (
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
-	"k8s.io/kubernetes/pkg/util/errors"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 )
 
 func TestURLErrorNotExistNoUpdate(t *testing.T) {
@@ -286,7 +286,7 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 		}
 		for _, pod := range update.Pods {
 			if errs := validation.ValidatePod(pod); len(errs) != 0 {
-				t.Errorf("%s: Expected no validation errors on %#v, Got %v", testCase.desc, pod, errors.NewAggregate(errs))
+				t.Errorf("%s: Expected no validation errors on %#v, Got %v", testCase.desc, pod, utilerrors.NewAggregate(errs))
 			}
 		}
 	}

--- a/pkg/kubelet/container_manager_linux.go
+++ b/pkg/kubelet/container_manager_linux.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/kubelet/cadvisor"
 	"k8s.io/kubernetes/pkg/util"
-	"k8s.io/kubernetes/pkg/util/errors"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/util/mount"
 	"k8s.io/kubernetes/pkg/util/oom"
 	"k8s.io/kubernetes/pkg/util/sets"
@@ -183,7 +183,7 @@ func setupKernelTunables(option KernelTunableBehavior) error {
 			}
 		}
 	}
-	return errors.NewAggregate(errList)
+	return utilerrors.NewAggregate(errList)
 }
 
 func (cm *containerManagerImpl) setupNode() error {
@@ -340,7 +340,7 @@ func ensureDockerInContainer(cadvisor cadvisor.Interface, oomScoreAdj int, manag
 		}
 	}
 
-	return errors.NewAggregate(errs)
+	return utilerrors.NewAggregate(errs)
 }
 
 // Gets the (CPU) container the specified pid is in.
@@ -414,7 +414,7 @@ func ensureSystemContainer(rootContainer *fs.Manager, manager *fs.Manager) error
 		errs = append(errs, fmt.Errorf("ran out of attempts to create system containers %q", manager.Cgroups.Name))
 	}
 
-	return errors.NewAggregate(errs)
+	return utilerrors.NewAggregate(errs)
 }
 
 // Determines whether the specified PID is a kernel PID.

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -64,7 +64,7 @@ import (
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/bandwidth"
-	utilErrors "k8s.io/kubernetes/pkg/util/errors"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	kubeio "k8s.io/kubernetes/pkg/util/io"
 	"k8s.io/kubernetes/pkg/util/mount"
 	nodeutil "k8s.io/kubernetes/pkg/util/node"
@@ -1483,7 +1483,7 @@ func (kl *Kubelet) cleanupOrphanedPodDirs(pods []*api.Pod, runningPods []*kubeco
 			errlist = append(errlist, err)
 		}
 	}
-	return utilErrors.NewAggregate(errlist)
+	return utilerrors.NewAggregate(errlist)
 }
 
 func (kl *Kubelet) cleanupBandwidthLimits(allPods []*api.Pod) error {

--- a/pkg/kubelet/network/plugins.go
+++ b/pkg/kubelet/network/plugins.go
@@ -27,7 +27,7 @@ import (
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
-	"k8s.io/kubernetes/pkg/util/errors"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/util/validation"
 )
 
@@ -116,7 +116,7 @@ func InitNetworkPlugin(plugins []NetworkPlugin, networkPluginName string, host H
 		allErrs = append(allErrs, fmt.Errorf("Network plugin %q not found.", networkPluginName))
 	}
 
-	return chosenPlugin, errors.NewAggregate(allErrs)
+	return chosenPlugin, utilerrors.NewAggregate(allErrs)
 }
 
 func UnescapePluginName(in string) string {

--- a/pkg/proxy/userspace/proxier.go
+++ b/pkg/proxy/userspace/proxier.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/kubernetes/pkg/proxy"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util"
-	"k8s.io/kubernetes/pkg/util/errors"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/util/iptables"
 )
 
@@ -652,7 +652,7 @@ func (proxier *Proxier) closePortal(service proxy.ServicePortName, info *service
 	} else {
 		glog.Errorf("Some errors closing iptables portals for service %q", service)
 	}
-	return errors.NewAggregate(el)
+	return utilerrors.NewAggregate(el)
 }
 
 func (proxier *Proxier) closeOnePortal(portal portal, protocol api.Protocol, proxyIP net.IP, proxyPort int, name proxy.ServicePortName) []error {
@@ -824,7 +824,7 @@ func iptablesFlush(ipt iptables.Interface) error {
 	if len(el) != 0 {
 		glog.Errorf("Some errors flushing old iptables portals: %v", el)
 	}
-	return errors.NewAggregate(el)
+	return utilerrors.NewAggregate(el)
 }
 
 // Used below.

--- a/pkg/util/fielderrors/fielderrors.go
+++ b/pkg/util/fielderrors/fielderrors.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	"k8s.io/kubernetes/pkg/util/errors"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 
 	"github.com/davecgh/go-spew/spew"
 )
@@ -174,7 +174,7 @@ func (list ValidationErrorList) PrefixIndex(index int) ValidationErrorList {
 
 // NewValidationErrorFieldPrefixMatcher returns an errors.Matcher that returns true
 // if the provided error is a ValidationError and has the provided ValidationErrorType.
-func NewValidationErrorTypeMatcher(t ValidationErrorType) errors.Matcher {
+func NewValidationErrorTypeMatcher(t ValidationErrorType) utilerrors.Matcher {
 	return func(err error) bool {
 		if e, ok := err.(*ValidationError); ok {
 			return e.Type == t
@@ -186,7 +186,7 @@ func NewValidationErrorTypeMatcher(t ValidationErrorType) errors.Matcher {
 // NewValidationErrorFieldPrefixMatcher returns an errors.Matcher that returns true
 // if the provided error is a ValidationError and has a field with the provided
 // prefix.
-func NewValidationErrorFieldPrefixMatcher(prefix string) errors.Matcher {
+func NewValidationErrorFieldPrefixMatcher(prefix string) utilerrors.Matcher {
 	return func(err error) bool {
 		if e, ok := err.(*ValidationError); ok {
 			return strings.HasPrefix(e.Field, prefix)
@@ -196,12 +196,12 @@ func NewValidationErrorFieldPrefixMatcher(prefix string) errors.Matcher {
 }
 
 // Filter removes items from the ValidationErrorList that match the provided fns.
-func (list ValidationErrorList) Filter(fns ...errors.Matcher) ValidationErrorList {
-	err := errors.FilterOut(errors.NewAggregate(list), fns...)
+func (list ValidationErrorList) Filter(fns ...utilerrors.Matcher) ValidationErrorList {
+	err := utilerrors.FilterOut(utilerrors.NewAggregate(list), fns...)
 	if err == nil {
 		return nil
 	}
 	// FilterOut that takes an Aggregate returns an Aggregate
-	agg := err.(errors.Aggregate)
+	agg := err.(utilerrors.Aggregate)
 	return ValidationErrorList(agg.Errors())
 }

--- a/pkg/volume/downwardapi/downwardapi.go
+++ b/pkg/volume/downwardapi/downwardapi.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/kubernetes/pkg/fieldpath"
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util"
-	utilErrors "k8s.io/kubernetes/pkg/util/errors"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/volume"
 
 	"github.com/golang/glog"
@@ -167,7 +167,7 @@ func (d *downwardAPIVolume) collectData() (map[string]string, error) {
 			data[fileName] = sortLines(values)
 		}
 	}
-	return data, utilErrors.NewAggregate(errlist)
+	return data, utilerrors.NewAggregate(errlist)
 }
 
 // isDataChanged iterate over all the entries to check whether at least one
@@ -283,7 +283,7 @@ func (d *downwardAPIVolume) writeDataInTimestampDir(data map[string]string) (str
 			errlist = append(errlist, err)
 		}
 	}
-	return timestampDir, utilErrors.NewAggregate(errlist)
+	return timestampDir, utilerrors.NewAggregate(errlist)
 }
 
 // updateSymlinksToCurrentDir creates the relative symlinks for all the files configured in this volume.

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -26,7 +26,7 @@ import (
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/types"
-	"k8s.io/kubernetes/pkg/util/errors"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/util/io"
 	"k8s.io/kubernetes/pkg/util/mount"
 	"k8s.io/kubernetes/pkg/util/validation"
@@ -261,7 +261,7 @@ func (pm *VolumePluginMgr) InitPlugins(plugins []VolumePlugin, host VolumeHost) 
 		pm.plugins[name] = plugin
 		glog.V(1).Infof("Loaded volume plugin %q", name)
 	}
-	return errors.NewAggregate(allErrs)
+	return utilerrors.NewAggregate(allErrs)
 }
 
 // FindPluginBySpec looks for a plugin that can support a given volume

--- a/plugin/pkg/admission/limitranger/admission.go
+++ b/plugin/pkg/admission/limitranger/admission.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/util/errors"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/watch"
 )
 
@@ -395,5 +395,5 @@ func PodLimitFunc(limitRange *api.LimitRange, pod *api.Pod) error {
 			}
 		}
 	}
-	return errors.NewAggregate(errs)
+	return utilerrors.NewAggregate(errs)
 }

--- a/plugin/pkg/admission/resourcequota/admission.go
+++ b/plugin/pkg/admission/resourcequota/admission.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/util/errors"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/watch"
 )
 
@@ -261,5 +261,5 @@ func IncrementUsage(a admission.Attributes, status *api.ResourceQuotaStatus, cli
 		}
 	}
 
-	return dirty, errors.NewAggregate(errs)
+	return dirty, utilerrors.NewAggregate(errs)
 }

--- a/plugin/pkg/auth/authenticator/request/union/union.go
+++ b/plugin/pkg/auth/authenticator/request/union/union.go
@@ -21,7 +21,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/auth/authenticator"
 	"k8s.io/kubernetes/pkg/auth/user"
-	"k8s.io/kubernetes/pkg/util/errors"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 )
 
 // unionAuthRequestHandler authenticates requests using a chain of authenticator.Requests
@@ -48,5 +48,5 @@ func (authHandler unionAuthRequestHandler) AuthenticateRequest(req *http.Request
 		}
 	}
 
-	return nil, false, errors.NewAggregate(errlist)
+	return nil, false, utilerrors.NewAggregate(errlist)
 }

--- a/plugin/pkg/auth/authenticator/request/x509/x509.go
+++ b/plugin/pkg/auth/authenticator/request/x509/x509.go
@@ -21,7 +21,7 @@ import (
 	"net/http"
 
 	"k8s.io/kubernetes/pkg/auth/user"
-	"k8s.io/kubernetes/pkg/util/errors"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 )
 
 // UserConversion defines an interface for extracting user info from a client certificate chain
@@ -75,7 +75,7 @@ func (a *Authenticator) AuthenticateRequest(req *http.Request) (user.Info, bool,
 			}
 		}
 	}
-	return nil, false, errors.NewAggregate(errlist)
+	return nil, false, utilerrors.NewAggregate(errlist)
 }
 
 // DefaultVerifyOptions returns VerifyOptions that use the system root certificates, current time,

--- a/plugin/pkg/scheduler/api/validation/validation.go
+++ b/plugin/pkg/scheduler/api/validation/validation.go
@@ -19,7 +19,7 @@ package validation
 import (
 	"fmt"
 
-	"k8s.io/kubernetes/pkg/util/errors"
+	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	schedulerapi "k8s.io/kubernetes/plugin/pkg/scheduler/api"
 )
 
@@ -34,5 +34,5 @@ func ValidatePolicy(policy schedulerapi.Policy) error {
 		}
 	}
 
-	return errors.NewAggregate(validationErrors)
+	return utilerrors.NewAggregate(validationErrors)
 }


### PR DESCRIPTION
change reseaon:
1: There are other errors package, for example pkg/api/errors, so use utilerrors to distinguish
2: Some useplace while import pkg/util/errors alias a local name, but not all. so i think it better to alias a same local name for all the useplace
3: Somewhere it use utilErrors to alias a local name , i think we should use utilerrors, change it and make consistent
