### PR TITLE
e2e: kubectl HTTP fix for #15713

### DIFF
--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -26,6 +26,7 @@ import (
 	"mime/multipart"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path"
@@ -197,8 +198,7 @@ var _ = Describe("Kubectl client", func() {
 			}
 		})
 
-		// FIXME(ncdc) remove Skipped once we sort out the kubectl build issues in GCE
-		It("[Skipped] should support exec through an HTTP proxy", func() {
+		It("should support exec through an HTTP proxy", func() {
 			// Note: We are skipping local since we want to verify an apiserver with HTTPS.
 			// At this time local only supports plain HTTP.
 			SkipIfProviderIs("local")
@@ -206,33 +206,51 @@ var _ = Describe("Kubectl client", func() {
 			if testContext.Host == "" {
 				Failf("--host variable must be set to the full URI to the api server on e2e run.")
 			}
+
+			// Make sure the apiServer is set to what kubectl requires
 			apiServer := testContext.Host
-			// If there is no api in URL try to add it
-			if !strings.Contains(apiServer, ":443/api") {
-				apiServer = apiServer + ":443/api"
+			apiServerUrl, err := url.Parse(apiServer)
+			if err != nil {
+				Failf("Unable to parse URL %s. Error=Ts", apiServer, err)
 			}
+			apiServerUrl.Scheme = "https"
+			apiServerUrl.Path = "/api"
+			if !strings.Contains(apiServer, ":443") {
+				apiServerUrl.Host = apiServerUrl.Host + ":443"
+			}
+			apiServer = apiServerUrl.String()
 
 			// Get the kube/config
-			// TODO: Can it be RepoRoot with jenkins e2e?
 			testWorkspace := os.Getenv("WORKSPACE")
 			if testWorkspace == "" {
 				// Not running in jenkins, assume RepoRoot
-				testWorkspace = testContext.RepoRoot // os.Getenv("HOME")
+				testWorkspace = testContext.RepoRoot
 			}
 
 			// Build the static kubectl
-			By("Building a static kubectl for upload")
-			kubectlContainerPath := path.Join(testWorkspace, "/examples/kubectl-container/")
-			staticKubectlBuild := exec.Command("make", "-C", kubectlContainerPath)
-			if out, err := staticKubectlBuild.Output(); err != nil {
-				Failf("Unable to create static kubectl. Error=%s, Output=%s", err, out)
-			}
-			// Verify the static kubectl path
-			testStaticKubectlPath := path.Join(kubectlContainerPath, "kubectl")
-			_, err := os.Stat(testStaticKubectlPath)
+			By("Finding a static kubectl for upload")
+			testStaticKubectlPath := path.Join(testWorkspace, "platforms/linux/386/kubectl")
+			_, err = os.Stat(testStaticKubectlPath)
 			if err != nil {
-				Failf("static kubectl path could not be accessed. Error=%s", err)
+				Logf("No kubectl in %s. Attempting a local build...", testStaticKubectlPath)
+				// Fall back to trying to build a local static kubectl
+				kubectlContainerPath := path.Join(testWorkspace, "/examples/kubectl-container/")
+				if _, err := os.Stat(path.Join(testWorkspace, "hack/build-go.sh")); err != nil {
+					Failf("Can't build static kubectl due to missing hack/build-go.sh. Error=%s", err)
+				}
+				By("Building a static kubectl for upload")
+				staticKubectlBuild := exec.Command("make", "-C", kubectlContainerPath)
+				if out, err := staticKubectlBuild.Output(); err != nil {
+					Failf("Unable to create static kubectl. Error=%s, Output=%q", err, out)
+				}
+				// Verify the static kubectl path
+				testStaticKubectlPath = path.Join(kubectlContainerPath, "kubectl")
+				_, err := os.Stat(testStaticKubectlPath)
+				if err != nil {
+					Failf("static kubectl path could not be found in %s. Error=%s", testStaticKubectlPath, err)
+				}
 			}
+			By(fmt.Sprintf("Using the kubectl in %s", testStaticKubectlPath))
 
 			// Verify the kubeconfig path
 			kubeConfigFilePath := testContext.KubeConfig


### PR DESCRIPTION
This PR attempts to allow the "Kubectl client Simple pod should support exec through an HTTP proxy" test to run in both the Jenkins e2e with repo checkout as well as the e2e with only `kubernetes.tar.gz` and `kubernetes-test.tar.gz` available.
### Finding kubectl
- First it attempts to find a `kubectl` in `platforms/linux/386/`. This `kubectl` seems to always be static.
- If the `kubectl` can not be found in `platforms/linux/386/` then a local build (using `examples/kubectl-container/`)  will be attempted as long as `hack/build-go.sh` exists. Then the binary will be looked for in`examples/kubectl-container/`.
- If neither of the above can provide a `kubectl` the test fails.
#### Testing e2e Without Repo

I attempted to replicate the e2e tests without the repo checkout by setting `WORKSPACE` to `_output/release-tars/kubernetes/` which housed only the data in `kubernetes.tar.gz` and `kubernetes-test.tar.gz` and running the test in GCE.

cc @jlowdermilk 
### Better apiServer Usage

The `apiServer` variable will update to the proper URL with or without `---server` including port or path.
