### PR TITLE
e2e: Add aws provider to daemon_restart test

### DIFF
--- a/test/e2e/daemon_restart.go
+++ b/test/e2e/daemon_restart.go
@@ -200,7 +200,7 @@ var _ = Describe("DaemonRestart", func() {
 
 		// These tests require SSH
 		// TODO(11834): Enable this test in GKE once experimental API there is switched on
-		SkipUnlessProviderIs("gce")
+		SkipUnlessProviderIs("gce", "aws")
 		framework.beforeEach()
 		ns = framework.Namespace.Name
 


### PR DESCRIPTION
(with this the e2e tests pass again on AWS for the kubernetes-e2e-aws job)
