### PR TITLE
RFC: Add annotation for pod metrics

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1175,7 +1175,10 @@ func (kl *Kubelet) GenerateRunContainerOptions(pod *api.Pod, container *api.Cont
 	if err != nil {
 		return nil, err
 	}
+	// If annotation is present then time the results
+	envVarTime := kubeletutil.RecordStartTimeByAnnotation(pod)
 	opts.Envs, err = kl.makeEnvironmentVariables(pod, container)
+	kubeletutil.RecordEndTimeByAnnotation(envVarTime, pod, "makeEnvironmentVariables")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubelet/util/timing.go
+++ b/pkg/kubelet/util/timing.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/api"
+)
+
+// RecordStartTimeByAnnotation returns the current time if the proper annotation
+// is on the pod. Otherwise it reurns a zero time
+func RecordStartTimeByAnnotation(pod *api.Pod) time.Time {
+	if _, ok := pod.Annotations["kuberenetes.io/podTiming"]; ok {
+		return time.Now()
+	}
+	return time.Time{}
+}
+
+// RecordEndTimeByAnnotation logs the time difference if startTime is non-zero
+func RecordEndTimeByAnnotation(startTime time.Time, pod *api.Pod, dataPoint string) {
+	if !startTime.IsZero() {
+		dataPoints, err := json.Marshal(map[string]string{
+			"UID":       string(pod.UID),
+			"PodName":   pod.Name,
+			"DataPoint": dataPoint,
+			"Timing":    time.Now().Sub(startTime).String(),
+		})
+		// Log the the marshal error but don't interrupt functionality
+		if err != nil {
+			glog.Errorf("Unable to record the pod timings. Error=%s", err)
+		}
+		glog.Infof("Pod Timing: %s", string(dataPoints))
+	}
+}

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -189,6 +189,7 @@ type RCConfig struct {
 	CpuLimit      int64 // millicores
 	MemRequest    int64 // bytes
 	MemLimit      int64 // bytes
+	Annotations   map[string]string
 
 	// Env vars, set the same for every pod.
 	Env map[string]string
@@ -1333,7 +1334,8 @@ func (config *RCConfig) create() error {
 			},
 			Template: &api.PodTemplateSpec{
 				ObjectMeta: api.ObjectMeta{
-					Labels: map[string]string{"name": config.Name},
+					Labels:      map[string]string{"name": config.Name},
+					Annotations: config.Annotations,
 				},
 				Spec: api.PodSpec{
 					Containers: []api.Container{


### PR DESCRIPTION
## General

While digging in to reverting the #13052 revert (#13656) @pmorie came up with an idea to add an annotation that would spit out extra metric data for pods. While the issue ultimately wasn't related to pod timing the idea of being able to annotate a pod and get some extra metrics for testing, or as a canary, seems like it could be useful.
#### Commits

This RFC PR contains two commits:
- **Annotation based pod timing in logs.**: Contains the pod timing modifications.
- **e2e: RCConfig can now take annotations**: Contains an update to `test/e2e/util.go` allowing RCConfig to accept annotations. This is a logical follow on for the first commit to let e2e tests use annotations.
## Annotation

The annotation in this RFC is named `kuberenetes.io/podTiming` and currently ignores the value. The code simply checks for the existence of the annotation to decide if the pod timing should execute.
#### Example YAML Using the Annotation

``` yaml
apiVersion: v1
kind: Pod
metadata:
  name: ttrue
  labels:
    app: ttrue
  annotations:
    kuberenetes.io/podTiming: "true"
spec:
  containers:
  - name: ttrue
    image: tianon/true
```
## Metrics Output

The output is being sent through the `Info` log level. It contains a header string followed by a structured JSON string for the metrics:

The header string is presented for an easy way to find the logs with grep or kibana
#### Log Format

```
[$LOGGER_FORMAT] HEADER: $JSON_STRUCTURE
```
#### JSON Structure

| Name | Type | Description | Example |
| --- | --- | --- | --- |
| UID | string | The pod's generated unique identifier | 4c8a1c85-728a-11e5-8f79-42010af00002 |
| PodName | string | The name given to the pod | ttrue |
| DataPoint | string | The metric being recorded | StartContainer |
| Timing | string | The human readable timing data | 613.934255ms |
#### Example

```
1014 15:43:22.043801    3832 timing.go:50] Pod Timing: {"DataPoint":"makeEnvironmentVariables","PodName":"ttrue
","Timing":"43.204µs","UID":"4c8a1c85-728a-11e5-8f79-42010af00002"}
W1014 15:43:22.657840    3832 timing.go:50] Pod Timing: {"DataPoint":"CreateContainer","PodName":"ttrue","Timing
":"613.934255ms","UID":"4c8a1c85-728a-11e5-8f79-42010af00002"}
W1014 15:43:22.928335    3832 timing.go:50] Pod Timing: {"DataPoint":"StartContainer","PodName":"ttrue","Timing"
:"270.408469ms","UID":"4c8a1c85-728a-11e5-8f79-42010af00002"}
W1014 15:43:22.944927    3832 timing.go:50] Pod Timing: {"DataPoint":"makeEnvironmentVariables","PodName":"ttrue
","Timing":"40.205µs","UID":"4c8a1c85-728a-11e5-8f79-42010af00002"}
W1014 15:43:23.045861    3832 timing.go:50] Pod Timing: {"DataPoint":"CreateContainer","PodName":"ttrue","Timing
":"100.724063ms","UID":"4c8a1c85-728a-11e5-8f79-42010af00002"}
W1014 15:43:23.136170    3832 timing.go:50] Pod Timing: {"DataPoint":"StartContainer","PodName":"ttrue","Timing"
:"90.162096ms","UID":"4c8a1c85-728a-11e5-8f79-42010af00002"}
```
## Thoughts/Questions
- I'm not sure if the annotation name I chose (based on reading names of other annotations) is sufficient or if there is a better naming convention to use.
- It seems like it could be more helpful to standardize the timing output to a specific unit such as `ms`. This would making non-human parsing much simpler.
- Would there be value in limiting what metrics are recorded using the value of the annotation?
- `kubelet/util/timing.go` was created to hold the new functions. Is there a better location for the code to live that won't cause circular dependency errors?
- Are there other similar metrics that should be recorded as well (that are not PR scope creep :smile:)?
