### PR TITLE
Fix races in ClusterDns e2e test

### DIFF
--- a/test/e2e/examples.go
+++ b/test/e2e/examples.go
@@ -535,7 +535,13 @@ var _ = Describe("Examples e2e", func() {
 			for _, ns := range namespaces {
 				newKubectlCommand("create", "-f", "-", getNsCmdFlag(ns)).withStdinData(updatedPodYaml).exec()
 			}
-			// remember that we cannot wait for the pods to be running because our pods terminate by themselves.
+
+			// wait until the pods have been scheduler, i.e. are not Pending anymore. Remember
+			// that we cannot wait for the pods to be running because our pods terminate by themselves.
+			for _, ns := range namespaces {
+				err := waitForPodNotPending(c, ns.Name, frontendPodName)
+				expectNoError(err)
+			}
 
 			// wait for pods to print their result
 			for _, ns := range namespaces {

--- a/test/e2e/kube-ui.go
+++ b/test/e2e/kube-ui.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/util/wait"
 
 	. "github.com/onsi/ginkgo"
@@ -30,7 +31,7 @@ import (
 var _ = Describe("kube-ui", func() {
 	const (
 		uiServiceName = "kube-ui"
-		uiRcName      = uiServiceName
+		uiAppName     = uiServiceName
 		uiNamespace   = api.NamespaceSystem
 
 		serverStartTimeout = 1 * time.Minute
@@ -44,7 +45,8 @@ var _ = Describe("kube-ui", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Checking to make sure the kube-ui pods are running")
-		err = waitForRCPodsRunning(f.Client, uiNamespace, uiRcName)
+		selector := labels.SelectorFromSet(labels.Set(map[string]string{"k8s-app": uiAppName}))
+		err = waitForPodsWithLabelRunning(f.Client, uiNamespace, selector)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Checking to make sure we get a response from the kube-ui.")

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1524,10 +1524,21 @@ func ScaleRC(c *client.Client, ns, name string, size uint, wait bool) error {
 	return waitForRCPodsRunning(c, ns, name)
 }
 
-// Wait up to 10 minutes for pods to become Running.
+// Wait up to 10 minutes for pods to become Running. Assume that the pods of the
+// rc are labels with {"name":rcName}.
 func waitForRCPodsRunning(c *client.Client, ns, rcName string) error {
+	selector := labels.SelectorFromSet(labels.Set(map[string]string{"name": rcName}))
+	err := waitForPodsWithLabelRunning(c, ns, selector)
+	if err != nil {
+		return fmt.Errorf("Error while waiting for replication controller %s pods to be running: %v", rcName, err)
+	}
+	return nil
+}
+
+// Wait up to 10 minutes for all matching pods to become Running and at least one
+// matching pod exists.
+func waitForPodsWithLabelRunning(c *client.Client, ns string, label labels.Selector) error {
 	running := false
-	label := labels.SelectorFromSet(labels.Set(map[string]string{"name": rcName}))
 	podStore := newPodStore(c, ns, label, fields.Everything())
 	defer podStore.Stop()
 waitLoop:
@@ -1545,7 +1556,7 @@ waitLoop:
 		break
 	}
 	if !running {
-		return fmt.Errorf("Timeout while waiting for replication controller %s pods to be running", rcName)
+		return fmt.Errorf("Timeout while waiting for pods with labels %q to be running", label.String())
 	}
 	return nil
 }

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1533,6 +1533,9 @@ func waitForRCPodsRunning(c *client.Client, ns, rcName string) error {
 waitLoop:
 	for start := time.Now(); time.Since(start) < 10*time.Minute; time.Sleep(5 * time.Second) {
 		pods := podStore.List()
+		if len(pods) == 0 {
+			continue waitLoop
+		}
 		for _, p := range pods {
 			if p.Status.Phase != api.PodRunning {
 				continue waitLoop


### PR DESCRIPTION
- waitForRCPodsRunning not waiting until internal podStore is up to date
- ClusterDns not waiting until frontend pod is Running
- kube-ui e2e test waits for wrong labels

**NOTE**: The ClusterDns example e2e test is marked with `[Conformance]`. Hence, this patch is also relevant for release-1.1 before tagging the new conformance test suite.
