### PR TITLE
[do not merge] Reintroduce service soak tested on 3 node cluster with blocking moved…

### DIFF
--- a/pkg/util/rand/rand.go
+++ b/pkg/util/rand/rand.go
@@ -18,6 +18,7 @@ limitations under the License.
 package rand
 
 import (
+	"fmt"
 	"math/rand"
 	"sync"
 	"time"
@@ -30,6 +31,21 @@ var rng = struct {
 	rand *rand.Rand
 }{
 	rand: rand.New(rand.NewSource(time.Now().UTC().UnixNano())),
+}
+
+// Intsn return a range of ints, from
+// [min, max]
+func Intsn(min int, n int, max int) []int {
+	rng.Lock()
+	defer rng.Unlock()
+	if max-min < 0 {
+		panic(fmt.Sprintf("Range (min,max) doesn't exist:", min, max))
+	}
+	m := make([]int, n)
+	for i := 0; int(i) < n; i++ {
+		m[i] = min + rng.rand.Intn(max-min)
+	}
+	return m
 }
 
 // String generates a random alphanumeric string n characters long.  This will

--- a/pkg/util/rand/rand_test.go
+++ b/pkg/util/rand/rand_test.go
@@ -22,6 +22,22 @@ import (
 	"testing"
 )
 
+func TestIntsn(t *testing.T) {
+	min := int(1)
+	total := int(10000)
+	max := int(30)
+
+	for _, r := range Intsn(min, total, max) {
+		if r < min || r > max {
+			t.Errorf("%v is not in range %v %v", r, min, max)
+		}
+	}
+
+	if l := len(Intsn(min, total, max)); l != total {
+		t.Errorf("Invalid return length : %v ", l, total)
+	}
+}
+
 func TestString(t *testing.T) {
 	valid := "0123456789abcdefghijklmnopqrstuvwxyz"
 	for _, l := range []int{0, 1, 2, 10, 123} {

--- a/test/e2e/networking.go
+++ b/test/e2e/networking.go
@@ -17,30 +17,35 @@ limitations under the License.
 package e2e
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
+	"github.com/golang/glog"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/util/intstr"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"k8s.io/kubernetes/pkg/util/rand"
+	"k8s.io/kubernetes/pkg/util/wait"
 )
 
+// versions ~ 1.3 (original RO test), 1.6 uses newer services/tokens,...
+const nettestVersion = "1.6"
+
 var _ = Describe("Networking", func() {
+
 	f := NewFramework("nettest")
-
-	var svcname = "nettest"
-
 	BeforeEach(func() {
-		//Assert basic external connectivity.
-		//Since this is not really a test of kubernetes in any way, we
-		//leave it as a pre-test assertion, rather than a Ginko test.
+		// Assert basic external connectivity.
+		// Since this is not really a test of kubernetes in any way, we
+		// leave it as a pre-test assertion, rather than a Ginko test.
 		By("Executing a successful http request from the external internet")
 		resp, err := http.Get("http://google.com")
 		if err != nil {
@@ -82,7 +87,7 @@ var _ = Describe("Networking", func() {
 	})
 
 	// First test because it has no dependencies on variables created later on.
-	It("should provide unchanging, static URL paths for kubernetes api services [Conformance]", func() {
+	It("should provide unchanging, static URL paths for kubernetes api services [Conformance].", func() {
 		tests := []struct {
 			path string
 		}{
@@ -102,155 +107,288 @@ var _ = Describe("Networking", func() {
 		}
 	})
 
-	//Now we can proceed with the test.
-	It("should function for intra-pod communication [Conformance]", func() {
+	// Each tuple defined in this struct array represents
+	// a number of services, and a timeout.  So for example,
+	// {1, 300} defines a test where 1 service is created and
+	// we give it 300 seconds to timeout.  This is how we test
+	// services in parallel... we can create a tuple like {5,400}
+	// to confirm that services over 5 ports all pass the networking test.
+	serviceSoakTests := []struct {
+		service        int
+		timeoutSeconds time.Duration
+	}{
+		// Note: On a GCE 3 node cluster, 30 ports is no problem.  > 50 seems to get blocked.
+		{3, time.Duration(100 * time.Second)},
+	}
 
-		By(fmt.Sprintf("Creating a service named %q in namespace %q", svcname, f.Namespace.Name))
-		svc, err := f.Client.Services(f.Namespace.Name).Create(&api.Service{
-			ObjectMeta: api.ObjectMeta{
-				Name: svcname,
-				Labels: map[string]string{
-					"name": svcname,
-				},
-			},
-			Spec: api.ServiceSpec{
-				Ports: []api.ServicePort{{
-					Protocol:   "TCP",
-					Port:       8080,
-					TargetPort: intstr.FromInt(8080),
-				}},
-				Selector: map[string]string{
-					"name": svcname,
-				},
-			},
-		})
-		if err != nil {
-			Failf("unable to create test service named [%s] %v", svc.Name, err)
+	for _, svcSoak := range serviceSoakTests {
+		// copy to local to avoid range overwriting
+		timeoutSeconds := svcSoak.timeoutSeconds
+		serviceNum := svcSoak.service
+		It(fmt.Sprintf("should function for intrapod communication between all hosts in %v parallel services [Conformance]", serviceNum),
+			func() {
+				// Create a list of a few 1000 ports to use as a grab bag.
+				minPort := 1000
+				maxPort := 10000
+				allPorts := rand.Intsn(minPort, 9000, maxPort)
+				Logf("Running service test with timeout = %v for %v, ports = ", timeout, serviceNum, allPorts)
+				runNetTest(timeoutSeconds, f, allPorts, serviceNum, nettestVersion)
+			})
+	}
+})
+
+type PeerTestResult struct {
+	passed    bool
+	completed bool
+	err       error
+}
+
+var netTestDone = false
+
+// pollPeerStatus will either fail, pass, or continue polling.
+// returns true if polling succeeds.  writing to "quit" exits polling.
+func pollPeerStatus(f *Framework, svc *api.Service, pollTimeoutSeconds time.Duration) PeerTestResult {
+	getDetails := func() ([]byte, error) {
+		return f.Client.Get().
+			Namespace(f.Namespace.Name).
+			Prefix("proxy").
+			Resource("services").
+			Name(svc.Name).
+			Suffix("read").
+			DoRaw()
+	}
+
+	// This can panic if the other tests complete first and the NS is destroyed.
+	getStatus := func() ([]byte, error) {
+		nsExists := f.Client.Get().Namespace(f.Namespace.Name)
+		if nsExists == nil {
+			return nil, errors.New("Ns doesnt exist")
 		}
+		return f.Client.Get().
+			Namespace(f.Namespace.Name).
+			Prefix("proxy").
+			Resource("services").
+			Name(svc.Name).
+			Suffix("status").
+			DoRaw()
+	}
 
-		// Clean up service
-		defer func() {
-			By("Cleaning up the service")
-			if err = f.Client.Services(f.Namespace.Name).Delete(svc.Name); err != nil {
-				Failf("unable to delete svc %v: %v", svc.Name, err)
-			}
-		}()
+	Logf("Begin polling " + svc.Name)
 
-		By("Creating a webserver (pending) pod on each node")
-
-		nodes, err := f.Client.Nodes().List(labels.Everything(), fields.Everything())
+	pollingFunction := func() PeerTestResult {
+		body, err := getStatus()
 		if err != nil {
 			Failf("Failed to list nodes: %v", err)
 		}
-		// previous tests may have cause failures of some nodes. Let's skip
-		// 'Not Ready' nodes, just in case (there is no need to fail the test).
-		filterNodes(nodes, func(node api.Node) bool {
-			return !node.Spec.Unschedulable && isNodeConditionSetAsExpected(&node, api.NodeReady, true)
-		})
 
-		if len(nodes.Items) == 0 {
-			Failf("No Ready nodes found.")
-		}
-		if len(nodes.Items) == 1 {
-			// in general, the test requires two nodes. But for local development, often a one node cluster
-			// is created, for simplicity and speed. (see issue #10012). We permit one-node test
-			// only in some cases
-			if !providerIs("local") {
-				Failf(fmt.Sprintf("The test requires two Ready nodes on %s, but found just one.", testContext.Provider))
-			}
-			Logf("Only one ready node is detected. The test has limited scope in such setting. " +
-				"Rerun it with at least two nodes to get complete coverage.")
-		}
-
-		podNames := LaunchNetTestPodPerNode(f, nodes, svcname, "1.6")
-
-		// Clean up the pods
-		defer func() {
-			By("Cleaning up the webserver pods")
-			for _, podName := range podNames {
-				if err = f.Client.Pods(f.Namespace.Name).Delete(podName, nil); err != nil {
-					Logf("Failed to delete pod %s: %v", podName, err)
-				}
-			}
-		}()
-
-		By("Waiting for the webserver pods to transition to Running state")
-		for _, podName := range podNames {
-			err = f.WaitForPodRunning(podName)
-			Expect(err).NotTo(HaveOccurred())
-		}
-
-		By("Waiting for connectivity to be verified")
-		passed := false
-
-		//once response OK, evaluate response body for pass/fail.
-		var body []byte
-		getDetails := func() ([]byte, error) {
-			return f.Client.Get().
-				Namespace(f.Namespace.Name).
-				Prefix("proxy").
-				Resource("services").
-				Name(svc.Name).
-				Suffix("read").
-				DoRaw()
-		}
-
-		getStatus := func() ([]byte, error) {
-			return f.Client.Get().
-				Namespace(f.Namespace.Name).
-				Prefix("proxy").
-				Resource("services").
-				Name(svc.Name).
-				Suffix("status").
-				DoRaw()
-		}
-
-		timeout := time.Now().Add(2 * time.Minute)
-		for i := 0; !passed && timeout.After(time.Now()); i++ {
-			time.Sleep(2 * time.Second)
-			Logf("About to make a proxy status call")
-			start := time.Now()
-			body, err = getStatus()
-			Logf("Proxy status call returned in %v", time.Since(start))
-			if err != nil {
-				Logf("Attempt %v: service/pod still starting. (error: '%v')", i, err)
-				continue
-			}
-			// Finally, we pass/fail the test based on if the container's response body, as to whether or not it was able to find peers.
-			switch {
-			case string(body) == "pass":
-				Logf("Passed on attempt %v. Cleaning up.", i)
-				passed = true
-			case string(body) == "running":
-				Logf("Attempt %v: test still running", i)
-			case string(body) == "fail":
-				if body, err = getDetails(); err != nil {
-					Failf("Failed on attempt %v. Cleaning up. Error reading details: %v", i, err)
-				} else {
-					Failf("Failed on attempt %v. Cleaning up. Details:\n%s", i, string(body))
-				}
-			case strings.Contains(string(body), "no endpoints available"):
-				Logf("Attempt %v: waiting on service/endpoints", i)
-			default:
-				Logf("Unexpected response:\n%s", body)
-			}
-		}
-
-		if !passed {
+		// Finally, we pass/fail the test based on the container's response body was able to find peers.
+		switch {
+		case string(body) == "pass":
+			return PeerTestResult{true, true, nil}
+		case string(body) == "running":
+		case string(body) == "fail":
 			if body, err = getDetails(); err != nil {
-				Failf("Timed out. Cleaning up. Error reading details: %v", err)
+				// Test completed, and it failed, with an error.
+				Failf("Failed on attempt. Error reading details: %v", err)
+				return PeerTestResult{
+					passed:    false,
+					completed: true,
+					err:       err}
 			} else {
-				Failf("Timed out. Cleaning up. Details:\n%s", string(body))
+				Failf("Failed on attempt. Details:\n%s", string(body))
+				// Test completed, and it failed.
+				return PeerTestResult{
+					passed:    false,
+					completed: true,
+					err:       err}
 			}
+		// The below cases all have ambiguous test status: test may or may not be over.
+		case netTestDone == true:
+		case strings.Contains(string(body), "no endpoints available"):
+			Logf("Attempt: waiting on service/endpoints")
+		default:
+			glog.V(1).Infof("Unexpected response:\n%s", body)
 		}
-		Expect(string(body)).To(Equal("pass"))
+		return PeerTestResult{
+			passed:    false,
+			completed: false,
+			err:       nil}
+	}
+
+	var testResult PeerTestResult
+	expectNoError(wait.Poll(2*time.Second, pollTimeoutSeconds,
+		func() (bool, error) {
+			testResult = pollingFunction()
+			return testResult.passed, testResult.err
+		}))
+
+	if testResult.completed && !testResult.passed {
+		if body, err := getDetails(); err != nil {
+			Failf("Timed out.  Major error : Couldn't read service details: %v", testResult.err)
+		} else {
+			Failf("Timed out. Service details :\n%s", string(body))
+		}
+	}
+
+	// Test result at this point will be either "cut short", or "passed".
+	return testResult
+}
+
+// runNetTest Creates a single pod on each host which serves
+// on a unique port in the cluster.  It then binds a service to
+// that port, so that there are "n" nodes to balance traffic to -
+// finally, each node reaches out to ping every other node in
+// the cluster on the given port.
+// The more ports given, the more services will be spun up,
+// i.e. one service per port.
+// To test basic pod networking, send a single port.
+// To soak test the services, we can send a range (i.e. 8000-9000).
+func runNetTest(timeoutSeconds time.Duration, f *Framework, portsGrabBag []int, minSvcPorts int, nettestVersion string) {
+	// Make sure this is false.
+	netTestDone = false
+	if len(portsGrabBag) < minSvcPorts {
+		panic("This test cannot proceed, the number of valid ports to pick from must be >= the min number of services ports to test.")
+	}
+
+	// To be safe, update the signal to all polling goroutines to end when the test is timed out.
+	go func() {
+		time.Sleep(timeoutSeconds)
+		netTestDone = true
+	}()
+
+	nodes, err := f.Client.Nodes().List(labels.Everything(), fields.Everything())
+	expectNoError(err, "Failed to list nodes")
+
+	// previous tests may have caused failures of some nodes. Let's skip
+	// 'Not Ready' nodes, just in case (there is no need to fail the test).
+	filterNodes(nodes, func(node api.Node) bool {
+		return !node.Spec.Unschedulable && isNodeConditionSetAsExpected(&node, api.NodeReady, true)
 	})
 
-})
+	if len(nodes.Items) == 0 {
+		Failf("No Ready nodes found.")
+	}
+	if len(nodes.Items) == 1 {
+		// in general, the test requires two nodes. But for local development, often a one node cluster
+		// is created, for simplicity and speed. (see issue #10012). We permit one-node test
+		// only in some cases
+		if !providerIs("local") {
+			Failf("The test requires two Ready nodes on %s, but found just one.", testContext.Provider)
+		}
+		Logf("Only one ready node is detected. The test has limited scope in such setting. " +
+			"Rerun it with at least two nodes to get complete coverage.")
+	}
 
-func LaunchNetTestPodPerNode(f *Framework, nodes *api.NodeList, name, version string) []string {
+	// Test doesn't register as passed until all channels report back.
+	portCompleteChannel := make(chan string, minSvcPorts)
+
+	// Trial-and-error for all services before we start: So we don't need a stochastic test.
+	servicesToTest := createNServices(f, minSvcPorts, portsGrabBag)
+
+	// This is where the actual port connectivity test is invoked.
+	for _, service := range servicesToTest {
+		go func() {
+			passed := CreatePodsAndWait(f, nodes, service, timeoutSeconds)
+			if passed {
+				portCompleteChannel <- service.Name
+			} else {
+				// Fail the test and set the done flag, so that all polling stops.
+				netTestDone = true
+				Failf("Test failed.")
+			}
+		}()
+	}
+
+	for pReturned := 0; pReturned < minSvcPorts; pReturned++ {
+		Logf("Waiting on ports to report back.  So far %v have been discovered...", pReturned)
+		Logf("... Another service has successfully been discovered: %v ( %v )", pReturned, <-portCompleteChannel)
+		Logf("Completion: %v/%v", pReturned, minSvcPorts)
+	}
+
+	Logf("Completed test on %v ports", minSvcPorts)
+}
+
+// createService creates a service.  Since we might create many service over many ports.
+// Given the stochastic nature of open ports, errors aren't necessarily test failures, so we return
+// all the data to the caller to decide how to proceed.
+func createService(f *Framework, port int) (*api.Service, error) {
+	svcname := fmt.Sprintf("nettest-soak-port-%v", port)
+	By(fmt.Sprintf("creating a service named %q in namespace %q", svcname, f.Namespace.Name))
+	service, err := f.Client.Services(f.Namespace.Name).Create(&api.Service{
+		ObjectMeta: api.ObjectMeta{
+			Name: svcname,
+			Labels: map[string]string{
+				"name": svcname,
+			},
+		},
+		Spec: api.ServiceSpec{
+			Ports: []api.ServicePort{{
+				Protocol:   "TCP",
+				Port:       port,
+				TargetPort: intstr.FromInt(port),
+			}},
+			Selector: map[string]string{
+				"name": svcname,
+			},
+		},
+	})
+
+	if err != nil {
+		Logf("unable to create test service named [%s] %v on port %v", service.Name, err, port)
+		return service, err
+		// return the ptr since thats what Get() returns for Get(name string) (*api.Service, error)
+	} else {
+		Logf("Created service successfully [%s]", service.Name)
+		return service, nil
+	}
+}
+
+// create an array of services, trying out multiple ports in the grab bag.
+func createNServices(f *Framework, n int, portsToTry []int) []*api.Service {
+	services := make([]*api.Service, n, n)
+	for p := 0; p < n; p++ {
+		if s, err := createService(f, portsToTry[p]); err == nil {
+			services[p] = s
+			Logf("Created service %v from element %v out of %v possible ports.", s, p, len(portsToTry))
+		} else {
+			glog.Warning("Skipping port %v due to error %v.", p, err)
+		}
+	}
+	return services
+}
+
+// testPort Runs a test over a single port.  Since this may take a while, it blocks.
+// Run it in a goroutine.  When it completes, it will write to the completionChannel.
+// Returns wether it passed or failed.
+func CreatePodsAndWait(f *Framework, nodes *api.NodeList, service *api.Service, timeout time.Duration) bool {
+	defer GinkgoRecover()
+	port := service.Spec.Ports[0].Port
+
+	Logf("launching pod for each service/node pair: total pods to launch = %v over service name:%v", nodes, service.Name)
+	podNames := CreateAllPods(port, nettestVersion, f, nodes, service.Name)
+	Logf("Launched test pods for %v", port)
+	By("waiting for all of the webserver pods to transition to Running + reaching the Passing state.")
+	for _, podName := range podNames {
+		err := f.WaitForPodRunning(podName)
+		Expect(err).NotTo(HaveOccurred())
+		By(fmt.Sprintf("waiting for connectivity to be verified [ pod = %v ,  port =  %v ] ", podName, port))
+
+		// This is where the actual test occurs: Each pod should pass this test.
+		netTestResult := pollPeerStatus(f, service, timeout)
+		if !netTestDone && !netTestResult.passed {
+			Failf("Failed on pod %v over port %v .", podName, port)
+			return false
+		}
+	}
+	// Getting here only happens if all pods can communicate over service, so this service worked on all nodes.
+	Logf("Finished test pods for %v", port)
+	return true
+}
+
+// launchNetTestPodPerNode launches nettest pods, and returns their names.
+func CreateAllPods(port int, version string, f *Framework, nodes *api.NodeList, svcName string) []string {
 	podNames := []string{}
-
+	Logf("launching net test pod per node %v on with service name %v", len(nodes.Items), svcName)
 	totalPods := len(nodes.Items)
 
 	Expect(totalPods).NotTo(Equal(0))
@@ -258,9 +396,9 @@ func LaunchNetTestPodPerNode(f *Framework, nodes *api.NodeList, name, version st
 	for _, node := range nodes.Items {
 		pod, err := f.Client.Pods(f.Namespace.Name).Create(&api.Pod{
 			ObjectMeta: api.ObjectMeta{
-				GenerateName: name + "-",
+				GenerateName: svcName + "-",
 				Labels: map[string]string{
-					"name": name,
+					"name": svcName,
 				},
 			},
 			Spec: api.PodSpec{
@@ -269,12 +407,13 @@ func LaunchNetTestPodPerNode(f *Framework, nodes *api.NodeList, name, version st
 						Name:  "webserver",
 						Image: "gcr.io/google_containers/nettest:" + version,
 						Args: []string{
-							"-service=" + name,
-							//peers >= totalPods should be asserted by the container.
-							//the nettest container finds peers by looking up list of svc endpoints.
+							"-port=" + strconv.Itoa(port),
+							"-service=" + svcName,
+							// peers >= totalPods should be asserted by the container.
+							// the nettest container finds peers by looking up list of svc endpoints.
 							fmt.Sprintf("-peers=%d", totalPods),
 							"-namespace=" + f.Namespace.Name},
-						Ports: []api.ContainerPort{{ContainerPort: 8080}},
+						Ports: []api.ContainerPort{{ContainerPort: port}},
 					},
 				},
 				NodeName:      node.Name,

--- a/test/e2e/networking.go
+++ b/test/e2e/networking.go
@@ -334,7 +334,7 @@ func runNetTest(timeoutSeconds time.Duration, f *Framework, portsGrabBag []int, 
 		go func(nodes *api.NodeList, svc *api.Service) {
 			passed := CreatePodsAndWait(f, nodes, svc, timeoutSeconds)
 			if passed {
-				portCompleteChannel <- service.Name
+				portCompleteChannel <- svc.Name
 			} else {
 				// Fail the test and set the done flag, so that all polling stops.
 				netTestDone = true


### PR DESCRIPTION
Here's an updated service networking soak that seems to be more stable when run multiple times on multinode clusters.... Before merge, of course, reminder that E2E currently doesn't run networking, so i'll attach manual test results during the review process. Depending on wether  #15656   is addressed by time of review, I'll attach manual multinode test results.
