### PR TITLE
Fail Jenkins if GCP resources are leaked

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -208,7 +208,6 @@ case ${JOB_NAME} in
   # Runs all non-flaky, non-slow tests on GCE, sequentially.
   kubernetes-e2e-gce)
     : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e"}
-    : ${E2E_DOWN:="false"}
     : ${E2E_NETWORK:="e2e-gce"}
     : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
           ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
@@ -218,12 +217,12 @@ case ${JOB_NAME} in
     : ${KUBE_GCE_INSTANCE_PREFIX="e2e-gce"}
     : ${PROJECT:="k8s-jkns-e2e-gce"}
     : ${ENABLE_DEPLOYMENTS:=true}
+    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
     ;;
 
   # Runs only the examples tests on GCE.
   kubernetes-e2e-gce-examples)
     : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-examples"}
-    : ${E2E_DOWN:="false"}
     : ${E2E_NETWORK:="e2e-examples"}
     : ${GINKGO_TEST_ARGS:="--ginkgo.focus=Example"}
     : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-examples"}
@@ -233,11 +232,11 @@ case ${JOB_NAME} in
   # Runs only the autoscaling tests on GCE.
   kubernetes-e2e-gce-autoscaling)
     : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-autoscaling"}
-    : ${E2E_DOWN:="false"}
     : ${E2E_NETWORK:="e2e-autoscaling"}
     : ${GINKGO_TEST_ARGS:="--ginkgo.focus=Autoscaling\sSuite"}
     : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-autoscaling"}
     : ${PROJECT:="k8s-jnks-e2e-gce-autoscaling"}
+    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
     # Override GCE default for cluster size autoscaling purposes.
     ENABLE_CLUSTER_MONITORING="googleinfluxdb"
     ENABLE_HORIZONTAL_POD_AUTOSCALER="true"
@@ -247,7 +246,6 @@ case ${JOB_NAME} in
   # Runs the flaky tests on GCE, sequentially.
   kubernetes-e2e-gce-flaky)
     : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-flaky"}
-    : ${E2E_DOWN:="false"}
     : ${E2E_NETWORK:="e2e-flaky"}
     : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
           ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
@@ -256,18 +254,19 @@ case ${JOB_NAME} in
           )"}
     : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-flaky"}
     : ${PROJECT:="k8s-jkns-e2e-gce-flaky"}
+    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
     ;;
 
   # Runs slow tests on GCE, sequentially.
   kubernetes-e2e-gce-slow)
     : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-slow"}
-    : ${E2E_DOWN:="false"}
     : ${E2E_NETWORK:="e2e-slow"}
     : ${GINKGO_TEST_ARGS:="--ginkgo.focus=$(join_regex_no_empty \
           ${GCE_SLOW_TESTS[@]:+${GCE_SLOW_TESTS[@]}} \
           )"}
     : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-slow"}
     : ${PROJECT:="k8s-jkns-e2e-gce-slow"}
+    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
     ;;
 
   # Runs a subset of tests on GCE in parallel. Run against all pending PRs.
@@ -341,6 +340,7 @@ case ${JOB_NAME} in
           )"}
     : ${KUBE_GCE_INSTANCE_PREFIX:="parallel-flaky"}
     : ${PROJECT:="k8s-jkns-e2e-gce-prl-flaky"}
+    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
     # Override GCE defaults.
     NUM_MINIONS=${NUM_MINIONS_PARALLEL}
     ;;
@@ -348,7 +348,6 @@ case ${JOB_NAME} in
   # Runs only the reboot tests on GCE.
   kubernetes-e2e-gce-reboot)
     : ${E2E_CLUSTER_NAME:="jenkins-gce-e2e-reboot"}
-    : ${E2E_DOWN:="false"}
     : ${E2E_NETWORK:="e2e-reboot"}
     : ${GINKGO_TEST_ARGS:="--ginkgo.focus=Reboot"}
     : ${KUBE_GCE_INSTANCE_PREFIX:="e2e-reboot"}
@@ -432,6 +431,7 @@ case ${JOB_NAME} in
     : ${E2E_SET_CLUSTER_API_VERSION:=y}
     : ${JENKINS_USE_SERVER_VERSION:=y}
     : ${PROJECT:="k8s-jkns-e2e-gke-prod"}
+    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
     : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
           ${GKE_REQUIRED_SKIP_TESTS[@]:+${GKE_REQUIRED_SKIP_TESTS[@]}} \
           ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
@@ -447,6 +447,7 @@ case ${JOB_NAME} in
     : ${E2E_SET_CLUSTER_API_VERSION:=y}
     : ${JENKINS_USE_SERVER_VERSION:=y}
     : ${PROJECT:="k8s-jkns-e2e-gke-staging"}
