### PR TITLE
Temp. skip exec+proxy e2e test

### DIFF
--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -197,7 +197,8 @@ var _ = Describe("Kubectl client", func() {
 			}
 		})
 
-		It("should support exec through an HTTP proxy", func() {
+		// FIXME(ncdc) remove Skipped once we sort out the kubectl build issues in GCE
+		It("[Skipped] should support exec through an HTTP proxy", func() {
 			// Note: We are skipping local since we want to verify an apiserver with HTTPS.
 			// At this time local only supports plain HTTP.
 			SkipIfProviderIs("local")


### PR DESCRIPTION
It's breaking GCE e2e. Will reenable once we've fixed the test.

Refs #15713
