### PR TITLE
kubelet/rkt: do not remove other systemd service.

### DIFF
--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -1096,7 +1096,7 @@ func (r *Runtime) GarbageCollect(gcPolicy kubecontainer.ContainerGCPolicy) error
 		return err
 	}
 	for _, f := range files {
-		if !runningKubernetesUnits.Has(f.Name()) && f.ModTime().Before(time.Now().Add(-gcPolicy.MinAge)) {
+		if strings.HasPrefix(f.Name(), kubernetesUnitPrefix) && !runningKubernetesUnits.Has(f.Name()) && f.ModTime().Before(time.Now().Add(-gcPolicy.MinAge)) {
 			glog.V(4).Infof("rkt: Removing inactive systemd service file: %v", f.Name())
 			if err := os.Remove(serviceFilePath(f.Name())); err != nil {
 				glog.Warningf("rkt: Failed to remove inactive systemd service file %v: %v", f.Name(), err)


### PR DESCRIPTION
Actually we still need to check if the service files have the `k8s` prefix, otherwise service files not managed by kubelet would be deleted in gc.
cc @timstclair 
