### PR TITLE
Fix capitalization of acronyms

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -99,8 +99,8 @@ type CMServer struct {
 
 	Master       string
 	Kubeconfig   string
-	KubeApiQps   float32
-	KubeApiBurst int
+	KubeAPIQPS   float32
+	KubeAPIBurst int
 }
 
 // NewCMServer creates a new CMServer with a default config.
@@ -131,8 +131,8 @@ func NewCMServer() *CMServer {
 			PersistentVolumeRecyclerMinimumTimeoutHostPath:   60,
 			PersistentVolumeRecyclerIncrementTimeoutHostPath: 30,
 		},
-		KubeApiQps:   20.0,
-		KubeApiBurst: 30,
+		KubeAPIQPS:   20.0,
+		KubeAPIBurst: 30,
 	}
 	return &s
 }
@@ -197,8 +197,8 @@ func (s *CMServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.Master, "master", s.Master, "The address of the Kubernetes API server (overrides any value in kubeconfig)")
 	fs.StringVar(&s.Kubeconfig, "kubeconfig", s.Kubeconfig, "Path to kubeconfig file with authorization and master location information.")
 	fs.StringVar(&s.RootCAFile, "root-ca-file", s.RootCAFile, "If set, this root certificate authority will be included in service account's token secret. This must be a valid PEM-encoded CA bundle.")
-	fs.Float32Var(&s.KubeApiQps, "kube-api-qps", s.KubeApiQps, "QPS to use while talking with kubernetes apiserver")
-	fs.IntVar(&s.KubeApiBurst, "kube-api-burst", s.KubeApiBurst, "Burst to use while talking with kubernetes apiserver")
+	fs.Float32Var(&s.KubeAPIQPS, "kube-api-qps", s.KubeAPIQPS, "QPS to use while talking with kubernetes apiserver")
+	fs.IntVar(&s.KubeAPIBurst, "kube-api-burst", s.KubeAPIBurst, "Burst to use while talking with kubernetes apiserver")
 }
 
 func (s *CMServer) resyncPeriod() time.Duration {
@@ -222,8 +222,8 @@ func (s *CMServer) Run(_ []string) error {
 	}
 
 	// Override kubeconfig qps/burst settings from flags
-	kubeconfig.QPS = s.KubeApiQps
-	kubeconfig.Burst = s.KubeApiBurst
+	kubeconfig.QPS = s.KubeAPIQPS
+	kubeconfig.Burst = s.KubeAPIBurst
 
 	kubeClient, err := client.New(kubeconfig)
 	if err != nil {

--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -65,8 +65,8 @@ type ProxyServerConfig struct {
 	nodeRef            *api.ObjectReference // Reference to this node.
 	MasqueradeAll      bool
 	CleanupAndExit     bool
-	KubeApiQps         float32
-	KubeApiBurst       int
+	KubeAPIQPS         float32
+	KubeAPIBurst       int
 	UDPIdleTimeout     time.Duration
 }
 
@@ -93,8 +93,8 @@ func (s *ProxyServerConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&s.ConfigSyncPeriod, "config-sync-period", s.ConfigSyncPeriod, "How often configuration from the apiserver is refreshed.  Must be greater than 0.")
 	fs.BoolVar(&s.MasqueradeAll, "masquerade-all", false, "If using the pure iptables proxy, SNAT everything")
 	fs.BoolVar(&s.CleanupAndExit, "cleanup-iptables", false, "If true cleanup iptables rules and exit.")
-	fs.Float32Var(&s.KubeApiQps, "kube-api-qps", s.KubeApiQps, "QPS to use while talking with kubernetes apiserver")
-	fs.IntVar(&s.KubeApiBurst, "kube-api-burst", s.KubeApiBurst, "Burst to use while talking with kubernetes apiserver")
+	fs.Float32Var(&s.KubeAPIQPS, "kube-api-qps", s.KubeAPIQPS, "QPS to use while talking with kubernetes apiserver")
+	fs.IntVar(&s.KubeAPIBurst, "kube-api-burst", s.KubeAPIBurst, "Burst to use while talking with kubernetes apiserver")
 	fs.DurationVar(&s.UDPIdleTimeout, "udp-timeout", s.UDPIdleTimeout, "How long an idle UDP connection will be kept open (e.g. '250ms', '2s').  Must be greater than 0. Only applicable for proxy-mode=userspace")
 }
 
@@ -122,8 +122,8 @@ func NewProxyConfig() *ProxyServerConfig {
 		ResourceContainer:  "/kube-proxy",
 		IptablesSyncPeriod: 30 * time.Second,
 		ConfigSyncPeriod:   15 * time.Minute,
-		KubeApiQps:         5.0,
-		KubeApiBurst:       10,
+		KubeAPIQPS:         5.0,
+		KubeAPIBurst:       10,
 		UDPIdleTimeout:     250 * time.Millisecond,
 	}
 }
