### PR TITLE
cluster/validate-cluster.sh: Allow for greater than NUM_MINIONS

### DIFF
--- a/cluster/validate-cluster.sh
+++ b/cluster/validate-cluster.sh
@@ -46,6 +46,9 @@ while true; do
 
   if (( "${found}" == "${EXPECTED_NUM_NODES}" )) && (( "${ready}" == "${EXPECTED_NUM_NODES}")); then
     break
+  elif (( "${found}" > "${EXPECTED_NUM_NODES}" )) && (( "${ready}" > "${EXPECTED_NUM_NODES}")); then
+    echo -e "${color_red}Detected ${ready} ready nodes, found ${found} nodes out of expected ${EXPECTED_NUM_NODES}. Found more nodes than expected, your cluster may not behave correctly.${color_norm}"
+    break
   else
     # Set the timeout to ~10minutes (40 x 15 second) to avoid timeouts for 100-node clusters.
     if (( attempt > 40 )); then


### PR DESCRIPTION
Fixes kubernetes/kubernetes#15887

Very simple tweak to allow more than NUM_MINIONS in a validated cluster. Example use case: someone tweaks the auto-scaling group on AWS to add more nodes than the local environment expects.
