### PR TITLE
let kubectl label use PATCH instead of PUT

### DIFF
--- a/pkg/kubectl/cmd/label_test.go
+++ b/pkg/kubectl/cmd/label_test.go
@@ -339,7 +339,7 @@ func TestLabelForResourceFromFile(t *testing.T) {
 					t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
 					return nil, nil
 				}
-			case "PUT":
+			case "PATCH":
 				switch req.URL.Path {
 				case "/namespaces/test/pods/cassandra":
 					return &http.Response{StatusCode: 200, Body: objBody(codec, &pods.Items[0])}, nil
@@ -386,7 +386,7 @@ func TestLabelMultipleObjects(t *testing.T) {
 					t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
 					return nil, nil
 				}
-			case "PUT":
+			case "PATCH":
 				switch req.URL.Path {
 				case "/namespaces/test/pods/foo":
 					return &http.Response{StatusCode: 200, Body: objBody(codec, &pods.Items[0])}, nil


### PR DESCRIPTION
Similar to #15597, this PR lets `kubectl label` use PATCH instead of PUT
Fix #15333

We can revert the retry function introduced to test-cmd.sh in #15325 after this one and #15597 are merged.

@bgrant0607 @JanetKuo @jlowdermilk 