@@ -195,8 +195,8 @@ func NewProxyServerDefault(config *ProxyServerConfig) (*ProxyServer, error) {
 	}
 
 	// Override kubeconfig qps/burst settings from flags
-	kubeconfig.QPS = config.KubeApiQps
-	kubeconfig.Burst = config.KubeApiBurst
+	kubeconfig.QPS = config.KubeAPIQPS
+	kubeconfig.Burst = config.KubeAPIBurst
 
 	client, err := kubeclient.New(kubeconfig)
 	if err != nil {

--- a/plugin/cmd/kube-scheduler/app/server.go
+++ b/plugin/cmd/kube-scheduler/app/server.go
@@ -56,8 +56,8 @@ type SchedulerServer struct {
 	Kubeconfig        string
 	BindPodsQPS       float32
 	BindPodsBurst     int
-	KubeApiQps        float32
-	KubeApiBurst      int
+	KubeAPIQPS        float32
+	KubeAPIBurst      int
 }
 
 // NewSchedulerServer creates a new SchedulerServer with default parameters
@@ -68,8 +68,8 @@ func NewSchedulerServer() *SchedulerServer {
 		AlgorithmProvider: factory.DefaultProvider,
 		BindPodsQPS:       50.0,
 		BindPodsBurst:     100,
-		KubeApiQps:        50.0,
-		KubeApiBurst:      100,
+		KubeAPIQPS:        50.0,
+		KubeAPIBurst:      100,
 	}
 	return &s
 }
@@ -85,8 +85,8 @@ func (s *SchedulerServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.Kubeconfig, "kubeconfig", s.Kubeconfig, "Path to kubeconfig file with authorization and master location information.")
 	fs.Float32Var(&s.BindPodsQPS, "bind-pods-qps", s.BindPodsQPS, "Number of bindings per second scheduler is allowed to continuously make")
 	fs.IntVar(&s.BindPodsBurst, "bind-pods-burst", s.BindPodsBurst, "Number of bindings per second scheduler is allowed to make during bursts")
-	fs.Float32Var(&s.KubeApiQps, "kube-api-qps", s.KubeApiQps, "QPS to use while talking with kubernetes apiserver")
-	fs.IntVar(&s.KubeApiBurst, "kube-api-burst", s.KubeApiBurst, "Burst to use while talking with kubernetes apiserver")
+	fs.Float32Var(&s.KubeAPIQPS, "kube-api-qps", s.KubeAPIQPS, "QPS to use while talking with kubernetes apiserver")
+	fs.IntVar(&s.KubeAPIBurst, "kube-api-burst", s.KubeAPIBurst, "Burst to use while talking with kubernetes apiserver")
 }
 
 // Run runs the specified SchedulerServer.  This should never exit.
@@ -105,8 +105,8 @@ func (s *SchedulerServer) Run(_ []string) error {
 	}
 
 	// Override kubeconfig qps/burst settings from flags
-	kubeconfig.QPS = s.KubeApiQps
-	kubeconfig.Burst = s.KubeApiBurst
+	kubeconfig.QPS = s.KubeAPIQPS
+	kubeconfig.Burst = s.KubeAPIBurst
 
 	kubeClient, err := client.New(kubeconfig)
 	if err != nil {


### PR DESCRIPTION
This references issue #15852:

globally search/replace 'KubeApiQps' to 'KubeAPIQPS' and 'KubeApiBurst' to 'KubeAPIBurst' to match GO rules
