### PR TITLE
Search for port number for service locator

### DIFF
--- a/pkg/registry/service/rest.go
+++ b/pkg/registry/service/rest.go
@@ -309,6 +309,15 @@ func (rs *REST) ResourceLocation(ctx api.Context, id string) (*url.URL, http.Rou
 					Scheme: svcScheme,
 					Host:   net.JoinHostPort(ip, strconv.Itoa(port)),
 				}, rs.proxyTransport, nil
+			} else {
+				port, err := strconv.ParseInt(portStr, 10, 64)
+				if err == nil && int(port) == ss.Ports[i].Port {
+					ip := ss.Addresses[rand.Intn(len(ss.Addresses))].IP
+					return &url.URL{
+						Scheme: svcScheme,
+						Host:   net.JoinHostPort(ip, portStr),
+					}, rs.proxyTransport, nil
+				}
 			}
 		}
 	}

--- a/pkg/registry/service/rest_test.go
+++ b/pkg/registry/service/rest_test.go
@@ -491,6 +491,18 @@ func TestServiceRegistryResourceLocation(t *testing.T) {
 		t.Errorf("Expected %v, but got %v", e, a)
 	}
 
+	// Test a name + port number.
+	location, _, err = redirector.ResourceLocation(ctx, "foo:93")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if location == nil {
+		t.Errorf("Unexpected nil: %v", location)
+	}
+	if e, a := "//1.2.3.4:93", location.String(); e != a {
+		t.Errorf("Expected %v, but got %v", e, a)
+	}
+
 	// Test a scheme + name + port.
 	location, _, err = redirector.ResourceLocation(ctx, "https:foo:p")
 	if err != nil {


### PR DESCRIPTION
If service port is created with name, then resouce locator will only look for port name, not port number.

E.g. if I create a service like below:

```
apiVersion: v1
kind: Service
metadata:
  name: appv1
spec:
  selector:
    name: app
    version: v1
  ports:
  - name: http
    port: 80
```

Then using proxy, I can only access the service using:

```
https:/localhost:8000/api/v1/proxy/namespaces/default/services/appv1:http
```

I think using port number is sometimes more intuitive. With the changes in this PR, we can also do:

```
https:/localhost:8000/api/v1/proxy/namespaces/default/services/appv1:80
```

However, I'm not sure if this is consistent with other endpoints, i.e. port name takes precedence over port number, and if it exists, ignore port number.
