### PR TITLE
Fix sorting from 3 bugs

### DIFF
--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
+	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/watch"
 )
 
@@ -220,25 +221,51 @@ func RunGet(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string
 		return printer.PrintObj(obj, out)
 	}
 
+	infos, err := b.Flatten().Do().Infos()
+	if err != nil {
+		return err
+	}
+	objs := make([]runtime.Object, len(infos))
+	for ix := range infos {
+		objs[ix] = infos[ix].Object
+	}
+
+	sorting, err := cmd.Flags().GetString("sort-by")
+	var sorter *kubectl.RuntimeSort
+	if err == nil && len(sorting) > 0 {
+		if sorter, err = kubectl.SortObjects(objs, sorting); err != nil {
+			return err
+		}
+	}
+
 	// use the default printer for each object
 	printer = nil
 	var lastMapping *meta.RESTMapping
 	w := kubectl.GetNewTabWriter(out)
 	defer w.Flush()
-	return b.Flatten().Do().Visit(func(r *resource.Info, err error) error {
-		if err != nil {
-			return err
+
+	for ix := range objs {
+		var mapping *meta.RESTMapping
+		if sorter != nil {
+			mapping = infos[sorter.OriginalPosition(ix)].Mapping
+		} else {
+			mapping = infos[ix].Mapping
 		}
-		if printer == nil || lastMapping == nil || r.Mapping == nil || r.Mapping.Resource != lastMapping.Resource {
-			printer, err = f.PrinterForMapping(cmd, r.Mapping, allNamespaces)
+		if printer == nil || lastMapping == nil || mapping == nil || mapping.Resource != lastMapping.Resource {
+			printer, err = f.PrinterForMapping(cmd, mapping, allNamespaces)
 			if err != nil {
 				return err
 			}
-			lastMapping = r.Mapping
+			lastMapping = mapping
 		}
 		if _, found := printer.(*kubectl.HumanReadablePrinter); found {
-			return printer.PrintObj(r.Object, w)
+			if err := printer.PrintObj(objs[ix], w); err != nil {
+				return err
+			}
 		}
-		return printer.PrintObj(r.Object, out)
-	})
+		if err := printer.PrintObj(objs[ix], out); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/kubectl/sorting_printer_test.go
+++ b/pkg/kubectl/sorting_printer_test.go
@@ -24,8 +24,34 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
+func encodeOrDie(obj runtime.Object) []byte {
+	data, err := api.Codec.Encode(obj)
+	if err != nil {
+		panic(err.Error())
+	}
+	return data
+}
+
 func TestSortingPrinter(t *testing.T) {
 	intPtr := func(val int) *int { return &val }
+
+	a := &api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Name: "a",
+		},
+	}
+
+	b := &api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Name: "b",
+		},
+	}
+
+	c := &api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Name: "c",
+		},
+	}
 
 	tests := []struct {
 		obj   runtime.Object
@@ -158,6 +184,42 @@ func TestSortingPrinter(t *testing.T) {
 				},
 			},
 			field: "{.spec.replicas}",
+		},
+		{
+			name: "v1.List in order",
+			obj: &api.List{
+				Items: []runtime.RawExtension{
+					{RawJSON: encodeOrDie(a)},
+					{RawJSON: encodeOrDie(b)},
+					{RawJSON: encodeOrDie(c)},
+				},
+			},
+			sort: &api.List{
+				Items: []runtime.RawExtension{
+					{RawJSON: encodeOrDie(a)},
+					{RawJSON: encodeOrDie(b)},
+					{RawJSON: encodeOrDie(c)},
+				},
+			},
+			field: "{.metadata.name}",
+		},
+		{
+			name: "v1.List in reverse",
+			obj: &api.List{
+				Items: []runtime.RawExtension{
+					{RawJSON: encodeOrDie(c)},
+					{RawJSON: encodeOrDie(b)},
+					{RawJSON: encodeOrDie(a)},
+				},
+			},
+			sort: &api.List{
+				Items: []runtime.RawExtension{
+					{RawJSON: encodeOrDie(a)},
+					{RawJSON: encodeOrDie(b)},
+					{RawJSON: encodeOrDie(c)},
+				},
+			},
+			field: "{.metadata.name}",
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
Bug 1)  SetList doesn't work for `v1.List` since `RawExtension` isn't a `runtime.Object`
Bug 2) The new use of the visitor pattern to visit all fields in a list doesn't work right for sorting.
Bug 3) use `massageJSONPath` here to allow a wider variety of formats.

Need to add unit tests to make sure that these things stay unbroken, but getting this out for review.

@deads2k @jlowdermilk @JanetKuo @kubernetes/kubectl 
