### PR TITLE
increase NUM_MINIONS for jenkins gce upgrade test

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -748,7 +748,7 @@ case ${JOB_NAME} in
     : ${E2E_TEST:="false"}
     : ${E2E_DOWN:="false"}
     : ${ENABLE_EXPERIMENTAL_API:=true}
-    : ${NUM_MINIONS:=3}
+    : ${NUM_MINIONS:=5}
     ;;
 
   kubernetes-upgrade-gce-step2-upgrade-master)
@@ -762,7 +762,7 @@ case ${JOB_NAME} in
     : ${E2E_DOWN:="false"}
     : ${GINKGO_TEST_ARGS:="--ginkgo.focus=Skipped.*Cluster\supgrade.*upgrade-master"}
     : ${ENABLE_EXPERIMENTAL_API:=true}
-    : ${NUM_MINIONS:=3}
+    : ${NUM_MINIONS:=5}
     ;;
 
   kubernetes-upgrade-gce-step3-e2e-old)
@@ -783,7 +783,7 @@ case ${JOB_NAME} in
           ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
           )"}
     : ${ENABLE_EXPERIMENTAL_API:=true}
-    : ${NUM_MINIONS:=3}
+    : ${NUM_MINIONS:=5}
     ;;
 
   kubernetes-upgrade-gce-step4-upgrade-cluster)
@@ -797,7 +797,7 @@ case ${JOB_NAME} in
     : ${E2E_DOWN:="false"}
     : ${GINKGO_TEST_ARGS:="--ginkgo.focus=Skipped.*Cluster\supgrade.*upgrade-cluster"}
     : ${ENABLE_EXPERIMENTAL_API:=true}
-    : ${NUM_MINIONS:=3}
+    : ${NUM_MINIONS:=5}
     ;;
 
   kubernetes-upgrade-gce-step5-e2e-old)
@@ -816,7 +816,7 @@ case ${JOB_NAME} in
           ${GCE_FLAKY_TESTS[@]:+${GCE_FLAKY_TESTS[@]}} \
           )"}
     : ${ENABLE_EXPERIMENTAL_API:=true}
-    : ${NUM_MINIONS:=3}
+    : ${NUM_MINIONS:=5}
     ;;
 
   kubernetes-upgrade-gce-step6-e2e-new)
@@ -836,7 +836,7 @@ case ${JOB_NAME} in
           ${GCE_SLOW_TESTS[@]:+${GCE_SLOW_TESTS[@]}} \
           )"}
     : ${ENABLE_EXPERIMENTAL_API:=true}
-    : ${NUM_MINIONS:=3}
+    : ${NUM_MINIONS:=5}
     ;;
 
   # Run Kubemark test on a fake 100 node cluster to have a comparison


### PR DESCRIPTION
Cluster is not validating because pods are not starting because of out of resource.
