### PR TITLE
AWS: Resync EBS code with GCE PD, misc fixes

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -155,11 +155,11 @@ type Volumes interface {
 	// Attach the disk to the specified instance
 	// instanceName can be empty to mean "the instance on which we are running"
 	// Returns the device (e.g. /dev/xvdf) where we attached the volume
-	AttachDisk(instanceName string, volumeName string, readOnly bool) (string, error)
+	AttachDisk(diskName string, instanceName string, readOnly bool) (string, error)
 	// Detach the disk from the specified instance
 	// instanceName can be empty to mean "the instance on which we are running"
 	// Returns the device where the volume was attached
-	DetachDisk(instanceName string, volumeName string) (string, error)
+	DetachDisk(diskName string, instanceName string) (string, error)
 
 	// Create a volume with the specified options
 	CreateDisk(volumeOptions *VolumeOptions) (volumeName string, err error)
@@ -1172,7 +1172,7 @@ func (aws *AWSCloud) getAwsInstance(nodeName string) (*awsInstance, error) {
 }
 
 // Implements Volumes.AttachDisk
-func (c *AWSCloud) AttachDisk(instanceName string, diskName string, readOnly bool) (string, error) {
+func (c *AWSCloud) AttachDisk(diskName string, instanceName string, readOnly bool) (string, error) {
 	disk, err := newAWSDisk(c, diskName)
 	if err != nil {
 		return "", err
@@ -1237,7 +1237,7 @@ func (c *AWSCloud) AttachDisk(instanceName string, diskName string, readOnly boo
 }
 
 // Implements Volumes.DetachDisk
-func (aws *AWSCloud) DetachDisk(instanceName string, diskName string) (string, error) {
+func (aws *AWSCloud) DetachDisk(diskName string, instanceName string) (string, error) {
 	disk, err := newAWSDisk(aws, diskName)
 	if err != nil {
 		return "", err

--- a/pkg/volume/aws_ebs/aws_util.go
+++ b/pkg/volume/aws_ebs/aws_util.go
@@ -260,7 +260,7 @@ func detachDiskAndVerify(c *awsElasticBlockStoreCleaner) {
 				// Log error, if any, and continue checking periodically.
 				glog.Errorf("Error verifying EBS Disk (%q) is detached: %v", c.volumeID, err)
 			} else if allPathsRemoved {
-				// All paths to the PD have been succefully removed
+				// All paths to the PD have been successfully removed
 				unmountPDAndRemoveGlobalPath(c)
 				glog.Infof("Successfully detached EBS Disk %q.", c.volumeID)
 				return

--- a/pkg/volume/aws_ebs/aws_util.go
+++ b/pkg/volume/aws_ebs/aws_util.go
@@ -17,46 +17,57 @@ limitations under the License.
 package aws_ebs
 
 import (
-	"errors"
+	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
-	aws_cloud "k8s.io/kubernetes/pkg/cloudprovider/providers/aws"
+	"k8s.io/kubernetes/pkg/cloudprovider"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/aws"
+	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/exec"
+	"k8s.io/kubernetes/pkg/util/keymutex"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/volume"
 )
 
+const (
+	diskPartitionSuffix = ""
+	diskXVDPath         = "/dev/xvd"
+	diskXVDPattern      = "/dev/xvd*"
+	maxChecks           = 60
+	maxRetries          = 10
+	checkSleepDuration  = time.Second
+	errorSleepDuration  = 5 * time.Second
+)
+
+// Singleton key mutex for keeping attach/detach operations for the same PD atomic
+var attachDetachMutex = keymutex.NewKeyMutex()
+
 type AWSDiskUtil struct{}
 
-// Attaches a disk specified by a volume.AWSElasticBlockStore to the current kubelet.
+// Attaches a disk to the current kubelet.
 // Mounts the disk to it's global path.
-func (util *AWSDiskUtil) AttachAndMountDisk(b *awsElasticBlockStoreBuilder, globalPDPath string) error {
-	volumes, err := b.getVolumeProvider()
+func (diskUtil *AWSDiskUtil) AttachAndMountDisk(b *awsElasticBlockStoreBuilder, globalPDPath string) error {
+	glog.V(5).Infof("AttachAndMountDisk(...) called for PD %q. Will block for existing operations, if any. (globalPDPath=%q)\r\n", b.volumeID, globalPDPath)
+
+	// Block execution until any pending detach operations for this PD have completed
+	attachDetachMutex.LockKey(b.volumeID)
+	defer attachDetachMutex.UnlockKey(b.volumeID)
+
+	glog.V(5).Infof("AttachAndMountDisk(...) called for PD %q. Awake and ready to execute. (globalPDPath=%q)\r\n", b.volumeID, globalPDPath)
+
+	xvdBefore, err := filepath.Glob(diskXVDPattern)
+	if err != nil {
+		glog.Errorf("Error filepath.Glob(\"%s\"): %v\r\n", diskXVDPattern, err)
+	}
+	xvdBeforeSet := sets.NewString(xvdBefore...)
+
+	devicePath, err := attachDiskAndVerify(b, xvdBeforeSet)
 	if err != nil {
 		return err
-	}
-	devicePath, err := volumes.AttachDisk("", b.volumeID, b.readOnly)
-	if err != nil {
-		return err
-	}
-	if b.partition != "" {
-		devicePath = devicePath + b.partition
-	}
-	//TODO(jonesdl) There should probably be better method than busy-waiting here.
-	numTries := 0
-	for {
-		_, err := os.Stat(devicePath)
-		if err == nil {
-			break
-		}
-		if err != nil && !os.IsNotExist(err) {
-			return err
-		}
-		numTries++
-		if numTries == 10 {
-			return errors.New("Could not attach disk: Timeout after 10s (" + devicePath + ")")
-		}
-		time.Sleep(time.Second)
 	}
 
 	// Only mount the PD globally once.
@@ -87,64 +98,292 @@ func (util *AWSDiskUtil) AttachAndMountDisk(b *awsElasticBlockStoreBuilder, glob
 
 // Unmounts the device and detaches the disk from the kubelet's host machine.
 func (util *AWSDiskUtil) DetachDisk(c *awsElasticBlockStoreCleaner) error {
-	// Unmount the global PD mount, which should be the only one.
-	globalPDPath := makeGlobalPDPath(c.plugin.host, c.volumeID)
-	if err := c.mounter.Unmount(globalPDPath); err != nil {
-		glog.V(2).Info("Error unmount dir ", globalPDPath, ": ", err)
-		return err
+	glog.V(5).Infof("DetachDisk(...) for PD %q\r\n", c.volumeID)
+
+	if err := unmountPDAndRemoveGlobalPath(c); err != nil {
+		glog.Errorf("Error unmounting PD %q: %v", c.volumeID, err)
 	}
-	if err := os.Remove(globalPDPath); err != nil {
-		glog.V(2).Info("Error removing dir ", globalPDPath, ": ", err)
-		return err
-	}
-	// Detach the disk
-	volumes, err := c.getVolumeProvider()
-	if err != nil {
-		glog.V(2).Info("Error getting volume provider for volumeID ", c.volumeID, ": ", err)
-		return err
-	}
-	if err := volumes.DetachDisk("", c.volumeID); err != nil {
-		glog.V(2).Info("Error detaching disk ", c.volumeID, ": ", err)
-		return err
-	}
+
+	// Detach disk asynchronously so that the kubelet sync loop is not blocked.
+	go detachDiskAndVerify(c)
 	return nil
 }
 
 func (util *AWSDiskUtil) DeleteVolume(d *awsElasticBlockStoreDeleter) error {
-	volumes, err := d.getVolumeProvider()
+	cloud, err := getCloudProvider()
 	if err != nil {
-		glog.V(2).Info("Error getting volume provider: ", err)
 		return err
 	}
 
-	if err := volumes.DeleteVolume(d.volumeID); err != nil {
-		glog.V(2).Infof("Error deleting AWS EBS volume %s: %v", d.volumeID, err)
+	if err = cloud.DeleteDisk(d.volumeID); err != nil {
+		glog.V(2).Infof("Error deleting EBS Disk volume %s: %v", d.volumeID, err)
 		return err
 	}
-	glog.V(2).Infof("Successfully deleted AWS EBS volume %s", d.volumeID)
+	glog.V(2).Infof("Successfully deleted EBS Disk volume %s", d.volumeID)
 	return nil
 }
 
 func (util *AWSDiskUtil) CreateVolume(c *awsElasticBlockStoreProvisioner) (volumeID string, volumeSizeGB int, err error) {
-	volumes, err := c.getVolumeProvider()
+	cloud, err := getCloudProvider()
 	if err != nil {
-		glog.V(2).Info("Error getting volume provider: ", err)
 		return "", 0, err
 	}
 
 	requestBytes := c.options.Capacity.Value()
-	// AWS works with gigabytes, convert to GiB with rounding up
-	requestGB := int(volume.RoundUpSize(requestBytes, 1024*1024*1024))
-	volSpec := &aws_cloud.VolumeOptions{
-		CapacityGB: requestGB,
-		Tags:       c.options.CloudTags,
-	}
+	// The cloud provider works with gigabytes, convert to GiB with rounding up
+	requestGB := volume.RoundUpSize(requestBytes, 1024*1024*1024)
 
-	name, err := volumes.CreateVolume(volSpec)
+	volumeOptions := &aws.VolumeOptions{}
+	volumeOptions.CapacityGB = int(requestGB)
+
+	name, err := cloud.CreateDisk(volumeOptions)
 	if err != nil {
-		glog.V(2).Infof("Error creating AWS EBS volume: %v", err)
+		glog.V(2).Infof("Error creating EBS Disk volume: %v", err)
 		return "", 0, err
 	}
-	glog.V(2).Infof("Successfully created AWS EBS volume %s", name)
-	return name, requestGB, nil
+	glog.V(2).Infof("Successfully created EBS Disk volume %s", name)
+	return name, int(requestGB), nil
+}
+
+// Attaches the specified persistent disk device to node, verifies that it is attached, and retries if it fails.
+func attachDiskAndVerify(b *awsElasticBlockStoreBuilder, xvdBeforeSet sets.String) (string, error) {
+	var awsCloud *aws.AWSCloud
+	for numRetries := 0; numRetries < maxRetries; numRetries++ {
+		var err error
+		if awsCloud == nil {
+			awsCloud, err = getCloudProvider()
+			if err != nil || awsCloud == nil {
+				// Retry on error. See issue #11321
+				glog.Errorf("Error getting AWSCloudProvider while detaching PD %q: %v", b.volumeID, err)
+				time.Sleep(errorSleepDuration)
+				continue
+			}
+		}
+
+		if numRetries > 0 {
+			glog.Warningf("Retrying attach for EBS Disk %q (retry count=%v).", b.volumeID, numRetries)
+		}
+
+		devicePath, err := awsCloud.AttachDisk(b.volumeID, b.plugin.host.GetHostName(), b.readOnly)
+		if err != nil {
+			glog.Errorf("Error attaching PD %q: %v", b.volumeID, err)
+			time.Sleep(errorSleepDuration)
+			continue
+		}
+
+		devicePaths := getDiskByIdPaths(b.awsElasticBlockStore, devicePath)
+
+		for numChecks := 0; numChecks < maxChecks; numChecks++ {
+			path, err := verifyDevicePath(devicePaths, xvdBeforeSet)
+			if err != nil {
+				// Log error, if any, and continue checking periodically. See issue #11321
+				glog.Errorf("Error verifying EBS Disk (%q) is attached: %v", b.volumeID, err)
+			} else if path != "" {
+				// A device path has successfully been created for the PD
+				glog.Infof("Successfully attached EBS Disk %q.", b.volumeID)
+				return path, nil
+			}
+
+			// Sleep then check again
+			glog.V(3).Infof("Waiting for EBS Disk %q to attach.", b.volumeID)
+			time.Sleep(checkSleepDuration)
+		}
+	}
+
+	return "", fmt.Errorf("Could not attach EBS Disk %q. Timeout waiting for mount paths to be created.", b.volumeID)
+}
+
+// Returns the first path that exists, or empty string if none exist.
+func verifyDevicePath(devicePaths []string, xvdBeforeSet sets.String) (string, error) {
+	if err := udevadmChangeToNewDrives(xvdBeforeSet); err != nil {
+		// udevadm errors should not block disk detachment, log and continue
+		glog.Errorf("udevadmChangeToNewDrives failed with: %v", err)
+	}
+
+	for _, path := range devicePaths {
+		if pathExists, err := pathExists(path); err != nil {
+			return "", fmt.Errorf("Error checking if path exists: %v", err)
+		} else if pathExists {
+			return path, nil
+		}
+	}
+
+	return "", nil
+}
+
+// Detaches the specified persistent disk device from node, verifies that it is detached, and retries if it fails.
+// This function is intended to be called asynchronously as a go routine.
+func detachDiskAndVerify(c *awsElasticBlockStoreCleaner) {
+	glog.V(5).Infof("detachDiskAndVerify(...) for pd %q. Will block for pending operations", c.volumeID)
+	defer util.HandleCrash()
+
+	// Block execution until any pending attach/detach operations for this PD have completed
+	attachDetachMutex.LockKey(c.volumeID)
+	defer attachDetachMutex.UnlockKey(c.volumeID)
+
+	glog.V(5).Infof("detachDiskAndVerify(...) for pd %q. Awake and ready to execute.", c.volumeID)
+
+	var awsCloud *aws.AWSCloud
+	for numRetries := 0; numRetries < maxRetries; numRetries++ {
+		var err error
+		if awsCloud == nil {
+			awsCloud, err = getCloudProvider()
+			if err != nil || awsCloud == nil {
+				// Retry on error. See issue #11321
+				glog.Errorf("Error getting AWSCloudProvider while detaching PD %q: %v", c.volumeID, err)
+				time.Sleep(errorSleepDuration)
+				continue
+			}
+		}
+
+		if numRetries > 0 {
+			glog.Warningf("Retrying detach for EBS Disk %q (retry count=%v).", c.volumeID, numRetries)
+		}
+
+		devicePath, err := awsCloud.DetachDisk(c.volumeID, c.plugin.host.GetHostName())
+		if err != nil {
+			glog.Errorf("Error detaching PD %q: %v", c.volumeID, err)
+			time.Sleep(errorSleepDuration)
+			continue
+		}
+
+		devicePaths := getDiskByIdPaths(c.awsElasticBlockStore, devicePath)
+
+		for numChecks := 0; numChecks < maxChecks; numChecks++ {
+			allPathsRemoved, err := verifyAllPathsRemoved(devicePaths)
+			if err != nil {
+				// Log error, if any, and continue checking periodically.
+				glog.Errorf("Error verifying EBS Disk (%q) is detached: %v", c.volumeID, err)
+			} else if allPathsRemoved {
+				// All paths to the PD have been succefully removed
+				unmountPDAndRemoveGlobalPath(c)
+				glog.Infof("Successfully detached EBS Disk %q.", c.volumeID)
+				return
+			}
+
+			// Sleep then check again
+			glog.V(3).Infof("Waiting for EBS Disk %q to detach.", c.volumeID)
+			time.Sleep(checkSleepDuration)
+		}
+
+	}
+
+	glog.Errorf("Failed to detach EBS Disk %q. One or more mount paths was not removed.", c.volumeID)
+}
+
+// Unmount the global PD mount, which should be the only one, and delete it.
+func unmountPDAndRemoveGlobalPath(c *awsElasticBlockStoreCleaner) error {
+	globalPDPath := makeGlobalPDPath(c.plugin.host, c.volumeID)
+
+	err := c.mounter.Unmount(globalPDPath)
+	os.Remove(globalPDPath)
+	return err
+}
+
+// Returns the first path that exists, or empty string if none exist.
+func verifyAllPathsRemoved(devicePaths []string) (bool, error) {
+	allPathsRemoved := true
+	for _, path := range devicePaths {
+		if err := udevadmChangeToDrive(path); err != nil {
+			// udevadm errors should not block disk detachment, log and continue
+			glog.Errorf("%v", err)
+		}
+		if exists, err := pathExists(path); err != nil {
+			return false, fmt.Errorf("Error checking if path exists: %v", err)
+		} else {
+			allPathsRemoved = allPathsRemoved && !exists
+		}
+	}
+
+	return allPathsRemoved, nil
+}
+
+// Returns list of all paths for given EBS mount
+// This is more interesting on GCE (where we are able to identify volumes under /dev/disk-by-id)
+// Here it is mostly about applying the partition path
+func getDiskByIdPaths(d *awsElasticBlockStore, devicePath string) []string {
+	devicePaths := []string{}
+	if devicePath != "" {
+		devicePaths = append(devicePaths, devicePath)
+	}
+
+	if d.partition != "" {
+		for i, path := range devicePaths {
+			devicePaths[i] = path + diskPartitionSuffix + d.partition
+		}
+	}
+
+	return devicePaths
+}
+
+// Checks if the specified path exists
+func pathExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	} else if os.IsNotExist(err) {
+		return false, nil
+	} else {
+		return false, err
+	}
+}
+
+// Return cloud provider
+func getCloudProvider() (*aws.AWSCloud, error) {
+	awsCloudProvider, err := cloudprovider.GetCloudProvider("aws", nil)
+	if err != nil || awsCloudProvider == nil {
+		return nil, err
+	}
+
+	// The conversion must be safe otherwise bug in GetCloudProvider()
+	return awsCloudProvider.(*aws.AWSCloud), nil
+}
+
+// TODO: This udev code is copy-and-paste from the gce_pd provider; refactor
+
+// Calls "udevadm trigger --action=change" for newly created "/dev/xvd*" drives (exist only in after set).
+// This is workaround for Issue #7972. Once the underlying issue has been resolved, this may be removed.
+func udevadmChangeToNewDrives(xvdBeforeSet sets.String) error {
+	xvdAfter, err := filepath.Glob(diskXVDPattern)
+	if err != nil {
+		return fmt.Errorf("Error filepath.Glob(\"%s\"): %v\r\n", diskXVDPattern, err)
+	}
+
+	for _, xvd := range xvdAfter {
+		if !xvdBeforeSet.Has(xvd) {
+			return udevadmChangeToDrive(xvd)
+		}
+	}
+
+	return nil
+}
+
+// Calls "udevadm trigger --action=change" on the specified drive.
+// drivePath must be the the block device path to trigger on, in the format "/dev/sd*", or a symlink to it.
+// This is workaround for Issue #7972. Once the underlying issue has been resolved, this may be removed.
+func udevadmChangeToDrive(drivePath string) error {
+	glog.V(5).Infof("udevadmChangeToDrive: drive=%q", drivePath)
+
+	// Evaluate symlink, if any
+	drive, err := filepath.EvalSymlinks(drivePath)
+	if err != nil {
+		return fmt.Errorf("udevadmChangeToDrive: filepath.EvalSymlinks(%q) failed with %v.", drivePath, err)
+	}
+	glog.V(5).Infof("udevadmChangeToDrive: symlink path is %q", drive)
+
+	// Check to make sure input is "/dev/xvd*"
+	if !strings.Contains(drive, diskXVDPath) {
+		return fmt.Errorf("udevadmChangeToDrive: expected input in the form \"%s\" but drive is %q.", diskXVDPattern, drive)
+	}
+
+	// Call "udevadm trigger --action=change --property-match=DEVNAME=/dev/sd..."
+	_, err = exec.New().Command(
+		"udevadm",
+		"trigger",
+		"--action=change",
+		fmt.Sprintf("--property-match=DEVNAME=%s", drive)).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("udevadmChangeToDrive: udevadm trigger failed for drive %q with %v.", drive, err)
+	}
+	return nil
 }

--- a/pkg/volume/aws_ebs/aws_util.go
+++ b/pkg/volume/aws_ebs/aws_util.go
@@ -115,11 +115,16 @@ func (util *AWSDiskUtil) DeleteVolume(d *awsElasticBlockStoreDeleter) error {
 		return err
 	}
 
-	if err = cloud.DeleteDisk(d.volumeID); err != nil {
+	deleted, err := cloud.DeleteDisk(d.volumeID)
+	if err != nil {
 		glog.V(2).Infof("Error deleting EBS Disk volume %s: %v", d.volumeID, err)
 		return err
 	}
-	glog.V(2).Infof("Successfully deleted EBS Disk volume %s", d.volumeID)
+	if deleted {
+		glog.V(2).Infof("Successfully deleted EBS Disk volume %s", d.volumeID)
+	} else {
+		glog.V(2).Infof("Successfully deleted EBS Disk volume %s (actually already deleted)", d.volumeID)
+	}
 	return nil
 }
 

--- a/pkg/volume/aws_ebs/aws_util.go
+++ b/pkg/volume/aws_ebs/aws_util.go
@@ -26,9 +26,9 @@ import (
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/aws"
-	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/exec"
 	"k8s.io/kubernetes/pkg/util/keymutex"
+	"k8s.io/kubernetes/pkg/util/runtime"
 	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/volume"
 )
@@ -220,7 +220,7 @@ func verifyDevicePath(devicePaths []string, xvdBeforeSet sets.String) (string, e
 // This function is intended to be called asynchronously as a go routine.
 func detachDiskAndVerify(c *awsElasticBlockStoreCleaner) {
 	glog.V(5).Infof("detachDiskAndVerify(...) for pd %q. Will block for pending operations", c.volumeID)
-	defer util.HandleCrash()
+	defer runtime.HandleCrash()
 
 	// Block execution until any pending attach/detach operations for this PD have completed
 	attachDetachMutex.LockKey(c.volumeID)

--- a/pkg/volume/gce_pd/gce_util.go
+++ b/pkg/volume/gce_pd/gce_util.go
@@ -262,7 +262,7 @@ func detachDiskAndVerify(c *gcePersistentDiskCleaner) {
 				// Log error, if any, and continue checking periodically.
 				glog.Errorf("Error verifying GCE PD (%q) is detached: %v", c.pdName, err)
 			} else if allPathsRemoved {
-				// All paths to the PD have been succefully removed
+				// All paths to the PD have been successfully removed
 				unmountPDAndRemoveGlobalPath(c)
 				glog.Infof("Successfully detached GCE PD %q.", c.pdName)
 				return

--- a/plugin/pkg/admission/persistentvolume/label/admission_test.go
+++ b/plugin/pkg/admission/persistentvolume/label/admission_test.go
@@ -33,11 +33,11 @@ type mockVolumes struct {
 
 var _ aws.Volumes = &mockVolumes{}
 
-func (v *mockVolumes) AttachDisk(instanceName string, volumeName string, readOnly bool) (string, error) {
+func (v *mockVolumes) AttachDisk(diskName string, instanceName string, readOnly bool) (string, error) {
 	return "", fmt.Errorf("not implemented")
 }
 
-func (v *mockVolumes) DetachDisk(instanceName string, volumeName string) (string, error) {
+func (v *mockVolumes) DetachDisk(diskName string, instanceName string) (string, error) {
 	return "", fmt.Errorf("not implemented")
 }
 

--- a/plugin/pkg/admission/persistentvolume/label/admission_test.go
+++ b/plugin/pkg/admission/persistentvolume/label/admission_test.go
@@ -37,11 +37,11 @@ func (v *mockVolumes) AttachDisk(instanceName string, volumeName string, readOnl
 	return "", fmt.Errorf("not implemented")
 }
 
-func (v *mockVolumes) DetachDisk(instanceName string, volumeName string) error {
-	return fmt.Errorf("not implemented")
+func (v *mockVolumes) DetachDisk(instanceName string, volumeName string) (string, error) {
+	return "", fmt.Errorf("not implemented")
 }
 
-func (v *mockVolumes) CreateVolume(volumeOptions *aws.VolumeOptions) (volumeName string, err error) {
+func (v *mockVolumes) CreateDisk(volumeOptions *aws.VolumeOptions) (volumeName string, err error) {
 	return "", fmt.Errorf("not implemented")
 }
 

--- a/plugin/pkg/admission/persistentvolume/label/admission_test.go
+++ b/plugin/pkg/admission/persistentvolume/label/admission_test.go
@@ -45,8 +45,8 @@ func (v *mockVolumes) CreateDisk(volumeOptions *aws.VolumeOptions) (volumeName s
 	return "", fmt.Errorf("not implemented")
 }
 
-func (v *mockVolumes) DeleteVolume(volumeName string) error {
-	return fmt.Errorf("not implemented")
+func (v *mockVolumes) DeleteDisk(volumeName string) (bool, error) {
+	return false, fmt.Errorf("not implemented")
 }
 
 func (v *mockVolumes) GetVolumeLabels(volumeName string) (map[string]string, error) {

--- a/test/e2e/pd.go
+++ b/test/e2e/pd.go
@@ -326,7 +326,7 @@ func createPD() (string, error) {
 		}
 		volumeOptions := &awscloud.VolumeOptions{}
 		volumeOptions.CapacityGB = 10
-		return volumes.CreateVolume(volumeOptions)
+		return volumes.CreateDisk(volumeOptions)
 	}
 }
 
@@ -353,7 +353,7 @@ func deletePD(pdName string) error {
 		if !ok {
 			return fmt.Errorf("Provider does not support volumes")
 		}
-		return volumes.DeleteVolume(pdName)
+		return volumes.DeleteDisk(pdName)
 	}
 }
 
@@ -383,7 +383,8 @@ func detachPD(hostName, pdName string) error {
 		if !ok {
 			return fmt.Errorf("Provider does not support volumes")
 		}
-		return volumes.DetachDisk(hostName, pdName)
+		_, err := volumes.DetachDisk(hostName, pdName)
+		return err
 	}
 }
 

--- a/test/e2e/pd.go
+++ b/test/e2e/pd.go
@@ -353,7 +353,15 @@ func deletePD(pdName string) error {
 		if !ok {
 			return fmt.Errorf("Provider does not support volumes")
 		}
-		return volumes.DeleteDisk(pdName)
+		deleted, err := volumes.DeleteDisk(pdName)
+		if err != nil {
+			return err
+		} else {
+			if !deleted {
+				Logf("Volume deletion implicitly succeeded because volume %q does not exist.", pdName)
+			}
+			return nil
+		}
 	}
 }
 

--- a/test/e2e/pd.go
+++ b/test/e2e/pd.go
@@ -391,7 +391,7 @@ func detachPD(hostName, pdName string) error {
 		if !ok {
 			return fmt.Errorf("Provider does not support volumes")
 		}
-		_, err := volumes.DetachDisk(hostName, pdName)
+		_, err := volumes.DetachDisk(pdName, hostName)
 		return err
 	}
 }


### PR DESCRIPTION
The main change here is to re-sync the AWS EBS code to the GCE PD code.  Sadly they are a copy-and-paste of each other (I would like to start moving common functionality into a shared directory, but first things first).

The GCE PD code accumulated nice retry logic around volume mounting which we want in EBS, as it should help with some AWS EBS edge cases (primarily in pkg/volume/aws_ebs/aws_util.go)

There are also some fixes to make the mount-device clearer (which fixes a mistake/confusion I made before), and to handle deleting a volume which doesn't exist (which allows the tests to pass, because the tests delete volumes twice assuming idempotency)
