### PR TITLE
Replace ssh with net=host hostexec pod and kubectl exec in e2e tests where possible

### DIFF
--- a/cluster/mesos/docker/docker-compose.yml
+++ b/cluster/mesos/docker/docker-compose.yml
@@ -86,6 +86,7 @@ apiserver:
     --service-node-port-range=30000-32767
     --cloud-provider=mesos
     --cloud-config=/opt/mesos-cloud.conf
+    --allow-privileged
     --tls-cert-file=/var/run/kubernetes/auth/apiserver.crt
     --tls-private-key-file=/var/run/kubernetes/auth/apiserver.key
     --runtime-config=experimental/v1alpha1
@@ -138,6 +139,7 @@ scheduler:
     --mesos-user=root
     --api-servers=http://apiserver:8888
     --mesos-master=mesosmaster1:5050
+    --allow-privileged
     --cluster-dns=10.10.10.10
     --cluster-domain=cluster.local
     --mesos-executor-cpus=1.0

--- a/contrib/mesos/pkg/scheduler/service/service.go
+++ b/contrib/mesos/pkg/scheduler/service/service.go
@@ -228,7 +228,7 @@ func (s *SchedulerServer) addCoreFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.authPath, "auth-path", s.authPath, "Path to .kubernetes_auth file, specifying how to authenticate to API server.")
 	fs.StringSliceVar(&s.etcdServerList, "etcd-servers", s.etcdServerList, "List of etcd servers to watch (http://ip:port), comma separated. Mutually exclusive with --etcd-config")
 	fs.StringVar(&s.etcdConfigFile, "etcd-config", s.etcdConfigFile, "The config file for the etcd client. Mutually exclusive with --etcd-servers.")
-	fs.BoolVar(&s.allowPrivileged, "allow-privileged", s.allowPrivileged, "If true, allow privileged containers.")
+	fs.BoolVar(&s.allowPrivileged, "allow-privileged", s.allowPrivileged, "Enable privileged containers in the kubelet (compare the same flag in the apiserver).")
 	fs.StringVar(&s.clusterDomain, "cluster-domain", s.clusterDomain, "Domain for this cluster.  If set, kubelet will configure all containers to search this domain in addition to the host's search domains")
 	fs.IPVar(&s.clusterDNS, "cluster-dns", s.clusterDNS, "IP address for a cluster DNS server. If set, kubelet will configure all containers to use this for DNS resolution in addition to the host's DNS servers")
 	fs.StringVar(&s.staticPodsConfigPath, "static-pods-config", s.staticPodsConfigPath, "Path for specification of static pods. Path should point to dir containing the staticPods configuration files. Defaults to none.")

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"math"
 	"math/rand"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -1077,7 +1078,8 @@ func (b kubectlBuilder) exec() (string, error) {
 	if err := cmd.Run(); err != nil {
 		return "", fmt.Errorf("Error running %v:\nCommand stdout:\n%v\nstderr:\n%v\n", cmd, cmd.Stdout, cmd.Stderr)
 	}
-	Logf(stdout.String())
+	Logf("stdout: %q", stdout.String())
+	Logf("stderr: %q", stderr.String())
 	// TODO: trimspace should be unnecessary after switching to use kubectl binary directly
 	return strings.TrimSpace(stdout.String()), nil
 }
@@ -1883,27 +1885,35 @@ func BadEvents(events []*api.Event) int {
 	return badEvents
 }
 
