### PR TITLE
Platform-specific setRLimit implementations

### DIFF
--- a/pkg/proxy/userspace/proxier.go
+++ b/pkg/proxy/userspace/proxier.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"time"
 
 	"github.com/golang/glog"
@@ -156,10 +155,6 @@ func NewProxier(loadBalancer LoadBalancer, listenIP net.IP, iptables iptables.In
 
 	glog.V(2).Infof("Setting proxy IP to %v and initializing iptables", hostIP)
 	return createProxier(loadBalancer, listenIP, iptables, hostIP, proxyPorts, syncPeriod)
-}
-
-func setRLimit(limit uint64) error {
-	return syscall.Setrlimit(syscall.RLIMIT_NOFILE, &syscall.Rlimit{Max: limit, Cur: limit})
 }
 
 func createProxier(loadBalancer LoadBalancer, listenIP net.IP, iptables iptables.Interface, hostIP net.IP, proxyPorts PortAllocator, syncPeriod time.Duration) (*Proxier, error) {

--- a/pkg/proxy/userspace/rlimit.go
+++ b/pkg/proxy/userspace/rlimit.go
@@ -1,0 +1,25 @@
+// +build !windows
+
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package userspace
+
+import "syscall"
+
+func setRLimit(limit uint64) error {
+	return syscall.Setrlimit(syscall.RLIMIT_NOFILE, &syscall.Rlimit{Max: limit, Cur: limit})
+}

--- a/pkg/proxy/userspace/rlimit_windows.go
+++ b/pkg/proxy/userspace/rlimit_windows.go
@@ -1,0 +1,23 @@
+// +build windows
+
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package userspace
+
+func setRLimit(limit uint64) error {
+	return nil
+}


### PR DESCRIPTION
When doing a cross-platform build that references the userspace package, errors show up in the windows build:

```
# k8s.io/kubernetes/pkg/proxy/userspace
Godeps/_workspace/src/k8s.io/kubernetes/pkg/proxy/userspace/proxier.go:162: undefined: syscall.Setrlimit
Godeps/_workspace/src/k8s.io/kubernetes/pkg/proxy/userspace/proxier.go:162: undefined: syscall.RLIMIT_NOFILE
Godeps/_workspace/src/k8s.io/kubernetes/pkg/proxy/userspace/proxier.go:162: undefined: syscall.Rlimit
```

Those do not exist in windows, so uses of them should be excluded from windows builds
