### PR TITLE
Correctly skip daemon restart tests unless running on GCE

### DIFF
--- a/test/e2e/daemon_restart.go
+++ b/test/e2e/daemon_restart.go
@@ -199,11 +199,8 @@ var _ = Describe("DaemonRestart", func() {
 	BeforeEach(func() {
 
 		// These tests require SSH
-		// TODO: Enable on gke after testing (#11834)
-		if !providerIs("gce") {
-			By(fmt.Sprintf("Skipping test, which is not implemented for %s", testContext.Provider))
-			return
-		}
+		// TODO(11834): Enable this test in GKE once experimental API there is switched on
+		SkipUnlessProviderIs("gce")
 		framework.beforeEach()
 		ns = framework.Namespace.Name
 
@@ -285,9 +282,6 @@ var _ = Describe("DaemonRestart", func() {
 
 	It("Scheduler should continue assigning pods to nodes across restart", func() {
 
-		// TODO: Enabale this test in GKE once experimental API there is switched on
-		SkipIfProviderIs("gke")
-
 		restarter := NewRestartConfig(
 			getMasterHost(), "kube-scheduler", ports.SchedulerPort, restartPollInterval, restartTimeout)
 
@@ -303,9 +297,6 @@ var _ = Describe("DaemonRestart", func() {
 	})
 
 	It("Kubelet should not restart containers across restart", func() {
-
-		// TODO: Enabale this test in GKE once experimental API there is switched on
-		SkipIfProviderIs("gke")
 
 		nodeIPs, err := getNodePublicIps(framework.Client)
 		expectNoError(err)


### PR DESCRIPTION
Supercedes #15062 by fixing the check in the `BeforeEach` to actually skip all "daemon restart" tests except when run on GCE.

(By luck we were already skipping "Controller Manager should not create/delete replicas across restart" on GKE, since it's marked flaky, but now we enforce that in the test.)

x-ref #15052 #11834 #15677 #15804
cc @kubernetes/goog-testing
