### PR TITLE
Fix kubectl explain

### DIFF
--- a/pkg/client/unversioned/client.go
+++ b/pkg/client/unversioned/client.go
@@ -26,7 +26,6 @@ import (
 	"github.com/emicklei/go-restful/swagger"
 
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/version"
 )
@@ -184,26 +183,32 @@ func (c *Client) ValidateComponents() (*api.ComponentStatusList, error) {
 // SwaggerSchemaInterface has a method to retrieve the swagger schema. Used in
 // client.Interface
 type SwaggerSchemaInterface interface {
-	SwaggerSchema(version string) (*swagger.ApiDeclaration, error)
+	SwaggerSchema(groupVersion string) (*swagger.ApiDeclaration, error)
 }
 
 // SwaggerSchema retrieves and parses the swagger API schema the server supports.
-func (c *Client) SwaggerSchema(version string) (*swagger.ApiDeclaration, error) {
-	if version == "" {
-		version = latest.GroupOrDie("").Version
+func (c *Client) SwaggerSchema(groupVersion string) (*swagger.ApiDeclaration, error) {
+	if groupVersion == "" {
+		return nil, fmt.Errorf("groupVersion cannot be empty")
 	}
 
-	vers, err := c.ServerAPIVersions()
+	groupList, err := c.Discovery().ServerGroups()
 	if err != nil {
 		return nil, err
 	}
-
+	groupVersions := extractGroupVersions(groupList)
 	// This check also takes care the case that kubectl is newer than the running endpoint
-	if stringDoesntExistIn(version, vers.Versions) {
-		return nil, fmt.Errorf("API version: %s is not supported by the server. Use one of: %v", version, vers.Versions)
+	if stringDoesntExistIn(groupVersion, groupVersions) {
+		return nil, fmt.Errorf("API version: %s is not supported by the server. Use one of: %v", groupVersion, groupVersions)
+	}
+	var path string
+	if groupVersion == "v1" {
+		path = "/swaggerapi/api/" + groupVersion
+	} else {
+		path = "/swaggerapi/apis/" + groupVersion
 	}
 
-	body, err := c.Get().AbsPath("/swaggerapi/api/" + version).Do().Raw()
+	body, err := c.Get().AbsPath(path).Do().Raw()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
fix  #15235
part of #15511
The first commit is #15659. Please only review the second commit.

With this PR, `kubectl explain` will accept resources in the extensions group, user can either call `kubectl explain extensions/hpa` or `kubectl explain hpa`.

Caveats: --api-version is not working properly with non-v1 groupVersion. This is a problem for all kubectl commands, so I don't plan to address it in this PR.

@kubernetes/goog-ux @lavalamp
