### PR TITLE
remove the use of ServerAPIVersions

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -481,19 +481,20 @@ func runReplicationControllerTest(c *client.Client) {
 }
 
 func runAPIVersionsTest(c *client.Client) {
-	v, err := c.ServerAPIVersions()
-	clientVersion := c.APIVersion()
+	apiGroupList, err := c.Discovery().ServerGroups()
 	if err != nil {
 		glog.Fatalf("Failed to get api versions: %v", err)
 	}
+	serverVersions := client.ExtractGroupVersions(apiGroupList)
+	clientVersion := c.APIVersion()
 	// Verify that the server supports the API version used by the client.
-	for _, version := range v.Versions {
+	for _, version := range serverVersions {
 		if version == clientVersion {
 			glog.Infof("Version test passed")
 			return
 		}
 	}
-	glog.Fatalf("Server does not support APIVersion used by client. Server supported APIVersions: '%v', client APIVersion: '%v'", v.Versions, clientVersion)
+	glog.Fatalf("Server does not support APIVersion used by client. Server supported APIVersions: '%v', client APIVersion: '%v'", serverVersions, clientVersion)
 }
 
 func runSelfLinkTestOnNamespace(c *client.Client, namespace string) {

--- a/pkg/client/unversioned/discovery_client.go
+++ b/pkg/client/unversioned/discovery_client.go
@@ -140,7 +140,7 @@ func (d *DiscoveryClient) ServerResources() (map[string]*unversioned.APIResource
 	if err != nil {
 		return nil, err
 	}
-	groupVersions := extractGroupVersions(apiGroups)
+	groupVersions := ExtractGroupVersions(apiGroups)
 	result := map[string]*unversioned.APIResourceList{}
 	for _, groupVersion := range groupVersions {
 		resources, err := d.ServerResourcesForGroupVersion(groupVersion)

--- a/pkg/client/unversioned/helper.go
+++ b/pkg/client/unversioned/helper.go
@@ -187,7 +187,7 @@ func MatchesServerVersion(client *Client, c *Config) error {
 	return nil
 }
 
-func extractGroupVersions(l *unversioned.APIGroupList) []string {
+func ExtractGroupVersions(l *unversioned.APIGroupList) []string {
 	var groupVersions []string
 	for _, g := range l.Groups {
 		for _, gv := range g.Versions {
@@ -241,7 +241,7 @@ func ServerAPIVersions(c *Config) (groupVersions []string, err error) {
 	if err != nil {
 		return nil, fmt.Errorf("unexpected error: %v", err)
 	}
-	groupVersions = append(groupVersions, extractGroupVersions(&apiGroupList)...)
+	groupVersions = append(groupVersions, ExtractGroupVersions(&apiGroupList)...)
 
 	return groupVersions, nil
 }
@@ -267,12 +267,13 @@ func NegotiateVersion(client *Client, c *Config, version string, clientRegistere
 	for _, v := range clientRegisteredVersions {
 		clientVersions.Insert(v)
 	}
-	apiVersions, err := client.ServerAPIVersions()
+	apiGroupList, err := client.Discovery().ServerGroups()
 	if err != nil {
 		return "", fmt.Errorf("couldn't read version from server: %v", err)
 	}
+	groupVersions := ExtractGroupVersions(apiGroupList)
 	serverVersions := sets.String{}
-	for _, v := range apiVersions.Versions {
+	for _, v := range groupVersions {
 		serverVersions.Insert(v)
 	}
 	// If no version requested, use config version (may also be empty).

--- a/pkg/client/unversioned/helper_blackbox_test.go
+++ b/pkg/client/unversioned/helper_blackbox_test.go
@@ -97,7 +97,7 @@ func TestNegotiateVersion(t *testing.T) {
 			}),
 		}
 		c := unversioned.NewOrDie(test.config)
-		c.Client = fakeClient.Client
+		c.DiscoveryClient.RESTClient = fakeClient.Client
 		response, err := unversioned.NegotiateVersion(c, test.config, test.version, test.clientVersions)
 		if err == nil && test.expectErr {
 			t.Errorf("expected error, got nil for [%s].", test.name)


### PR DESCRIPTION
With this PR and #15796 and #15808, we removed all the use of ServerAPIVersions(). We can remove that function after these are merged.

assign to @JanetKuo as she reviewed the other two PRs
cc @lavalamp 
