### PR TITLE
Disable keep-alive for liveness/readiness probes

### DIFF
--- a/pkg/probe/http/http.go
+++ b/pkg/probe/http/http.go
@@ -30,7 +30,7 @@ import (
 
 func New() HTTPProber {
 	tlsConfig := &tls.Config{InsecureSkipVerify: true}
-	transport := &http.Transport{TLSClientConfig: tlsConfig}
+	transport := &http.Transport{TLSClientConfig: tlsConfig, DisableKeepAlives: true}
 	return httpProber{transport}
 }
 


### PR DESCRIPTION
Keep-alive is often not useful for probing because kubelet checks many pods
with different addresses and ports. Disable keep-alive so prober does not
have to handle closed connections.
