### PR TITLE
Proxy: do not send X-Forwarded-Host or X-Forwarded-Proto with an empty value

### DIFF
--- a/pkg/util/proxy/transport.go
+++ b/pkg/util/proxy/transport.go
@@ -86,8 +86,12 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		forwardedURI = forwardedURI + "/"
 	}
 	req.Header.Set("X-Forwarded-Uri", forwardedURI)
-	req.Header.Set("X-Forwarded-Host", t.Host)
-	req.Header.Set("X-Forwarded-Proto", t.Scheme)
+	if len(t.Host) > 0 {
+		req.Header.Set("X-Forwarded-Host", t.Host)
+	}
+	if len(t.Scheme) > 0 {
+		req.Header.Set("X-Forwarded-Proto", t.Scheme)
+	}
 
 	rt := t.RoundTripper
 	if rt == nil {

--- a/pkg/util/proxy/transport_test.go
+++ b/pkg/util/proxy/transport_test.go
@@ -45,6 +45,14 @@ func TestProxyTransport(t *testing.T) {
 		Host:        "foo.com",
 		PathPrepend: "/proxy/minion/minion1:8080",
 	}
+	emptyHostTransport := &Transport{
+		Scheme:      "https",
+		PathPrepend: "/proxy/minion/minion1:10250",
+	}
+	emptySchemeTransport := &Transport{
+		Host:        "foo.com",
+		PathPrepend: "/proxy/minion/minion1:10250",
+	}
 	type Item struct {
 		input        string
 		sourceURL    string
@@ -158,6 +166,22 @@ func TestProxyTransport(t *testing.T) {
 			contentType:  "text/html",
 			forwardedURI: "/proxy/minion/minion1:10250/logs/log.log",
 		},
+		"no host": {
+			input:        "<html></html>",
+			sourceURL:    "http://myminion.com/logs/log.log",
+			transport:    emptyHostTransport,
+			output:       "<html></html>",
+			contentType:  "text/html",
+			forwardedURI: "/proxy/minion/minion1:10250/logs/log.log",
+		},
+		"no scheme": {
+			input:        "<html></html>",
+			sourceURL:    "http://myminion.com/logs/log.log",
+			transport:    emptySchemeTransport,
+			output:       "<html></html>",
+			contentType:  "text/html",
+			forwardedURI: "/proxy/minion/minion1:10250/logs/log.log",
+		},
 	}
 
 	testItem := func(name string, item *Item) {
@@ -166,11 +190,25 @@ func TestProxyTransport(t *testing.T) {
 			if got, want := r.Header.Get("X-Forwarded-Uri"), item.forwardedURI; got != want {
 				t.Errorf("%v: X-Forwarded-Uri = %q, want %q", name, got, want)
 			}
-			if got, want := r.Header.Get("X-Forwarded-Host"), item.transport.Host; got != want {
-				t.Errorf("%v: X-Forwarded-Host = %q, want %q", name, got, want)
+			if len(item.transport.Host) == 0 {
+				_, present := r.Header["X-Forwarded-Host"]
+				if present {
+					t.Errorf("%v: X-Forwarded-Host header should not be present", name)
+				}
+			} else {
+				if got, want := r.Header.Get("X-Forwarded-Host"), item.transport.Host; got != want {
+					t.Errorf("%v: X-Forwarded-Host = %q, want %q", name, got, want)
+				}
 			}
-			if got, want := r.Header.Get("X-Forwarded-Proto"), item.transport.Scheme; got != want {
-				t.Errorf("%v: X-Forwarded-Proto = %q, want %q", name, got, want)
+			if len(item.transport.Scheme) == 0 {
+				_, present := r.Header["X-Forwarded-Proto"]
+				if present {
+					t.Errorf("%v: X-Forwarded-Proto header should not be present", name)
+				}
+			} else {
+				if got, want := r.Header.Get("X-Forwarded-Proto"), item.transport.Scheme; got != want {
+					t.Errorf("%v: X-Forwarded-Proto = %q, want %q", name, got, want)
+				}
 			}
 
 			// Send response.


### PR DESCRIPTION
An X-Forwarded-Host header with an empty value confuses some servers like Ruby 2.0 WEBrick, resulting in a 400 response.