+    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
     : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
           ${GKE_REQUIRED_SKIP_TESTS[@]:+${GKE_REQUIRED_SKIP_TESTS[@]}} \
           ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
@@ -462,6 +463,7 @@ case ${JOB_NAME} in
     : ${E2E_NETWORK:="e2e-gke-test"}
     : ${JENKINS_PUBLISHED_VERSION:="release/latest"}
     : ${PROJECT:="k8s-jkns-e2e-gke-ci"}
+    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
     : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
           ${GKE_REQUIRED_SKIP_TESTS[@]:+${GKE_REQUIRED_SKIP_TESTS[@]}} \
           ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
@@ -477,6 +479,7 @@ case ${JOB_NAME} in
     : ${E2E_NETWORK:="e2e-gke-ci"}
     : ${E2E_SET_CLUSTER_API_VERSION:=y}
     : ${PROJECT:="k8s-jkns-e2e-gke-ci"}
+    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
     : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
           ${GKE_REQUIRED_SKIP_TESTS[@]:+${GKE_REQUIRED_SKIP_TESTS[@]}} \
           ${GCE_DEFAULT_SKIP_TESTS[@]:+${GCE_DEFAULT_SKIP_TESTS[@]}} \
@@ -493,6 +496,7 @@ case ${JOB_NAME} in
     : ${E2E_NETWORK:="e2e-gke-ci"}
     : ${E2E_SET_CLUSTER_API_VERSION:=y}
     : ${PROJECT:="k8s-jkns-e2e-gke-ci"}
