### PR TITLE
Manual cherry pick of #14959 #15316 #15340 #15422 upstream release 1.1

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -1177,7 +1177,9 @@ function kube::release::gcs::publish() {
 
   local contents
   if [[ ${KUBE_GCS_MAKE_PUBLIC} =~ ^[yY]$ ]]; then
+    kube::log::status "Making uploaded version file public and non-cacheable."
     gsutil acl ch -R -g all:R "${publish_file_dst}" >/dev/null 2>&1 || return 1
+    gsutil setmeta -h "Cache-Control:private, max-age=0" "${publish_file_dst}" >/dev/null 2>&1 || return 1
     # If public, validate public link
     local -r public_link="https://storage.googleapis.com/${KUBE_GCS_RELEASE_BUCKET}/${publish_file}"
     kube::log::status "Validating uploaded version file at ${public_link}"

--- a/build/mark-new-version.sh
+++ b/build/mark-new-version.sh
@@ -115,28 +115,31 @@ gofmt -s -w "${VERSION_FILE}"
 
 echo "+++ Committing version change"
 git add "${VERSION_FILE}"
-git commit -m "Kubernetes version $NEW_VERSION"
+git commit -m "Kubernetes version ${NEW_VERSION}"
 
 echo "+++ Tagging version"
-git tag -a -m "Kubernetes version $NEW_VERSION" "${NEW_VERSION}"
+git tag -a -m "Kubernetes version ${NEW_VERSION}" "${NEW_VERSION}"
 # We have to sleep for a bit so that the timestamp of the beta tag is after the
 # timestamp of the release version, so that future commits are described as
 # beta, and not release versions.
+echo "+++ Waiting for 5 seconds to ensure timestamps are different before continuing"
 sleep 5
+echo "+++ Tagging beta tag"
 declare -r beta_ver="v${VERSION_MAJOR}.${VERSION_MINOR}.$((${VERSION_PATCH}+1))-beta"
-git tag -a -m "Kubernetes version $beta_ver" "${beta_ver}"
+git tag -a -m "Kubernetes version ${beta_ver}" "${beta_ver}"
 newtag=$(git rev-parse --short HEAD)
 
 if [[ "${VERSION_PATCH}" == "0" ]]; then
   declare -r alpha_ver="v${VERSION_MAJOR}.$((${VERSION_MINOR}+1)).0-alpha.0"
-  git tag -a -m "Kubernetes pre-release branch ${alpha-ver}" "${alpha_ver}" "${head_commit}"
+  git tag -a -m "Kubernetes pre-release branch ${alpha_ver}" "${alpha_ver}" "${head_commit}"
 fi
 
 echo ""
 echo "Success you must now:"
 echo ""
-echo "- Push the tag:"
-echo "   git push ${push_url} v${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}"
+echo "- Push the tags:"
+echo "   git push ${push_url} ${NEW_VERSION}"
+echo "   git push ${push_url} ${beta_ver}"
 
 if [[ "${VERSION_PATCH}" == "0" ]]; then
   echo "- Push the alpha tag:"

--- a/build/mark-new-version.sh
+++ b/build/mark-new-version.sh
@@ -20,6 +20,11 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+if [ "$#" -ne 1 ]; then
+  echo "Usage: ${0} <version>"
+  exit 1
+fi
+
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 NEW_VERSION=${1-}

--- a/build/mark-new-version.sh
+++ b/build/mark-new-version.sh
@@ -119,6 +119,12 @@ git commit -m "Kubernetes version $NEW_VERSION"
 
 echo "+++ Tagging version"
 git tag -a -m "Kubernetes version $NEW_VERSION" "${NEW_VERSION}"
+# We have to sleep for a bit so that the timestamp of the beta tag is after the
+# timestamp of the release version, so that future commits are described as
+# beta, and not release versions.
+sleep 5
+declare -r beta_ver="v${VERSION_MAJOR}.${VERSION_MINOR}.$((${VERSION_PATCH}+1))-beta"
+git tag -a -m "Kubernetes version $beta_ver" "${beta_ver}"
 newtag=$(git rev-parse --short HEAD)
 
 if [[ "${VERSION_PATCH}" == "0" ]]; then

--- a/build/push-ci-build.sh
+++ b/build/push-ci-build.sh
@@ -36,21 +36,20 @@ function kube::release::semantic_version() {
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 LATEST=$(kube::release::semantic_version)
 
-KUBE_GCS_NO_CACHING=n
-KUBE_GCS_MAKE_PUBLIC=y
-KUBE_GCS_UPLOAD_RELEASE=y
-KUBE_GCS_DELETE_EXISTING=y
-KUBE_GCS_RELEASE_BUCKET=kubernetes-release
+KUBE_GCS_NO_CACHING='n'
+KUBE_GCS_MAKE_PUBLIC='y'
+KUBE_GCS_UPLOAD_RELEASE='y'
+KUBE_GCS_DELETE_EXISTING='y'
+KUBE_GCS_RELEASE_BUCKET='kubernetes-release'
 KUBE_GCS_RELEASE_PREFIX="ci/${LATEST}"
-KUBE_GCS_LATEST_FILE="ci/latest.txt"
-KUBE_GCS_LATEST_CONTENTS=${LATEST}
+KUBE_GCS_PUBLISH_VERSION="${LATEST}"
 
 source "$KUBE_ROOT/build/common.sh"
 
 MAX_ATTEMPTS=3
 attempt=0
 while [[ ${attempt} -lt ${MAX_ATTEMPTS} ]]; do
-  kube::release::gcs::release && kube::release::gcs::publish_latest && break || true
+  kube::release::gcs::release && kube::release::gcs::publish_ci && break || true
   attempt=$((attempt + 1))
   sleep 5
 done

--- a/build/push-official-release.sh
+++ b/build/push-official-release.sh
@@ -20,29 +20,28 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_RELEASE_VERSION=${1-}
-
-VERSION_REGEX="^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
-[[ ${KUBE_RELEASE_VERSION} =~ $VERSION_REGEX ]] || {
-  echo "!!! You must specify the version you are releasing in the form of '$VERSION_REGEX'" >&2
+if [ "$#" -ne 1 ]; then
+  echo "Usage: ${0} <version>"
   exit 1
-}
+fi
 
-KUBE_GCS_NO_CACHING=n
-KUBE_GCS_MAKE_PUBLIC=y
-KUBE_GCS_UPLOAD_RELEASE=y
-KUBE_GCS_RELEASE_BUCKET=kubernetes-release
-KUBE_GCS_RELEASE_PREFIX=release/${KUBE_RELEASE_VERSION}
-KUBE_GCS_LATEST_FILE="release/latest.txt"
-KUBE_GCS_LATEST_CONTENTS=${KUBE_RELEASE_VERSION}
+KUBE_RELEASE_VERSION="${1-}"
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "$KUBE_ROOT/build/common.sh"
+KUBE_GCS_NO_CACHING='n'
+KUBE_GCS_MAKE_PUBLIC='y'
+KUBE_GCS_UPLOAD_RELEASE='y'
+KUBE_GCS_RELEASE_BUCKET='kubernetes-release'
+KUBE_GCS_RELEASE_PREFIX="release/${KUBE_RELEASE_VERSION}"
+KUBE_GCS_PUBLISH_VERSION="${KUBE_RELEASE_VERSION}"
 
-if ${KUBE_ROOT}/cluster/kubectl.sh version | grep Client | grep dirty; then
+KUBE_ROOT="$(dirname "${BASH_SOURCE}")/.."
+source "${KUBE_ROOT}/build/common.sh"
+
+if "${KUBE_ROOT}/cluster/kubectl.sh" 'version' | grep 'Client' | grep 'dirty'; then
   echo "!!! Tag at invalid point, or something else is bad. Build is dirty. Don't push this build." >&2
   exit 1
 fi
 
+kube::release::parse_and_validate_release_version "${KUBE_RELEASE_VERSION}"
 kube::release::gcs::release
-kube::release::gcs::publish_latest_official
+kube::release::gcs::publish_official 'latest'

--- a/build/versionize-docs.sh
+++ b/build/versionize-docs.sh
@@ -72,4 +72,4 @@ done
 $SED -ri -e "s|(releases.k8s.io)/[^/]+|\1/${NEW_VERSION}|" pkg/api/v[0-9]*/types.go
 
 ${KUBE_ROOT}/hack/update-generated-docs.sh
-${KUBE_ROOT}/hack/update-swagger-spec.sh
+${KUBE_ROOT}/hack/update-generated-swagger-docs.sh

--- a/docs/design/versioning.md
+++ b/docs/design/versioning.md
@@ -16,9 +16,9 @@ Legend:
 
 * Kube 1.0.0, 1.0.1 -- DONE!
 * Kube 1.0.X (X>1): Standard operating procedure. We patch the release-1.0 branch as needed and increment the patch number.
-* Kube 1.1.0-alpha.X: Released roughly every two weeks by cutting from HEAD. No cherrypick releases. If there is a critical bugfix, a new release from HEAD can be created ahead of schedule. (This applies to the beta releases as well.)
-* Kube 1.1.0-beta.X: When HEAD is feature-complete, we go into code freeze 2 weeks prior to the desired 1.1.0 date and only merge PRs essential to 1.1. Releases continue to be cut from HEAD until we're essentially done.
-* Kube 1.1.0: Final release. Should occur between 3 and 4 months after 1.0.
+* Kube 1.1.0-alpha.X: Released roughly every two weeks by cutting from HEAD. No cherrypick releases. If there is a critical bugfix, a new release from HEAD can be created ahead of schedule.
+* Kube 1.1.0-beta: When HEAD is feature-complete, we will cut the release-1.1.0 branch 2 weeks prior to the desired 1.1.0 date and only merge PRs essential to 1.1.  This cut will be marked as 1.1.0-beta, and HEAD will be revved to 1.2.0-alpha.0.
+* Kube 1.1.0: Final release, cut from the release-1.1.0 branch cut two weeks prior. Should occur between 3 and 4 months after 1.0.  1.1.1-beta will be tagged at the same time on the same branch.
 
 ### Major version timeline
 

--- a/hack/update-generated-swagger-docs.sh
+++ b/hack/update-generated-swagger-docs.sh
@@ -66,3 +66,4 @@ for group_version in "${GROUP_VERSIONS[@]}"; do
 done
 
 "${KUBE_ROOT}/hack/update-swagger-spec.sh"
+"${KUBE_ROOT}/hack/gen-swagger-doc/run-gen-swagger-docs.sh"


### PR DESCRIPTION
This combines the commits made in PRs #14959, #15316, #15340, #15422, and will allow us to push beta builds from the release-1.1 branch to `ci/` in GCS, (part of #14771).
