### PR TITLE
Add localIP address to network status.

### DIFF
--- a/pkg/kubelet/config/config.go
+++ b/pkg/kubelet/config/config.go
@@ -340,6 +340,7 @@ var localAnnotations = []string{
 	kubetypes.ConfigSourceAnnotationKey,
 	kubetypes.ConfigMirrorAnnotationKey,
 	kubetypes.ConfigFirstSeenAnnotationKey,
+	kubetypes.StatusLocalAddressAnnotationKey,
 }
 
 func isLocalAnnotationKey(key string) bool {

--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -309,9 +309,10 @@ var (
 
 // Internal information kept for containers from inspection
 type containerStatusResult struct {
-	status api.ContainerStatus
-	ip     string
-	err    error
+	status  api.ContainerStatus
+	ip      string
+	localIP string
+	err     error
 }
 
 const podIPDownwardAPISelector = "status.podIP"
@@ -319,8 +320,9 @@ const podIPDownwardAPISelector = "status.podIP"
 // determineContainerIP determines the IP address of the given container.  It is expected
 // that the container passed is the infrastructure container of a pod and the responsibility
 // of the caller to ensure that the correct container is passed.
-func (dm *DockerManager) determineContainerIP(podNamespace, podName string, container *docker.Container) string {
+func (dm *DockerManager) determineContainerIP(podNamespace, podName string, container *docker.Container) (string, string) {
 	result := ""
+	localIP := ""
 
 	if container.NetworkSettings != nil {
 		result = container.NetworkSettings.IPAddress
@@ -332,14 +334,17 @@ func (dm *DockerManager) determineContainerIP(podNamespace, podName string, cont
 			glog.Errorf("NetworkPlugin %s failed on the status hook for pod '%s' - %v", dm.networkPlugin.Name(), podName, err)
 		} else if netStatus != nil {
 			result = netStatus.IP.String()
+			if len(netStatus.LocalIP) > 0 {
+				localIP = netStatus.LocalIP.String()
+			}
 		}
 	}
 
-	return result
+	return result, localIP
 }
 
 func (dm *DockerManager) inspectContainer(dockerID, containerName, tPath string, pod *api.Pod) *containerStatusResult {
-	result := containerStatusResult{api.ContainerStatus{}, "", nil}
+	result := containerStatusResult{api.ContainerStatus{}, "", "", nil}
 
 	inspectResult, err := dm.client.InspectContainer(dockerID)
 	if err != nil {
@@ -375,7 +380,7 @@ func (dm *DockerManager) inspectContainer(dockerID, containerName, tPath string,
 			StartedAt: unversioned.NewTime(inspectResult.State.StartedAt),
 		}
 		if containerName == PodInfraContainerName {
-			result.ip = dm.determineContainerIP(pod.Namespace, pod.Name, inspectResult)
+			result.ip, result.localIP = dm.determineContainerIP(pod.Namespace, pod.Name, inspectResult)
 		}
 	} else if !inspectResult.State.FinishedAt.IsZero() || inspectResult.State.ExitCode != 0 {
 		// When a container fails to start State.ExitCode is non-zero, FinishedAt and StartedAt are both zero
@@ -505,6 +510,11 @@ func (dm *DockerManager) GetPodStatus(pod *api.Pod) (*api.PodStatus, error) {
 			// Found network container
 			if result.status.State.Running != nil {
 				podStatus.PodIP = result.ip
+				if result.localIP != "" {
+					pod.Annotations[kubetypes.StatusLocalAddressAnnotationKey] = result.localIP
+				} else {
+					delete(pod.Annotations, kubetypes.StatusLocalAddressAnnotationKey)
+				}
 			}
 		} else {
 			statuses[dockerContainerName] = &result.status
@@ -1883,7 +1893,11 @@ func (dm *DockerManager) SyncPod(pod *api.Pod, runningPod kubecontainer.Pod, pod
 
 		// Find the pod IP after starting the infra container in order to expose
 		// it safely via the downward API without a race and be able to use podIP in kubelet-managed /etc/hosts file.
-		pod.Status.PodIP = dm.determineContainerIP(pod.Name, pod.Namespace, podInfraContainer)
+		var localIP string
+		pod.Status.PodIP, localIP = dm.determineContainerIP(pod.Namespace, pod.Name, podInfraContainer)
+		if localIP != "" {
+			pod.Annotations[kubetypes.StatusLocalAddressAnnotationKey] = localIP
+		}
 	}
 
 	// Start everything

--- a/pkg/kubelet/kubelet_probe_test.go
+++ b/pkg/kubelet/kubelet_probe_test.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	cadvisorApi "github.com/google/cadvisor/info/v1"
+	cadvisorApiv2 "github.com/google/cadvisor/info/v2"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/kubelet/dockertools"
+	"k8s.io/kubernetes/pkg/kubelet/network"
+	"k8s.io/kubernetes/pkg/kubelet/prober"
+	proberesults "k8s.io/kubernetes/pkg/kubelet/prober/results"
+	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
+	"k8s.io/kubernetes/pkg/probe"
+	httprobe "k8s.io/kubernetes/pkg/probe/http"
+	"k8s.io/kubernetes/pkg/util"
+)
+
+// networkPluginMock returns a status update with both a podIP and localIP
+type networkPluginMock struct {
+	statusValues map[string]*network.PodNetworkStatus
+}
+
+func (m *networkPluginMock) Init(host network.Host) error {
+	return nil
+}
+
+func (m *networkPluginMock) Name() string {
+	return "networkPluginMock"
+}
+
+func (m *networkPluginMock) SetUpPod(namespace string, name string, podInfraContainerID kubetypes.DockerID) error {
+	return nil
+}
+
+func (m *networkPluginMock) TearDownPod(namespace string, name string, podInfraContainerID kubetypes.DockerID) error {
+	return nil
+}
+
+func (m *networkPluginMock) Status(namespace string, name string, podInfraContainerID kubetypes.DockerID) (*network.PodNetworkStatus, error) {
+	podFullName := fmt.Sprintf("%s/%s", namespace, name)
+	if status, ok := m.statusValues[podFullName]; ok {
+		return status, nil
+	}
+	return nil, fmt.Errorf("unexpected status call for %s", podFullName)
+}
+
+// mockHttpProber records the host component of url requests.
+type mockHttpProber struct {
+	requestHosts []string
+	waitGroup    *sync.WaitGroup
+	mutex        sync.Mutex
+}
+
+func newMockHttpProber(wg *sync.WaitGroup) *mockHttpProber {
+	mock := new(mockHttpProber)
+	mock.requestHosts = make([]string, 0)
+	mock.waitGroup = wg
+	return mock
+}
+
+func (m *mockHttpProber) Probe(url *url.URL, timeout time.Duration) (probe.Result, string, error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.requestHosts = append(m.requestHosts, url.Host)
+	m.waitGroup.Done()
+	return probe.Success, "", nil
+}
+
+type fakeOptionGenerator struct{}
+
+func (*fakeOptionGenerator) GenerateRunContainerOptions(pod *api.Pod, container *api.Container) (*kubecontainer.RunContainerOptions, error) {
+	opts := &kubecontainer.RunContainerOptions{}
+	return opts, nil
+}
+
+func initFakeRuntime(kubelet *Kubelet, httpProber httprobe.HTTPProber) {
+	fakeDocker := &dockertools.FakeDockerClient{}
+
+	kubelet.probeManager = prober.NewTestManagerWithHttpProbe(
+		120*time.Second,
+		kubelet.statusManager,
+		proberesults.NewManager(),
+		kubelet.livenessManager,
+		kubelet.runner,
+		kubelet.containerRefManager,
+		kubelet.recorder,
+		httpProber)
+
+	dockerManager := dockertools.NewFakeDockerManager(
+		fakeDocker, kubelet.recorder, kubelet.livenessManager, kubelet.containerRefManager, &cadvisorApi.MachineInfo{},
+		dockertools.PodInfraContainerImage, 0, 0, "", kubelet.os,
+		kubelet.networkPlugin, &fakeOptionGenerator{}, nil, nil)
+
+	kubelet.containerRuntime = dockerManager
+	kubelet.runtimeCache = kubecontainer.NewFakeRuntimeCache(dockerManager)
+}
+
+func TestKubeletProbeAddress(t *testing.T) {
+	testKubelet := newTestKubelet(t)
+	kubelet := testKubelet.kubelet
+
+	kubelet.nodeLister = testNodeLister{nodes: []api.Node{
+		{
+			ObjectMeta: api.ObjectMeta{Name: testKubeletHostname},
+			Status:     api.NodeStatus{Addresses: []api.NodeAddress{{api.NodeInternalIP, testKubeletHostname}}},
+		},
+	}}
+
+	networkMock := &networkPluginMock{}
+	networkMock.statusValues = make(map[string]*network.PodNetworkStatus)
+	kubelet.networkPlugin, _ = network.InitNetworkPlugin(
+		[]network.NetworkPlugin{networkMock}, "networkPluginMock", network.NewFakeHost(kubelet.kubeClient))
+
+	wg := &sync.WaitGroup{}
+	mockHttpProber := newMockHttpProber(wg)
+
+	initFakeRuntime(kubelet, mockHttpProber)
+
+	testKubelet.fakeCadvisor.On("MachineInfo").Return(&cadvisorApi.MachineInfo{}, nil)
+	testKubelet.fakeCadvisor.On("DockerImagesFsInfo").Return(cadvisorApiv2.FsInfo{}, nil)
+	testKubelet.fakeCadvisor.On("RootFsInfo").Return(cadvisorApiv2.FsInfo{}, nil)
+
+	probe := &api.Probe{
+		Handler: api.Handler{
+			HTTPGet: &api.HTTPGetAction{
+				Scheme: api.URISchemeHTTP,
+				Path:   "healthz",
+				Port:   util.NewIntOrStringFromInt(8080),
+			},
+		},
+	}
+
+	pods := []*api.Pod{
+		{
+			ObjectMeta: api.ObjectMeta{
+				Namespace:   "ns",
+				Name:        "test1",
+				UID:         "61a9c401da78",
+				Annotations: map[string]string{},
+				SelfLink:    testapi.Default.SelfLink("pod", ""),
+			},
+			Spec: api.PodSpec{Containers: []api.Container{{Name: "test1-c1", Image: "fake-image", LivenessProbe: probe}}},
+		},
+		{
+			ObjectMeta: api.ObjectMeta{
+				Namespace:   "ns",
+				Name:        "test2",
+				UID:         "e267f88312c1",
+				Annotations: map[string]string{},
+				SelfLink:    testapi.Default.SelfLink("pod", ""),
+			},
+			Spec: api.PodSpec{Containers: []api.Container{{Name: "test2-c1", Image: "fake-image", LivenessProbe: probe}}},
+		},
+	}
+
+	testValues := []struct {
+		podName  string
+		status   *network.PodNetworkStatus
+		expected string
+	}{
+		{
+			"ns/test1",
+			&network.PodNetworkStatus{IP: net.ParseIP("10.0.255.250"), LocalIP: net.ParseIP("169.254.0.2")},
+			"169.254.0.2:8080",
+		},
+		{
+			"ns/test2",
+			&network.PodNetworkStatus{IP: net.ParseIP("10.0.255.251")},
+			"10.0.255.251:8080",
+		},
+	}
+	for _, test := range testValues {
+		networkMock.statusValues[test.podName] = test.status
+	}
+	wg.Add(len(testValues))
+	kubelet.HandlePodAdditions(pods)
+
+	wg.Wait()
+
+	for i, test := range testValues {
+		if !reflect.DeepEqual(mockHttpProber.requestHosts[i], test.expected) {
+			t.Errorf("expected %+v, got %+v", test.expected, mockHttpProber.requestHosts[i])
+		}
+	}
+}

--- a/pkg/kubelet/network/plugins.go
+++ b/pkg/kubelet/network/plugins.go
@@ -65,6 +65,11 @@ type PodNetworkStatus struct {
 	//   - service endpoints are constructed with
 	//   - will be reported in the PodStatus.PodIP field (will override the IP reported by docker)
 	IP net.IP `json:"ip" description:"Primary IP address of the pod"`
+
+	// LocalIP is an optional alternative ipv4/ipv6 address of the pod that is used by the prober
+	// for readyness/liveness checks. This is used in solutions where nodes have access to local
+	// pods (e.g. using a linklocal address or an address that is local to the node)
+	LocalIP net.IP `json:"localIP,omitempty" description:"Alternative address of the pod used for probes"`
 }
 
 // Host is an interface that plugins can use to access the kubelet.

--- a/pkg/kubelet/prober/testing.go
+++ b/pkg/kubelet/prober/testing.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prober
+
+import (
+	"time"
+
+	"k8s.io/kubernetes/pkg/client/record"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/kubelet/prober/results"
+	"k8s.io/kubernetes/pkg/kubelet/status"
+	httprobe "k8s.io/kubernetes/pkg/probe/http"
+)
+
+func NewTestManagerWithHttpProbe(
+	defaultProbePeriod time.Duration,
+	statusManager status.Manager,
+	readinessManager results.Manager,
+	livenessManager results.Manager,
+	runner kubecontainer.ContainerCommandRunner,
+	refManager *kubecontainer.RefManager,
+	recorder record.EventRecorder,
+	httpProber httprobe.HTTPProber) Manager {
+
+	prober := &prober{
+		exec:       nil,
+		http:       httpProber,
+		tcp:        nil,
+		runner:     runner,
+		refManager: refManager,
+		recorder:   recorder,
+	}
+	return &manager{
+		defaultProbePeriod: defaultProbePeriod,
+		statusManager:      statusManager,
+		prober:             prober,
+		readinessManager:   readinessManager,
+		livenessManager:    livenessManager,
+		workers:            make(map[probeKey]*worker),
+	}
+
+}

--- a/pkg/kubelet/types/pod_update.go
+++ b/pkg/kubelet/types/pod_update.go
@@ -26,6 +26,7 @@ const ConfigSourceAnnotationKey = "kubernetes.io/config.source"
 const ConfigMirrorAnnotationKey = "kubernetes.io/config.mirror"
 const ConfigFirstSeenAnnotationKey = "kubernetes.io/config.seen"
 const ConfigHashAnnotationKey = "kubernetes.io/config.hash"
+const StatusLocalAddressAnnotationKey = "kubernetes.io/status.localAddress"
 
 // PodOperation defines what changes will be made on a pod configuration.
 type PodOperation int


### PR DESCRIPTION
When present, use the localIP address when performing readyness/liveness probes.
