### PR TITLE
Token config file

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -83,6 +83,7 @@ type APIServer struct {
 	BasicAuthFile              string
 	ClientCAFile               string
 	TokenAuthFile              string
+	TokenConfigFile            string
 	OIDCIssuerURL              string
 	OIDCClientID               string
 	OIDCCAFile                 string
@@ -199,6 +200,7 @@ func (s *APIServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.BasicAuthFile, "basic-auth-file", s.BasicAuthFile, "If set, the file that will be used to admit requests to the secure port of the API server via http basic authentication.")
 	fs.StringVar(&s.ClientCAFile, "client-ca-file", s.ClientCAFile, "If set, any request presenting a client certificate signed by one of the authorities in the client-ca-file is authenticated with an identity corresponding to the CommonName of the client certificate.")
 	fs.StringVar(&s.TokenAuthFile, "token-auth-file", s.TokenAuthFile, "If set, the file that will be used to secure the secure port of the API server via token authentication.")
+	fs.StringVar(&s.TokenConfigFile, "token-config-file", s.TokenConfigFile, "A file containing a list of users and tokens, similar to -token-auth-file but the format is yaml|json")
 	fs.StringVar(&s.OIDCIssuerURL, "oidc-issuer-url", s.OIDCIssuerURL, "The URL of the OpenID issuer, only HTTPS scheme will be accepted. If set, it will be used to verify the OIDC JSON Web Token (JWT)")
 	fs.StringVar(&s.OIDCClientID, "oidc-client-id", s.OIDCClientID, "The client ID for the OpenID Connect client, must be set if oidc-issuer-url is set")
 	fs.StringVar(&s.OIDCCAFile, "oidc-ca-file", s.OIDCCAFile, "If set, the OpenID server's certificate will be verified by one of the authorities in the oidc-ca-file, otherwise the host's root CA set will be used")

--- a/docs/admin/authentication.md
+++ b/docs/admin/authentication.md
@@ -52,6 +52,23 @@ optional group names.
 When using token authentication from an http client the apiserver expects an `Authorization`
 header with a value of `Bearer SOMETOKEN`.
 
+**Token Config File** is enabled by passing the `--token-config-file=SOMEFILE` option to the
+apiserver. The token config performs the same function as the above but is written in a yaml
+or json format (the decoder will attempt to automatically detect the format, though adding a
+extension is preferential). The file *MUST* contain token, name and uid fields with an optional
+groups array
+
+For example
+
+```JSON
+[
+	{ "token": "token1", "name": "user1", "uid": "uid1" },
+	{ "token": "token2", "name": "user2", "uid": "uid2" },
+	{ "token": "token3", "name": "user3", "uid": "uid3", "groups": [ "group1", "group2" ] },
+	{ "token": "token4", "name": "user4", "uid": "uid4", "groups": [ "group1" ] }
+]
+```
+
 **OpenID Connect ID Token** is enabled by passing the following options to the apiserver:
 - `--oidc-issuer-url` (required) tells the apiserver where to connect to the OpenID provider. Only HTTPS scheme will be accepted.
 - `--oidc-client-id` (required) is used by apiserver to verify the audience of the token.

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -289,6 +289,7 @@ tcp-services
 tls-cert-file
 tls-private-key-file
 token-auth-file
+token-config-file
 ttl-secs
 type-src
 udp-port

--- a/pkg/apiserver/authn.go
+++ b/pkg/apiserver/authn.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/auth/authenticator/request/union"
 	"k8s.io/kubernetes/plugin/pkg/auth/authenticator/request/x509"
 	"k8s.io/kubernetes/plugin/pkg/auth/authenticator/token/oidc"
+	"k8s.io/kubernetes/plugin/pkg/auth/authenticator/token/tokenconfig"
 	"k8s.io/kubernetes/plugin/pkg/auth/authenticator/token/tokenfile"
 )
 
