### PR TITLE
AWS: install netcat-traditional, instead of netcat-openbsd

### DIFF
--- a/cluster/saltbase/salt/base.sls
+++ b/cluster/saltbase/salt/base.sls
@@ -12,3 +12,9 @@ pkg-core:
       - glusterfs-client
       - socat
 {% endif %}
+# Ubuntu installs netcat-openbsd by default, but on GCE/Debian netcat-traditional is installed.
+# They behave slightly differently.
+# For sanity, we try to make sure we have the same netcat on all OSes (#15166)
+{% if grains['os'] == 'Ubuntu' %}
+      - netcat-traditional
+{% endif %}


### PR DESCRIPTION
We want to match the version of netcat that is installed on GCE.  We
were having problems with netcat-openbsd having slightly different
timeout behaviour (on UDP packets; when there was no listener).
