### PR TITLE
Fix update-generated-swagger-docs.sh

### DIFF
--- a/hack/update-generated-swagger-docs.sh
+++ b/hack/update-generated-swagger-docs.sh
@@ -66,4 +66,3 @@ for group_version in "${GROUP_VERSIONS[@]}"; do
 done
 
 "${KUBE_ROOT}/hack/update-swagger-spec.sh"
-"${KUBE_ROOT}/hack/gen-swagger-doc/run-gen-swagger-docs.sh"


### PR DESCRIPTION
This reverts part of #15422, namely commit:
https://github.com/ihmccreery/kubernetes/commit/ea6c3856743d7f12378f1a05b3eef7c6bdbc5d04

Currently this script is just broken and returns the following error:

```
...
+++ [1016 02:13:02] Clean up complete
Usage: run-gen-swagger-docs.sh <API version> <absolute output path, default to PWD>
```

This is OK until you actually want to update swagger docs :)

This bug blocks PR #15706 

@ihmccreery @zmerlynn @lavalamp 