@@ -37,6 +38,7 @@ type AuthenticatorConfig struct {
 	BasicAuthFile         string
 	ClientCAFile          string
 	TokenAuthFile         string
+	TokenConfigFile       string
 	OIDCIssuerURL         string
 	OIDCClientID          string
 	OIDCCAFile            string
@@ -128,6 +130,16 @@ func newAuthenticatorFromBasicAuthFile(basicAuthFile string) (authenticator.Requ
 // newAuthenticatorFromTokenFile returns an authenticator.Request or an error
 func newAuthenticatorFromTokenFile(tokenAuthFile string) (authenticator.Request, error) {
 	tokenAuthenticator, err := tokenfile.NewCSV(tokenAuthFile)
+	if err != nil {
+		return nil, err
+	}
+
+	return bearertoken.New(tokenAuthenticator), nil
+}
+
+// newAuthenticatorFromTokenConfigFile returns an authenticator.Request or an error
+func newAuthenticatorFromTokenConfigFile(tokenAuthFile string) (authenticator.Request, error) {
+	tokenAuthenticator, err := tokenconfig.NewTokenConfig(tokenAuthFile)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/pkg/auth/authenticator/token/tokenconfig/tokenconfig.go
+++ b/plugin/pkg/auth/authenticator/token/tokenconfig/tokenconfig.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tokenconfig
+
+import (
+	"fmt"
+	"os"
+
+	"k8s.io/kubernetes/pkg/auth/user"
+	"k8s.io/kubernetes/pkg/util/yaml"
+)
+
+// TokenConfigAuthenticator read the tokens in yaml or json format for a local file
+type TokenConfigAuthenticator struct {
+	// a map of token to users
+	tokens map[string]*user.DefaultInfo
+}
+
+// tokenEntry is a token entry in the config file
+type tokenEntry struct {
+	// the token for this user
+	Token string `json:"token",yaml:"token"`
+	// the name of the user
+	Name string `json:"name",yaml:"name"`
+	// the uid associated to the user
+	UID string `json:"uid",yaml"uid"`
+	// the groups the user is in
+	Groups []string `json:"groups,omitempty", yaml:"groups,omitempty"`
+}
+
+// NewTokenConfig parses a json or yaml file and extracts the tokens from it
+//  path:      the filename which contains the tokens, in either json or yaml format
+func NewTokenConfig(path string) (*TokenConfigAuthenticator, error) {
+	var entries []*tokenEntry
+
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// step: parse and decode the file for us
+	if err := yaml.NewYAMLToJSONDecoder(file).Decode(&entries); err != nil {
+		return nil, err
+	}
+
+	// step: build a map and at the same time perform some validation of the input
+	users := make(map[string]*user.DefaultInfo, 0)
+
+	for i, x := range entries {
+		if x.Token == "" {
+			return nil, fmt.Errorf("entry on line %d should have a 'token' field", i)
+		}
+		if x.Name == "" {
+			return nil, fmt.Errorf("entry for token: %s should have a 'name' field", x.Token)
+		}
+		if x.UID == "" {
+			return nil, fmt.Errorf("entry for user: %s should have a 'uid' field", x.Name)
+		}
+		// should we error on duplicate uids / tokens perhaps?
+
+		users[x.Token] = &user.DefaultInfo{
+			Name:   x.Name,
+			UID:    x.UID,
+			Groups: x.Groups,
+		}
+	}
+
+	return &TokenConfigAuthenticator{
+		tokens: users,
+	}, nil
+}
+
+func (a *TokenConfigAuthenticator) AuthenticateToken(value string) (user.Info, bool, error) {
+	user, ok := a.tokens[value]
+	if !ok {
+		return nil, false, nil
+	}
+	return user, true, nil
+}

--- a/plugin/pkg/auth/authenticator/token/tokenconfig/tokenconfig_test.go
+++ b/plugin/pkg/auth/authenticator/token/tokenconfig/tokenconfig_test.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tokenconfig
+
+import (
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/auth/user"
+)
+
+func TestTokenConfigJSONFile(t *testing.T) {
+	auth, err := newWithContents(t, `
+[
+	{ "token": "token1", "name": "user1", "uid": "uid1" },
+	{ "token": "token2", "name": "user2", "uid": "uid2" },
+	{ "token": "token3", "name": "user3", "uid": "uid3", "groups": [ "group1", "group2" ] },
+	{ "token": "token4", "name": "user4", "uid": "uid4", "groups": [ "group1" ] }
+]`)
+	if err != nil {
+		t.Fatalf("unable to read tokenfile: %v", err)
+	}
+
+	testCases := []struct {
+		Token string
+		User  *user.DefaultInfo
+		Ok    bool
+		Err   bool
+	}{
+		{
+			Token: "token1",
+			User:  &user.DefaultInfo{Name: "user1", UID: "uid1"},
+			Ok:    true,
+		},
+		{
+			Token: "token2",
+			User:  &user.DefaultInfo{Name: "user2", UID: "uid2"},
+			Ok:    true,
+		},
+		{
+			Token: "token3",
+			User:  &user.DefaultInfo{Name: "user3", UID: "uid3", Groups: []string{"group1", "group2"}},
+			Ok:    true,
+		},
+		{
+			Token: "token4",
+			User:  &user.DefaultInfo{Name: "user4", UID: "uid4", Groups: []string{"group1"}},
+			Ok:    true,
+		},
+		{
+			Token: "token5",
+		},
+		{
+			Token: "token6",
+		},
+	}
+	for i, testCase := range testCases {
+		user, ok, err := auth.AuthenticateToken(testCase.Token)
+		if testCase.User == nil {
+			if user != nil {
+				t.Errorf("%d: unexpected non-nil user %#v", i, user)
+			}
+		} else if !reflect.DeepEqual(testCase.User, user) {
+			t.Errorf("%d: expected user %#v, got %#v", i, testCase.User, user)
+		}
+
+		if testCase.Ok != ok {
+			t.Errorf("%d: expected auth %v, got %v", i, testCase.Ok, ok)
+		}
+		switch {
+		case err == nil && testCase.Err:
+			t.Errorf("%d: unexpected nil error", i)
+		case err != nil && !testCase.Err:
+			t.Errorf("%d: unexpected error: %v", i, err)
+		}
+	}
+}
+
+func TestTokenConfigYAMLFile(t *testing.T) {
+	auth, err := newWithContents(t, `
+- token: token1
+  name: user1
+  uid: uid1
+- token: token2
+  name: user2
+  uid: uid2
+- token: token3
+  name: user3
+  uid: uid3
+  groups: [ "group1", "group2" ]
+- token: token4
+  name: user4
+  uid: uid4
+  groups:
+    - group1
+`)
+	if err != nil {
+		t.Fatalf("unable to read tokenfile: %v", err)
+	}
+
+	testCases := []struct {
+		Token string
+		User  *user.DefaultInfo
+		Ok    bool
+		Err   bool
+	}{
+		{
+			Token: "token1",
+			User:  &user.DefaultInfo{Name: "user1", UID: "uid1"},
+			Ok:    true,
+		},
+		{
+			Token: "token2",
+			User:  &user.DefaultInfo{Name: "user2", UID: "uid2"},
+			Ok:    true,
+		},
+		{
+			Token: "token3",
+			User:  &user.DefaultInfo{Name: "user3", UID: "uid3", Groups: []string{"group1", "group2"}},
+			Ok:    true,
+		},
+		{
+			Token: "token4",
+			User:  &user.DefaultInfo{Name: "user4", UID: "uid4", Groups: []string{"group1"}},
+			Ok:    true,
+		},
+		{
+			Token: "token5",
+		},
+		{
+			Token: "token6",
+		},
+	}
+	for i, testCase := range testCases {
+		user, ok, err := auth.AuthenticateToken(testCase.Token)
+		if testCase.User == nil {
+			if user != nil {
+				t.Errorf("%d: unexpected non-nil user %#v", i, user)
+			}
+		} else if !reflect.DeepEqual(testCase.User, user) {
+			t.Errorf("%d: expected user %#v, got %#v", i, testCase.User, user)
+		}
+
+		if testCase.Ok != ok {
+			t.Errorf("%d: expected auth %v, got %v", i, testCase.Ok, ok)
+		}
+		switch {
+		case err == nil && testCase.Err:
+			t.Errorf("%d: unexpected nil error", i)
+		case err != nil && !testCase.Err:
+			t.Errorf("%d: unexpected error: %v", i, err)
+		}
+	}
+}
+
+func TestBadTokenConfigFile(t *testing.T) {
+	_, err := newWithContents(t, `
+- token: token1
+  uid: uid1
+- token: token2
+  name: user2
+  uid: uid2
+`)
+	if err == nil {
+		t.Fatalf("unexpected non error")
+	}
+}
+
+func TestBadTokenConfigMissingYAMLFields(t *testing.T) {
+	_, err := newWithContents(t, `
+[
+	{ "token": "token1", "name": "user1", "uid": "uid1" },
+	{ "token": "token2", "name": "user2" }
+]
+`)
+	if err == nil {
+		t.Fatalf("unexpected non error")
+	}
+}
+
+func TestBadTokenConfigMissingJSONFields(t *testing.T) {
+	_, err := newWithContents(t, `
+[
+	{ "token": "token1", "name": "user1", "uid": "uid1" },
+	{ "token": "token2", "name": "user2" }
+]
+`)
+	if err == nil {
+		t.Fatalf("unexpected non error")
+	}
+}
+
+func newWithContents(t *testing.T, contents string) (auth *TokenConfigAuthenticator, err error) {
+	f, err := ioutil.TempFile("", "tokenfile_test")
+	if err != nil {
+		t.Fatalf("unexpected error creating tokenfile: %v", err)
+	}
+	f.Close()
+	defer os.Remove(f.Name())
+
+	if err := ioutil.WriteFile(f.Name(), []byte(contents), 0700); err != nil {
+		t.Fatalf("unexpected error writing tokenfile: %v", err)
+	}
+
+	return NewTokenConfig(f.Name())
+}


### PR DESCRIPTION
**Summary**: adding the --token-config-file=PATH option to the apiserver to read the tokens from a JSON|YAML file as csv format provided by -token-auth-file isnt the most flexible to future use??

**Notes**: note sure if we should integrate the csv and this together, would be nice just to have one option and support all three? ... also the name might be a issue 

[docs]
- updating the documentation related to authentication to reflect changes

[plugin/auth/authenticator]
- adding the tokenconfig package and the unit tests

[cmd/kube-apiserber]
- added the extra option to the kube-apiserver

[pkg/apiserver]
- added the tokenconfig to the union of authenticators
