### PR TITLE
Proxy resync period should not be 30 seconds

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -46,6 +46,7 @@ cluster-domain
 cluster-name
 cluster-tag
 concurrent-endpoint-syncs
+config-sync-period
 configure-cbr0
 contain-pod-resources
 container-port


### PR DESCRIPTION
The proxy was resynchronizing services and endpoints every 30 seconds, which is
far more frequent than necessary. Set at 10 minutes, since the proxy must have
all services and all endpoints.
