### PR TITLE
add nonResourceURL detection

### DIFF
--- a/pkg/apiserver/api_installer.go
+++ b/pkg/apiserver/api_installer.go
@@ -39,7 +39,7 @@ import (
 
 type APIInstaller struct {
 	group             *APIGroupVersion
-	info              *APIRequestInfoResolver
+	info              *RequestInfoResolver
 	prefix            string // Path prefix where API resources are to be registered.
 	minRequestTimeout time.Duration
 }

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -83,9 +83,9 @@ type APIGroupVersion struct {
 	// TODO: caesarxuchao: Version actually contains "group/version", refactor it to avoid confusion.
 	Version string
 
-	// APIRequestInfoResolver is used to parse URLs for the legacy proxy handler.  Don't use this for anything else
+	// RequestInfoResolver is used to parse URLs for the legacy proxy handler.  Don't use this for anything else
 	// TODO: refactor proxy handler to use sub resources
-	APIRequestInfoResolver *APIRequestInfoResolver
+	RequestInfoResolver *RequestInfoResolver
 
 	// ServerVersion controls the Kubernetes APIVersion used for common objects in the apiserver
 	// schema like api.Status, api.DeleteOptions, and api.ListOptions. Other implementors may
@@ -161,7 +161,7 @@ func (g *APIGroupVersion) newInstaller() *APIInstaller {
 	prefix := path.Join(g.Root, g.Version)
 	installer := &APIInstaller{
 		group:             g,
-		info:              g.APIRequestInfoResolver,
+		info:              g.RequestInfoResolver,
 		prefix:            prefix,
 		minRequestTimeout: g.MinRequestTimeout,
 	}
@@ -217,14 +217,14 @@ func logStackOnRecover(panicReason interface{}, httpWriter http.ResponseWriter) 
 	errorJSON(apierrors.NewGenericServerResponse(http.StatusInternalServerError, "", "", "", "", 0, false), latest.GroupOrDie("").Codec, httpWriter)
 }
 
-func InstallServiceErrorHandler(container *restful.Container, requestResolver *APIRequestInfoResolver, apiVersions []string) {
+func InstallServiceErrorHandler(container *restful.Container, requestResolver *RequestInfoResolver, apiVersions []string) {
 	container.ServiceErrorHandler(func(serviceErr restful.ServiceError, request *restful.Request, response *restful.Response) {
 		serviceErrorHandler(requestResolver, apiVersions, serviceErr, request, response)
 	})
 }
 
-func serviceErrorHandler(requestResolver *APIRequestInfoResolver, apiVersions []string, serviceErr restful.ServiceError, request *restful.Request, response *restful.Response) {
-	requestInfo, err := requestResolver.GetAPIRequestInfo(request.Request)
+func serviceErrorHandler(requestResolver *RequestInfoResolver, apiVersions []string, serviceErr restful.ServiceError, request *restful.Request, response *restful.Response) {
+	requestInfo, err := requestResolver.GetRequestInfo(request.Request)
 	codec := latest.GroupOrDie("").Codec
 	if err == nil && requestInfo.APIVersion != "" {
 		// check if the api version is valid.

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -198,16 +198,16 @@ func handleLinker(storage map[string]rest.Storage, selfLinker runtime.SelfLinker
 	return handleInternal(true, storage, admissionControl, selfLinker)
 }
 
-func newTestAPIRequestInfoResolver() *APIRequestInfoResolver {
-	return &APIRequestInfoResolver{sets.NewString("api", "apis"), sets.NewString("api")}
+func newTestRequestInfoResolver() *RequestInfoResolver {
+	return &RequestInfoResolver{sets.NewString("api", "apis"), sets.NewString("api")}
 }
 
 func handleInternal(legacy bool, storage map[string]rest.Storage, admissionControl admission.Interface, selfLinker runtime.SelfLinker) http.Handler {
 	group := &APIGroupVersion{
 		Storage: storage,
 
-		Root: "/api",
-		APIRequestInfoResolver: newTestAPIRequestInfoResolver(),
+		Root:                "/api",
+		RequestInfoResolver: newTestRequestInfoResolver(),
 
 		Creater:   api.Scheme,
 		Convertor: api.Scheme,
@@ -2074,13 +2074,13 @@ func TestCreateChecksDecode(t *testing.T) {
 func TestUpdateREST(t *testing.T) {
 	makeGroup := func(storage map[string]rest.Storage) *APIGroupVersion {
 		return &APIGroupVersion{
-			Storage: storage,
-			Root:    "/api",
-			APIRequestInfoResolver: newTestAPIRequestInfoResolver(),
-			Creater:                api.Scheme,
-			Convertor:              api.Scheme,
-			Typer:                  api.Scheme,
-			Linker:                 selfLinker,
+			Storage:             storage,
+			Root:                "/api",
+			RequestInfoResolver: newTestRequestInfoResolver(),
+			Creater:             api.Scheme,
+			Convertor:           api.Scheme,
+			Typer:               api.Scheme,
+			Linker:              selfLinker,
 
 			Admit:   admissionControl,
 			Context: requestContextMapper,
@@ -2157,12 +2157,12 @@ func TestParentResourceIsRequired(t *testing.T) {
 		Storage: map[string]rest.Storage{
 			"simple/sub": storage,
 		},
-		Root: "/api",
-		APIRequestInfoResolver: newTestAPIRequestInfoResolver(),
-		Creater:                api.Scheme,
-		Convertor:              api.Scheme,
-		Typer:                  api.Scheme,
-		Linker:                 selfLinker,
+		Root:                "/api",
+		RequestInfoResolver: newTestRequestInfoResolver(),
+		Creater:             api.Scheme,
+		Convertor:           api.Scheme,
+		Typer:               api.Scheme,
+		Linker:              selfLinker,
 
 		Admit:   admissionControl,
 		Context: requestContextMapper,
@@ -2186,12 +2186,12 @@ func TestParentResourceIsRequired(t *testing.T) {
 			"simple":     &SimpleRESTStorage{},
 			"simple/sub": storage,
 		},
-		Root: "/api",
-		APIRequestInfoResolver: newTestAPIRequestInfoResolver(),
-		Creater:                api.Scheme,
-		Convertor:              api.Scheme,
-		Typer:                  api.Scheme,
-		Linker:                 selfLinker,
+		Root:                "/api",
+		RequestInfoResolver: newTestRequestInfoResolver(),
+		Creater:             api.Scheme,
+		Convertor:           api.Scheme,
+		Typer:               api.Scheme,
+		Linker:              selfLinker,
 
 		Admit:   admissionControl,
 		Context: requestContextMapper,

--- a/pkg/apiserver/errors.go
+++ b/pkg/apiserver/errors.go
@@ -87,7 +87,7 @@ func forbidden(w http.ResponseWriter, req *http.Request) {
 	fmt.Fprintf(w, "Forbidden: %#v", req.RequestURI)
 }
 
-// errAPIPrefixNotFound indicates that a APIRequestInfo resolution failed because the request isn't under
+// errAPIPrefixNotFound indicates that a RequestInfo resolution failed because the request isn't under
 // any known API prefixes
 type errAPIPrefixNotFound struct {
 	SpecifiedPrefix string

--- a/pkg/apiserver/proxy.go
+++ b/pkg/apiserver/proxy.go
@@ -42,11 +42,11 @@ import (
 // ProxyHandler provides a http.Handler which will proxy traffic to locations
 // specified by items implementing Redirector.
 type ProxyHandler struct {
-	prefix                 string
-	storage                map[string]rest.Storage
-	codec                  runtime.Codec
-	context                api.RequestContextMapper
-	apiRequestInfoResolver *APIRequestInfoResolver
+	prefix              string
+	storage             map[string]rest.Storage
+	codec               runtime.Codec
+	context             api.RequestContextMapper
+	requestInfoResolver *RequestInfoResolver
 }
 
 func (r *ProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
@@ -58,8 +58,8 @@ func (r *ProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	reqStart := time.Now()
 	defer metrics.Monitor(&verb, &apiResource, util.GetClient(req), &httpCode, reqStart)
 
-	requestInfo, err := r.apiRequestInfoResolver.GetAPIRequestInfo(req)
-	if err != nil {
+	requestInfo, err := r.requestInfoResolver.GetRequestInfo(req)
+	if err != nil || !requestInfo.IsResourceRequest {
 		notFound(w, req)
 		httpCode = http.StatusNotFound
 		return


### PR DESCRIPTION
Adds a well structured way for authorizers to determine if a URL is or is not an API request.

@kubernetes/kube-iam 
@liggitt ptal.
