### PR TITLE
Delete namespace in case of scalability failures

### DIFF
--- a/test/e2e/density.go
+++ b/test/e2e/density.go
@@ -122,6 +122,10 @@ var _ = Describe("Density", func() {
 	})
 
 	AfterEach(func() {
+		// We can't call it explicitly at the end, because it will not be called
+		// if Expect() fails.
+		defer framework.afterEach()
+
 		// Remove any remaining pods from this test if the
 		// replication controller still exists and the replica count
 		// isn't 0.  This means the controller wasn't cleaned up
@@ -146,8 +150,6 @@ var _ = Describe("Density", func() {
 		highLatencyRequests, err := HighLatencyRequests(c, 3*time.Second)
 		expectNoError(err)
 		Expect(highLatencyRequests).NotTo(BeNumerically(">", 0), "There should be no high-latency requests")
-
-		framework.afterEach()
 	})
 
 	// Tests with "Skipped" substring in their name will be skipped when running

--- a/test/e2e/load.go
+++ b/test/e2e/load.go
@@ -74,14 +74,16 @@ var _ = Describe("Load capacity", func() {
 
 	// TODO add flag that allows to skip cleanup on failure
 	AfterEach(func() {
+		// We can't call it explicitly at the end, because it will not be called
+		// if Expect() fails.
+		defer framework.afterEach()
+
 		deleteAllRC(configs)
 
 		// Verify latency metrics
 		highLatencyRequests, err := HighLatencyRequests(c, 3*time.Second)
 		expectNoError(err, "Too many instances metrics above the threshold")
 		Expect(highLatencyRequests).NotTo(BeNumerically(">", 0))
-
-		framework.afterEach()
 	})
 
 	type Load struct {


### PR DESCRIPTION
Without this change, when test fails in AfterEach function (via Expect() function), the namespace won't be deleted, which affects next tests. This PR fixes this issue.

Motivated by:
http://kubekins.dls.corp.google.com/view/Critical%20Builds/job/kubernetes-e2e-gce-scalability/2724/

cc @gmarek 
