### PR TITLE
disabled parallel provisioning in vagrant

### DIFF
--- a/cluster/vagrant/util.sh
+++ b/cluster/vagrant/util.sh
@@ -299,7 +299,7 @@ function kube-up {
   get-tokens
   create-provision-scripts
 
-  vagrant up
+  vagrant up --no-parallel
 
   export KUBE_CERT="/tmp/$RANDOM-kubecfg.crt"
   export KUBE_KEY="/tmp/$RANDOM-kubecfg.key"


### PR DESCRIPTION
In my environment (Ubuntu/vagrant1.7.4/libvirt) master and minion is provisioned simutanously. Various problems occure. Most of all the create-kubeconfig step fails, because salt is not finished yet. With sequential provisioning, the minion is provisioned after the master. Therefore, salt has enough time to finish.

This might fix:

https://github.com/kubernetes/kubernetes/issues/11819

and

https://github.com/kubernetes/kubernetes/issues/11813
