### PR TITLE
single column groups option in tokenfile 

### DIFF
--- a/docs/admin/authentication.md
+++ b/docs/admin/authentication.md
@@ -47,7 +47,11 @@ be changed without restarting apiserver.
 
 The token file format is implemented in `plugin/pkg/auth/authenticator/token/tokenfile/...`
 and is a csv file with a minimum of 3 columns: token, user name, user uid, followed by
-optional group names.
+optional group names. Note, if you have more than one group the column must be double quoted e.g.
+
+```csv
+token,user,uid,"group1,group2,group3"
+```
 
 When using token authentication from an http client the apiserver expects an `Authorization`
 header with a value of `Bearer SOMETOKEN`.

--- a/plugin/pkg/auth/authenticator/token/tokenfile/tokenfile.go
+++ b/plugin/pkg/auth/authenticator/token/tokenfile/tokenfile.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"k8s.io/kubernetes/pkg/auth/user"
 )
@@ -58,8 +59,8 @@ func NewCSV(path string) (*TokenAuthenticator, error) {
 		}
 		tokens[record[0]] = obj
 
-		if len(record) > 3 {
-			obj.Groups = record[3:]
+		if len(record) >= 4 {
+			obj.Groups = strings.Split(record[3], ",")
 		}
 	}
 

--- a/plugin/pkg/auth/authenticator/token/tokenfile/tokenfile_test.go
+++ b/plugin/pkg/auth/authenticator/token/tokenfile/tokenfile_test.go
@@ -29,8 +29,11 @@ func TestTokenFile(t *testing.T) {
 	auth, err := newWithContents(t, `
 token1,user1,uid1
 token2,user2,uid2
-token3,user3,uid3,group1,group2
-token4,user4,uid4,group2
+token3,user3,uid3,"group1,group2"
+token4,user4,uid4,"group2"
+token5,user5,uid5,group5
+token6,user6,uid6,group5,otherdata
+token7,user7,uid7,"group1,group2",otherdata
 `)
 	if err != nil {
 		t.Fatalf("unable to read tokenfile: %v", err)
@@ -64,9 +67,21 @@ token4,user4,uid4,group2
 		},
 		{
 			Token: "token5",
+			User:  &user.DefaultInfo{Name: "user5", UID: "uid5", Groups: []string{"group5"}},
+			Ok:    true,
 		},
 		{
 			Token: "token6",
+			User:  &user.DefaultInfo{Name: "user6", UID: "uid6", Groups: []string{"group5"}},
+			Ok:    true,
+		},
+		{
+			Token: "token7",
+			User:  &user.DefaultInfo{Name: "user7", UID: "uid7", Groups: []string{"group1", "group2"}},
+			Ok:    true,
+		},
+		{
+			Token: "token8",
 		},
 	}
 	for i, testCase := range testCases {


### PR DESCRIPTION
[tokenfile]
- the groups field has been changed to a single column option as requested in https://github.com/kubernetes/kubernetes/pull/15704

[docs]
- updated the docs related the the tokefile along with an example
