### PR TITLE
enable deamonset extensions in e2e test clusters

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -108,6 +108,11 @@ ENABLE_DEPLOYMENTS="${KUBE_ENABLE_DEPLOYMENTS:-false}"
 if [[ "${ENABLE_DEPLOYMENTS}" == "true" ]]; then
   ENABLE_EXPERIMENTAL_API=true
 fi
+# Optional: Enable daemonset experimental feature, not ready for production use.
+ENABLE_DAEMONSETS="${KUBE_ENABLE_DAEMONSETS:-false}"
+if [[ "${ENABLE_DAEMONSETS}" == "true" ]]; then
+  ENABLE_EXPERIMENTAL_API=true
+fi
 
 # Admission Controllers to invoke prior to persisting objects in cluster
 ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -46,7 +46,7 @@ CLUSTER_IP_RANGE="${CLUSTER_IP_RANGE:-10.245.0.0/16}"
 MASTER_IP_RANGE="${MASTER_IP_RANGE:-10.246.0.0/24}"
 MINION_SCOPES="${MINION_SCOPES:-compute-rw,monitoring,logging-write,storage-ro}"
 RUNTIME_CONFIG="${KUBE_RUNTIME_CONFIG:-}"
-ENABLE_EXPERIMENTAL_API="${KUBE_ENABLE_EXPERIMENTAL_API:-false}"
+ENABLE_EXPERIMENTAL_API="${KUBE_ENABLE_EXPERIMENTAL_API:-true}"
 TERMINATED_POD_GC_THRESHOLD=${TERMINATED_POD_GC_THRESHOLD:-100}
 
 # Increase the sleep interval value if concerned about API rate limits. 3, in seconds, is the default.
@@ -116,6 +116,12 @@ fi
 # Optional: Enable deployment experimental feature, not ready for production use.
 ENABLE_DEPLOYMENTS="${KUBE_ENABLE_DEPLOYMENTS:-false}"
 if [[ "${ENABLE_DEPLOYMENTS}" == "true" ]]; then
+  ENABLE_EXPERIMENTAL_API=true
+fi
+
+# Optional: Enable daemonset experimental feature, not ready for production use.
+ENABLE_DAEMONSETS="${KUBE_ENABLE_DAEMONSETS:-true}"
+if [[ "${ENABLE_DAEMONSETS}" == "true" ]]; then
   ENABLE_EXPERIMENTAL_API=true
 fi
 

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -66,6 +66,13 @@ function verify-prereqs {
       RUNTIME_CONFIG="${RUNTIME_CONFIG},extensions/v1beta1/deployments=true"
     fi
   fi
+  if [[ "${ENABLE_DAEMONSETS}" == "true" ]]; then
+    if [[ -z "${RUNTIME_CONFIG}" ]]; then
+      RUNTIME_CONFIG="extensions/v1beta1/daemonsets=true"
+    else
+      RUNTIME_CONFIG="${RUNTIME_CONFIG},extensions/v1beta1/daemonsets=true"
+    fi
+  fi
 
 
   local cmd


### PR DESCRIPTION
Otherwise not all e2e tests will work
