### PR TITLE
An attempt to fix flake in TestControllerSyncJob (14500)

### DIFF
--- a/pkg/controller/job/controller_test.go
+++ b/pkg/controller/job/controller_test.go
@@ -166,7 +166,14 @@ func TestControllerSyncJob(t *testing.T) {
 		manager := NewJobController(client, controller.NoResyncPeriodFunc)
 		fakePodControl := controller.FakePodControl{Err: tc.podControllerError}
 		manager.podControl = &fakePodControl
-		manager.podStoreSynced = alwaysReady
+		var job *extensions.Job
+		manager.podStoreSynced = func() bool {
+			selector, _ := extensions.PodSelectorAsSelector(job.Spec.Selector)
+			podList, _ := manager.podStore.Pods(job.Namespace).List(selector)
+			active := len(controller.FilterActivePods(podList.Items))
+			succeeded, failed := getStatus(podList.Items)
+			return active == tc.activePods && succeeded == tc.succeededPods && failed == tc.failedPods
+		}
 		var actual *extensions.Job
 		manager.updateHandler = func(job *extensions.Job) error {
 			actual = job
@@ -174,7 +181,7 @@ func TestControllerSyncJob(t *testing.T) {
 		}
 
 		// job & pods setup
-		job := newJob(tc.parallelism, tc.completions)
+		job = newJob(tc.parallelism, tc.completions)
 		manager.jobStore.Store.Add(job)
 		for _, pod := range newPodList(tc.activePods, api.PodRunning, job) {
 			manager.podStore.Store.Add(&pod)


### PR DESCRIPTION
This tries to address the problem from #14500. I've changed the `podStoreSynced` from being `alwaysReady` to actually check if the initial state matches the desired. I'm not sure if that fixes the problem, but at least it will narrow the issue a bit. Currently I'm not sure if the problem is in controller or the test setup. For some reason I'm thinking about the latter, that's why I'm proposing this change. Would like to hear what others interested in the issue think about it.

@davidopp @bgrant0607 @brendandburns @mikedanese
