### PR TITLE
Add handling of old non-capitalized event reason to scheduler-predicates test

### DIFF
--- a/test/e2e/scheduler_predicates.go
+++ b/test/e2e/scheduler_predicates.go
@@ -110,6 +110,22 @@ func verifyResult(c *client.Client, podName string, ns string) {
 			"reason":                   "FailedScheduling",
 		}.AsSelector())
 	expectNoError(err)
+	// If we failed to find event with a capitalized first letter of reason
+	// try looking for one starting with a small one for backward compatibility.
+	// If we don't do it we end up in #15806.
+	// TODO: remove this block when we don't care about supporting v1.0 too much.
+	if len(schedEvents.Items) == 0 {
+		schedEvents, err = c.Events(ns).List(
+			labels.Everything(),
+			fields.Set{
+				"involvedObject.kind":      "Pod",
+				"involvedObject.name":      podName,
+				"involvedObject.namespace": ns,
+				"source":                   "scheduler",
+				"reason":                   "failedScheduling",
+			}.AsSelector())
+		expectNoError(err)
+	}
 
 	printed := false
 	printOnce := func(msg string) string {


### PR DESCRIPTION
One of the ways to fix #15806
