### PR TITLE
update skydns config so that it does not rely on /etc/hosts

### DIFF
--- a/cluster/addons/dns/skydns-rc.yaml.in
+++ b/cluster/addons/dns/skydns-rc.yaml.in
@@ -56,7 +56,7 @@ spec:
             memory: 50Mi
         args:
         # command = "/skydns"
-        - -machines=http://localhost:4001
+        - -machines=http://127.0.0.1:4001
         - -addr=0.0.0.0:53
         - -ns-rotate=false
         - -domain={{ pillar['dns_domain'] }}.


### PR DESCRIPTION
cherry-pick #15962
Helps workound corrupt /etc/hosts file issue where localhost cannot be resolved. (due to docker bug)
