### PR TITLE
Update supervisord to use `docker ps` instead of `docker version`.

### DIFF
--- a/cluster/saltbase/salt/supervisor/docker-checker.sh
+++ b/cluster/saltbase/salt/supervisor/docker-checker.sh
@@ -25,7 +25,7 @@ echo "waiting a minute for startup"
 sleep 60
 
 while true; do
-  if ! sudo timeout 10 docker version > /dev/null; then
+  if ! sudo timeout 10 docker ps > /dev/null; then
     echo "Docker failed!"
     exit 2
   fi


### PR DESCRIPTION
This change will help work around Aufs issues in docker that can
be resolved by re-starting docker daemon.

Partial workaround for #10959.
