### PR TITLE
Minor performance tweaks to the AWS cloud-init

### DIFF
--- a/cluster/aws/templates/common.sh
+++ b/cluster/aws/templates/common.sh
@@ -29,9 +29,9 @@ function apt-get-install {
 }
 
 apt-get-install curl
+apt-get dist-upgrade -q -y
 
 # Retry a download until we get it.
-#
 # $1 is the URL to download
 download-or-bust() {
   local -r url="$1"
@@ -44,10 +44,7 @@ download-or-bust() {
   done
 }
 
-
-
-# Install salt from GCS.  See README.md for instructions on how to update these
-# debs.
+# Install salt from GCS. See README.md for instructions on how to update these debs.
 install-salt() {
   local salt_mode="$1"
 

--- a/cluster/aws/templates/format-disks.sh
+++ b/cluster/aws/templates/format-disks.sh
@@ -157,7 +157,6 @@ else
   fi
 fi
 
-
 if [[ ${docker_storage} == "btrfs" ]]; then
   DOCKER_OPTS="${DOCKER_OPTS} -s btrfs"
 elif [[ ${docker_storage} == "aufs-nolvm" || ${docker_storage} == "aufs" ]]; then

--- a/cluster/aws/templates/salt-minion.sh
+++ b/cluster/aws/templates/salt-minion.sh
@@ -58,4 +58,7 @@ env_to_salt non_masquerade_cidr
 
 install-salt
 
+# Cleanup to free some disk space.
+apt-get autoclean
+
 service salt-minion start

--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -1142,9 +1142,9 @@ function wait-master() {
   # Wait 3 minutes for cluster to come up.  We hit it with a "highstate" after that to
   # make sure that everything is well configured.
   # TODO: Can we poll here?
-  echo "Waiting 3 minutes for cluster to settle"
+  echo "Waiting 1 minute for cluster to settle"
   local i
-  for (( i=0; i < 6*3; i++)); do
+  for (( i=0; i < 6*1; i++)); do
     printf "."
     sleep 10
   done


### PR DESCRIPTION
This patch introduces minor tweaks to improve instance start time and reliability on AWS under kubernetes and kube-up.sh.

Tested on AWS.

Generally the changes are:
- Remove redundant `apt-get update` calls, especially since they are called without any sources changes and in some cases immediately after a previous update has just finished.
  - Cleanup some apt-get commands
  - Perform a dist-upgrade to pull security updates in on instance start.

Generally it's optimal to build a custom base image with updates pulled, system level motds/settings customized, and package sources optimized. However, it's always wise to pull in security updates when minting a new instance. I see performance increases of up to 3 minutes with these changes on my cluster.

Generally though, this doesn't really change what the scripts do very much.
