### PR TITLE
Set Docker's default log level to warning to reduce log spam.

### DIFF
--- a/cluster/saltbase/salt/docker/docker-defaults
+++ b/cluster/saltbase/salt/docker/docker-defaults
@@ -1,3 +1,3 @@
 {% set grains_opts = grains.get('docker_opts', '') -%}
-DOCKER_OPTS="{{grains_opts}} --bridge=cbr0 --iptables=false --ip-masq=false"
+DOCKER_OPTS="{{grains_opts}} --bridge=cbr0 --iptables=false --ip-masq=false --log-level=warn"
 DOCKER_NOFILE=1000000


### PR DESCRIPTION
This may be controversial, but continuing discussion from #15590 here.

@kubernetes/goog-node @yujuhong @vishh @dchen1107 @jimmidyson 