+    : ${FAIL_ON_GCP_RESOURCE_LEAK:="true"}
     : ${GINKGO_TEST_ARGS:="--ginkgo.skip=$(join_regex_allow_empty \
           ${GKE_REQUIRED_SKIP_TESTS[@]:+${GKE_REQUIRED_SKIP_TESTS[@]}} \
           ${REBOOT_SKIP_TESTS[@]:+${REBOOT_SKIP_TESTS[@]}} \
@@ -1244,5 +1248,8 @@ if [[ "${E2E_DOWN,,}" == "true" ]]; then
 fi
 
 if [[ -f "${gcp_resources_before}" && -f "${gcp_resources_after}" ]]; then
-  diff -sw -U0 -F'^\[.*\]$' "${gcp_resources_before}" "${gcp_resources_after}" || true
+  if ! diff -sw -U0 -F'^\[.*\]$' "${gcp_resources_before}" "${gcp_resources_after}" && [[ "${FAIL_ON_GCP_RESOURCE_LEAK:-}" == "true" ]]; then
+    echo "!!! FAIL: Google Cloud Platform resources leaked while running tests!"
+    exit 1
+  fi
 fi


### PR DESCRIPTION
I'm only enabling this for Jenkins jobs using their own projects.

I've verified that the most recent build for each of these projects had no leaked resources:
- kubernetes-e2e-gce-autoscaling
- kubernetes-e2e-gce-flaky
- kubernetes-e2e-gce-slow
- kubernetes-e2e-gce-parallel-flaky
- kubernetes-e2e-gce-reboot
- kubernetes-e2e-gke-ci-reboot
- kubernetes-e2e-gke-ci

kubernetes-e2e-gce appears to usually pass, but the most recent run shows the managed group not being deleted. From https://goto.google.com/k8s-test/job/kubernetes-e2e-gce/9036/console:

```
+ go run ./hack/e2e.go -v --down
2015/10/20 18:12:38 e2e.go:303: Running: teardown
Project: k8s-jkns-e2e-gce
Zone: us-central1-f
Shutting down test cluster in background.
Deleted [https://www.googleapis.com/compute/v1/projects/k8s-jkns-e2e-gce/global/firewalls/e2e-gce-minion-e2e-gce-http-alt].
Deleted [https://www.googleapis.com/compute/v1/projects/k8s-jkns-e2e-gce/global/firewalls/e2e-gce-minion-e2e-gce-nodeports].
Bringing down cluster using provider: gce
Project: k8s-jkns-e2e-gce
Zone: us-central1-f
Bringing down cluster
ERROR: (gcloud.compute.instance-templates.delete) Some requests did not succeed:
 - The instance_template resource 'e2e-gce-minion-template' is already being used by 'e2e-gce-minion-group'

Updated [https://www.googleapis.com/compute/v1/projects/k8s-jkns-e2e-gce/zones/us-central1-f/instances/e2e-gce-master].
Deleted [https://www.googleapis.com/compute/v1/projects/k8s-jkns-e2e-gce/zones/us-central1-f/instances/e2e-gce-master].
Deleting nodes e2e-gce-minion-9ouo e2e-gce-minion-kz8x e2e-gce-minion-u656
Deleted [https://www.googleapis.com/compute/v1/projects/k8s-jkns-e2e-gce/zones/us-central1-f/instances/e2e-gce-minion-9ouo].
Deleted [https://www.googleapis.com/compute/v1/projects/k8s-jkns-e2e-gce/zones/us-central1-f/instances/e2e-gce-minion-kz8x].
Deleted [https://www.googleapis.com/compute/v1/projects/k8s-jkns-e2e-gce/zones/us-central1-f/instances/e2e-gce-minion-u656].
Deleted [https://www.googleapis.com/compute/v1/projects/k8s-jkns-e2e-gce/global/firewalls/e2e-gce-master-https].
Deleted [https://www.googleapis.com/compute/v1/projects/k8s-jkns-e2e-gce/global/firewalls/e2e-gce-minion-all].
Deleting routes e2e-gce-3082e5b9-7785-11e5-bb52-42010af00002 e2e-gce-308ff85e-7785-11e5-bb52-42010af00002 e2e-gce-31e53d3e-7785-11e5-bb52-42010af00002
Deleted [https://www.googleapis.com/compute/v1/projects/k8s-jkns-e2e-gce/global/routes/e2e-gce-3082e5b9-7785-11e5-bb52-42010af00002].
Deleted [https://www.googleapis.com/compute/v1/projects/k8s-jkns-e2e-gce/global/routes/e2e-gce-308ff85e-7785-11e5-bb52-42010af00002].
Deleted [https://www.googleapis.com/compute/v1/projects/k8s-jkns-e2e-gce/global/routes/e2e-gce-31e53d3e-7785-11e5-bb52-42010af00002].
Deleted [https://www.googleapis.com/compute/v1/projects/k8s-jkns-e2e-gce/regions/us-central1/addresses/e2e-gce-master-ip].
property "clusters.k8s-jkns-e2e-gce_e2e-gce" unset.
property "users.k8s-jkns-e2e-gce_e2e-gce" unset.
property "users.k8s-jkns-e2e-gce_e2e-gce-basic-auth" unset.
property "contexts.k8s-jkns-e2e-gce_e2e-gce" unset.
property "current-context" unset.
Cleared config for k8s-jkns-e2e-gce_e2e-gce from /var/lib/jenkins/jobs/kubernetes-e2e-gce/workspace/.kube/config
Done
2015/10/20 18:17:29 e2e.go:305: Step 'teardown' finished in 4m51.404459356s
+ [[ true == \t\r\u\e ]]
+ ./cluster/gce/list-resources.sh
+ [[ -f /var/lib/jenkins/jobs/kubernetes-e2e-gce/workspace/_artifacts/gcp-resources-before.txt ]]
+ [[ -f /var/lib/jenkins/jobs/kubernetes-e2e-gce/workspace/_artifacts/gcp-resources-after.txt ]]
+ diff -sw -U0 '-F^\[.*\]$' /var/lib/jenkins/jobs/kubernetes-e2e-gce/workspace/_artifacts/gcp-resources-before.txt /var/lib/jenkins/jobs/kubernetes-e2e-gce/workspace/_artifacts/gcp-resources-after.txt
--- /var/lib/jenkins/jobs/kubernetes-e2e-gce/workspace/_artifacts/gcp-resources-before.txt  2015-10-20 16:46:30.631914606 -0700
+++ /var/lib/jenkins/jobs/kubernetes-e2e-gce/workspace/_artifacts/gcp-resources-after.txt   2015-10-20 18:17:47.069147326 -0700
@@ -9,0 +10 @@ [ instance-templates ]
+e2e-gce-minion-template n1-standard-2             2015-10-20T16:47:48.147-07:00
@@ -13,0 +15 @@ [ instance-groups ]
+e2e-gce-minion-group us-central1-f e2e-gce Yes     3
@@ -17,0 +20,3 @@ [ instances ]
+e2e-gce-minion-9ouo us-central1-f n1-standard-2             10.240.0.4  104.197.188.246 RUNNING
+e2e-gce-minion-kz8x us-central1-f n1-standard-2             10.240.0.2  104.197.5.163   RUNNING
+e2e-gce-minion-u656 us-central1-f n1-standard-2             10.240.0.3  104.197.145.44  RUNNING
@@ -49,0 +55,3 @@ [ disks ]
+e2e-gce-minion-9ouo                          us-central1-f 100     pd-standard READY
+e2e-gce-minion-kz8x                          us-central1-f 100     pd-standard READY
+e2e-gce-minion-u656                          us-central1-f 100     pd-standard READY
+ true
```

So it's very possible this PR may break things, but hopefully such breakage will lead to fixes?

cc @kubernetes/goog-testing 
x-ref #15084
