### PR TITLE
Fix the incorrect min pods when "kubectl get hpa"

### DIFF
--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -1409,7 +1409,7 @@ func printHorizontalPodAutoscaler(hpa *extensions.HorizontalPodAutoscaler, w io.
 		reference,
 		target,
 		current,
-		minPods,
+		*minPods,
 		maxPods,
 		translateTimestamp(hpa.CreationTimestamp),
 	); err != nil {


### PR DESCRIPTION
Fixes #15898
We recently change HorizontalPodAutoscalerSpec.MinReplicas from int to *int, and it breaks `kubectl get hpa`:

``` console
$ kubectl get hpa
NAME       REFERENCE                                      TARGET    CURRENT     MINPODS        MAXPODS   AGE
frontend   ReplicationController/default/frontend/scale   80%       <waiting>   833360461832   4         59s
```

Fixed it to:

``` console
$ kubectl get hpa
NAME       REFERENCE                                      TARGET    CURRENT     MINPODS   MAXPODS   AGE
frontend   ReplicationController/default/frontend/scale   80%       <waiting>   1         4         2m
```

cc @bgrant0607 @jszczepkowski shall we add this fix to 1.1?
