### PR TITLE
kubelet: enforce an initial empty SET PodUpdate

### DIFF
--- a/pkg/kubelet/config/config.go
+++ b/pkg/kubelet/config/config.go
@@ -159,13 +159,10 @@ func (s *podStorage) Merge(source string, change interface{}) error {
 	// deliver update notifications
 	switch s.mode {
 	case PodConfigNotificationIncremental:
-		if firstSet {
-			s.updates <- kubetypes.PodUpdate{Pods: s.MergedState().([]*api.Pod), Op: kubetypes.SET, Source: source}
-		}
 		if len(deletes.Pods) > 0 {
 			s.updates <- *deletes
 		}
-		if len(adds.Pods) > 0 {
+		if len(adds.Pods) > 0 || firstSet {
 			s.updates <- *adds
 		}
 		if len(updates.Pods) > 0 {


### PR DESCRIPTION
In PodConfigNotificationIncremental PodConfig mode, when no pods are available
for a source, the Merge function correctly concluded that neither ADD, UPDATE nor
REMOVE updates are to be sent to the kubelet. But as a consequence the kubelet will
not mark that source as seen.

This is usually not a problem for the apiserver source. But it is a problem for
an empty "file" source, e.g. by passing an empty directory to the kubelet for
static pods. Then the file source will never be seen and the kubelet will stay
in its special not-all-source-seen mode.

Fixes https://github.com/mesosphere/kubernetes-mesos/issues/557
