### PR TITLE
[DO NOT MERGE] verify patch field name is valid in server

### DIFF
--- a/pkg/util/strategicpatch/patch.go
+++ b/pkg/util/strategicpatch/patch.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strings"
 
 	forkedjson "k8s.io/kubernetes/third_party/forked/json"
 )
@@ -537,9 +538,28 @@ func mergeMap(original, patch map[string]interface{}, t reflect.Type) (map[strin
 
 		_, ok := original[k]
 		if !ok {
-			// If it's not in the original document, just take the patch value.
-			original[k] = patchV
-			continue
+			// If it's not in the original document, and t is not a struct, just take the patch value.
+			if t.Kind() != reflect.Struct {
+				original[k] = patchV
+				continue
+			}
+			// If it's not in the original document, and t is a struct, verify k is a valid field of
+			// t.
+			found := false
+			for i := 0; i < t.NumField(); i++ {
+				tag := t.Field(i).Tag.Get("json")
+				jsonName := strings.Split(tag, ",")[0]
+				if jsonName == k || strings.ToLower(t.Field(i).Name) == strings.ToLower(k) {
+					found = true
+					break
+				}
+			}
+			if found {
+				original[k] = patchV
+				continue
+			} else {
+				return nil, fmt.Errorf("There is no field named %q in type %q", k, t.Name())
+			}
 		}
 
 		// If the data type is a pointer, resolve the element.


### PR DESCRIPTION
fix #11173

This PR verifies the field name in patch is valid at the server side. Per offline discussion with @bgrant0607, this requires more thoughts because client and server may supports different version, so it's possible a field is valid from client's perspective but invalid at server. We may revisit this problem later.
