### PR TITLE
rbd: support NoDiskConflicts scheduler predicates

### DIFF
--- a/plugin/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/plugin/pkg/scheduler/algorithm/predicates/predicates.go
@@ -56,11 +56,11 @@ func isVolumeConflict(volume api.Volume, pod *api.Pod) bool {
 	if volume.GCEPersistentDisk != nil {
 		disk := volume.GCEPersistentDisk
 
-		manifest := &(pod.Spec)
-		for ix := range manifest.Volumes {
-			if manifest.Volumes[ix].GCEPersistentDisk != nil &&
-				manifest.Volumes[ix].GCEPersistentDisk.PDName == disk.PDName &&
-				!(manifest.Volumes[ix].GCEPersistentDisk.ReadOnly && disk.ReadOnly) {
+		existingPods := &(pod.Spec)
+		for ix := range existingPods.Volumes {
+			if existingPods.Volumes[ix].GCEPersistentDisk != nil &&
+				existingPods.Volumes[ix].GCEPersistentDisk.PDName == disk.PDName &&
+				!(existingPods.Volumes[ix].GCEPersistentDisk.ReadOnly && disk.ReadOnly) {
 				return true
 			}
 		}
@@ -68,10 +68,10 @@ func isVolumeConflict(volume api.Volume, pod *api.Pod) bool {
 	if volume.AWSElasticBlockStore != nil {
 		volumeID := volume.AWSElasticBlockStore.VolumeID
 
-		manifest := &(pod.Spec)
-		for ix := range manifest.Volumes {
-			if manifest.Volumes[ix].AWSElasticBlockStore != nil &&
-				manifest.Volumes[ix].AWSElasticBlockStore.VolumeID == volumeID {
+		existingPods := &(pod.Spec)
+		for ix := range existingPods.Volumes {
+			if existingPods.Volumes[ix].AWSElasticBlockStore != nil &&
+				existingPods.Volumes[ix].AWSElasticBlockStore.VolumeID == volumeID {
 				return true
 			}
 		}
@@ -81,12 +81,12 @@ func isVolumeConflict(volume api.Volume, pod *api.Pod) bool {
 		pool := volume.RBD.RBDPool
 		image := volume.RBD.RBDImage
 
-		manifest := &(pod.Spec)
-		for ix := range manifest.Volumes {
-			if manifest.Volumes[ix].RBD != nil {
-				mon_m := manifest.Volumes[ix].RBD.CephMonitors
-				pool_m := manifest.Volumes[ix].RBD.RBDPool
-				image_m := manifest.Volumes[ix].RBD.RBDImage
+		existingPods := &(pod.Spec)
+		for ix := range existingPods.Volumes {
+			if existingPods.Volumes[ix].RBD != nil {
+				mon_m := existingPods.Volumes[ix].RBD.CephMonitors
+				pool_m := existingPods.Volumes[ix].RBD.RBDPool
+				image_m := existingPods.Volumes[ix].RBD.RBDImage
 				if haveSame(mon, mon_m) && pool_m == pool && image_m == image {
 					return true
 				}
@@ -97,15 +97,14 @@ func isVolumeConflict(volume api.Volume, pod *api.Pod) bool {
 }
 
 // NoDiskConflict evaluates if a pod can fit due to the volumes it requests, and those that
-// are already mounted. Some times of volumes are mounted onto node machines.  For now, these mounts
-// are exclusive so if there is already a volume mounted on that node, another pod can't schedule
-// there. This is GCE, Amazon EBS, and Ceph RBD specific for now.
+// are already mounted. If there is already a volume mounted on that node, another pod that uses the same volume
+// can't be scheduled there. This is GCE, Amazon EBS, and Ceph RBD specific for now.
 // TODO: migrate this into some per-volume specific code?
 func NoDiskConflict(pod *api.Pod, existingPods []*api.Pod, node string) (bool, error) {
-	manifest := &(pod.Spec)
-	for ix := range manifest.Volumes {
+	podSpec := &(pod.Spec)
+	for ix := range podSpec.Volumes {
 		for podIx := range existingPods {
-			if isVolumeConflict(manifest.Volumes[ix], existingPods[podIx]) {
+			if isVolumeConflict(podSpec.Volumes[ix], existingPods[podIx]) {
 				return false, nil
 			}
 		}

--- a/plugin/pkg/scheduler/algorithm/predicates/predicates_test.go
+++ b/plugin/pkg/scheduler/algorithm/predicates/predicates_test.go
@@ -435,6 +435,61 @@ func TestAWSDiskConflicts(t *testing.T) {
 	}
 }
 
+func TestRBDDiskConflicts(t *testing.T) {
+	volState := api.PodSpec{
+		Volumes: []api.Volume{
+			{
+				VolumeSource: api.VolumeSource{
+					RBD: &api.RBDVolumeSource{
+						CephMonitors: []string{"a", "b"},
+						RBDPool:      "foo",
+						RBDImage:     "bar",
+						FSType:       "ext4",
+					},
+				},
+			},
+		},
+	}
+	volState2 := api.PodSpec{
+		Volumes: []api.Volume{
+			{
+				VolumeSource: api.VolumeSource{
+					RBD: &api.RBDVolumeSource{
+						CephMonitors: []string{"c", "d"},
+						RBDPool:      "foo",
+						RBDImage:     "bar",
+						FSType:       "ext4",
+					},
+				},
+			},
+		},
+	}
+	tests := []struct {
+		pod          *api.Pod
+		existingPods []*api.Pod
+		isOk         bool
+		test         string
+	}{
+		{&api.Pod{}, []*api.Pod{}, true, "nothing"},
+		{&api.Pod{}, []*api.Pod{{Spec: volState}}, true, "one state"},
+		{&api.Pod{Spec: volState}, []*api.Pod{{Spec: volState}}, false, "same state"},
+		{&api.Pod{Spec: volState2}, []*api.Pod{{Spec: volState}}, true, "different state"},
+	}
+
+	for _, test := range tests {
+		ok, err := NoDiskConflict(test.pod, test.existingPods, "machine")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if test.isOk && !ok {
+			t.Errorf("expected ok, got none.  %v %v %s", test.pod, test.existingPods, test.test)
+		}
+		if !test.isOk && ok {
+			t.Errorf("expected no ok, got one.  %v %v %s", test.pod, test.existingPods, test.test)
+		}
+	}
+}
+
 func TestPodFitsSelector(t *testing.T) {
 	tests := []struct {
 		pod    *api.Pod


### PR DESCRIPTION
Currently rbd doesn't support NoDiskConflicts, so scheduler may put pods that use the same rbd image on the same host and cause trouble.