-// NodeSSHHosts returns SSH-able host names for all nodes. It returns an error
-// if it can't find an external IP for every node, though it still returns all
-// hosts that it found in that case.
-func NodeSSHHosts(c *client.Client) ([]string, error) {
-	var hosts []string
-	nodelist, err := c.Nodes().List(labels.Everything(), fields.Everything())
-	if err != nil {
-		return hosts, fmt.Errorf("error getting nodes: %v", err)
-	}
+// NodeAddresses returns the first address of the given type of each node.
+func NodeAddresses(nodelist *api.NodeList, addrType api.NodeAddressType) []string {
+	hosts := []string{}
 	for _, n := range nodelist.Items {
 		for _, addr := range n.Status.Addresses {
 			// Use the first external IP address we find on the node, and
 			// use at most one per node.
 			// TODO(roberthbailey): Use the "preferred" address for the node, once
 			// such a thing is defined (#2462).
-			if addr.Type == api.NodeExternalIP {
-				hosts = append(hosts, addr.Address+":22")
+			if addr.Type == addrType {
+				hosts = append(hosts, addr.Address)
 				break
 			}
 		}
 	}
+	return hosts
+}
+
+// NodeSSHHosts returns SSH-able host names for all nodes. It returns an error
+// if it can't find an external IP for every node, though it still returns all
+// hosts that it found in that case.
+func NodeSSHHosts(c *client.Client) ([]string, error) {
+	nodelist, err := c.Nodes().List(labels.Everything(), fields.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("error getting nodes: %v", err)
+	}
+
+	// TODO(roberthbailey): Use the "preferred" address for the node, once such a thing is defined (#2462).
+	hosts := NodeAddresses(nodelist, api.NodeExternalIP)
 
 	// Error if any node didn't have an external IP.
 	if len(hosts) != len(nodelist.Items) {
@@ -1911,7 +1921,12 @@ func NodeSSHHosts(c *client.Client) ([]string, error) {
 			"only found %d external IPs on nodes, but found %d nodes. Nodelist: %v",
 			len(hosts), len(nodelist.Items), nodelist)
 	}
-	return hosts, nil
+
+	sshHosts := make([]string, 0, len(hosts))
+	for _, h := range hosts {
+		sshHosts = append(sshHosts, net.JoinHostPort(h, "22"))
+	}
+	return sshHosts, nil
 }
 
 // SSH synchronously SSHs to a node running on provider and runs cmd. If there
@@ -1982,8 +1997,15 @@ func NewHostExecPodSpec(ns, name string) *api.Pod {
 
 // RunHostCmd runs the given cmd in the context of the given pod using `kubectl exec`
 // inside of a shell.
-func RunHostCmd(ns, name, cmd string) string {
-	return runKubectlOrDie("exec", fmt.Sprintf("--namespace=%v", ns), name, "--", "/bin/sh", "-c", cmd)
+func RunHostCmd(ns, name, cmd string) (string, error) {
+	return runKubectl("exec", fmt.Sprintf("--namespace=%v", ns), name, "--", "/bin/sh", "-c", cmd)
+}
+
+// RunHostCmdOrDie calls RunHostCmd and dies on error.
+func RunHostCmdOrDie(ns, name, cmd string) string {
+	stdout, err := RunHostCmd(ns, name, cmd)
+	expectNoError(err)
+	return stdout
 }
 
 // LaunchHostExecPod launches a hostexec pod in the given namespace and waits

--- a/test/images/hostexec/Dockerfile
+++ b/test/images/hostexec/Dockerfile
@@ -14,6 +14,9 @@
 
 FROM alpine:3.2
 
+# install necessary packages:
+# - curl, nc: used by a lot of e2e tests
+# - iproute2: includes ss used in NodePort tests
 run apk --update add curl netcat-openbsd iproute2 && rm -rf /var/cache/apk/*
 
 # wait forever


### PR DESCRIPTION
- added RunHostCmd to test/e2e/util.go to run a command in a shell in a hostexec container
- ported kubeproxy e2e tests to hostexec
  - speed-up by parallel pod launch
  - speed-up pod delete with zero grace period
  - fix timeouts with blocking udp tests
- ported privilegedPod e2e test to hostexec
- ported NodePort e2e tests to hostexec
- make all of them work with mesos/docker cluster

Prerequisites: https://github.com/kubernetes/kubernetes/pull/17101

_NOTE_: When #17101 is merged, commit 9e9df46 can be removed to use the gcr.io image.
