### PR TITLE
Check the health of docker daemon periodically 

### DIFF
--- a/pkg/kubelet/container/fake_runtime.go
+++ b/pkg/kubelet/container/fake_runtime.go
@@ -312,3 +312,12 @@ func (f *FakeRuntime) GarbageCollect(gcPolicy ContainerGCPolicy) error {
 	f.CalledFunctions = append(f.CalledFunctions, "GarbageCollect")
 	return f.Err
 }
+
+func (f *FakeRuntime) Ping() error {
+	f.Lock()
+	defer f.Unlock()
+
+	f.CalledFunctions = append(f.CalledFunctions, "Ping")
+	return f.Err
+
+}

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -106,6 +106,8 @@ type Runtime interface {
 	ContainerCommandRunner
 	// ContainerAttach encapsulates the attaching to containers for testability
 	ContainerAttacher
+	// Ping determines the health of the runtime. Returns error if runtime is unhealthy or unreachable. Returns nil otherwise.
+	Ping() error
 }
 
 type ContainerAttacher interface {

--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -1396,3 +1396,8 @@ func (r *Runtime) RemoveImage(image kubecontainer.ImageSpec) error {
 	}
 	return nil
 }
+
+func (r *Runtime) Ping() error {
+	// TODO(yifan): Add any health check that can improve perceived system stability.
+	return nil
+}


### PR DESCRIPTION
Mark the node asNotReady if docker daemon is unresponsive.

This is a workaround for #10959. 
