### PR TITLE
Fixed the error for kubectl edit multiple resources

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -910,6 +910,26 @@ __EOF__
         kube::test::get_object_assert 'rc mock2' "{{${labels_field}.status}}" 'replaced'
       fi
     fi
+    # Command: kubectl edit multiple resources
+    temp_editor="${KUBE_TEMP}/tmp-editor.sh"
+    echo -e '#!/bin/bash\nsed -i "s/status\:\ replaced/status\:\ edited/g" $@' > "${temp_editor}"
+    chmod +x "${temp_editor}"
+    EDITOR="${temp_editor}" kubectl edit "${kube_flags[@]}" -f "${file}"
+    # Post-condition: mock service (and mock2) and mock rc (and mock2) are edited
+    if [ "$has_svc" = true ]; then
+      kube::test::get_object_assert 'services mock' "{{${labels_field}.status}}" 'edited'
+      if [ "$two_svcs" = true ]; then
+        kube::test::get_object_assert 'services mock2' "{{${labels_field}.status}}" 'edited'
+      fi
+    fi
+    if [ "$has_rc" = true ]; then
+      kube::test::get_object_assert 'rc mock' "{{${labels_field}.status}}" 'edited'
+      if [ "$two_rcs" = true ]; then
+        kube::test::get_object_assert 'rc mock2' "{{${labels_field}.status}}" 'edited'
+      fi
+    fi
+    # cleaning
+    rm "${temp_editor}"
     # Command
     # We need to set --overwrite, because otherwise, if the first attempt to run "kubectl label" 
     # fails on some, but not all, of the resources, retries will fail because it tries to modify

--- a/pkg/api/meta/meta.go
+++ b/pkg/api/meta/meta.go
@@ -402,6 +402,10 @@ func (a genericAccessor) Annotations() map[string]string {
 }
 
 func (a genericAccessor) SetAnnotations(annotations map[string]string) {
+	if a.annotations == nil {
+		emptyAnnotations := make(map[string]string)
+		a.annotations = &emptyAnnotations
+	}
 	*a.annotations = annotations
 }
 


### PR DESCRIPTION
Fixes #15907

2 bugs are fixed:
1) panic when editing a list object
2) editing a list of objects failed to update (without an error)

``` console
$ kubectl get pods 
NAME         READY     STATUS    RESTARTS   AGE
mock-9e7dn   1/1       Running   0          3m
mock-adkeu   1/1       Running   0          3m

$ kubectl edit pods 
# Do some edit, and then save...
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x73edf2]

goroutine 1 [running]:
k8s.io/kubernetes/pkg/api/meta.(*genericAccessor).SetAnnotations(0xc208031cc0, 0xc20818f7d0)
    <autogenerated>:20 +0xd2
k8s.io/kubernetes/pkg/kubectl.GetModifiedConfiguration(0xc208221e80, 0xc208280200, 0x0, 0x0, 0x0, 0x0, 0x0)
    /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubectl/apply.go:102 +0x224
k8s.io/kubernetes/pkg/kubectl.UpdateApplyAnnotation(0xc208221e80, 0x0, 0x0)
    /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubectl/apply.go:169 +0x3f
k8s.io/kubernetes/pkg/kubectl/cmd.RunEdit(0xc2080b6f00, 0x7f05615e6fb0, 0xc20802e008, 0xc20813de00, 0xc208190010, 0x1, 0x1, 0x1bda6d0, 0x0, 0x0, ...)
    /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubectl/cmd/edit.go:214 +0x1609
k8s.io/kubernetes/pkg/kubectl/cmd.func·018(0xc20813de00, 0xc208190010, 0x1, 0x1)
    /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubectl/cmd/edit.go:83 +0x7e
```

cc @bgrant0607 @jackgr @kubernetes/kubectl this should be v1.1
