### PR TITLE
Add storage to the cloud provider API and implement for the Google Cloud Platform

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -780,6 +780,10 @@
 			"Rev": "0c2979aeaa5b573e60d3ddffe5ce8dca8df309bd"
 		},
 		{
+			"ImportPath": "google.golang.org/api/storage/v1",
+			"Rev": "0c2979aeaa5b573e60d3ddffe5ce8dca8df309bd"
+		},
+		{
 			"ImportPath": "google.golang.org/cloud/compute/metadata",
 			"Rev": "2e43671e4ad874a7bca65746ff3edb38e6e93762"
 		},

--- a/Godeps/_workspace/src/google.golang.org/api/storage/v1/storage-api.json
+++ b/Godeps/_workspace/src/google.golang.org/api/storage/v1/storage-api.json
@@ -1,0 +1,2815 @@
+{
+ "kind": "discovery#restDescription",
+ "etag": "\"ye6orv2F-1npMW3u9suM3a7C5Bo/ALzt_o9hBNBIakQJmeXCNhSU8II\"",
+ "discoveryVersion": "v1",
+ "id": "storage:v1",
+ "name": "storage",
+ "version": "v1",
+ "revision": "20150630",
+ "title": "Cloud Storage API",
+ "description": "Lets you store and retrieve potentially-large, immutable data objects.",
+ "ownerDomain": "google.com",
+ "ownerName": "Google",
+ "icons": {
+  "x16": "https://www.google.com/images/icons/product/cloud_storage-16.png",
+  "x32": "https://www.google.com/images/icons/product/cloud_storage-32.png"
+ },
+ "documentationLink": "https://developers.google.com/storage/docs/json_api/",
+ "labels": [
+  "labs"
+ ],
+ "protocol": "rest",
+ "baseUrl": "https://www.googleapis.com/storage/v1/",
+ "basePath": "/storage/v1/",
+ "rootUrl": "https://www.googleapis.com/",
+ "servicePath": "storage/v1/",
+ "batchPath": "batch",
+ "parameters": {
+  "alt": {
+   "type": "string",
+   "description": "Data format for the response.",
+   "default": "json",
+   "enum": [
+    "json"
+   ],
+   "enumDescriptions": [
+    "Responses with Content-Type of application/json"
+   ],
+   "location": "query"
+  },
+  "fields": {
+   "type": "string",
+   "description": "Selector specifying which fields to include in a partial response.",
+   "location": "query"
+  },
+  "key": {
+   "type": "string",
+   "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
+   "location": "query"
+  },
+  "oauth_token": {
+   "type": "string",
+   "description": "OAuth 2.0 token for the current user.",
+   "location": "query"
+  },
+  "prettyPrint": {
+   "type": "boolean",
+   "description": "Returns response with indentations and line breaks.",
+   "default": "true",
+   "location": "query"
+  },
+  "quotaUser": {
+   "type": "string",
+   "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters. Overrides userIp if both are provided.",
+   "location": "query"
+  },
+  "userIp": {
+   "type": "string",
+   "description": "IP address of the site where the request originates. Use this if you want to enforce per-user limits.",
+   "location": "query"
+  }
+ },
+ "auth": {
+  "oauth2": {
+   "scopes": {
+    "https://www.googleapis.com/auth/cloud-platform": {
+     "description": "View and manage your data across Google Cloud Platform services"
+    },
+    "https://www.googleapis.com/auth/devstorage.full_control": {
+     "description": "Manage your data and permissions in Google Cloud Storage"
+    },
+    "https://www.googleapis.com/auth/devstorage.read_only": {
+     "description": "View your data in Google Cloud Storage"
+    },
+    "https://www.googleapis.com/auth/devstorage.read_write": {
+     "description": "Manage your data in Google Cloud Storage"
+    }
+   }
+  }
+ },
+ "schemas": {
+  "Bucket": {
+   "id": "Bucket",
+   "type": "object",
+   "description": "A bucket.",
+   "properties": {
+    "acl": {
+     "type": "array",
+     "description": "Access controls on the bucket.",
+     "items": {
+      "$ref": "BucketAccessControl"
+     },
+     "annotations": {
+      "required": [
+       "storage.buckets.update"
+      ]
+     }
+    },
+    "cors": {
+     "type": "array",
+     "description": "The bucket's Cross-Origin Resource Sharing (CORS) configuration.",
+     "items": {
+      "type": "object",
+      "properties": {
+       "maxAgeSeconds": {
+        "type": "integer",
+        "description": "The value, in seconds, to return in the  Access-Control-Max-Age header used in preflight responses.",
+        "format": "int32"
+       },
+       "method": {
+        "type": "array",
+        "description": "The list of HTTP methods on which to include CORS response headers, (GET, OPTIONS, POST, etc) Note: \"*\" is permitted in the list of methods, and means \"any method\".",
+        "items": {
+         "type": "string"
+        }
+       },
+       "origin": {
+        "type": "array",
+        "description": "The list of Origins eligible to receive CORS response headers. Note: \"*\" is permitted in the list of origins, and means \"any Origin\".",
+        "items": {
+         "type": "string"
+        }
+       },
+       "responseHeader": {
+        "type": "array",
+        "description": "The list of HTTP headers other than the simple response headers to give permission for the user-agent to share across domains.",
+        "items": {
+         "type": "string"
+        }
+       }
+      }
+     }
+    },
+    "defaultObjectAcl": {
+     "type": "array",
+     "description": "Default access controls to apply to new objects when no ACL is provided.",
+     "items": {
+      "$ref": "ObjectAccessControl"
+     }
+    },
+    "etag": {
+     "type": "string",
+     "description": "HTTP 1.1 Entity tag for the bucket."
+    },
+    "id": {
+     "type": "string",
+     "description": "The ID of the bucket."
+    },
+    "kind": {
+     "type": "string",
+     "description": "The kind of item this is. For buckets, this is always storage#bucket.",
+     "default": "storage#bucket"
+    },
+    "lifecycle": {
+     "type": "object",
+     "description": "The bucket's lifecycle configuration. See lifecycle management for more information.",
+     "properties": {
+      "rule": {
+       "type": "array",
+       "description": "A lifecycle management rule, which is made of an action to take and the condition(s) under which the action will be taken.",
+       "items": {
+        "type": "object",
+        "properties": {
+         "action": {
+          "type": "object",
+          "description": "The action to take.",
+          "properties": {
+           "type": {
+            "type": "string",
+            "description": "Type of the action. Currently, only Delete is supported."
+           }
+          }
+         },
+         "condition": {
+          "type": "object",
+          "description": "The condition(s) under which the action will be taken.",
+          "properties": {
+           "age": {
+            "type": "integer",
+            "description": "Age of an object (in days). This condition is satisfied when an object reaches the specified age.",
+            "format": "int32"
+           },
+           "createdBefore": {
+            "type": "string",
+            "description": "A date in RFC 3339 format with only the date part (for instance, \"2013-01-15\"). This condition is satisfied when an object is created before midnight of the specified date in UTC.",
+            "format": "date"
+           },
+           "isLive": {
+            "type": "boolean",
+            "description": "Relevant only for versioned objects. If the value is true, this condition matches live objects; if the value is false, it matches archived objects."
+           },
+           "numNewerVersions": {
+            "type": "integer",
+            "description": "Relevant only for versioned objects. If the value is N, this condition is satisfied when there are at least N versions (including the live version) newer than this version of the object.",
+            "format": "int32"
+           }
+          }
+         }
+        }
+       }
+      }
+     }
+    },
+    "location": {
+     "type": "string",
+     "description": "The location of the bucket. Object data for objects in the bucket resides in physical storage within this region. Defaults to US. See the developer's guide for the authoritative list."
+    },
+    "logging": {
+     "type": "object",
+     "description": "The bucket's logging configuration, which defines the destination bucket and optional name prefix for the current bucket's logs.",
+     "properties": {
+      "logBucket": {
+       "type": "string",
+       "description": "The destination bucket where the current bucket's logs should be placed."
+      },
+      "logObjectPrefix": {
+       "type": "string",
+       "description": "A prefix for log object names."
+      }
+     }
+    },
+    "metageneration": {
+     "type": "string",
+     "description": "The metadata generation of this bucket.",
+     "format": "int64"
+    },
+    "name": {
+     "type": "string",
+     "description": "The name of the bucket.",
+     "annotations": {
+      "required": [
+       "storage.buckets.insert"
+      ]
+     }
+    },
+    "owner": {
+     "type": "object",
+     "description": "The owner of the bucket. This is always the project team's owner group.",
+     "properties": {
+      "entity": {
+       "type": "string",
+       "description": "The entity, in the form project-owner-projectId."
+      },
+      "entityId": {
+       "type": "string",
+       "description": "The ID for the entity."
+      }
+     }
+    },
+    "projectNumber": {
+     "type": "string",
+     "description": "The project number of the project the bucket belongs to.",
+     "format": "uint64"
+    },
+    "selfLink": {
+     "type": "string",
+     "description": "The URI of this bucket."
+    },
+    "storageClass": {
+     "type": "string",
+     "description": "The bucket's storage class. This defines how objects in the bucket are stored and determines the SLA and the cost of storage. Values include STANDARD, NEARLINE and DURABLE_REDUCED_AVAILABILITY. Defaults to STANDARD. For more information, see storage classes."
+    },
+    "timeCreated": {
+     "type": "string",
+     "description": "Creation time of the bucket in RFC 3339 format.",
+     "format": "date-time"
+    },
+    "versioning": {
+     "type": "object",
+     "description": "The bucket's versioning configuration.",
+     "properties": {
+      "enabled": {
+       "type": "boolean",
+       "description": "While set to true, versioning is fully enabled for this bucket."
+      }
+     }
+    },
+    "website": {
+     "type": "object",
+     "description": "The bucket's website configuration.",
+     "properties": {
+      "mainPageSuffix": {
+       "type": "string",
+       "description": "Behaves as the bucket's directory index where missing objects are treated as potential directories."
+      },
+      "notFoundPage": {
+       "type": "string",
+       "description": "The custom object to return when a requested resource is not found."
+      }
+     }
+    }
+   }
+  },
+  "BucketAccessControl": {
+   "id": "BucketAccessControl",
+   "type": "object",
+   "description": "An access-control entry.",
+   "properties": {
+    "bucket": {
+     "type": "string",
+     "description": "The name of the bucket."
+    },
+    "domain": {
+     "type": "string",
+     "description": "The domain associated with the entity, if any."
+    },
+    "email": {
+     "type": "string",
+     "description": "The email address associated with the entity, if any."
+    },
+    "entity": {
+     "type": "string",
+     "description": "The entity holding the permission, in one of the following forms: \n- user-userId \n- user-email \n- group-groupId \n- group-email \n- domain-domain \n- project-team-projectId \n- allUsers \n- allAuthenticatedUsers Examples: \n- The user liz@example.com would be user-liz@example.com. \n- The group example@googlegroups.com would be group-example@googlegroups.com. \n- To refer to all members of the Google Apps for Business domain example.com, the entity would be domain-example.com.",
+     "annotations": {
+      "required": [
+       "storage.bucketAccessControls.insert"
+      ]
+     }
+    },
+    "entityId": {
+     "type": "string",
+     "description": "The ID for the entity, if any."
+    },
+    "etag": {
+     "type": "string",
+     "description": "HTTP 1.1 Entity tag for the access-control entry."
+    },
+    "id": {
+     "type": "string",
+     "description": "The ID of the access-control entry."
+    },
+    "kind": {
+     "type": "string",
+     "description": "The kind of item this is. For bucket access control entries, this is always storage#bucketAccessControl.",
+     "default": "storage#bucketAccessControl"
+    },
+    "projectTeam": {
+     "type": "object",
+     "description": "The project team associated with the entity, if any.",
+     "properties": {
+      "projectNumber": {
+       "type": "string",
+       "description": "The project number."
+      },
+      "team": {
+       "type": "string",
+       "description": "The team. Can be owners, editors, or viewers."
+      }
+     }
+    },
+    "role": {
+     "type": "string",
+     "description": "The access permission for the entity. Can be READER, WRITER, or OWNER.",
+     "annotations": {
+      "required": [
+       "storage.bucketAccessControls.insert"
+      ]
+     }
+    },
+    "selfLink": {
+     "type": "string",
+     "description": "The link to this access-control entry."
+    }
+   }
+  },
+  "BucketAccessControls": {
+   "id": "BucketAccessControls",
+   "type": "object",
+   "description": "An access-control list.",
+   "properties": {
+    "items": {
+     "type": "array",
+     "description": "The list of items.",
+     "items": {
+      "$ref": "BucketAccessControl"
+     }
+    },
+    "kind": {
+     "type": "string",
+     "description": "The kind of item this is. For lists of bucket access control entries, this is always storage#bucketAccessControls.",
+     "default": "storage#bucketAccessControls"
+    }
+   }
+  },
+  "Buckets": {
+   "id": "Buckets",
+   "type": "object",
+   "description": "A list of buckets.",
+   "properties": {
+    "items": {
+     "type": "array",
+     "description": "The list of items.",
+     "items": {
+      "$ref": "Bucket"
+     }
+    },
+    "kind": {
+     "type": "string",
+     "description": "The kind of item this is. For lists of buckets, this is always storage#buckets.",
+     "default": "storage#buckets"
+    },
+    "nextPageToken": {
+     "type": "string",
+     "description": "The continuation token, used to page through large result sets. Provide this value in a subsequent request to return the next page of results."
+    }
+   }
+  },
+  "Channel": {
+   "id": "Channel",
+   "type": "object",
+   "description": "An notification channel used to watch for resource changes.",
+   "properties": {
+    "address": {
+     "type": "string",
+     "description": "The address where notifications are delivered for this channel."
+    },
+    "expiration": {
+     "type": "string",
+     "description": "Date and time of notification channel expiration, expressed as a Unix timestamp, in milliseconds. Optional.",
+     "format": "int64"
+    },
+    "id": {
+     "type": "string",
+     "description": "A UUID or similar unique string that identifies this channel."
+    },
+    "kind": {
+     "type": "string",
+     "description": "Identifies this as a notification channel used to watch for changes to a resource. Value: the fixed string \"api#channel\".",
+     "default": "api#channel"
+    },
+    "params": {
+     "type": "object",
+     "description": "Additional parameters controlling delivery channel behavior. Optional.",
+     "additionalProperties": {
+      "type": "string",
+      "description": "Declares a new parameter by name."
+     }
+    },
+    "payload": {
+     "type": "boolean",
+     "description": "A Boolean value to indicate whether payload is wanted. Optional."
+    },
+    "resourceId": {
+     "type": "string",
+     "description": "An opaque ID that identifies the resource being watched on this channel. Stable across different API versions."
+    },
+    "resourceUri": {
+     "type": "string",
+     "description": "A version-specific identifier for the watched resource."
+    },
+    "token": {
+     "type": "string",
+     "description": "An arbitrary string delivered to the target address with each notification delivered over this channel. Optional."
+    },
+    "type": {
+     "type": "string",
+     "description": "The type of delivery mechanism used for this channel."
+    }
+   }
+  },
+  "ComposeRequest": {
+   "id": "ComposeRequest",
+   "type": "object",
+   "description": "A Compose request.",
+   "properties": {
+    "destination": {
+     "$ref": "Object",
+     "description": "Properties of the resulting object."
+    },
+    "kind": {
+     "type": "string",
+     "description": "The kind of item this is.",
+     "default": "storage#composeRequest"
+    },
+    "sourceObjects": {
+     "type": "array",
+     "description": "The list of source objects that will be concatenated into a single object.",
+     "items": {
+      "type": "object",
+      "properties": {
+       "generation": {
+        "type": "string",
+        "description": "The generation of this object to use as the source.",
+        "format": "int64"
+       },
+       "name": {
+        "type": "string",
+        "description": "The source object's name. The source object's bucket is implicitly the destination bucket.",
+        "annotations": {
+         "required": [
+          "storage.objects.compose"
+         ]
+        }
+       },
+       "objectPreconditions": {
+        "type": "object",
+        "description": "Conditions that must be met for this operation to execute.",
+        "properties": {
+         "ifGenerationMatch": {
+          "type": "string",
+          "description": "Only perform the composition if the generation of the source object that would be used matches this value. If this value and a generation are both specified, they must be the same value or the call will fail.",
+          "format": "int64"
+         }
+        }
+       }
+      }
+     },
+     "annotations": {
+      "required": [
+       "storage.objects.compose"
+      ]
+     }
+    }
+   }
+  },
+  "Object": {
+   "id": "Object",
+   "type": "object",
+   "description": "An object.",
+   "properties": {
+    "acl": {
+     "type": "array",
+     "description": "Access controls on the object.",
+     "items": {
+      "$ref": "ObjectAccessControl"
+     },
+     "annotations": {
+      "required": [
+       "storage.objects.update"
+      ]
+     }
+    },
+    "bucket": {
+     "type": "string",
+     "description": "The name of the bucket containing this object."
+    },
+    "cacheControl": {
+     "type": "string",
+     "description": "Cache-Control directive for the object data."
+    },
+    "componentCount": {
+     "type": "integer",
+     "description": "Number of underlying components that make up this object. Components are accumulated by compose operations.",
+     "format": "int32"
+    },
+    "contentDisposition": {
+     "type": "string",
+     "description": "Content-Disposition of the object data."
+    },
+    "contentEncoding": {
+     "type": "string",
+     "description": "Content-Encoding of the object data."
+    },
+    "contentLanguage": {
+     "type": "string",
+     "description": "Content-Language of the object data."
+    },
+    "contentType": {
+     "type": "string",
+     "description": "Content-Type of the object data.",
+     "annotations": {
+      "required": [
+       "storage.objects.insert",
+       "storage.objects.update"
+      ]
+     }
+    },
+    "crc32c": {
+     "type": "string",
+     "description": "CRC32c checksum, as described in RFC 4960, Appendix B; encoded using base64 in big-endian byte order. For more information about using the CRC32c checksum, see Hashes and ETags: Best Practices."
+    },
+    "etag": {
+     "type": "string",
+     "description": "HTTP 1.1 Entity tag for the object."
+    },
+    "generation": {
+     "type": "string",
+     "description": "The content generation of this object. Used for object versioning.",
+     "format": "int64"
+    },
+    "id": {
+     "type": "string",
+     "description": "The ID of the object."
+    },
+    "kind": {
+     "type": "string",
+     "description": "The kind of item this is. For objects, this is always storage#object.",
+     "default": "storage#object"
+    },
+    "md5Hash": {
+     "type": "string",
+     "description": "MD5 hash of the data; encoded using base64. For more information about using the MD5 hash, see Hashes and ETags: Best Practices."
+    },
+    "mediaLink": {
+     "type": "string",
+     "description": "Media download link."
+    },
+    "metadata": {
+     "type": "object",
+     "description": "User-provided metadata, in key/value pairs.",
+     "additionalProperties": {
+      "type": "string",
+      "description": "An individual metadata entry."
+     }
+    },
+    "metageneration": {
+     "type": "string",
+     "description": "The version of the metadata for this object at this generation. Used for preconditions and for detecting changes in metadata. A metageneration number is only meaningful in the context of a particular generation of a particular object.",
+     "format": "int64"
+    },
+    "name": {
+     "type": "string",
+     "description": "The name of this object. Required if not specified by URL parameter."
+    },
+    "owner": {
+     "type": "object",
+     "description": "The owner of the object. This will always be the uploader of the object.",
+     "properties": {
+      "entity": {
+       "type": "string",
+       "description": "The entity, in the form user-userId."
+      },
+      "entityId": {
+       "type": "string",
+       "description": "The ID for the entity."
+      }
+     }
+    },
+    "selfLink": {
+     "type": "string",
+     "description": "The link to this object."
+    },
+    "size": {
+     "type": "string",
+     "description": "Content-Length of the data in bytes.",
+     "format": "uint64"
+    },
+    "storageClass": {
+     "type": "string",
+     "description": "Storage class of the object."
+    },
+    "timeDeleted": {
+     "type": "string",
+     "description": "The deletion time of the object in RFC 3339 format. Will be returned if and only if this version of the object has been deleted.",
+     "format": "date-time"
+    },
+    "updated": {
+     "type": "string",
+     "description": "The creation or modification time of the object in RFC 3339 format. For buckets with versioning enabled, changing an object's metadata does not change this property.",
+     "format": "date-time"
+    }
+   }
+  },
+  "ObjectAccessControl": {
+   "id": "ObjectAccessControl",
+   "type": "object",
+   "description": "An access-control entry.",
+   "properties": {
+    "bucket": {
+     "type": "string",
+     "description": "The name of the bucket."
+    },
+    "domain": {
+     "type": "string",
+     "description": "The domain associated with the entity, if any."
+    },
+    "email": {
+     "type": "string",
+     "description": "The email address associated with the entity, if any."
+    },
+    "entity": {
+     "type": "string",
+     "description": "The entity holding the permission, in one of the following forms: \n- user-userId \n- user-email \n- group-groupId \n- group-email \n- domain-domain \n- project-team-projectId \n- allUsers \n- allAuthenticatedUsers Examples: \n- The user liz@example.com would be user-liz@example.com. \n- The group example@googlegroups.com would be group-example@googlegroups.com. \n- To refer to all members of the Google Apps for Business domain example.com, the entity would be domain-example.com."
+    },
+    "entityId": {
+     "type": "string",
+     "description": "The ID for the entity, if any."
+    },
+    "etag": {
+     "type": "string",
+     "description": "HTTP 1.1 Entity tag for the access-control entry."
+    },
+    "generation": {
+     "type": "string",
+     "description": "The content generation of the object.",
+     "format": "int64"
+    },
+    "id": {
+     "type": "string",
+     "description": "The ID of the access-control entry."
+    },
+    "kind": {
+     "type": "string",
+     "description": "The kind of item this is. For object access control entries, this is always storage#objectAccessControl.",
+     "default": "storage#objectAccessControl"
+    },
+    "object": {
+     "type": "string",
+     "description": "The name of the object."
+    },
+    "projectTeam": {
+     "type": "object",
+     "description": "The project team associated with the entity, if any.",
+     "properties": {
+      "projectNumber": {
+       "type": "string",
+       "description": "The project number."
+      },
+      "team": {
+       "type": "string",
+       "description": "The team. Can be owners, editors, or viewers."
+      }
+     }
+    },
+    "role": {
+     "type": "string",
+     "description": "The access permission for the entity. Can be READER or OWNER."
+    },
+    "selfLink": {
+     "type": "string",
+     "description": "The link to this access-control entry."
+    }
+   }
+  },
+  "ObjectAccessControls": {
+   "id": "ObjectAccessControls",
+   "type": "object",
+   "description": "An access-control list.",
+   "properties": {
+    "items": {
+     "type": "array",
+     "description": "The list of items.",
+     "items": {
+      "type": "any"
+     }
+    },
+    "kind": {
+     "type": "string",
+     "description": "The kind of item this is. For lists of object access control entries, this is always storage#objectAccessControls.",
+     "default": "storage#objectAccessControls"
+    }
+   }
+  },
+  "Objects": {
+   "id": "Objects",
+   "type": "object",
+   "description": "A list of objects.",
+   "properties": {
+    "items": {
+     "type": "array",
+     "description": "The list of items.",
+     "items": {
+      "$ref": "Object"
+     }
+    },
+    "kind": {
+     "type": "string",
+     "description": "The kind of item this is. For lists of objects, this is always storage#objects.",
+     "default": "storage#objects"
+    },
+    "nextPageToken": {
+     "type": "string",
+     "description": "The continuation token, used to page through large result sets. Provide this value in a subsequent request to return the next page of results."
+    },
+    "prefixes": {
+     "type": "array",
+     "description": "The list of prefixes of objects matching-but-not-listed up to and including the requested delimiter.",
+     "items": {
+      "type": "string"
+     }
+    }
+   }
+  },
+  "RewriteResponse": {
+   "id": "RewriteResponse",
+   "type": "object",
+   "description": "A rewrite response.",
+   "properties": {
+    "done": {
+     "type": "boolean",
+     "description": "true if the copy is finished; otherwise, false if the copy is in progress. This property is always present in the response."
+    },
+    "kind": {
+     "type": "string",
+     "description": "The kind of item this is.",
+     "default": "storage#rewriteResponse"
+    },
+    "objectSize": {
+     "type": "string",
+     "description": "The total size of the object being copied in bytes. This property is always present in the response.",
+     "format": "uint64"
+    },
+    "resource": {
+     "$ref": "Object",
+     "description": "A resource containing the metadata for the copied-to object. This property is present in the response only when copying completes."
+    },
+    "rewriteToken": {
+     "type": "string",
+     "description": "A token to use in subsequent requests to continue copying data. This token is present in the response only when there is more data to copy."
+    },
+    "totalBytesRewritten": {
+     "type": "string",
+     "description": "The total bytes written so far, which can be used to provide a waiting user with a progress indicator. This property is always present in the response.",
+     "format": "uint64"
+    }
+   }
+  }
+ },
+ "resources": {
+  "bucketAccessControls": {
+   "methods": {
+    "delete": {
+     "id": "storage.bucketAccessControls.delete",
+     "path": "b/{bucket}/acl/{entity}",
+     "httpMethod": "DELETE",
+     "description": "Permanently deletes the ACL entry for the specified entity on the specified bucket.",
+     "parameters": {
+      "bucket": {
+       "type": "string",
+       "description": "Name of a bucket.",
+       "required": true,
+       "location": "path"
+      },
+      "entity": {
+       "type": "string",
+       "description": "The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId, group-emailAddress, allUsers, or allAuthenticatedUsers.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "bucket",
+      "entity"
+     ],
+     "scopes": [
+      "https://www.googleapis.com/auth/devstorage.full_control"
+     ]
+    },
+    "get": {
+     "id": "storage.bucketAccessControls.get",
+     "path": "b/{bucket}/acl/{entity}",
+     "httpMethod": "GET",
+     "description": "Returns the ACL entry for the specified entity on the specified bucket.",
+     "parameters": {
+      "bucket": {
+       "type": "string",
+       "description": "Name of a bucket.",
+       "required": true,
+       "location": "path"
+      },
+      "entity": {
+       "type": "string",
+       "description": "The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId, group-emailAddress, allUsers, or allAuthenticatedUsers.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "bucket",
+      "entity"
+     ],
+     "response": {
+      "$ref": "BucketAccessControl"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/devstorage.full_control"
+     ]
+    },
+    "insert": {
+     "id": "storage.bucketAccessControls.insert",
+     "path": "b/{bucket}/acl",
+     "httpMethod": "POST",
+     "description": "Creates a new ACL entry on the specified bucket.",
+     "parameters": {
+      "bucket": {
+       "type": "string",
+       "description": "Name of a bucket.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "bucket"
+     ],
+     "request": {
+      "$ref": "BucketAccessControl"
+     },
+     "response": {
+      "$ref": "BucketAccessControl"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/devstorage.full_control"
+     ]
+    },
+    "list": {
+     "id": "storage.bucketAccessControls.list",
+     "path": "b/{bucket}/acl",
+     "httpMethod": "GET",
+     "description": "Retrieves ACL entries on the specified bucket.",
+     "parameters": {
+      "bucket": {
+       "type": "string",
+       "description": "Name of a bucket.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "bucket"
+     ],
+     "response": {
+      "$ref": "BucketAccessControls"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/devstorage.full_control"
+     ]
+    },
+    "patch": {
+     "id": "storage.bucketAccessControls.patch",
+     "path": "b/{bucket}/acl/{entity}",
+     "httpMethod": "PATCH",
+     "description": "Updates an ACL entry on the specified bucket. This method supports patch semantics.",
+     "parameters": {
+      "bucket": {
+       "type": "string",
+       "description": "Name of a bucket.",
+       "required": true,
+       "location": "path"
+      },
+      "entity": {
+       "type": "string",
+       "description": "The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId, group-emailAddress, allUsers, or allAuthenticatedUsers.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "bucket",
+      "entity"
+     ],
+     "request": {
+      "$ref": "BucketAccessControl"
+     },
+     "response": {
+      "$ref": "BucketAccessControl"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/devstorage.full_control"
+     ]
+    },
+    "update": {
+     "id": "storage.bucketAccessControls.update",
+     "path": "b/{bucket}/acl/{entity}",
+     "httpMethod": "PUT",
+     "description": "Updates an ACL entry on the specified bucket.",
+     "parameters": {
+      "bucket": {
+       "type": "string",
+       "description": "Name of a bucket.",
+       "required": true,
+       "location": "path"
+      },
+      "entity": {
+       "type": "string",
+       "description": "The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId, group-emailAddress, allUsers, or allAuthenticatedUsers.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "bucket",
+      "entity"
+     ],
+     "request": {
+      "$ref": "BucketAccessControl"
+     },
+     "response": {
+      "$ref": "BucketAccessControl"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/devstorage.full_control"
+     ]
+    }
+   }
+  },
+  "buckets": {
+   "methods": {
+    "delete": {
+     "id": "storage.buckets.delete",
+     "path": "b/{bucket}",
+     "httpMethod": "DELETE",
+     "description": "Permanently deletes an empty bucket.",
+     "parameters": {
+      "bucket": {
+       "type": "string",
+       "description": "Name of a bucket.",
+       "required": true,
+       "location": "path"
+      },
+      "ifMetagenerationMatch": {
+       "type": "string",
+       "description": "If set, only deletes the bucket if its metageneration matches this value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifMetagenerationNotMatch": {
+       "type": "string",
+       "description": "If set, only deletes the bucket if its metageneration does not match this value.",
+       "format": "int64",
+       "location": "query"
+      }
+     },
+     "parameterOrder": [
+      "bucket"
+     ],
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/devstorage.full_control",
+      "https://www.googleapis.com/auth/devstorage.read_write"
+     ]
+    },
+    "get": {
+     "id": "storage.buckets.get",
+     "path": "b/{bucket}",
+     "httpMethod": "GET",
+     "description": "Returns metadata for the specified bucket.",
+     "parameters": {
+      "bucket": {
+       "type": "string",
+       "description": "Name of a bucket.",
+       "required": true,
+       "location": "path"
+      },
+      "ifMetagenerationMatch": {
+       "type": "string",
+       "description": "Makes the return of the bucket metadata conditional on whether the bucket's current metageneration matches the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifMetagenerationNotMatch": {
+       "type": "string",
+       "description": "Makes the return of the bucket metadata conditional on whether the bucket's current metageneration does not match the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "projection": {
+       "type": "string",
+       "description": "Set of properties to return. Defaults to noAcl.",
+       "enum": [
+        "full",
+        "noAcl"
+       ],
+       "enumDescriptions": [
+        "Include all properties.",
+        "Omit acl and defaultObjectAcl properties."
+       ],
+       "location": "query"
+      }
+     },
+     "parameterOrder": [
+      "bucket"
+     ],
+     "response": {
+      "$ref": "Bucket"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/devstorage.full_control",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/devstorage.read_write"
+     ]
+    },
+    "insert": {
+     "id": "storage.buckets.insert",
+     "path": "b",
+     "httpMethod": "POST",
+     "description": "Creates a new bucket.",
+     "parameters": {
+      "predefinedAcl": {
+       "type": "string",
+       "description": "Apply a predefined set of access controls to this bucket.",
+       "enum": [
+        "authenticatedRead",
+        "private",
+        "projectPrivate",
+        "publicRead",
+        "publicReadWrite"
+       ],
+       "enumDescriptions": [
+        "Project team owners get OWNER access, and allAuthenticatedUsers get READER access.",
+        "Project team owners get OWNER access.",
+        "Project team members get access according to their roles.",
+        "Project team owners get OWNER access, and allUsers get READER access.",
+        "Project team owners get OWNER access, and allUsers get WRITER access."
+       ],
+       "location": "query"
+      },
+      "predefinedDefaultObjectAcl": {
+       "type": "string",
+       "description": "Apply a predefined set of default object access controls to this bucket.",
+       "enum": [
+        "authenticatedRead",
+        "bucketOwnerFullControl",
+        "bucketOwnerRead",
+        "private",
+        "projectPrivate",
+        "publicRead"
+       ],
+       "enumDescriptions": [
+        "Object owner gets OWNER access, and allAuthenticatedUsers get READER access.",
+        "Object owner gets OWNER access, and project team owners get OWNER access.",
+        "Object owner gets OWNER access, and project team owners get READER access.",
+        "Object owner gets OWNER access.",
+        "Object owner gets OWNER access, and project team members get access according to their roles.",
+        "Object owner gets OWNER access, and allUsers get READER access."
+       ],
+       "location": "query"
+      },
+      "project": {
+       "type": "string",
+       "description": "A valid API project identifier.",
+       "required": true,
+       "location": "query"
+      },
+      "projection": {
+       "type": "string",
+       "description": "Set of properties to return. Defaults to noAcl, unless the bucket resource specifies acl or defaultObjectAcl properties, when it defaults to full.",
+       "enum": [
+        "full",
+        "noAcl"
+       ],
+       "enumDescriptions": [
+        "Include all properties.",
+        "Omit acl and defaultObjectAcl properties."
+       ],
+       "location": "query"
+      }
+     },
+     "parameterOrder": [
+      "project"
+     ],
+     "request": {
+      "$ref": "Bucket"
+     },
+     "response": {
+      "$ref": "Bucket"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/devstorage.full_control",
+      "https://www.googleapis.com/auth/devstorage.read_write"
+     ]
+    },
+    "list": {
+     "id": "storage.buckets.list",
+     "path": "b",
+     "httpMethod": "GET",
+     "description": "Retrieves a list of buckets for a given project.",
+     "parameters": {
+      "maxResults": {
+       "type": "integer",
+       "description": "Maximum number of buckets to return.",
+       "format": "uint32",
+       "minimum": "0",
+       "location": "query"
+      },
+      "pageToken": {
+       "type": "string",
+       "description": "A previously-returned page token representing part of the larger set of results to view.",
+       "location": "query"
+      },
+      "prefix": {
+       "type": "string",
+       "description": "Filter results to buckets whose names begin with this prefix.",
+       "location": "query"
+      },
+      "project": {
+       "type": "string",
+       "description": "A valid API project identifier.",
+       "required": true,
+       "location": "query"
+      },
+      "projection": {
+       "type": "string",
+       "description": "Set of properties to return. Defaults to noAcl.",
+       "enum": [
+        "full",
+        "noAcl"
+       ],
+       "enumDescriptions": [
+        "Include all properties.",
+        "Omit acl and defaultObjectAcl properties."
+       ],
+       "location": "query"
+      }
+     },
+     "parameterOrder": [
+      "project"
+     ],
+     "response": {
+      "$ref": "Buckets"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/devstorage.full_control",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/devstorage.read_write"
+     ]
+    },
+    "patch": {
+     "id": "storage.buckets.patch",
+     "path": "b/{bucket}",
+     "httpMethod": "PATCH",
+     "description": "Updates a bucket. This method supports patch semantics.",
+     "parameters": {
+      "bucket": {
+       "type": "string",
+       "description": "Name of a bucket.",
+       "required": true,
+       "location": "path"
+      },
+      "ifMetagenerationMatch": {
+       "type": "string",
+       "description": "Makes the return of the bucket metadata conditional on whether the bucket's current metageneration matches the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifMetagenerationNotMatch": {
+       "type": "string",
+       "description": "Makes the return of the bucket metadata conditional on whether the bucket's current metageneration does not match the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "predefinedAcl": {
+       "type": "string",
+       "description": "Apply a predefined set of access controls to this bucket.",
+       "enum": [
+        "authenticatedRead",
+        "private",
+        "projectPrivate",
+        "publicRead",
+        "publicReadWrite"
+       ],
+       "enumDescriptions": [
+        "Project team owners get OWNER access, and allAuthenticatedUsers get READER access.",
+        "Project team owners get OWNER access.",
+        "Project team members get access according to their roles.",
+        "Project team owners get OWNER access, and allUsers get READER access.",
+        "Project team owners get OWNER access, and allUsers get WRITER access."
+       ],
+       "location": "query"
+      },
+      "predefinedDefaultObjectAcl": {
+       "type": "string",
+       "description": "Apply a predefined set of default object access controls to this bucket.",
+       "enum": [
+        "authenticatedRead",
+        "bucketOwnerFullControl",
+        "bucketOwnerRead",
+        "private",
+        "projectPrivate",
+        "publicRead"
+       ],
+       "enumDescriptions": [
+        "Object owner gets OWNER access, and allAuthenticatedUsers get READER access.",
+        "Object owner gets OWNER access, and project team owners get OWNER access.",
+        "Object owner gets OWNER access, and project team owners get READER access.",
+        "Object owner gets OWNER access.",
+        "Object owner gets OWNER access, and project team members get access according to their roles.",
+        "Object owner gets OWNER access, and allUsers get READER access."
+       ],
+       "location": "query"
+      },
+      "projection": {
+       "type": "string",
+       "description": "Set of properties to return. Defaults to full.",
+       "enum": [
+        "full",
+        "noAcl"
+       ],
+       "enumDescriptions": [
+        "Include all properties.",
+        "Omit acl and defaultObjectAcl properties."
+       ],
+       "location": "query"
+      }
+     },
+     "parameterOrder": [
+      "bucket"
+     ],
+     "request": {
+      "$ref": "Bucket"
+     },
+     "response": {
+      "$ref": "Bucket"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/devstorage.full_control",
+      "https://www.googleapis.com/auth/devstorage.read_write"
+     ]
+    },
+    "update": {
+     "id": "storage.buckets.update",
+     "path": "b/{bucket}",
+     "httpMethod": "PUT",
+     "description": "Updates a bucket.",
+     "parameters": {
+      "bucket": {
+       "type": "string",
+       "description": "Name of a bucket.",
+       "required": true,
+       "location": "path"
+      },
+      "ifMetagenerationMatch": {
+       "type": "string",
+       "description": "Makes the return of the bucket metadata conditional on whether the bucket's current metageneration matches the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifMetagenerationNotMatch": {
+       "type": "string",
+       "description": "Makes the return of the bucket metadata conditional on whether the bucket's current metageneration does not match the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "predefinedAcl": {
+       "type": "string",
+       "description": "Apply a predefined set of access controls to this bucket.",
+       "enum": [
+        "authenticatedRead",
+        "private",
+        "projectPrivate",
+        "publicRead",
+        "publicReadWrite"
+       ],
+       "enumDescriptions": [
+        "Project team owners get OWNER access, and allAuthenticatedUsers get READER access.",
+        "Project team owners get OWNER access.",
+        "Project team members get access according to their roles.",
+        "Project team owners get OWNER access, and allUsers get READER access.",
+        "Project team owners get OWNER access, and allUsers get WRITER access."
+       ],
+       "location": "query"
+      },
+      "predefinedDefaultObjectAcl": {
+       "type": "string",
+       "description": "Apply a predefined set of default object access controls to this bucket.",
+       "enum": [
+        "authenticatedRead",
+        "bucketOwnerFullControl",
+        "bucketOwnerRead",
+        "private",
+        "projectPrivate",
+        "publicRead"
+       ],
+       "enumDescriptions": [
+        "Object owner gets OWNER access, and allAuthenticatedUsers get READER access.",
+        "Object owner gets OWNER access, and project team owners get OWNER access.",
+        "Object owner gets OWNER access, and project team owners get READER access.",
+        "Object owner gets OWNER access.",
+        "Object owner gets OWNER access, and project team members get access according to their roles.",
+        "Object owner gets OWNER access, and allUsers get READER access."
+       ],
+       "location": "query"
+      },
+      "projection": {
+       "type": "string",
+       "description": "Set of properties to return. Defaults to full.",
+       "enum": [
+        "full",
+        "noAcl"
+       ],
+       "enumDescriptions": [
+        "Include all properties.",
+        "Omit acl and defaultObjectAcl properties."
+       ],
+       "location": "query"
+      }
+     },
+     "parameterOrder": [
+      "bucket"
+     ],
+     "request": {
+      "$ref": "Bucket"
+     },
+     "response": {
+      "$ref": "Bucket"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/devstorage.full_control",
+      "https://www.googleapis.com/auth/devstorage.read_write"
+     ]
+    }
+   }
+  },
+  "channels": {
+   "methods": {
+    "stop": {
+     "id": "storage.channels.stop",
+     "path": "channels/stop",
+     "httpMethod": "POST",
+     "description": "Stop watching resources through this channel",
+     "request": {
+      "$ref": "Channel",
+      "parameterName": "resource"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/devstorage.full_control",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/devstorage.read_write"
+     ]
+    }
+   }
+  },
+  "defaultObjectAccessControls": {
+   "methods": {
+    "delete": {
+     "id": "storage.defaultObjectAccessControls.delete",
+     "path": "b/{bucket}/defaultObjectAcl/{entity}",
+     "httpMethod": "DELETE",
+     "description": "Permanently deletes the default object ACL entry for the specified entity on the specified bucket.",
+     "parameters": {
+      "bucket": {
+       "type": "string",
+       "description": "Name of a bucket.",
+       "required": true,
+       "location": "path"
+      },
+      "entity": {
+       "type": "string",
+       "description": "The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId, group-emailAddress, allUsers, or allAuthenticatedUsers.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "bucket",
+      "entity"
+     ],
+     "scopes": [
+      "https://www.googleapis.com/auth/devstorage.full_control"
+     ]
+    },
+    "get": {
+     "id": "storage.defaultObjectAccessControls.get",
+     "path": "b/{bucket}/defaultObjectAcl/{entity}",
+     "httpMethod": "GET",
+     "description": "Returns the default object ACL entry for the specified entity on the specified bucket.",
+     "parameters": {
+      "bucket": {
+       "type": "string",
+       "description": "Name of a bucket.",
+       "required": true,
+       "location": "path"
+      },
+      "entity": {
+       "type": "string",
+       "description": "The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId, group-emailAddress, allUsers, or allAuthenticatedUsers.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "bucket",
+      "entity"
+     ],
+     "response": {
+      "$ref": "ObjectAccessControl"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/devstorage.full_control"
+     ]
+    },
+    "insert": {
+     "id": "storage.defaultObjectAccessControls.insert",
+     "path": "b/{bucket}/defaultObjectAcl",
+     "httpMethod": "POST",
+     "description": "Creates a new default object ACL entry on the specified bucket.",
+     "parameters": {
+      "bucket": {
+       "type": "string",
+       "description": "Name of a bucket.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "bucket"
+     ],
+     "request": {
+      "$ref": "ObjectAccessControl"
+     },
+     "response": {
+      "$ref": "ObjectAccessControl"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/devstorage.full_control"
+     ]
+    },
+    "list": {
+     "id": "storage.defaultObjectAccessControls.list",
+     "path": "b/{bucket}/defaultObjectAcl",
+     "httpMethod": "GET",
+     "description": "Retrieves default object ACL entries on the specified bucket.",
+     "parameters": {
+      "bucket": {
+       "type": "string",
+       "description": "Name of a bucket.",
+       "required": true,
+       "location": "path"
+      },
+      "ifMetagenerationMatch": {
+       "type": "string",
+       "description": "If present, only return default ACL listing if the bucket's current metageneration matches this value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifMetagenerationNotMatch": {
+       "type": "string",
+       "description": "If present, only return default ACL listing if the bucket's current metageneration does not match the given value.",
+       "format": "int64",
+       "location": "query"
+      }
+     },
+     "parameterOrder": [
+      "bucket"
+     ],
+     "response": {
+      "$ref": "ObjectAccessControls"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/devstorage.full_control"
+     ]
+    },
+    "patch": {
+     "id": "storage.defaultObjectAccessControls.patch",
+     "path": "b/{bucket}/defaultObjectAcl/{entity}",
+     "httpMethod": "PATCH",
+     "description": "Updates a default object ACL entry on the specified bucket. This method supports patch semantics.",
+     "parameters": {
+      "bucket": {
+       "type": "string",
+       "description": "Name of a bucket.",
+       "required": true,
+       "location": "path"
+      },
+      "entity": {
+       "type": "string",
+       "description": "The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId, group-emailAddress, allUsers, or allAuthenticatedUsers.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "bucket",
+      "entity"
+     ],
+     "request": {
+      "$ref": "ObjectAccessControl"
+     },
+     "response": {
+      "$ref": "ObjectAccessControl"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/devstorage.full_control"
+     ]
+    },
+    "update": {
+     "id": "storage.defaultObjectAccessControls.update",
+     "path": "b/{bucket}/defaultObjectAcl/{entity}",
+     "httpMethod": "PUT",
+     "description": "Updates a default object ACL entry on the specified bucket.",
+     "parameters": {
+      "bucket": {
+       "type": "string",
+       "description": "Name of a bucket.",
+       "required": true,
+       "location": "path"
+      },
+      "entity": {
+       "type": "string",
+       "description": "The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId, group-emailAddress, allUsers, or allAuthenticatedUsers.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "bucket",
+      "entity"
+     ],
+     "request": {
+      "$ref": "ObjectAccessControl"
+     },
+     "response": {
+      "$ref": "ObjectAccessControl"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/devstorage.full_control"
+     ]
+    }
+   }
+  },
+  "objectAccessControls": {
+   "methods": {
+    "delete": {
+     "id": "storage.objectAccessControls.delete",
+     "path": "b/{bucket}/o/{object}/acl/{entity}",
+     "httpMethod": "DELETE",
+     "description": "Permanently deletes the ACL entry for the specified entity on the specified object.",
+     "parameters": {
+      "bucket": {
+       "type": "string",
+       "description": "Name of a bucket.",
+       "required": true,
+       "location": "path"
+      },
+      "entity": {
+       "type": "string",
+       "description": "The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId, group-emailAddress, allUsers, or allAuthenticatedUsers.",
+       "required": true,
+       "location": "path"
+      },
+      "generation": {
+       "type": "string",
+       "description": "If present, selects a specific revision of this object (as opposed to the latest version, the default).",
+       "format": "int64",
+       "location": "query"
+      },
+      "object": {
+       "type": "string",
+       "description": "Name of the object.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "bucket",
+      "object",
+      "entity"
+     ],
+     "scopes": [
+      "https://www.googleapis.com/auth/devstorage.full_control"
+     ]
+    },
+    "get": {
+     "id": "storage.objectAccessControls.get",
+     "path": "b/{bucket}/o/{object}/acl/{entity}",
+     "httpMethod": "GET",
+     "description": "Returns the ACL entry for the specified entity on the specified object.",
+     "parameters": {
+      "bucket": {
+       "type": "string",
+       "description": "Name of a bucket.",
+       "required": true,
+       "location": "path"
+      },
+      "entity": {
+       "type": "string",
+       "description": "The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId, group-emailAddress, allUsers, or allAuthenticatedUsers.",
+       "required": true,
+       "location": "path"
+      },
+      "generation": {
+       "type": "string",
+       "description": "If present, selects a specific revision of this object (as opposed to the latest version, the default).",
+       "format": "int64",
+       "location": "query"
+      },
+      "object": {
+       "type": "string",
+       "description": "Name of the object.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "bucket",
+      "object",
+      "entity"
+     ],
+     "response": {
+      "$ref": "ObjectAccessControl"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/devstorage.full_control"
+     ]
+    },
+    "insert": {
+     "id": "storage.objectAccessControls.insert",
+     "path": "b/{bucket}/o/{object}/acl",
+     "httpMethod": "POST",
+     "description": "Creates a new ACL entry on the specified object.",
+     "parameters": {
+      "bucket": {
+       "type": "string",
+       "description": "Name of a bucket.",
+       "required": true,
+       "location": "path"
+      },
+      "generation": {
+       "type": "string",
+       "description": "If present, selects a specific revision of this object (as opposed to the latest version, the default).",
+       "format": "int64",
+       "location": "query"
+      },
+      "object": {
+       "type": "string",
+       "description": "Name of the object.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "bucket",
+      "object"
+     ],
+     "request": {
+      "$ref": "ObjectAccessControl"
+     },
+     "response": {
+      "$ref": "ObjectAccessControl"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/devstorage.full_control"
+     ]
+    },
+    "list": {
+     "id": "storage.objectAccessControls.list",
+     "path": "b/{bucket}/o/{object}/acl",
+     "httpMethod": "GET",
+     "description": "Retrieves ACL entries on the specified object.",
+     "parameters": {
+      "bucket": {
+       "type": "string",
+       "description": "Name of a bucket.",
+       "required": true,
+       "location": "path"
+      },
+      "generation": {
+       "type": "string",
+       "description": "If present, selects a specific revision of this object (as opposed to the latest version, the default).",
+       "format": "int64",
+       "location": "query"
+      },
+      "object": {
+       "type": "string",
+       "description": "Name of the object.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "bucket",
+      "object"
+     ],
+     "response": {
+      "$ref": "ObjectAccessControls"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/devstorage.full_control"
+     ]
+    },
+    "patch": {
+     "id": "storage.objectAccessControls.patch",
+     "path": "b/{bucket}/o/{object}/acl/{entity}",
+     "httpMethod": "PATCH",
+     "description": "Updates an ACL entry on the specified object. This method supports patch semantics.",
+     "parameters": {
+      "bucket": {
+       "type": "string",
+       "description": "Name of a bucket.",
+       "required": true,
+       "location": "path"
+      },
+      "entity": {
+       "type": "string",
+       "description": "The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId, group-emailAddress, allUsers, or allAuthenticatedUsers.",
+       "required": true,
+       "location": "path"
+      },
+      "generation": {
+       "type": "string",
+       "description": "If present, selects a specific revision of this object (as opposed to the latest version, the default).",
+       "format": "int64",
+       "location": "query"
+      },
+      "object": {
+       "type": "string",
+       "description": "Name of the object.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "bucket",
+      "object",
+      "entity"
+     ],
+     "request": {
+      "$ref": "ObjectAccessControl"
+     },
+     "response": {
+      "$ref": "ObjectAccessControl"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/devstorage.full_control"
+     ]
+    },
+    "update": {
+     "id": "storage.objectAccessControls.update",
+     "path": "b/{bucket}/o/{object}/acl/{entity}",
+     "httpMethod": "PUT",
+     "description": "Updates an ACL entry on the specified object.",
+     "parameters": {
+      "bucket": {
+       "type": "string",
+       "description": "Name of a bucket.",
+       "required": true,
+       "location": "path"
+      },
+      "entity": {
+       "type": "string",
+       "description": "The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId, group-emailAddress, allUsers, or allAuthenticatedUsers.",
+       "required": true,
+       "location": "path"
+      },
+      "generation": {
+       "type": "string",
+       "description": "If present, selects a specific revision of this object (as opposed to the latest version, the default).",
+       "format": "int64",
+       "location": "query"
+      },
+      "object": {
+       "type": "string",
+       "description": "Name of the object.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "bucket",
+      "object",
+      "entity"
+     ],
+     "request": {
+      "$ref": "ObjectAccessControl"
+     },
+     "response": {
+      "$ref": "ObjectAccessControl"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/devstorage.full_control"
+     ]
+    }
+   }
+  },
+  "objects": {
+   "methods": {
+    "compose": {
+     "id": "storage.objects.compose",
+     "path": "b/{destinationBucket}/o/{destinationObject}/compose",
+     "httpMethod": "POST",
+     "description": "Concatenates a list of existing objects into a new object in the same bucket.",
+     "parameters": {
+      "destinationBucket": {
+       "type": "string",
+       "description": "Name of the bucket in which to store the new object.",
+       "required": true,
+       "location": "path"
+      },
+      "destinationObject": {
+       "type": "string",
+       "description": "Name of the new object.",
+       "required": true,
+       "location": "path"
+      },
+      "destinationPredefinedAcl": {
+       "type": "string",
+       "description": "Apply a predefined set of access controls to the destination object.",
+       "enum": [
+        "authenticatedRead",
+        "bucketOwnerFullControl",
+        "bucketOwnerRead",
+        "private",
+        "projectPrivate",
+        "publicRead"
+       ],
+       "enumDescriptions": [
+        "Object owner gets OWNER access, and allAuthenticatedUsers get READER access.",
+        "Object owner gets OWNER access, and project team owners get OWNER access.",
+        "Object owner gets OWNER access, and project team owners get READER access.",
+        "Object owner gets OWNER access.",
+        "Object owner gets OWNER access, and project team members get access according to their roles.",
+        "Object owner gets OWNER access, and allUsers get READER access."
+       ],
+       "location": "query"
+      },
+      "ifGenerationMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the object's current generation matches the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifMetagenerationMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the object's current metageneration matches the given value.",
+       "format": "int64",
+       "location": "query"
+      }
+     },
+     "parameterOrder": [
+      "destinationBucket",
+      "destinationObject"
+     ],
+     "request": {
+      "$ref": "ComposeRequest"
+     },
+     "response": {
+      "$ref": "Object"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/devstorage.full_control",
+      "https://www.googleapis.com/auth/devstorage.read_write"
+     ],
+     "supportsMediaDownload": true
+    },
+    "copy": {
+     "id": "storage.objects.copy",
+     "path": "b/{sourceBucket}/o/{sourceObject}/copyTo/b/{destinationBucket}/o/{destinationObject}",
+     "httpMethod": "POST",
+     "description": "Copies a source object to a destination object. Optionally overrides metadata.",
+     "parameters": {
+      "destinationBucket": {
+       "type": "string",
+       "description": "Name of the bucket in which to store the new object. Overrides the provided object metadata's bucket value, if any.",
+       "required": true,
+       "location": "path"
+      },
+      "destinationObject": {
+       "type": "string",
+       "description": "Name of the new object. Required when the object metadata is not otherwise provided. Overrides the object metadata's name value, if any.",
+       "required": true,
+       "location": "path"
+      },
+      "destinationPredefinedAcl": {
+       "type": "string",
+       "description": "Apply a predefined set of access controls to the destination object.",
+       "enum": [
+        "authenticatedRead",
+        "bucketOwnerFullControl",
+        "bucketOwnerRead",
+        "private",
+        "projectPrivate",
+        "publicRead"
+       ],
+       "enumDescriptions": [
+        "Object owner gets OWNER access, and allAuthenticatedUsers get READER access.",
+        "Object owner gets OWNER access, and project team owners get OWNER access.",
+        "Object owner gets OWNER access, and project team owners get READER access.",
+        "Object owner gets OWNER access.",
+        "Object owner gets OWNER access, and project team members get access according to their roles.",
+        "Object owner gets OWNER access, and allUsers get READER access."
+       ],
+       "location": "query"
+      },
+      "ifGenerationMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the destination object's current generation matches the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifGenerationNotMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the destination object's current generation does not match the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifMetagenerationMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the destination object's current metageneration matches the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifMetagenerationNotMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the destination object's current metageneration does not match the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifSourceGenerationMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the source object's generation matches the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifSourceGenerationNotMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the source object's generation does not match the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifSourceMetagenerationMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the source object's current metageneration matches the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifSourceMetagenerationNotMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the source object's current metageneration does not match the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "projection": {
+       "type": "string",
+       "description": "Set of properties to return. Defaults to noAcl, unless the object resource specifies the acl property, when it defaults to full.",
+       "enum": [
+        "full",
+        "noAcl"
+       ],
+       "enumDescriptions": [
+        "Include all properties.",
+        "Omit the acl property."
+       ],
+       "location": "query"
+      },
+      "sourceBucket": {
+       "type": "string",
+       "description": "Name of the bucket in which to find the source object.",
+       "required": true,
+       "location": "path"
+      },
+      "sourceGeneration": {
+       "type": "string",
+       "description": "If present, selects a specific revision of the source object (as opposed to the latest version, the default).",
+       "format": "int64",
+       "location": "query"
+      },
+      "sourceObject": {
+       "type": "string",
+       "description": "Name of the source object.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "sourceBucket",
+      "sourceObject",
+      "destinationBucket",
+      "destinationObject"
+     ],
+     "request": {
+      "$ref": "Object"
+     },
+     "response": {
+      "$ref": "Object"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/devstorage.full_control",
+      "https://www.googleapis.com/auth/devstorage.read_write"
+     ],
+     "supportsMediaDownload": true
+    },
+    "delete": {
+     "id": "storage.objects.delete",
+     "path": "b/{bucket}/o/{object}",
+     "httpMethod": "DELETE",
+     "description": "Deletes an object and its metadata. Deletions are permanent if versioning is not enabled for the bucket, or if the generation parameter is used.",
+     "parameters": {
+      "bucket": {
+       "type": "string",
+       "description": "Name of the bucket in which the object resides.",
+       "required": true,
+       "location": "path"
+      },
+      "generation": {
+       "type": "string",
+       "description": "If present, permanently deletes a specific revision of this object (as opposed to the latest version, the default).",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifGenerationMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the object's current generation matches the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifGenerationNotMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the object's current generation does not match the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifMetagenerationMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the object's current metageneration matches the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifMetagenerationNotMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the object's current metageneration does not match the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "object": {
+       "type": "string",
+       "description": "Name of the object.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "bucket",
+      "object"
+     ],
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/devstorage.full_control",
+      "https://www.googleapis.com/auth/devstorage.read_write"
+     ]
+    },
+    "get": {
+     "id": "storage.objects.get",
+     "path": "b/{bucket}/o/{object}",
+     "httpMethod": "GET",
+     "description": "Retrieves an object or its metadata.",
+     "parameters": {
+      "bucket": {
+       "type": "string",
+       "description": "Name of the bucket in which the object resides.",
+       "required": true,
+       "location": "path"
+      },
+      "generation": {
+       "type": "string",
+       "description": "If present, selects a specific revision of this object (as opposed to the latest version, the default).",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifGenerationMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the object's generation matches the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifGenerationNotMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the object's generation does not match the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifMetagenerationMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the object's current metageneration matches the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifMetagenerationNotMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the object's current metageneration does not match the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "object": {
+       "type": "string",
+       "description": "Name of the object.",
+       "required": true,
+       "location": "path"
+      },
+      "projection": {
+       "type": "string",
+       "description": "Set of properties to return. Defaults to noAcl.",
+       "enum": [
+        "full",
+        "noAcl"
+       ],
+       "enumDescriptions": [
+        "Include all properties.",
+        "Omit the acl property."
+       ],
+       "location": "query"
+      }
+     },
+     "parameterOrder": [
+      "bucket",
+      "object"
+     ],
+     "response": {
+      "$ref": "Object"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/devstorage.full_control",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/devstorage.read_write"
+     ],
+     "supportsMediaDownload": true
+    },
+    "insert": {
+     "id": "storage.objects.insert",
+     "path": "b/{bucket}/o",
+     "httpMethod": "POST",
+     "description": "Stores a new object and metadata.",
+     "parameters": {
+      "bucket": {
+       "type": "string",
+       "description": "Name of the bucket in which to store the new object. Overrides the provided object metadata's bucket value, if any.",
+       "required": true,
+       "location": "path"
+      },
+      "contentEncoding": {
+       "type": "string",
+       "description": "If set, sets the contentEncoding property of the final object to this value. Setting this parameter is equivalent to setting the contentEncoding metadata property. This can be useful when uploading an object with uploadType=media to indicate the encoding of the content being uploaded.",
+       "location": "query"
+      },
+      "ifGenerationMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the object's current generation matches the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifGenerationNotMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the object's current generation does not match the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifMetagenerationMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the object's current metageneration matches the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifMetagenerationNotMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the object's current metageneration does not match the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "name": {
+       "type": "string",
+       "description": "Name of the object. Required when the object metadata is not otherwise provided. Overrides the object metadata's name value, if any.",
+       "location": "query"
+      },
+      "predefinedAcl": {
+       "type": "string",
+       "description": "Apply a predefined set of access controls to this object.",
+       "enum": [
+        "authenticatedRead",
+        "bucketOwnerFullControl",
+        "bucketOwnerRead",
+        "private",
+        "projectPrivate",
+        "publicRead"
+       ],
+       "enumDescriptions": [
+        "Object owner gets OWNER access, and allAuthenticatedUsers get READER access.",
+        "Object owner gets OWNER access, and project team owners get OWNER access.",
+        "Object owner gets OWNER access, and project team owners get READER access.",
+        "Object owner gets OWNER access.",
+        "Object owner gets OWNER access, and project team members get access according to their roles.",
+        "Object owner gets OWNER access, and allUsers get READER access."
+       ],
+       "location": "query"
+      },
+      "projection": {
+       "type": "string",
+       "description": "Set of properties to return. Defaults to noAcl, unless the object resource specifies the acl property, when it defaults to full.",
+       "enum": [
+        "full",
+        "noAcl"
+       ],
+       "enumDescriptions": [
+        "Include all properties.",
+        "Omit the acl property."
+       ],
+       "location": "query"
+      }
+     },
+     "parameterOrder": [
+      "bucket"
+     ],
+     "request": {
+      "$ref": "Object"
+     },
+     "response": {
+      "$ref": "Object"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/devstorage.full_control",
+      "https://www.googleapis.com/auth/devstorage.read_write"
+     ],
+     "supportsMediaDownload": true,
+     "supportsMediaUpload": true,
+     "mediaUpload": {
+      "accept": [
+       "*/*"
+      ],
+      "protocols": {
+       "simple": {
+        "multipart": true,
+        "path": "/upload/storage/v1/b/{bucket}/o"
+       },
+       "resumable": {
+        "multipart": true,
+        "path": "/resumable/upload/storage/v1/b/{bucket}/o"
+       }
+      }
+     }
+    },
+    "list": {
+     "id": "storage.objects.list",
+     "path": "b/{bucket}/o",
+     "httpMethod": "GET",
+     "description": "Retrieves a list of objects matching the criteria.",
+     "parameters": {
+      "bucket": {
+       "type": "string",
+       "description": "Name of the bucket in which to look for objects.",
+       "required": true,
+       "location": "path"
+      },
+      "delimiter": {
+       "type": "string",
+       "description": "Returns results in a directory-like mode. items will contain only objects whose names, aside from the prefix, do not contain delimiter. Objects whose names, aside from the prefix, contain delimiter will have their name, truncated after the delimiter, returned in prefixes. Duplicate prefixes are omitted.",
+       "location": "query"
+      },
+      "maxResults": {
+       "type": "integer",
+       "description": "Maximum number of items plus prefixes to return. As duplicate prefixes are omitted, fewer total results may be returned than requested. The default value of this parameter is 1,000 items.",
+       "format": "uint32",
+       "minimum": "0",
+       "location": "query"
+      },
+      "pageToken": {
+       "type": "string",
+       "description": "A previously-returned page token representing part of the larger set of results to view.",
+       "location": "query"
+      },
+      "prefix": {
+       "type": "string",
+       "description": "Filter results to objects whose names begin with this prefix.",
+       "location": "query"
+      },
+      "projection": {
+       "type": "string",
+       "description": "Set of properties to return. Defaults to noAcl.",
+       "enum": [
+        "full",
+        "noAcl"
+       ],
+       "enumDescriptions": [
+        "Include all properties.",
+        "Omit the acl property."
+       ],
+       "location": "query"
+      },
+      "versions": {
+       "type": "boolean",
+       "description": "If true, lists all versions of an object as distinct results. The default is false. For more information, see Object Versioning.",
+       "location": "query"
+      }
+     },
+     "parameterOrder": [
+      "bucket"
+     ],
+     "response": {
+      "$ref": "Objects"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/devstorage.full_control",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/devstorage.read_write"
+     ],
+     "supportsSubscription": true
+    },
+    "patch": {
+     "id": "storage.objects.patch",
+     "path": "b/{bucket}/o/{object}",
+     "httpMethod": "PATCH",
+     "description": "Updates an object's metadata. This method supports patch semantics.",
+     "parameters": {
+      "bucket": {
+       "type": "string",
+       "description": "Name of the bucket in which the object resides.",
+       "required": true,
+       "location": "path"
+      },
+      "generation": {
+       "type": "string",
+       "description": "If present, selects a specific revision of this object (as opposed to the latest version, the default).",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifGenerationMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the object's current generation matches the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifGenerationNotMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the object's current generation does not match the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifMetagenerationMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the object's current metageneration matches the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifMetagenerationNotMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the object's current metageneration does not match the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "object": {
+       "type": "string",
+       "description": "Name of the object.",
+       "required": true,
+       "location": "path"
+      },
+      "predefinedAcl": {
+       "type": "string",
+       "description": "Apply a predefined set of access controls to this object.",
+       "enum": [
+        "authenticatedRead",
+        "bucketOwnerFullControl",
+        "bucketOwnerRead",
+        "private",
+        "projectPrivate",
+        "publicRead"
+       ],
+       "enumDescriptions": [
+        "Object owner gets OWNER access, and allAuthenticatedUsers get READER access.",
+        "Object owner gets OWNER access, and project team owners get OWNER access.",
+        "Object owner gets OWNER access, and project team owners get READER access.",
+        "Object owner gets OWNER access.",
+        "Object owner gets OWNER access, and project team members get access according to their roles.",
+        "Object owner gets OWNER access, and allUsers get READER access."
+       ],
+       "location": "query"
+      },
+      "projection": {
+       "type": "string",
+       "description": "Set of properties to return. Defaults to full.",
+       "enum": [
+        "full",
+        "noAcl"
+       ],
+       "enumDescriptions": [
+        "Include all properties.",
+        "Omit the acl property."
+       ],
+       "location": "query"
+      }
+     },
+     "parameterOrder": [
+      "bucket",
+      "object"
+     ],
+     "request": {
+      "$ref": "Object"
+     },
+     "response": {
+      "$ref": "Object"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/devstorage.full_control",
+      "https://www.googleapis.com/auth/devstorage.read_write"
+     ]
+    },
+    "rewrite": {
+     "id": "storage.objects.rewrite",
+     "path": "b/{sourceBucket}/o/{sourceObject}/rewriteTo/b/{destinationBucket}/o/{destinationObject}",
+     "httpMethod": "POST",
+     "description": "Rewrites a source object to a destination object. Optionally overrides metadata.",
+     "parameters": {
+      "destinationBucket": {
+       "type": "string",
+       "description": "Name of the bucket in which to store the new object. Overrides the provided object metadata's bucket value, if any.",
+       "required": true,
+       "location": "path"
+      },
+      "destinationObject": {
+       "type": "string",
+       "description": "Name of the new object. Required when the object metadata is not otherwise provided. Overrides the object metadata's name value, if any.",
+       "required": true,
+       "location": "path"
+      },
+      "destinationPredefinedAcl": {
+       "type": "string",
+       "description": "Apply a predefined set of access controls to the destination object.",
+       "enum": [
+        "authenticatedRead",
+        "bucketOwnerFullControl",
+        "bucketOwnerRead",
+        "private",
+        "projectPrivate",
+        "publicRead"
+       ],
+       "enumDescriptions": [
+        "Object owner gets OWNER access, and allAuthenticatedUsers get READER access.",
+        "Object owner gets OWNER access, and project team owners get OWNER access.",
+        "Object owner gets OWNER access, and project team owners get READER access.",
+        "Object owner gets OWNER access.",
+        "Object owner gets OWNER access, and project team members get access according to their roles.",
+        "Object owner gets OWNER access, and allUsers get READER access."
+       ],
+       "location": "query"
+      },
+      "ifGenerationMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the destination object's current generation matches the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifGenerationNotMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the destination object's current generation does not match the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifMetagenerationMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the destination object's current metageneration matches the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifMetagenerationNotMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the destination object's current metageneration does not match the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifSourceGenerationMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the source object's generation matches the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifSourceGenerationNotMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the source object's generation does not match the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifSourceMetagenerationMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the source object's current metageneration matches the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifSourceMetagenerationNotMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the source object's current metageneration does not match the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "maxBytesRewrittenPerCall": {
+       "type": "string",
+       "description": "The maximum number of bytes that will be rewritten per rewrite request. Most callers shouldn't need to specify this parameter - it is primarily in place to support testing. If specified the value must be an integral multiple of 1 MiB (1048576). Also, this only applies to requests where the source and destination span locations and/or storage classes. Finally, this value must not change across rewrite calls else you'll get an error that the rewriteToken is invalid.",
+       "format": "int64",
+       "location": "query"
+      },
+      "projection": {
+       "type": "string",
+       "description": "Set of properties to return. Defaults to noAcl, unless the object resource specifies the acl property, when it defaults to full.",
+       "enum": [
+        "full",
+        "noAcl"
+       ],
+       "enumDescriptions": [
+        "Include all properties.",
+        "Omit the acl property."
+       ],
+       "location": "query"
+      },
+      "rewriteToken": {
+       "type": "string",
+       "description": "Include this field (from the previous rewrite response) on each rewrite request after the first one, until the rewrite response 'done' flag is true. Calls that provide a rewriteToken can omit all other request fields, but if included those fields must match the values provided in the first rewrite request.",
+       "location": "query"
+      },
+      "sourceBucket": {
+       "type": "string",
+       "description": "Name of the bucket in which to find the source object.",
+       "required": true,
+       "location": "path"
+      },
+      "sourceGeneration": {
+       "type": "string",
+       "description": "If present, selects a specific revision of the source object (as opposed to the latest version, the default).",
+       "format": "int64",
+       "location": "query"
+      },
+      "sourceObject": {
+       "type": "string",
+       "description": "Name of the source object.",
+       "required": true,
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "sourceBucket",
+      "sourceObject",
+      "destinationBucket",
+      "destinationObject"
+     ],
+     "request": {
+      "$ref": "Object"
+     },
+     "response": {
+      "$ref": "RewriteResponse"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/devstorage.full_control",
+      "https://www.googleapis.com/auth/devstorage.read_write"
+     ]
+    },
+    "update": {
+     "id": "storage.objects.update",
+     "path": "b/{bucket}/o/{object}",
+     "httpMethod": "PUT",
+     "description": "Updates an object's metadata.",
+     "parameters": {
+      "bucket": {
+       "type": "string",
+       "description": "Name of the bucket in which the object resides.",
+       "required": true,
+       "location": "path"
+      },
+      "generation": {
+       "type": "string",
+       "description": "If present, selects a specific revision of this object (as opposed to the latest version, the default).",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifGenerationMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the object's current generation matches the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifGenerationNotMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the object's current generation does not match the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifMetagenerationMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the object's current metageneration matches the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "ifMetagenerationNotMatch": {
+       "type": "string",
+       "description": "Makes the operation conditional on whether the object's current metageneration does not match the given value.",
+       "format": "int64",
+       "location": "query"
+      },
+      "object": {
+       "type": "string",
+       "description": "Name of the object.",
+       "required": true,
+       "location": "path"
+      },
+      "predefinedAcl": {
+       "type": "string",
+       "description": "Apply a predefined set of access controls to this object.",
+       "enum": [
+        "authenticatedRead",
+        "bucketOwnerFullControl",
+        "bucketOwnerRead",
+        "private",
+        "projectPrivate",
+        "publicRead"
+       ],
+       "enumDescriptions": [
+        "Object owner gets OWNER access, and allAuthenticatedUsers get READER access.",
+        "Object owner gets OWNER access, and project team owners get OWNER access.",
+        "Object owner gets OWNER access, and project team owners get READER access.",
+        "Object owner gets OWNER access.",
+        "Object owner gets OWNER access, and project team members get access according to their roles.",
+        "Object owner gets OWNER access, and allUsers get READER access."
+       ],
+       "location": "query"
+      },
+      "projection": {
+       "type": "string",
+       "description": "Set of properties to return. Defaults to full.",
+       "enum": [
+        "full",
+        "noAcl"
+       ],
+       "enumDescriptions": [
+        "Include all properties.",
+        "Omit the acl property."
+       ],
+       "location": "query"
+      }
+     },
+     "parameterOrder": [
+      "bucket",
+      "object"
+     ],
+     "request": {
+      "$ref": "Object"
+     },
+     "response": {
+      "$ref": "Object"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/devstorage.full_control",
+      "https://www.googleapis.com/auth/devstorage.read_write"
+     ],
+     "supportsMediaDownload": true
+    },
+    "watchAll": {
+     "id": "storage.objects.watchAll",
+     "path": "b/{bucket}/o/watch",
+     "httpMethod": "POST",
+     "description": "Watch for changes on all objects in a bucket.",
+     "parameters": {
+      "bucket": {
+       "type": "string",
+       "description": "Name of the bucket in which to look for objects.",
+       "required": true,
+       "location": "path"
+      },
+      "delimiter": {
+       "type": "string",
+       "description": "Returns results in a directory-like mode. items will contain only objects whose names, aside from the prefix, do not contain delimiter. Objects whose names, aside from the prefix, contain delimiter will have their name, truncated after the delimiter, returned in prefixes. Duplicate prefixes are omitted.",
+       "location": "query"
+      },
+      "maxResults": {
+       "type": "integer",
+       "description": "Maximum number of items plus prefixes to return. As duplicate prefixes are omitted, fewer total results may be returned than requested. The default value of this parameter is 1,000 items.",
+       "format": "uint32",
+       "minimum": "0",
+       "location": "query"
+      },
+      "pageToken": {
+       "type": "string",
+       "description": "A previously-returned page token representing part of the larger set of results to view.",
+       "location": "query"
+      },
+      "prefix": {
+       "type": "string",
+       "description": "Filter results to objects whose names begin with this prefix.",
+       "location": "query"
+      },
+      "projection": {
+       "type": "string",
+       "description": "Set of properties to return. Defaults to noAcl.",
+       "enum": [
+        "full",
+        "noAcl"
+       ],
+       "enumDescriptions": [
+        "Include all properties.",
+        "Omit the acl property."
+       ],
+       "location": "query"
+      },
+      "versions": {
+       "type": "boolean",
+       "description": "If true, lists all versions of an object as distinct results. The default is false. For more information, see Object Versioning.",
+       "location": "query"
+      }
+     },
+     "parameterOrder": [
+      "bucket"
+     ],
+     "request": {
+      "$ref": "Channel",
+      "parameterName": "resource"
+     },
+     "response": {
+      "$ref": "Channel"
+     },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/devstorage.full_control",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/devstorage.read_write"
+     ],
+     "supportsSubscription": true
+    }
+   }
+  }
+ }
+}

--- a/Godeps/_workspace/src/google.golang.org/api/storage/v1/storage-gen.go
+++ b/Godeps/_workspace/src/google.golang.org/api/storage/v1/storage-gen.go
@@ -1,0 +1,6200 @@
+// Package storage provides access to the Cloud Storage API.
+//
+// See https://developers.google.com/storage/docs/json_api/
+//
+// Usage example:
+//
+//   import "google.golang.org/api/storage/v1"
+//   ...
+//   storageService, err := storage.New(oauthHttpClient)
+package storage
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"golang.org/x/net/context"
+	"google.golang.org/api/googleapi"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// Always reference these packages, just in case the auto-generated code
+// below doesn't.
+var _ = bytes.NewBuffer
+var _ = strconv.Itoa
+var _ = fmt.Sprintf
+var _ = json.NewDecoder
+var _ = io.Copy
+var _ = url.Parse
+var _ = googleapi.Version
+var _ = errors.New
+var _ = strings.Replace
+var _ = context.Background
+
+const apiId = "storage:v1"
+const apiName = "storage"
+const apiVersion = "v1"
+const basePath = "https://www.googleapis.com/storage/v1/"
+
+// OAuth2 scopes used by this API.
+const (
+	// View and manage your data across Google Cloud Platform services
+	CloudPlatformScope = "https://www.googleapis.com/auth/cloud-platform"
+
+	// Manage your data and permissions in Google Cloud Storage
+	DevstorageFullControlScope = "https://www.googleapis.com/auth/devstorage.full_control"
+
+	// View your data in Google Cloud Storage
+	DevstorageReadOnlyScope = "https://www.googleapis.com/auth/devstorage.read_only"
+
+	// Manage your data in Google Cloud Storage
+	DevstorageReadWriteScope = "https://www.googleapis.com/auth/devstorage.read_write"
+)
+
+func New(client *http.Client) (*Service, error) {
+	if client == nil {
+		return nil, errors.New("client is nil")
+	}
+	s := &Service{client: client, BasePath: basePath}
+	s.BucketAccessControls = NewBucketAccessControlsService(s)
+	s.Buckets = NewBucketsService(s)
+	s.Channels = NewChannelsService(s)
+	s.DefaultObjectAccessControls = NewDefaultObjectAccessControlsService(s)
+	s.ObjectAccessControls = NewObjectAccessControlsService(s)
+	s.Objects = NewObjectsService(s)
+	return s, nil
+}
+
+type Service struct {
+	client    *http.Client
+	BasePath  string // API endpoint base URL
+	UserAgent string // optional additional User-Agent fragment
+
+	BucketAccessControls *BucketAccessControlsService
+
+	Buckets *BucketsService
+
+	Channels *ChannelsService
+
+	DefaultObjectAccessControls *DefaultObjectAccessControlsService
+
+	ObjectAccessControls *ObjectAccessControlsService
+
+	Objects *ObjectsService
+}
+
+func (s *Service) userAgent() string {
+	if s.UserAgent == "" {
+		return googleapi.UserAgent
+	}
+	return googleapi.UserAgent + " " + s.UserAgent
+}
+
+func NewBucketAccessControlsService(s *Service) *BucketAccessControlsService {
+	rs := &BucketAccessControlsService{s: s}
+	return rs
+}
+
+type BucketAccessControlsService struct {
+	s *Service
+}
+
+func NewBucketsService(s *Service) *BucketsService {
+	rs := &BucketsService{s: s}
+	return rs
+}
+
+type BucketsService struct {
+	s *Service
+}
+
+func NewChannelsService(s *Service) *ChannelsService {
+	rs := &ChannelsService{s: s}
+	return rs
+}
+
+type ChannelsService struct {
+	s *Service
+}
+
+func NewDefaultObjectAccessControlsService(s *Service) *DefaultObjectAccessControlsService {
+	rs := &DefaultObjectAccessControlsService{s: s}
+	return rs
+}
+
+type DefaultObjectAccessControlsService struct {
+	s *Service
+}
+
+func NewObjectAccessControlsService(s *Service) *ObjectAccessControlsService {
+	rs := &ObjectAccessControlsService{s: s}
+	return rs
+}
+
+type ObjectAccessControlsService struct {
+	s *Service
+}
+
+func NewObjectsService(s *Service) *ObjectsService {
+	rs := &ObjectsService{s: s}
+	return rs
+}
+
+type ObjectsService struct {
+	s *Service
+}
+
+// Bucket: A bucket.
+type Bucket struct {
+	// Acl: Access controls on the bucket.
+	Acl []*BucketAccessControl `json:"acl,omitempty"`
+
+	// Cors: The bucket's Cross-Origin Resource Sharing (CORS)
+	// configuration.
+	Cors []*BucketCors `json:"cors,omitempty"`
+
+	// DefaultObjectAcl: Default access controls to apply to new objects
+	// when no ACL is provided.
+	DefaultObjectAcl []*ObjectAccessControl `json:"defaultObjectAcl,omitempty"`
+
+	// Etag: HTTP 1.1 Entity tag for the bucket.
+	Etag string `json:"etag,omitempty"`
+
+	// Id: The ID of the bucket.
+	Id string `json:"id,omitempty"`
+
+	// Kind: The kind of item this is. For buckets, this is always
+	// storage#bucket.
+	Kind string `json:"kind,omitempty"`
+
+	// Lifecycle: The bucket's lifecycle configuration. See lifecycle
+	// management for more information.
+	Lifecycle *BucketLifecycle `json:"lifecycle,omitempty"`
+
+	// Location: The location of the bucket. Object data for objects in the
+	// bucket resides in physical storage within this region. Defaults to
+	// US. See the developer's guide for the authoritative list.
+	Location string `json:"location,omitempty"`
+
+	// Logging: The bucket's logging configuration, which defines the
+	// destination bucket and optional name prefix for the current bucket's
+	// logs.
+	Logging *BucketLogging `json:"logging,omitempty"`
+
+	// Metageneration: The metadata generation of this bucket.
+	Metageneration int64 `json:"metageneration,omitempty,string"`
+
+	// Name: The name of the bucket.
+	Name string `json:"name,omitempty"`
+
+	// Owner: The owner of the bucket. This is always the project team's
+	// owner group.
+	Owner *BucketOwner `json:"owner,omitempty"`
+
+	// ProjectNumber: The project number of the project the bucket belongs
+	// to.
+	ProjectNumber uint64 `json:"projectNumber,omitempty,string"`
+
+	// SelfLink: The URI of this bucket.
+	SelfLink string `json:"selfLink,omitempty"`
+
+	// StorageClass: The bucket's storage class. This defines how objects in
+	// the bucket are stored and determines the SLA and the cost of storage.
+	// Values include STANDARD, NEARLINE and DURABLE_REDUCED_AVAILABILITY.
+	// Defaults to STANDARD. For more information, see storage classes.
+	StorageClass string `json:"storageClass,omitempty"`
+
+	// TimeCreated: Creation time of the bucket in RFC 3339 format.
+	TimeCreated string `json:"timeCreated,omitempty"`
+
+	// Versioning: The bucket's versioning configuration.
+	Versioning *BucketVersioning `json:"versioning,omitempty"`
+
+	// Website: The bucket's website configuration.
+	Website *BucketWebsite `json:"website,omitempty"`
+}
+
+type BucketCors struct {
+	// MaxAgeSeconds: The value, in seconds, to return in the
+	// Access-Control-Max-Age header used in preflight responses.
+	MaxAgeSeconds int64 `json:"maxAgeSeconds,omitempty"`
+
+	// Method: The list of HTTP methods on which to include CORS response
+	// headers, (GET, OPTIONS, POST, etc) Note: "*" is permitted in the list
+	// of methods, and means "any method".
+	Method []string `json:"method,omitempty"`
+
+	// Origin: The list of Origins eligible to receive CORS response
+	// headers. Note: "*" is permitted in the list of origins, and means
+	// "any Origin".
+	Origin []string `json:"origin,omitempty"`
+
+	// ResponseHeader: The list of HTTP headers other than the simple
+	// response headers to give permission for the user-agent to share
+	// across domains.
+	ResponseHeader []string `json:"responseHeader,omitempty"`
+}
+
+// BucketLifecycle: The bucket's lifecycle configuration. See lifecycle
+// management for more information.
+type BucketLifecycle struct {
+	// Rule: A lifecycle management rule, which is made of an action to take
+	// and the condition(s) under which the action will be taken.
+	Rule []*BucketLifecycleRule `json:"rule,omitempty"`
+}
+
+type BucketLifecycleRule struct {
+	// Action: The action to take.
+	Action *BucketLifecycleRuleAction `json:"action,omitempty"`
+
+	// Condition: The condition(s) under which the action will be taken.
+	Condition *BucketLifecycleRuleCondition `json:"condition,omitempty"`
+}
+
+// BucketLifecycleRuleAction: The action to take.
+type BucketLifecycleRuleAction struct {
+	// Type: Type of the action. Currently, only Delete is supported.
+	Type string `json:"type,omitempty"`
+}
+
+// BucketLifecycleRuleCondition: The condition(s) under which the action
+// will be taken.
+type BucketLifecycleRuleCondition struct {
+	// Age: Age of an object (in days). This condition is satisfied when an
+	// object reaches the specified age.
+	Age int64 `json:"age,omitempty"`
+
+	// CreatedBefore: A date in RFC 3339 format with only the date part (for
+	// instance, "2013-01-15"). This condition is satisfied when an object
+	// is created before midnight of the specified date in UTC.
+	CreatedBefore string `json:"createdBefore,omitempty"`
+
+	// IsLive: Relevant only for versioned objects. If the value is true,
+	// this condition matches live objects; if the value is false, it
+	// matches archived objects.
+	IsLive bool `json:"isLive,omitempty"`
+
+	// NumNewerVersions: Relevant only for versioned objects. If the value
+	// is N, this condition is satisfied when there are at least N versions
+	// (including the live version) newer than this version of the object.
+	NumNewerVersions int64 `json:"numNewerVersions,omitempty"`
+}
+
+// BucketLogging: The bucket's logging configuration, which defines the
+// destination bucket and optional name prefix for the current bucket's
+// logs.
+type BucketLogging struct {
+	// LogBucket: The destination bucket where the current bucket's logs
+	// should be placed.
+	LogBucket string `json:"logBucket,omitempty"`
+
+	// LogObjectPrefix: A prefix for log object names.
+	LogObjectPrefix string `json:"logObjectPrefix,omitempty"`
+}
+
+// BucketOwner: The owner of the bucket. This is always the project
+// team's owner group.
+type BucketOwner struct {
+	// Entity: The entity, in the form project-owner-projectId.
+	Entity string `json:"entity,omitempty"`
+
+	// EntityId: The ID for the entity.
+	EntityId string `json:"entityId,omitempty"`
+}
+
+// BucketVersioning: The bucket's versioning configuration.
+type BucketVersioning struct {
+	// Enabled: While set to true, versioning is fully enabled for this
+	// bucket.
+	Enabled bool `json:"enabled,omitempty"`
+}
+
+// BucketWebsite: The bucket's website configuration.
+type BucketWebsite struct {
+	// MainPageSuffix: Behaves as the bucket's directory index where missing
+	// objects are treated as potential directories.
+	MainPageSuffix string `json:"mainPageSuffix,omitempty"`
+
+	// NotFoundPage: The custom object to return when a requested resource
+	// is not found.
+	NotFoundPage string `json:"notFoundPage,omitempty"`
+}
+
+// BucketAccessControl: An access-control entry.
+type BucketAccessControl struct {
+	// Bucket: The name of the bucket.
+	Bucket string `json:"bucket,omitempty"`
+
+	// Domain: The domain associated with the entity, if any.
+	Domain string `json:"domain,omitempty"`
+
+	// Email: The email address associated with the entity, if any.
+	Email string `json:"email,omitempty"`
+
+	// Entity: The entity holding the permission, in one of the following
+	// forms:
+	// - user-userId
+	// - user-email
+	// - group-groupId
+	// - group-email
+	// - domain-domain
+	// - project-team-projectId
+	// - allUsers
+	// - allAuthenticatedUsers Examples:
+	// - The user liz@example.com would be user-liz@example.com.
+	// - The group example@googlegroups.com would be
+	// group-example@googlegroups.com.
+	// - To refer to all members of the Google Apps for Business domain
+	// example.com, the entity would be domain-example.com.
+	Entity string `json:"entity,omitempty"`
+
+	// EntityId: The ID for the entity, if any.
+	EntityId string `json:"entityId,omitempty"`
+
+	// Etag: HTTP 1.1 Entity tag for the access-control entry.
+	Etag string `json:"etag,omitempty"`
+
+	// Id: The ID of the access-control entry.
+	Id string `json:"id,omitempty"`
+
+	// Kind: The kind of item this is. For bucket access control entries,
+	// this is always storage#bucketAccessControl.
+	Kind string `json:"kind,omitempty"`
+
+	// ProjectTeam: The project team associated with the entity, if any.
+	ProjectTeam *BucketAccessControlProjectTeam `json:"projectTeam,omitempty"`
+
+	// Role: The access permission for the entity. Can be READER, WRITER, or
+	// OWNER.
+	Role string `json:"role,omitempty"`
+
+	// SelfLink: The link to this access-control entry.
+	SelfLink string `json:"selfLink,omitempty"`
+}
+
+// BucketAccessControlProjectTeam: The project team associated with the
+// entity, if any.
+type BucketAccessControlProjectTeam struct {
+	// ProjectNumber: The project number.
+	ProjectNumber string `json:"projectNumber,omitempty"`
+
+	// Team: The team. Can be owners, editors, or viewers.
+	Team string `json:"team,omitempty"`
+}
+
+// BucketAccessControls: An access-control list.
+type BucketAccessControls struct {
+	// Items: The list of items.
+	Items []*BucketAccessControl `json:"items,omitempty"`
+
+	// Kind: The kind of item this is. For lists of bucket access control
+	// entries, this is always storage#bucketAccessControls.
+	Kind string `json:"kind,omitempty"`
+}
+
+// Buckets: A list of buckets.
+type Buckets struct {
+	// Items: The list of items.
+	Items []*Bucket `json:"items,omitempty"`
+
+	// Kind: The kind of item this is. For lists of buckets, this is always
+	// storage#buckets.
+	Kind string `json:"kind,omitempty"`
+
+	// NextPageToken: The continuation token, used to page through large
+	// result sets. Provide this value in a subsequent request to return the
+	// next page of results.
+	NextPageToken string `json:"nextPageToken,omitempty"`
+}
+
+// Channel: An notification channel used to watch for resource changes.
+type Channel struct {
+	// Address: The address where notifications are delivered for this
+	// channel.
+	Address string `json:"address,omitempty"`
+
+	// Expiration: Date and time of notification channel expiration,
+	// expressed as a Unix timestamp, in milliseconds. Optional.
+	Expiration int64 `json:"expiration,omitempty,string"`
+
+	// Id: A UUID or similar unique string that identifies this channel.
+	Id string `json:"id,omitempty"`
+
+	// Kind: Identifies this as a notification channel used to watch for
+	// changes to a resource. Value: the fixed string "api#channel".
+	Kind string `json:"kind,omitempty"`
+
+	// Params: Additional parameters controlling delivery channel behavior.
+	// Optional.
+	Params map[string]string `json:"params,omitempty"`
+
+	// Payload: A Boolean value to indicate whether payload is wanted.
+	// Optional.
+	Payload bool `json:"payload,omitempty"`
+
+	// ResourceId: An opaque ID that identifies the resource being watched
+	// on this channel. Stable across different API versions.
+	ResourceId string `json:"resourceId,omitempty"`
+
+	// ResourceUri: A version-specific identifier for the watched resource.
+	ResourceUri string `json:"resourceUri,omitempty"`
+
+	// Token: An arbitrary string delivered to the target address with each
+	// notification delivered over this channel. Optional.
+	Token string `json:"token,omitempty"`
+
+	// Type: The type of delivery mechanism used for this channel.
+	Type string `json:"type,omitempty"`
+}
+
+// ComposeRequest: A Compose request.
+type ComposeRequest struct {
+	// Destination: Properties of the resulting object.
+	Destination *Object `json:"destination,omitempty"`
+
+	// Kind: The kind of item this is.
+	Kind string `json:"kind,omitempty"`
+
+	// SourceObjects: The list of source objects that will be concatenated
+	// into a single object.
+	SourceObjects []*ComposeRequestSourceObjects `json:"sourceObjects,omitempty"`
+}
+
+type ComposeRequestSourceObjects struct {
+	// Generation: The generation of this object to use as the source.
+	Generation int64 `json:"generation,omitempty,string"`
+
+	// Name: The source object's name. The source object's bucket is
+	// implicitly the destination bucket.
+	Name string `json:"name,omitempty"`
+
+	// ObjectPreconditions: Conditions that must be met for this operation
+	// to execute.
+	ObjectPreconditions *ComposeRequestSourceObjectsObjectPreconditions `json:"objectPreconditions,omitempty"`
+}
+
+// ComposeRequestSourceObjectsObjectPreconditions: Conditions that must
+// be met for this operation to execute.
+type ComposeRequestSourceObjectsObjectPreconditions struct {
+	// IfGenerationMatch: Only perform the composition if the generation of
+	// the source object that would be used matches this value. If this
+	// value and a generation are both specified, they must be the same
+	// value or the call will fail.
+	IfGenerationMatch int64 `json:"ifGenerationMatch,omitempty,string"`
+}
+
+// Object: An object.
+type Object struct {
+	// Acl: Access controls on the object.
+	Acl []*ObjectAccessControl `json:"acl,omitempty"`
+
+	// Bucket: The name of the bucket containing this object.
+	Bucket string `json:"bucket,omitempty"`
+
+	// CacheControl: Cache-Control directive for the object data.
+	CacheControl string `json:"cacheControl,omitempty"`
+
+	// ComponentCount: Number of underlying components that make up this
+	// object. Components are accumulated by compose operations.
+	ComponentCount int64 `json:"componentCount,omitempty"`
+
+	// ContentDisposition: Content-Disposition of the object data.
+	ContentDisposition string `json:"contentDisposition,omitempty"`
+
+	// ContentEncoding: Content-Encoding of the object data.
+	ContentEncoding string `json:"contentEncoding,omitempty"`
+
+	// ContentLanguage: Content-Language of the object data.
+	ContentLanguage string `json:"contentLanguage,omitempty"`
+
+	// ContentType: Content-Type of the object data.
+	ContentType string `json:"contentType,omitempty"`
+
+	// Crc32c: CRC32c checksum, as described in RFC 4960, Appendix B;
+	// encoded using base64 in big-endian byte order. For more information
+	// about using the CRC32c checksum, see Hashes and ETags: Best
+	// Practices.
+	Crc32c string `json:"crc32c,omitempty"`
+
+	// Etag: HTTP 1.1 Entity tag for the object.
+	Etag string `json:"etag,omitempty"`
+
+	// Generation: The content generation of this object. Used for object
+	// versioning.
+	Generation int64 `json:"generation,omitempty,string"`
+
+	// Id: The ID of the object.
+	Id string `json:"id,omitempty"`
+
+	// Kind: The kind of item this is. For objects, this is always
+	// storage#object.
+	Kind string `json:"kind,omitempty"`
+
+	// Md5Hash: MD5 hash of the data; encoded using base64. For more
+	// information about using the MD5 hash, see Hashes and ETags: Best
+	// Practices.
+	Md5Hash string `json:"md5Hash,omitempty"`
+
+	// MediaLink: Media download link.
+	MediaLink string `json:"mediaLink,omitempty"`
+
+	// Metadata: User-provided metadata, in key/value pairs.
+	Metadata map[string]string `json:"metadata,omitempty"`
+
+	// Metageneration: The version of the metadata for this object at this
+	// generation. Used for preconditions and for detecting changes in
+	// metadata. A metageneration number is only meaningful in the context
+	// of a particular generation of a particular object.
+	Metageneration int64 `json:"metageneration,omitempty,string"`
+
+	// Name: The name of this object. Required if not specified by URL
+	// parameter.
+	Name string `json:"name,omitempty"`
+
+	// Owner: The owner of the object. This will always be the uploader of
+	// the object.
+	Owner *ObjectOwner `json:"owner,omitempty"`
+
+	// SelfLink: The link to this object.
+	SelfLink string `json:"selfLink,omitempty"`
+
+	// Size: Content-Length of the data in bytes.
+	Size uint64 `json:"size,omitempty,string"`
+
+	// StorageClass: Storage class of the object.
+	StorageClass string `json:"storageClass,omitempty"`
+
+	// TimeDeleted: The deletion time of the object in RFC 3339 format. Will
+	// be returned if and only if this version of the object has been
+	// deleted.
+	TimeDeleted string `json:"timeDeleted,omitempty"`
+
+	// Updated: The creation or modification time of the object in RFC 3339
+	// format. For buckets with versioning enabled, changing an object's
+	// metadata does not change this property.
+	Updated string `json:"updated,omitempty"`
+}
+
+// ObjectOwner: The owner of the object. This will always be the
+// uploader of the object.
+type ObjectOwner struct {
+	// Entity: The entity, in the form user-userId.
+	Entity string `json:"entity,omitempty"`
+
+	// EntityId: The ID for the entity.
+	EntityId string `json:"entityId,omitempty"`
+}
+
+// ObjectAccessControl: An access-control entry.
+type ObjectAccessControl struct {
+	// Bucket: The name of the bucket.
+	Bucket string `json:"bucket,omitempty"`
+
+	// Domain: The domain associated with the entity, if any.
+	Domain string `json:"domain,omitempty"`
+
+	// Email: The email address associated with the entity, if any.
+	Email string `json:"email,omitempty"`
+
+	// Entity: The entity holding the permission, in one of the following
+	// forms:
+	// - user-userId
+	// - user-email
+	// - group-groupId
+	// - group-email
+	// - domain-domain
+	// - project-team-projectId
+	// - allUsers
+	// - allAuthenticatedUsers Examples:
+	// - The user liz@example.com would be user-liz@example.com.
+	// - The group example@googlegroups.com would be
+	// group-example@googlegroups.com.
+	// - To refer to all members of the Google Apps for Business domain
+	// example.com, the entity would be domain-example.com.
+	Entity string `json:"entity,omitempty"`
+
+	// EntityId: The ID for the entity, if any.
+	EntityId string `json:"entityId,omitempty"`
+
+	// Etag: HTTP 1.1 Entity tag for the access-control entry.
+	Etag string `json:"etag,omitempty"`
+
+	// Generation: The content generation of the object.
+	Generation int64 `json:"generation,omitempty,string"`
+
+	// Id: The ID of the access-control entry.
+	Id string `json:"id,omitempty"`
+
+	// Kind: The kind of item this is. For object access control entries,
+	// this is always storage#objectAccessControl.
+	Kind string `json:"kind,omitempty"`
+
+	// Object: The name of the object.
+	Object string `json:"object,omitempty"`
+
+	// ProjectTeam: The project team associated with the entity, if any.
+	ProjectTeam *ObjectAccessControlProjectTeam `json:"projectTeam,omitempty"`
+
+	// Role: The access permission for the entity. Can be READER or OWNER.
+	Role string `json:"role,omitempty"`
+
+	// SelfLink: The link to this access-control entry.
+	SelfLink string `json:"selfLink,omitempty"`
+}
+
+// ObjectAccessControlProjectTeam: The project team associated with the
+// entity, if any.
+type ObjectAccessControlProjectTeam struct {
+	// ProjectNumber: The project number.
+	ProjectNumber string `json:"projectNumber,omitempty"`
+
+	// Team: The team. Can be owners, editors, or viewers.
+	Team string `json:"team,omitempty"`
+}
+
+// ObjectAccessControls: An access-control list.
+type ObjectAccessControls struct {
+	// Items: The list of items.
+	Items []interface{} `json:"items,omitempty"`
+
+	// Kind: The kind of item this is. For lists of object access control
+	// entries, this is always storage#objectAccessControls.
+	Kind string `json:"kind,omitempty"`
+}
+
+// Objects: A list of objects.
+type Objects struct {
+	// Items: The list of items.
+	Items []*Object `json:"items,omitempty"`
+
+	// Kind: The kind of item this is. For lists of objects, this is always
+	// storage#objects.
+	Kind string `json:"kind,omitempty"`
+
+	// NextPageToken: The continuation token, used to page through large
+	// result sets. Provide this value in a subsequent request to return the
+	// next page of results.
+	NextPageToken string `json:"nextPageToken,omitempty"`
+
+	// Prefixes: The list of prefixes of objects matching-but-not-listed up
+	// to and including the requested delimiter.
+	Prefixes []string `json:"prefixes,omitempty"`
+}
+
+// RewriteResponse: A rewrite response.
+type RewriteResponse struct {
+	// Done: true if the copy is finished; otherwise, false if the copy is
+	// in progress. This property is always present in the response.
+	Done bool `json:"done,omitempty"`
+
+	// Kind: The kind of item this is.
+	Kind string `json:"kind,omitempty"`
+
+	// ObjectSize: The total size of the object being copied in bytes. This
+	// property is always present in the response.
+	ObjectSize uint64 `json:"objectSize,omitempty,string"`
+
+	// Resource: A resource containing the metadata for the copied-to
+	// object. This property is present in the response only when copying
+	// completes.
+	Resource *Object `json:"resource,omitempty"`
+
+	// RewriteToken: A token to use in subsequent requests to continue
+	// copying data. This token is present in the response only when there
+	// is more data to copy.
+	RewriteToken string `json:"rewriteToken,omitempty"`
+
+	// TotalBytesRewritten: The total bytes written so far, which can be
+	// used to provide a waiting user with a progress indicator. This
+	// property is always present in the response.
+	TotalBytesRewritten uint64 `json:"totalBytesRewritten,omitempty,string"`
+}
+
+// method id "storage.bucketAccessControls.delete":
+
+type BucketAccessControlsDeleteCall struct {
+	s      *Service
+	bucket string
+	entity string
+	opt_   map[string]interface{}
+}
+
+// Delete: Permanently deletes the ACL entry for the specified entity on
+// the specified bucket.
+func (r *BucketAccessControlsService) Delete(bucket string, entity string) *BucketAccessControlsDeleteCall {
+	c := &BucketAccessControlsDeleteCall{s: r.s, opt_: make(map[string]interface{})}
+	c.bucket = bucket
+	c.entity = entity
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *BucketAccessControlsDeleteCall) Fields(s ...googleapi.Field) *BucketAccessControlsDeleteCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *BucketAccessControlsDeleteCall) Do() error {
+	var body io.Reader = nil
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "b/{bucket}/acl/{entity}")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("DELETE", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"bucket": c.bucket,
+		"entity": c.entity,
+	})
+	req.Header.Set("User-Agent", c.s.userAgent())
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return err
+	}
+	return nil
+	// {
+	//   "description": "Permanently deletes the ACL entry for the specified entity on the specified bucket.",
+	//   "httpMethod": "DELETE",
+	//   "id": "storage.bucketAccessControls.delete",
+	//   "parameterOrder": [
+	//     "bucket",
+	//     "entity"
+	//   ],
+	//   "parameters": {
+	//     "bucket": {
+	//       "description": "Name of a bucket.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "entity": {
+	//       "description": "The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId, group-emailAddress, allUsers, or allAuthenticatedUsers.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "b/{bucket}/acl/{entity}",
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/devstorage.full_control"
+	//   ]
+	// }
+
+}
+
+// method id "storage.bucketAccessControls.get":
+
+type BucketAccessControlsGetCall struct {
+	s      *Service
+	bucket string
+	entity string
+	opt_   map[string]interface{}
+}
+
+// Get: Returns the ACL entry for the specified entity on the specified
+// bucket.
+func (r *BucketAccessControlsService) Get(bucket string, entity string) *BucketAccessControlsGetCall {
+	c := &BucketAccessControlsGetCall{s: r.s, opt_: make(map[string]interface{})}
+	c.bucket = bucket
+	c.entity = entity
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *BucketAccessControlsGetCall) Fields(s ...googleapi.Field) *BucketAccessControlsGetCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *BucketAccessControlsGetCall) Do() (*BucketAccessControl, error) {
+	var body io.Reader = nil
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "b/{bucket}/acl/{entity}")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"bucket": c.bucket,
+		"entity": c.entity,
+	})
+	req.Header.Set("User-Agent", c.s.userAgent())
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	var ret *BucketAccessControl
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Returns the ACL entry for the specified entity on the specified bucket.",
+	//   "httpMethod": "GET",
+	//   "id": "storage.bucketAccessControls.get",
+	//   "parameterOrder": [
+	//     "bucket",
+	//     "entity"
+	//   ],
+	//   "parameters": {
+	//     "bucket": {
+	//       "description": "Name of a bucket.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "entity": {
+	//       "description": "The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId, group-emailAddress, allUsers, or allAuthenticatedUsers.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "b/{bucket}/acl/{entity}",
+	//   "response": {
+	//     "$ref": "BucketAccessControl"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/devstorage.full_control"
+	//   ]
+	// }
+
+}
+
+// method id "storage.bucketAccessControls.insert":
+
+type BucketAccessControlsInsertCall struct {
+	s                   *Service
+	bucket              string
+	bucketaccesscontrol *BucketAccessControl
+	opt_                map[string]interface{}
+}
+
+// Insert: Creates a new ACL entry on the specified bucket.
+func (r *BucketAccessControlsService) Insert(bucket string, bucketaccesscontrol *BucketAccessControl) *BucketAccessControlsInsertCall {
+	c := &BucketAccessControlsInsertCall{s: r.s, opt_: make(map[string]interface{})}
+	c.bucket = bucket
+	c.bucketaccesscontrol = bucketaccesscontrol
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *BucketAccessControlsInsertCall) Fields(s ...googleapi.Field) *BucketAccessControlsInsertCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *BucketAccessControlsInsertCall) Do() (*BucketAccessControl, error) {
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.bucketaccesscontrol)
+	if err != nil {
+		return nil, err
+	}
+	ctype := "application/json"
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "b/{bucket}/acl")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"bucket": c.bucket,
+	})
+	req.Header.Set("Content-Type", ctype)
+	req.Header.Set("User-Agent", c.s.userAgent())
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	var ret *BucketAccessControl
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Creates a new ACL entry on the specified bucket.",
+	//   "httpMethod": "POST",
+	//   "id": "storage.bucketAccessControls.insert",
+	//   "parameterOrder": [
+	//     "bucket"
+	//   ],
+	//   "parameters": {
+	//     "bucket": {
+	//       "description": "Name of a bucket.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "b/{bucket}/acl",
+	//   "request": {
+	//     "$ref": "BucketAccessControl"
+	//   },
+	//   "response": {
+	//     "$ref": "BucketAccessControl"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/devstorage.full_control"
+	//   ]
+	// }
+
+}
+
+// method id "storage.bucketAccessControls.list":
+
+type BucketAccessControlsListCall struct {
+	s      *Service
+	bucket string
+	opt_   map[string]interface{}
+}
+
+// List: Retrieves ACL entries on the specified bucket.
+func (r *BucketAccessControlsService) List(bucket string) *BucketAccessControlsListCall {
+	c := &BucketAccessControlsListCall{s: r.s, opt_: make(map[string]interface{})}
+	c.bucket = bucket
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *BucketAccessControlsListCall) Fields(s ...googleapi.Field) *BucketAccessControlsListCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *BucketAccessControlsListCall) Do() (*BucketAccessControls, error) {
+	var body io.Reader = nil
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "b/{bucket}/acl")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"bucket": c.bucket,
+	})
+	req.Header.Set("User-Agent", c.s.userAgent())
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	var ret *BucketAccessControls
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Retrieves ACL entries on the specified bucket.",
+	//   "httpMethod": "GET",
+	//   "id": "storage.bucketAccessControls.list",
+	//   "parameterOrder": [
+	//     "bucket"
+	//   ],
+	//   "parameters": {
+	//     "bucket": {
+	//       "description": "Name of a bucket.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "b/{bucket}/acl",
+	//   "response": {
+	//     "$ref": "BucketAccessControls"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/devstorage.full_control"
+	//   ]
+	// }
+
+}
+
+// method id "storage.bucketAccessControls.patch":
+
+type BucketAccessControlsPatchCall struct {
+	s                   *Service
+	bucket              string
+	entity              string
+	bucketaccesscontrol *BucketAccessControl
+	opt_                map[string]interface{}
+}
+
+// Patch: Updates an ACL entry on the specified bucket. This method
+// supports patch semantics.
+func (r *BucketAccessControlsService) Patch(bucket string, entity string, bucketaccesscontrol *BucketAccessControl) *BucketAccessControlsPatchCall {
+	c := &BucketAccessControlsPatchCall{s: r.s, opt_: make(map[string]interface{})}
+	c.bucket = bucket
+	c.entity = entity
+	c.bucketaccesscontrol = bucketaccesscontrol
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *BucketAccessControlsPatchCall) Fields(s ...googleapi.Field) *BucketAccessControlsPatchCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *BucketAccessControlsPatchCall) Do() (*BucketAccessControl, error) {
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.bucketaccesscontrol)
+	if err != nil {
+		return nil, err
+	}
+	ctype := "application/json"
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "b/{bucket}/acl/{entity}")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("PATCH", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"bucket": c.bucket,
+		"entity": c.entity,
+	})
+	req.Header.Set("Content-Type", ctype)
+	req.Header.Set("User-Agent", c.s.userAgent())
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	var ret *BucketAccessControl
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Updates an ACL entry on the specified bucket. This method supports patch semantics.",
+	//   "httpMethod": "PATCH",
+	//   "id": "storage.bucketAccessControls.patch",
+	//   "parameterOrder": [
+	//     "bucket",
+	//     "entity"
+	//   ],
+	//   "parameters": {
+	//     "bucket": {
+	//       "description": "Name of a bucket.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "entity": {
+	//       "description": "The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId, group-emailAddress, allUsers, or allAuthenticatedUsers.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "b/{bucket}/acl/{entity}",
+	//   "request": {
+	//     "$ref": "BucketAccessControl"
+	//   },
+	//   "response": {
+	//     "$ref": "BucketAccessControl"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/devstorage.full_control"
+	//   ]
+	// }
+
+}
+
+// method id "storage.bucketAccessControls.update":
+
+type BucketAccessControlsUpdateCall struct {
+	s                   *Service
+	bucket              string
+	entity              string
+	bucketaccesscontrol *BucketAccessControl
+	opt_                map[string]interface{}
+}
+
+// Update: Updates an ACL entry on the specified bucket.
+func (r *BucketAccessControlsService) Update(bucket string, entity string, bucketaccesscontrol *BucketAccessControl) *BucketAccessControlsUpdateCall {
+	c := &BucketAccessControlsUpdateCall{s: r.s, opt_: make(map[string]interface{})}
+	c.bucket = bucket
+	c.entity = entity
+	c.bucketaccesscontrol = bucketaccesscontrol
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *BucketAccessControlsUpdateCall) Fields(s ...googleapi.Field) *BucketAccessControlsUpdateCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *BucketAccessControlsUpdateCall) Do() (*BucketAccessControl, error) {
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.bucketaccesscontrol)
+	if err != nil {
+		return nil, err
+	}
+	ctype := "application/json"
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "b/{bucket}/acl/{entity}")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("PUT", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"bucket": c.bucket,
+		"entity": c.entity,
+	})
+	req.Header.Set("Content-Type", ctype)
+	req.Header.Set("User-Agent", c.s.userAgent())
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	var ret *BucketAccessControl
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Updates an ACL entry on the specified bucket.",
+	//   "httpMethod": "PUT",
+	//   "id": "storage.bucketAccessControls.update",
+	//   "parameterOrder": [
+	//     "bucket",
+	//     "entity"
+	//   ],
+	//   "parameters": {
+	//     "bucket": {
+	//       "description": "Name of a bucket.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "entity": {
+	//       "description": "The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId, group-emailAddress, allUsers, or allAuthenticatedUsers.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "b/{bucket}/acl/{entity}",
+	//   "request": {
+	//     "$ref": "BucketAccessControl"
+	//   },
+	//   "response": {
+	//     "$ref": "BucketAccessControl"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/devstorage.full_control"
+	//   ]
+	// }
+
+}
+
+// method id "storage.buckets.delete":
+
+type BucketsDeleteCall struct {
+	s      *Service
+	bucket string
+	opt_   map[string]interface{}
+}
+
+// Delete: Permanently deletes an empty bucket.
+func (r *BucketsService) Delete(bucket string) *BucketsDeleteCall {
+	c := &BucketsDeleteCall{s: r.s, opt_: make(map[string]interface{})}
+	c.bucket = bucket
+	return c
+}
+
+// IfMetagenerationMatch sets the optional parameter
+// "ifMetagenerationMatch": If set, only deletes the bucket if its
+// metageneration matches this value.
+func (c *BucketsDeleteCall) IfMetagenerationMatch(ifMetagenerationMatch int64) *BucketsDeleteCall {
+	c.opt_["ifMetagenerationMatch"] = ifMetagenerationMatch
+	return c
+}
+
+// IfMetagenerationNotMatch sets the optional parameter
+// "ifMetagenerationNotMatch": If set, only deletes the bucket if its
+// metageneration does not match this value.
+func (c *BucketsDeleteCall) IfMetagenerationNotMatch(ifMetagenerationNotMatch int64) *BucketsDeleteCall {
+	c.opt_["ifMetagenerationNotMatch"] = ifMetagenerationNotMatch
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *BucketsDeleteCall) Fields(s ...googleapi.Field) *BucketsDeleteCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *BucketsDeleteCall) Do() error {
+	var body io.Reader = nil
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["ifMetagenerationMatch"]; ok {
+		params.Set("ifMetagenerationMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifMetagenerationNotMatch"]; ok {
+		params.Set("ifMetagenerationNotMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "b/{bucket}")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("DELETE", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"bucket": c.bucket,
+	})
+	req.Header.Set("User-Agent", c.s.userAgent())
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return err
+	}
+	return nil
+	// {
+	//   "description": "Permanently deletes an empty bucket.",
+	//   "httpMethod": "DELETE",
+	//   "id": "storage.buckets.delete",
+	//   "parameterOrder": [
+	//     "bucket"
+	//   ],
+	//   "parameters": {
+	//     "bucket": {
+	//       "description": "Name of a bucket.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "ifMetagenerationMatch": {
+	//       "description": "If set, only deletes the bucket if its metageneration matches this value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifMetagenerationNotMatch": {
+	//       "description": "If set, only deletes the bucket if its metageneration does not match this value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "b/{bucket}",
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/devstorage.full_control",
+	//     "https://www.googleapis.com/auth/devstorage.read_write"
+	//   ]
+	// }
+
+}
+
+// method id "storage.buckets.get":
+
+type BucketsGetCall struct {
+	s      *Service
+	bucket string
+	opt_   map[string]interface{}
+}
+
+// Get: Returns metadata for the specified bucket.
+func (r *BucketsService) Get(bucket string) *BucketsGetCall {
+	c := &BucketsGetCall{s: r.s, opt_: make(map[string]interface{})}
+	c.bucket = bucket
+	return c
+}
+
+// IfMetagenerationMatch sets the optional parameter
+// "ifMetagenerationMatch": Makes the return of the bucket metadata
+// conditional on whether the bucket's current metageneration matches
+// the given value.
+func (c *BucketsGetCall) IfMetagenerationMatch(ifMetagenerationMatch int64) *BucketsGetCall {
+	c.opt_["ifMetagenerationMatch"] = ifMetagenerationMatch
+	return c
+}
+
+// IfMetagenerationNotMatch sets the optional parameter
+// "ifMetagenerationNotMatch": Makes the return of the bucket metadata
+// conditional on whether the bucket's current metageneration does not
+// match the given value.
+func (c *BucketsGetCall) IfMetagenerationNotMatch(ifMetagenerationNotMatch int64) *BucketsGetCall {
+	c.opt_["ifMetagenerationNotMatch"] = ifMetagenerationNotMatch
+	return c
+}
+
+// Projection sets the optional parameter "projection": Set of
+// properties to return. Defaults to noAcl.
+//
+// Possible values:
+//   "full" - Include all properties.
+//   "noAcl" - Omit acl and defaultObjectAcl properties.
+func (c *BucketsGetCall) Projection(projection string) *BucketsGetCall {
+	c.opt_["projection"] = projection
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *BucketsGetCall) Fields(s ...googleapi.Field) *BucketsGetCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *BucketsGetCall) Do() (*Bucket, error) {
+	var body io.Reader = nil
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["ifMetagenerationMatch"]; ok {
+		params.Set("ifMetagenerationMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifMetagenerationNotMatch"]; ok {
+		params.Set("ifMetagenerationNotMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["projection"]; ok {
+		params.Set("projection", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "b/{bucket}")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"bucket": c.bucket,
+	})
+	req.Header.Set("User-Agent", c.s.userAgent())
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	var ret *Bucket
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Returns metadata for the specified bucket.",
+	//   "httpMethod": "GET",
+	//   "id": "storage.buckets.get",
+	//   "parameterOrder": [
+	//     "bucket"
+	//   ],
+	//   "parameters": {
+	//     "bucket": {
+	//       "description": "Name of a bucket.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "ifMetagenerationMatch": {
+	//       "description": "Makes the return of the bucket metadata conditional on whether the bucket's current metageneration matches the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifMetagenerationNotMatch": {
+	//       "description": "Makes the return of the bucket metadata conditional on whether the bucket's current metageneration does not match the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "projection": {
+	//       "description": "Set of properties to return. Defaults to noAcl.",
+	//       "enum": [
+	//         "full",
+	//         "noAcl"
+	//       ],
+	//       "enumDescriptions": [
+	//         "Include all properties.",
+	//         "Omit acl and defaultObjectAcl properties."
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "b/{bucket}",
+	//   "response": {
+	//     "$ref": "Bucket"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/devstorage.full_control",
+	//     "https://www.googleapis.com/auth/devstorage.read_only",
+	//     "https://www.googleapis.com/auth/devstorage.read_write"
+	//   ]
+	// }
+
+}
+
+// method id "storage.buckets.insert":
+
+type BucketsInsertCall struct {
+	s         *Service
+	projectid string
+	bucket    *Bucket
+	opt_      map[string]interface{}
+}
+
+// Insert: Creates a new bucket.
+func (r *BucketsService) Insert(projectid string, bucket *Bucket) *BucketsInsertCall {
+	c := &BucketsInsertCall{s: r.s, opt_: make(map[string]interface{})}
+	c.projectid = projectid
+	c.bucket = bucket
+	return c
+}
+
+// PredefinedAcl sets the optional parameter "predefinedAcl": Apply a
+// predefined set of access controls to this bucket.
+//
+// Possible values:
+//   "authenticatedRead" - Project team owners get OWNER access, and
+// allAuthenticatedUsers get READER access.
+//   "private" - Project team owners get OWNER access.
+//   "projectPrivate" - Project team members get access according to
+// their roles.
+//   "publicRead" - Project team owners get OWNER access, and allUsers
+// get READER access.
+//   "publicReadWrite" - Project team owners get OWNER access, and
+// allUsers get WRITER access.
+func (c *BucketsInsertCall) PredefinedAcl(predefinedAcl string) *BucketsInsertCall {
+	c.opt_["predefinedAcl"] = predefinedAcl
+	return c
+}
+
+// PredefinedDefaultObjectAcl sets the optional parameter
+// "predefinedDefaultObjectAcl": Apply a predefined set of default
+// object access controls to this bucket.
+//
+// Possible values:
+//   "authenticatedRead" - Object owner gets OWNER access, and
+// allAuthenticatedUsers get READER access.
+//   "bucketOwnerFullControl" - Object owner gets OWNER access, and
+// project team owners get OWNER access.
+//   "bucketOwnerRead" - Object owner gets OWNER access, and project
+// team owners get READER access.
+//   "private" - Object owner gets OWNER access.
+//   "projectPrivate" - Object owner gets OWNER access, and project team
+// members get access according to their roles.
+//   "publicRead" - Object owner gets OWNER access, and allUsers get
+// READER access.
+func (c *BucketsInsertCall) PredefinedDefaultObjectAcl(predefinedDefaultObjectAcl string) *BucketsInsertCall {
+	c.opt_["predefinedDefaultObjectAcl"] = predefinedDefaultObjectAcl
+	return c
+}
+
+// Projection sets the optional parameter "projection": Set of
+// properties to return. Defaults to noAcl, unless the bucket resource
+// specifies acl or defaultObjectAcl properties, when it defaults to
+// full.
+//
+// Possible values:
+//   "full" - Include all properties.
+//   "noAcl" - Omit acl and defaultObjectAcl properties.
+func (c *BucketsInsertCall) Projection(projection string) *BucketsInsertCall {
+	c.opt_["projection"] = projection
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *BucketsInsertCall) Fields(s ...googleapi.Field) *BucketsInsertCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *BucketsInsertCall) Do() (*Bucket, error) {
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.bucket)
+	if err != nil {
+		return nil, err
+	}
+	ctype := "application/json"
+	params := make(url.Values)
+	params.Set("alt", "json")
+	params.Set("project", fmt.Sprintf("%v", c.projectid))
+	if v, ok := c.opt_["predefinedAcl"]; ok {
+		params.Set("predefinedAcl", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["predefinedDefaultObjectAcl"]; ok {
+		params.Set("predefinedDefaultObjectAcl", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["projection"]; ok {
+		params.Set("projection", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "b")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	googleapi.SetOpaque(req.URL)
+	req.Header.Set("Content-Type", ctype)
+	req.Header.Set("User-Agent", c.s.userAgent())
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	var ret *Bucket
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Creates a new bucket.",
+	//   "httpMethod": "POST",
+	//   "id": "storage.buckets.insert",
+	//   "parameterOrder": [
+	//     "project"
+	//   ],
+	//   "parameters": {
+	//     "predefinedAcl": {
+	//       "description": "Apply a predefined set of access controls to this bucket.",
+	//       "enum": [
+	//         "authenticatedRead",
+	//         "private",
+	//         "projectPrivate",
+	//         "publicRead",
+	//         "publicReadWrite"
+	//       ],
+	//       "enumDescriptions": [
+	//         "Project team owners get OWNER access, and allAuthenticatedUsers get READER access.",
+	//         "Project team owners get OWNER access.",
+	//         "Project team members get access according to their roles.",
+	//         "Project team owners get OWNER access, and allUsers get READER access.",
+	//         "Project team owners get OWNER access, and allUsers get WRITER access."
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "predefinedDefaultObjectAcl": {
+	//       "description": "Apply a predefined set of default object access controls to this bucket.",
+	//       "enum": [
+	//         "authenticatedRead",
+	//         "bucketOwnerFullControl",
+	//         "bucketOwnerRead",
+	//         "private",
+	//         "projectPrivate",
+	//         "publicRead"
+	//       ],
+	//       "enumDescriptions": [
+	//         "Object owner gets OWNER access, and allAuthenticatedUsers get READER access.",
+	//         "Object owner gets OWNER access, and project team owners get OWNER access.",
+	//         "Object owner gets OWNER access, and project team owners get READER access.",
+	//         "Object owner gets OWNER access.",
+	//         "Object owner gets OWNER access, and project team members get access according to their roles.",
+	//         "Object owner gets OWNER access, and allUsers get READER access."
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "project": {
+	//       "description": "A valid API project identifier.",
+	//       "location": "query",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "projection": {
+	//       "description": "Set of properties to return. Defaults to noAcl, unless the bucket resource specifies acl or defaultObjectAcl properties, when it defaults to full.",
+	//       "enum": [
+	//         "full",
+	//         "noAcl"
+	//       ],
+	//       "enumDescriptions": [
+	//         "Include all properties.",
+	//         "Omit acl and defaultObjectAcl properties."
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "b",
+	//   "request": {
+	//     "$ref": "Bucket"
+	//   },
+	//   "response": {
+	//     "$ref": "Bucket"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/devstorage.full_control",
+	//     "https://www.googleapis.com/auth/devstorage.read_write"
+	//   ]
+	// }
+
+}
+
+// method id "storage.buckets.list":
+
+type BucketsListCall struct {
+	s         *Service
+	projectid string
+	opt_      map[string]interface{}
+}
+
+// List: Retrieves a list of buckets for a given project.
+func (r *BucketsService) List(projectid string) *BucketsListCall {
+	c := &BucketsListCall{s: r.s, opt_: make(map[string]interface{})}
+	c.projectid = projectid
+	return c
+}
+
+// MaxResults sets the optional parameter "maxResults": Maximum number
+// of buckets to return.
+func (c *BucketsListCall) MaxResults(maxResults int64) *BucketsListCall {
+	c.opt_["maxResults"] = maxResults
+	return c
+}
+
+// PageToken sets the optional parameter "pageToken": A
+// previously-returned page token representing part of the larger set of
+// results to view.
+func (c *BucketsListCall) PageToken(pageToken string) *BucketsListCall {
+	c.opt_["pageToken"] = pageToken
+	return c
+}
+
+// Prefix sets the optional parameter "prefix": Filter results to
+// buckets whose names begin with this prefix.
+func (c *BucketsListCall) Prefix(prefix string) *BucketsListCall {
+	c.opt_["prefix"] = prefix
+	return c
+}
+
+// Projection sets the optional parameter "projection": Set of
+// properties to return. Defaults to noAcl.
+//
+// Possible values:
+//   "full" - Include all properties.
+//   "noAcl" - Omit acl and defaultObjectAcl properties.
+func (c *BucketsListCall) Projection(projection string) *BucketsListCall {
+	c.opt_["projection"] = projection
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *BucketsListCall) Fields(s ...googleapi.Field) *BucketsListCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *BucketsListCall) Do() (*Buckets, error) {
+	var body io.Reader = nil
+	params := make(url.Values)
+	params.Set("alt", "json")
+	params.Set("project", fmt.Sprintf("%v", c.projectid))
+	if v, ok := c.opt_["maxResults"]; ok {
+		params.Set("maxResults", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["pageToken"]; ok {
+		params.Set("pageToken", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["prefix"]; ok {
+		params.Set("prefix", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["projection"]; ok {
+		params.Set("projection", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "b")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	googleapi.SetOpaque(req.URL)
+	req.Header.Set("User-Agent", c.s.userAgent())
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	var ret *Buckets
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Retrieves a list of buckets for a given project.",
+	//   "httpMethod": "GET",
+	//   "id": "storage.buckets.list",
+	//   "parameterOrder": [
+	//     "project"
+	//   ],
+	//   "parameters": {
+	//     "maxResults": {
+	//       "description": "Maximum number of buckets to return.",
+	//       "format": "uint32",
+	//       "location": "query",
+	//       "minimum": "0",
+	//       "type": "integer"
+	//     },
+	//     "pageToken": {
+	//       "description": "A previously-returned page token representing part of the larger set of results to view.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "prefix": {
+	//       "description": "Filter results to buckets whose names begin with this prefix.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "project": {
+	//       "description": "A valid API project identifier.",
+	//       "location": "query",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "projection": {
+	//       "description": "Set of properties to return. Defaults to noAcl.",
+	//       "enum": [
+	//         "full",
+	//         "noAcl"
+	//       ],
+	//       "enumDescriptions": [
+	//         "Include all properties.",
+	//         "Omit acl and defaultObjectAcl properties."
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "b",
+	//   "response": {
+	//     "$ref": "Buckets"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/devstorage.full_control",
+	//     "https://www.googleapis.com/auth/devstorage.read_only",
+	//     "https://www.googleapis.com/auth/devstorage.read_write"
+	//   ]
+	// }
+
+}
+
+// method id "storage.buckets.patch":
+
+type BucketsPatchCall struct {
+	s       *Service
+	bucket  string
+	bucket2 *Bucket
+	opt_    map[string]interface{}
+}
+
+// Patch: Updates a bucket. This method supports patch semantics.
+func (r *BucketsService) Patch(bucket string, bucket2 *Bucket) *BucketsPatchCall {
+	c := &BucketsPatchCall{s: r.s, opt_: make(map[string]interface{})}
+	c.bucket = bucket
+	c.bucket2 = bucket2
+	return c
+}
+
+// IfMetagenerationMatch sets the optional parameter
+// "ifMetagenerationMatch": Makes the return of the bucket metadata
+// conditional on whether the bucket's current metageneration matches
+// the given value.
+func (c *BucketsPatchCall) IfMetagenerationMatch(ifMetagenerationMatch int64) *BucketsPatchCall {
+	c.opt_["ifMetagenerationMatch"] = ifMetagenerationMatch
+	return c
+}
+
+// IfMetagenerationNotMatch sets the optional parameter
+// "ifMetagenerationNotMatch": Makes the return of the bucket metadata
+// conditional on whether the bucket's current metageneration does not
+// match the given value.
+func (c *BucketsPatchCall) IfMetagenerationNotMatch(ifMetagenerationNotMatch int64) *BucketsPatchCall {
+	c.opt_["ifMetagenerationNotMatch"] = ifMetagenerationNotMatch
+	return c
+}
+
+// PredefinedAcl sets the optional parameter "predefinedAcl": Apply a
+// predefined set of access controls to this bucket.
+//
+// Possible values:
+//   "authenticatedRead" - Project team owners get OWNER access, and
+// allAuthenticatedUsers get READER access.
+//   "private" - Project team owners get OWNER access.
+//   "projectPrivate" - Project team members get access according to
+// their roles.
+//   "publicRead" - Project team owners get OWNER access, and allUsers
+// get READER access.
+//   "publicReadWrite" - Project team owners get OWNER access, and
+// allUsers get WRITER access.
+func (c *BucketsPatchCall) PredefinedAcl(predefinedAcl string) *BucketsPatchCall {
+	c.opt_["predefinedAcl"] = predefinedAcl
+	return c
+}
+
+// PredefinedDefaultObjectAcl sets the optional parameter
+// "predefinedDefaultObjectAcl": Apply a predefined set of default
+// object access controls to this bucket.
+//
+// Possible values:
+//   "authenticatedRead" - Object owner gets OWNER access, and
+// allAuthenticatedUsers get READER access.
+//   "bucketOwnerFullControl" - Object owner gets OWNER access, and
+// project team owners get OWNER access.
+//   "bucketOwnerRead" - Object owner gets OWNER access, and project
+// team owners get READER access.
+//   "private" - Object owner gets OWNER access.
+//   "projectPrivate" - Object owner gets OWNER access, and project team
+// members get access according to their roles.
+//   "publicRead" - Object owner gets OWNER access, and allUsers get
+// READER access.
+func (c *BucketsPatchCall) PredefinedDefaultObjectAcl(predefinedDefaultObjectAcl string) *BucketsPatchCall {
+	c.opt_["predefinedDefaultObjectAcl"] = predefinedDefaultObjectAcl
+	return c
+}
+
+// Projection sets the optional parameter "projection": Set of
+// properties to return. Defaults to full.
+//
+// Possible values:
+//   "full" - Include all properties.
+//   "noAcl" - Omit acl and defaultObjectAcl properties.
+func (c *BucketsPatchCall) Projection(projection string) *BucketsPatchCall {
+	c.opt_["projection"] = projection
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *BucketsPatchCall) Fields(s ...googleapi.Field) *BucketsPatchCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *BucketsPatchCall) Do() (*Bucket, error) {
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.bucket2)
+	if err != nil {
+		return nil, err
+	}
+	ctype := "application/json"
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["ifMetagenerationMatch"]; ok {
+		params.Set("ifMetagenerationMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifMetagenerationNotMatch"]; ok {
+		params.Set("ifMetagenerationNotMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["predefinedAcl"]; ok {
+		params.Set("predefinedAcl", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["predefinedDefaultObjectAcl"]; ok {
+		params.Set("predefinedDefaultObjectAcl", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["projection"]; ok {
+		params.Set("projection", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "b/{bucket}")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("PATCH", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"bucket": c.bucket,
+	})
+	req.Header.Set("Content-Type", ctype)
+	req.Header.Set("User-Agent", c.s.userAgent())
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	var ret *Bucket
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Updates a bucket. This method supports patch semantics.",
+	//   "httpMethod": "PATCH",
+	//   "id": "storage.buckets.patch",
+	//   "parameterOrder": [
+	//     "bucket"
+	//   ],
+	//   "parameters": {
+	//     "bucket": {
+	//       "description": "Name of a bucket.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "ifMetagenerationMatch": {
+	//       "description": "Makes the return of the bucket metadata conditional on whether the bucket's current metageneration matches the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifMetagenerationNotMatch": {
+	//       "description": "Makes the return of the bucket metadata conditional on whether the bucket's current metageneration does not match the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "predefinedAcl": {
+	//       "description": "Apply a predefined set of access controls to this bucket.",
+	//       "enum": [
+	//         "authenticatedRead",
+	//         "private",
+	//         "projectPrivate",
+	//         "publicRead",
+	//         "publicReadWrite"
+	//       ],
+	//       "enumDescriptions": [
+	//         "Project team owners get OWNER access, and allAuthenticatedUsers get READER access.",
+	//         "Project team owners get OWNER access.",
+	//         "Project team members get access according to their roles.",
+	//         "Project team owners get OWNER access, and allUsers get READER access.",
+	//         "Project team owners get OWNER access, and allUsers get WRITER access."
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "predefinedDefaultObjectAcl": {
+	//       "description": "Apply a predefined set of default object access controls to this bucket.",
+	//       "enum": [
+	//         "authenticatedRead",
+	//         "bucketOwnerFullControl",
+	//         "bucketOwnerRead",
+	//         "private",
+	//         "projectPrivate",
+	//         "publicRead"
+	//       ],
+	//       "enumDescriptions": [
+	//         "Object owner gets OWNER access, and allAuthenticatedUsers get READER access.",
+	//         "Object owner gets OWNER access, and project team owners get OWNER access.",
+	//         "Object owner gets OWNER access, and project team owners get READER access.",
+	//         "Object owner gets OWNER access.",
+	//         "Object owner gets OWNER access, and project team members get access according to their roles.",
+	//         "Object owner gets OWNER access, and allUsers get READER access."
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "projection": {
+	//       "description": "Set of properties to return. Defaults to full.",
+	//       "enum": [
+	//         "full",
+	//         "noAcl"
+	//       ],
+	//       "enumDescriptions": [
+	//         "Include all properties.",
+	//         "Omit acl and defaultObjectAcl properties."
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "b/{bucket}",
+	//   "request": {
+	//     "$ref": "Bucket"
+	//   },
+	//   "response": {
+	//     "$ref": "Bucket"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/devstorage.full_control",
+	//     "https://www.googleapis.com/auth/devstorage.read_write"
+	//   ]
+	// }
+
+}
+
+// method id "storage.buckets.update":
+
+type BucketsUpdateCall struct {
+	s       *Service
+	bucket  string
+	bucket2 *Bucket
+	opt_    map[string]interface{}
+}
+
+// Update: Updates a bucket.
+func (r *BucketsService) Update(bucket string, bucket2 *Bucket) *BucketsUpdateCall {
+	c := &BucketsUpdateCall{s: r.s, opt_: make(map[string]interface{})}
+	c.bucket = bucket
+	c.bucket2 = bucket2
+	return c
+}
+
+// IfMetagenerationMatch sets the optional parameter
+// "ifMetagenerationMatch": Makes the return of the bucket metadata
+// conditional on whether the bucket's current metageneration matches
+// the given value.
+func (c *BucketsUpdateCall) IfMetagenerationMatch(ifMetagenerationMatch int64) *BucketsUpdateCall {
+	c.opt_["ifMetagenerationMatch"] = ifMetagenerationMatch
+	return c
+}
+
+// IfMetagenerationNotMatch sets the optional parameter
+// "ifMetagenerationNotMatch": Makes the return of the bucket metadata
+// conditional on whether the bucket's current metageneration does not
+// match the given value.
+func (c *BucketsUpdateCall) IfMetagenerationNotMatch(ifMetagenerationNotMatch int64) *BucketsUpdateCall {
+	c.opt_["ifMetagenerationNotMatch"] = ifMetagenerationNotMatch
+	return c
+}
+
+// PredefinedAcl sets the optional parameter "predefinedAcl": Apply a
+// predefined set of access controls to this bucket.
+//
+// Possible values:
+//   "authenticatedRead" - Project team owners get OWNER access, and
+// allAuthenticatedUsers get READER access.
+//   "private" - Project team owners get OWNER access.
+//   "projectPrivate" - Project team members get access according to
+// their roles.
+//   "publicRead" - Project team owners get OWNER access, and allUsers
+// get READER access.
+//   "publicReadWrite" - Project team owners get OWNER access, and
+// allUsers get WRITER access.
+func (c *BucketsUpdateCall) PredefinedAcl(predefinedAcl string) *BucketsUpdateCall {
+	c.opt_["predefinedAcl"] = predefinedAcl
+	return c
+}
+
+// PredefinedDefaultObjectAcl sets the optional parameter
+// "predefinedDefaultObjectAcl": Apply a predefined set of default
+// object access controls to this bucket.
+//
+// Possible values:
+//   "authenticatedRead" - Object owner gets OWNER access, and
+// allAuthenticatedUsers get READER access.
+//   "bucketOwnerFullControl" - Object owner gets OWNER access, and
+// project team owners get OWNER access.
+//   "bucketOwnerRead" - Object owner gets OWNER access, and project
+// team owners get READER access.
+//   "private" - Object owner gets OWNER access.
+//   "projectPrivate" - Object owner gets OWNER access, and project team
+// members get access according to their roles.
+//   "publicRead" - Object owner gets OWNER access, and allUsers get
+// READER access.
+func (c *BucketsUpdateCall) PredefinedDefaultObjectAcl(predefinedDefaultObjectAcl string) *BucketsUpdateCall {
+	c.opt_["predefinedDefaultObjectAcl"] = predefinedDefaultObjectAcl
+	return c
+}
+
+// Projection sets the optional parameter "projection": Set of
+// properties to return. Defaults to full.
+//
+// Possible values:
+//   "full" - Include all properties.
+//   "noAcl" - Omit acl and defaultObjectAcl properties.
+func (c *BucketsUpdateCall) Projection(projection string) *BucketsUpdateCall {
+	c.opt_["projection"] = projection
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *BucketsUpdateCall) Fields(s ...googleapi.Field) *BucketsUpdateCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *BucketsUpdateCall) Do() (*Bucket, error) {
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.bucket2)
+	if err != nil {
+		return nil, err
+	}
+	ctype := "application/json"
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["ifMetagenerationMatch"]; ok {
+		params.Set("ifMetagenerationMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifMetagenerationNotMatch"]; ok {
+		params.Set("ifMetagenerationNotMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["predefinedAcl"]; ok {
+		params.Set("predefinedAcl", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["predefinedDefaultObjectAcl"]; ok {
+		params.Set("predefinedDefaultObjectAcl", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["projection"]; ok {
+		params.Set("projection", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "b/{bucket}")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("PUT", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"bucket": c.bucket,
+	})
+	req.Header.Set("Content-Type", ctype)
+	req.Header.Set("User-Agent", c.s.userAgent())
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	var ret *Bucket
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Updates a bucket.",
+	//   "httpMethod": "PUT",
+	//   "id": "storage.buckets.update",
+	//   "parameterOrder": [
+	//     "bucket"
+	//   ],
+	//   "parameters": {
+	//     "bucket": {
+	//       "description": "Name of a bucket.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "ifMetagenerationMatch": {
+	//       "description": "Makes the return of the bucket metadata conditional on whether the bucket's current metageneration matches the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifMetagenerationNotMatch": {
+	//       "description": "Makes the return of the bucket metadata conditional on whether the bucket's current metageneration does not match the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "predefinedAcl": {
+	//       "description": "Apply a predefined set of access controls to this bucket.",
+	//       "enum": [
+	//         "authenticatedRead",
+	//         "private",
+	//         "projectPrivate",
+	//         "publicRead",
+	//         "publicReadWrite"
+	//       ],
+	//       "enumDescriptions": [
+	//         "Project team owners get OWNER access, and allAuthenticatedUsers get READER access.",
+	//         "Project team owners get OWNER access.",
+	//         "Project team members get access according to their roles.",
+	//         "Project team owners get OWNER access, and allUsers get READER access.",
+	//         "Project team owners get OWNER access, and allUsers get WRITER access."
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "predefinedDefaultObjectAcl": {
+	//       "description": "Apply a predefined set of default object access controls to this bucket.",
+	//       "enum": [
+	//         "authenticatedRead",
+	//         "bucketOwnerFullControl",
+	//         "bucketOwnerRead",
+	//         "private",
+	//         "projectPrivate",
+	//         "publicRead"
+	//       ],
+	//       "enumDescriptions": [
+	//         "Object owner gets OWNER access, and allAuthenticatedUsers get READER access.",
+	//         "Object owner gets OWNER access, and project team owners get OWNER access.",
+	//         "Object owner gets OWNER access, and project team owners get READER access.",
+	//         "Object owner gets OWNER access.",
+	//         "Object owner gets OWNER access, and project team members get access according to their roles.",
+	//         "Object owner gets OWNER access, and allUsers get READER access."
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "projection": {
+	//       "description": "Set of properties to return. Defaults to full.",
+	//       "enum": [
+	//         "full",
+	//         "noAcl"
+	//       ],
+	//       "enumDescriptions": [
+	//         "Include all properties.",
+	//         "Omit acl and defaultObjectAcl properties."
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "b/{bucket}",
+	//   "request": {
+	//     "$ref": "Bucket"
+	//   },
+	//   "response": {
+	//     "$ref": "Bucket"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/devstorage.full_control",
+	//     "https://www.googleapis.com/auth/devstorage.read_write"
+	//   ]
+	// }
+
+}
+
+// method id "storage.channels.stop":
+
+type ChannelsStopCall struct {
+	s       *Service
+	channel *Channel
+	opt_    map[string]interface{}
+}
+
+// Stop: Stop watching resources through this channel
+func (r *ChannelsService) Stop(channel *Channel) *ChannelsStopCall {
+	c := &ChannelsStopCall{s: r.s, opt_: make(map[string]interface{})}
+	c.channel = channel
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ChannelsStopCall) Fields(s ...googleapi.Field) *ChannelsStopCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *ChannelsStopCall) Do() error {
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.channel)
+	if err != nil {
+		return err
+	}
+	ctype := "application/json"
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "channels/stop")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	googleapi.SetOpaque(req.URL)
+	req.Header.Set("Content-Type", ctype)
+	req.Header.Set("User-Agent", c.s.userAgent())
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return err
+	}
+	return nil
+	// {
+	//   "description": "Stop watching resources through this channel",
+	//   "httpMethod": "POST",
+	//   "id": "storage.channels.stop",
+	//   "path": "channels/stop",
+	//   "request": {
+	//     "$ref": "Channel",
+	//     "parameterName": "resource"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/devstorage.full_control",
+	//     "https://www.googleapis.com/auth/devstorage.read_only",
+	//     "https://www.googleapis.com/auth/devstorage.read_write"
+	//   ]
+	// }
+
+}
+
+// method id "storage.defaultObjectAccessControls.delete":
+
+type DefaultObjectAccessControlsDeleteCall struct {
+	s      *Service
+	bucket string
+	entity string
+	opt_   map[string]interface{}
+}
+
+// Delete: Permanently deletes the default object ACL entry for the
+// specified entity on the specified bucket.
+func (r *DefaultObjectAccessControlsService) Delete(bucket string, entity string) *DefaultObjectAccessControlsDeleteCall {
+	c := &DefaultObjectAccessControlsDeleteCall{s: r.s, opt_: make(map[string]interface{})}
+	c.bucket = bucket
+	c.entity = entity
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *DefaultObjectAccessControlsDeleteCall) Fields(s ...googleapi.Field) *DefaultObjectAccessControlsDeleteCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *DefaultObjectAccessControlsDeleteCall) Do() error {
+	var body io.Reader = nil
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "b/{bucket}/defaultObjectAcl/{entity}")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("DELETE", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"bucket": c.bucket,
+		"entity": c.entity,
+	})
+	req.Header.Set("User-Agent", c.s.userAgent())
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return err
+	}
+	return nil
+	// {
+	//   "description": "Permanently deletes the default object ACL entry for the specified entity on the specified bucket.",
+	//   "httpMethod": "DELETE",
+	//   "id": "storage.defaultObjectAccessControls.delete",
+	//   "parameterOrder": [
+	//     "bucket",
+	//     "entity"
+	//   ],
+	//   "parameters": {
+	//     "bucket": {
+	//       "description": "Name of a bucket.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "entity": {
+	//       "description": "The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId, group-emailAddress, allUsers, or allAuthenticatedUsers.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "b/{bucket}/defaultObjectAcl/{entity}",
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/devstorage.full_control"
+	//   ]
+	// }
+
+}
+
+// method id "storage.defaultObjectAccessControls.get":
+
+type DefaultObjectAccessControlsGetCall struct {
+	s      *Service
+	bucket string
+	entity string
+	opt_   map[string]interface{}
+}
+
+// Get: Returns the default object ACL entry for the specified entity on
+// the specified bucket.
+func (r *DefaultObjectAccessControlsService) Get(bucket string, entity string) *DefaultObjectAccessControlsGetCall {
+	c := &DefaultObjectAccessControlsGetCall{s: r.s, opt_: make(map[string]interface{})}
+	c.bucket = bucket
+	c.entity = entity
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *DefaultObjectAccessControlsGetCall) Fields(s ...googleapi.Field) *DefaultObjectAccessControlsGetCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *DefaultObjectAccessControlsGetCall) Do() (*ObjectAccessControl, error) {
+	var body io.Reader = nil
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "b/{bucket}/defaultObjectAcl/{entity}")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"bucket": c.bucket,
+		"entity": c.entity,
+	})
+	req.Header.Set("User-Agent", c.s.userAgent())
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	var ret *ObjectAccessControl
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Returns the default object ACL entry for the specified entity on the specified bucket.",
+	//   "httpMethod": "GET",
+	//   "id": "storage.defaultObjectAccessControls.get",
+	//   "parameterOrder": [
+	//     "bucket",
+	//     "entity"
+	//   ],
+	//   "parameters": {
+	//     "bucket": {
+	//       "description": "Name of a bucket.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "entity": {
+	//       "description": "The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId, group-emailAddress, allUsers, or allAuthenticatedUsers.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "b/{bucket}/defaultObjectAcl/{entity}",
+	//   "response": {
+	//     "$ref": "ObjectAccessControl"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/devstorage.full_control"
+	//   ]
+	// }
+
+}
+
+// method id "storage.defaultObjectAccessControls.insert":
+
+type DefaultObjectAccessControlsInsertCall struct {
+	s                   *Service
+	bucket              string
+	objectaccesscontrol *ObjectAccessControl
+	opt_                map[string]interface{}
+}
+
+// Insert: Creates a new default object ACL entry on the specified
+// bucket.
+func (r *DefaultObjectAccessControlsService) Insert(bucket string, objectaccesscontrol *ObjectAccessControl) *DefaultObjectAccessControlsInsertCall {
+	c := &DefaultObjectAccessControlsInsertCall{s: r.s, opt_: make(map[string]interface{})}
+	c.bucket = bucket
+	c.objectaccesscontrol = objectaccesscontrol
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *DefaultObjectAccessControlsInsertCall) Fields(s ...googleapi.Field) *DefaultObjectAccessControlsInsertCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *DefaultObjectAccessControlsInsertCall) Do() (*ObjectAccessControl, error) {
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.objectaccesscontrol)
+	if err != nil {
+		return nil, err
+	}
+	ctype := "application/json"
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "b/{bucket}/defaultObjectAcl")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"bucket": c.bucket,
+	})
+	req.Header.Set("Content-Type", ctype)
+	req.Header.Set("User-Agent", c.s.userAgent())
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	var ret *ObjectAccessControl
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Creates a new default object ACL entry on the specified bucket.",
+	//   "httpMethod": "POST",
+	//   "id": "storage.defaultObjectAccessControls.insert",
+	//   "parameterOrder": [
+	//     "bucket"
+	//   ],
+	//   "parameters": {
+	//     "bucket": {
+	//       "description": "Name of a bucket.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "b/{bucket}/defaultObjectAcl",
+	//   "request": {
+	//     "$ref": "ObjectAccessControl"
+	//   },
+	//   "response": {
+	//     "$ref": "ObjectAccessControl"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/devstorage.full_control"
+	//   ]
+	// }
+
+}
+
+// method id "storage.defaultObjectAccessControls.list":
+
+type DefaultObjectAccessControlsListCall struct {
+	s      *Service
+	bucket string
+	opt_   map[string]interface{}
+}
+
+// List: Retrieves default object ACL entries on the specified bucket.
+func (r *DefaultObjectAccessControlsService) List(bucket string) *DefaultObjectAccessControlsListCall {
+	c := &DefaultObjectAccessControlsListCall{s: r.s, opt_: make(map[string]interface{})}
+	c.bucket = bucket
+	return c
+}
+
+// IfMetagenerationMatch sets the optional parameter
+// "ifMetagenerationMatch": If present, only return default ACL listing
+// if the bucket's current metageneration matches this value.
+func (c *DefaultObjectAccessControlsListCall) IfMetagenerationMatch(ifMetagenerationMatch int64) *DefaultObjectAccessControlsListCall {
+	c.opt_["ifMetagenerationMatch"] = ifMetagenerationMatch
+	return c
+}
+
+// IfMetagenerationNotMatch sets the optional parameter
+// "ifMetagenerationNotMatch": If present, only return default ACL
+// listing if the bucket's current metageneration does not match the
+// given value.
+func (c *DefaultObjectAccessControlsListCall) IfMetagenerationNotMatch(ifMetagenerationNotMatch int64) *DefaultObjectAccessControlsListCall {
+	c.opt_["ifMetagenerationNotMatch"] = ifMetagenerationNotMatch
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *DefaultObjectAccessControlsListCall) Fields(s ...googleapi.Field) *DefaultObjectAccessControlsListCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *DefaultObjectAccessControlsListCall) Do() (*ObjectAccessControls, error) {
+	var body io.Reader = nil
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["ifMetagenerationMatch"]; ok {
+		params.Set("ifMetagenerationMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifMetagenerationNotMatch"]; ok {
+		params.Set("ifMetagenerationNotMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "b/{bucket}/defaultObjectAcl")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"bucket": c.bucket,
+	})
+	req.Header.Set("User-Agent", c.s.userAgent())
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	var ret *ObjectAccessControls
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Retrieves default object ACL entries on the specified bucket.",
+	//   "httpMethod": "GET",
+	//   "id": "storage.defaultObjectAccessControls.list",
+	//   "parameterOrder": [
+	//     "bucket"
+	//   ],
+	//   "parameters": {
+	//     "bucket": {
+	//       "description": "Name of a bucket.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "ifMetagenerationMatch": {
+	//       "description": "If present, only return default ACL listing if the bucket's current metageneration matches this value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifMetagenerationNotMatch": {
+	//       "description": "If present, only return default ACL listing if the bucket's current metageneration does not match the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "b/{bucket}/defaultObjectAcl",
+	//   "response": {
+	//     "$ref": "ObjectAccessControls"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/devstorage.full_control"
+	//   ]
+	// }
+
+}
+
+// method id "storage.defaultObjectAccessControls.patch":
+
+type DefaultObjectAccessControlsPatchCall struct {
+	s                   *Service
+	bucket              string
+	entity              string
+	objectaccesscontrol *ObjectAccessControl
+	opt_                map[string]interface{}
+}
+
+// Patch: Updates a default object ACL entry on the specified bucket.
+// This method supports patch semantics.
+func (r *DefaultObjectAccessControlsService) Patch(bucket string, entity string, objectaccesscontrol *ObjectAccessControl) *DefaultObjectAccessControlsPatchCall {
+	c := &DefaultObjectAccessControlsPatchCall{s: r.s, opt_: make(map[string]interface{})}
+	c.bucket = bucket
+	c.entity = entity
+	c.objectaccesscontrol = objectaccesscontrol
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *DefaultObjectAccessControlsPatchCall) Fields(s ...googleapi.Field) *DefaultObjectAccessControlsPatchCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *DefaultObjectAccessControlsPatchCall) Do() (*ObjectAccessControl, error) {
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.objectaccesscontrol)
+	if err != nil {
+		return nil, err
+	}
+	ctype := "application/json"
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "b/{bucket}/defaultObjectAcl/{entity}")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("PATCH", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"bucket": c.bucket,
+		"entity": c.entity,
+	})
+	req.Header.Set("Content-Type", ctype)
+	req.Header.Set("User-Agent", c.s.userAgent())
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	var ret *ObjectAccessControl
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Updates a default object ACL entry on the specified bucket. This method supports patch semantics.",
+	//   "httpMethod": "PATCH",
+	//   "id": "storage.defaultObjectAccessControls.patch",
+	//   "parameterOrder": [
+	//     "bucket",
+	//     "entity"
+	//   ],
+	//   "parameters": {
+	//     "bucket": {
+	//       "description": "Name of a bucket.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "entity": {
+	//       "description": "The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId, group-emailAddress, allUsers, or allAuthenticatedUsers.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "b/{bucket}/defaultObjectAcl/{entity}",
+	//   "request": {
+	//     "$ref": "ObjectAccessControl"
+	//   },
+	//   "response": {
+	//     "$ref": "ObjectAccessControl"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/devstorage.full_control"
+	//   ]
+	// }
+
+}
+
+// method id "storage.defaultObjectAccessControls.update":
+
+type DefaultObjectAccessControlsUpdateCall struct {
+	s                   *Service
+	bucket              string
+	entity              string
+	objectaccesscontrol *ObjectAccessControl
+	opt_                map[string]interface{}
+}
+
+// Update: Updates a default object ACL entry on the specified bucket.
+func (r *DefaultObjectAccessControlsService) Update(bucket string, entity string, objectaccesscontrol *ObjectAccessControl) *DefaultObjectAccessControlsUpdateCall {
+	c := &DefaultObjectAccessControlsUpdateCall{s: r.s, opt_: make(map[string]interface{})}
+	c.bucket = bucket
+	c.entity = entity
+	c.objectaccesscontrol = objectaccesscontrol
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *DefaultObjectAccessControlsUpdateCall) Fields(s ...googleapi.Field) *DefaultObjectAccessControlsUpdateCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *DefaultObjectAccessControlsUpdateCall) Do() (*ObjectAccessControl, error) {
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.objectaccesscontrol)
+	if err != nil {
+		return nil, err
+	}
+	ctype := "application/json"
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "b/{bucket}/defaultObjectAcl/{entity}")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("PUT", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"bucket": c.bucket,
+		"entity": c.entity,
+	})
+	req.Header.Set("Content-Type", ctype)
+	req.Header.Set("User-Agent", c.s.userAgent())
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	var ret *ObjectAccessControl
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Updates a default object ACL entry on the specified bucket.",
+	//   "httpMethod": "PUT",
+	//   "id": "storage.defaultObjectAccessControls.update",
+	//   "parameterOrder": [
+	//     "bucket",
+	//     "entity"
+	//   ],
+	//   "parameters": {
+	//     "bucket": {
+	//       "description": "Name of a bucket.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "entity": {
+	//       "description": "The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId, group-emailAddress, allUsers, or allAuthenticatedUsers.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "b/{bucket}/defaultObjectAcl/{entity}",
+	//   "request": {
+	//     "$ref": "ObjectAccessControl"
+	//   },
+	//   "response": {
+	//     "$ref": "ObjectAccessControl"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/devstorage.full_control"
+	//   ]
+	// }
+
+}
+
+// method id "storage.objectAccessControls.delete":
+
+type ObjectAccessControlsDeleteCall struct {
+	s      *Service
+	bucket string
+	object string
+	entity string
+	opt_   map[string]interface{}
+}
+
+// Delete: Permanently deletes the ACL entry for the specified entity on
+// the specified object.
+func (r *ObjectAccessControlsService) Delete(bucket string, object string, entity string) *ObjectAccessControlsDeleteCall {
+	c := &ObjectAccessControlsDeleteCall{s: r.s, opt_: make(map[string]interface{})}
+	c.bucket = bucket
+	c.object = object
+	c.entity = entity
+	return c
+}
+
+// Generation sets the optional parameter "generation": If present,
+// selects a specific revision of this object (as opposed to the latest
+// version, the default).
+func (c *ObjectAccessControlsDeleteCall) Generation(generation int64) *ObjectAccessControlsDeleteCall {
+	c.opt_["generation"] = generation
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ObjectAccessControlsDeleteCall) Fields(s ...googleapi.Field) *ObjectAccessControlsDeleteCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *ObjectAccessControlsDeleteCall) Do() error {
+	var body io.Reader = nil
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["generation"]; ok {
+		params.Set("generation", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "b/{bucket}/o/{object}/acl/{entity}")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("DELETE", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"bucket": c.bucket,
+		"object": c.object,
+		"entity": c.entity,
+	})
+	req.Header.Set("User-Agent", c.s.userAgent())
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return err
+	}
+	return nil
+	// {
+	//   "description": "Permanently deletes the ACL entry for the specified entity on the specified object.",
+	//   "httpMethod": "DELETE",
+	//   "id": "storage.objectAccessControls.delete",
+	//   "parameterOrder": [
+	//     "bucket",
+	//     "object",
+	//     "entity"
+	//   ],
+	//   "parameters": {
+	//     "bucket": {
+	//       "description": "Name of a bucket.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "entity": {
+	//       "description": "The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId, group-emailAddress, allUsers, or allAuthenticatedUsers.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "generation": {
+	//       "description": "If present, selects a specific revision of this object (as opposed to the latest version, the default).",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "object": {
+	//       "description": "Name of the object.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "b/{bucket}/o/{object}/acl/{entity}",
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/devstorage.full_control"
+	//   ]
+	// }
+
+}
+
+// method id "storage.objectAccessControls.get":
+
+type ObjectAccessControlsGetCall struct {
+	s      *Service
+	bucket string
+	object string
+	entity string
+	opt_   map[string]interface{}
+}
+
+// Get: Returns the ACL entry for the specified entity on the specified
+// object.
+func (r *ObjectAccessControlsService) Get(bucket string, object string, entity string) *ObjectAccessControlsGetCall {
+	c := &ObjectAccessControlsGetCall{s: r.s, opt_: make(map[string]interface{})}
+	c.bucket = bucket
+	c.object = object
+	c.entity = entity
+	return c
+}
+
+// Generation sets the optional parameter "generation": If present,
+// selects a specific revision of this object (as opposed to the latest
+// version, the default).
+func (c *ObjectAccessControlsGetCall) Generation(generation int64) *ObjectAccessControlsGetCall {
+	c.opt_["generation"] = generation
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ObjectAccessControlsGetCall) Fields(s ...googleapi.Field) *ObjectAccessControlsGetCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *ObjectAccessControlsGetCall) Do() (*ObjectAccessControl, error) {
+	var body io.Reader = nil
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["generation"]; ok {
+		params.Set("generation", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "b/{bucket}/o/{object}/acl/{entity}")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"bucket": c.bucket,
+		"object": c.object,
+		"entity": c.entity,
+	})
+	req.Header.Set("User-Agent", c.s.userAgent())
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	var ret *ObjectAccessControl
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Returns the ACL entry for the specified entity on the specified object.",
+	//   "httpMethod": "GET",
+	//   "id": "storage.objectAccessControls.get",
+	//   "parameterOrder": [
+	//     "bucket",
+	//     "object",
+	//     "entity"
+	//   ],
+	//   "parameters": {
+	//     "bucket": {
+	//       "description": "Name of a bucket.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "entity": {
+	//       "description": "The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId, group-emailAddress, allUsers, or allAuthenticatedUsers.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "generation": {
+	//       "description": "If present, selects a specific revision of this object (as opposed to the latest version, the default).",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "object": {
+	//       "description": "Name of the object.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "b/{bucket}/o/{object}/acl/{entity}",
+	//   "response": {
+	//     "$ref": "ObjectAccessControl"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/devstorage.full_control"
+	//   ]
+	// }
+
+}
+
+// method id "storage.objectAccessControls.insert":
+
+type ObjectAccessControlsInsertCall struct {
+	s                   *Service
+	bucket              string
+	object              string
+	objectaccesscontrol *ObjectAccessControl
+	opt_                map[string]interface{}
+}
+
+// Insert: Creates a new ACL entry on the specified object.
+func (r *ObjectAccessControlsService) Insert(bucket string, object string, objectaccesscontrol *ObjectAccessControl) *ObjectAccessControlsInsertCall {
+	c := &ObjectAccessControlsInsertCall{s: r.s, opt_: make(map[string]interface{})}
+	c.bucket = bucket
+	c.object = object
+	c.objectaccesscontrol = objectaccesscontrol
+	return c
+}
+
+// Generation sets the optional parameter "generation": If present,
+// selects a specific revision of this object (as opposed to the latest
+// version, the default).
+func (c *ObjectAccessControlsInsertCall) Generation(generation int64) *ObjectAccessControlsInsertCall {
+	c.opt_["generation"] = generation
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ObjectAccessControlsInsertCall) Fields(s ...googleapi.Field) *ObjectAccessControlsInsertCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *ObjectAccessControlsInsertCall) Do() (*ObjectAccessControl, error) {
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.objectaccesscontrol)
+	if err != nil {
+		return nil, err
+	}
+	ctype := "application/json"
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["generation"]; ok {
+		params.Set("generation", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "b/{bucket}/o/{object}/acl")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"bucket": c.bucket,
+		"object": c.object,
+	})
+	req.Header.Set("Content-Type", ctype)
+	req.Header.Set("User-Agent", c.s.userAgent())
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	var ret *ObjectAccessControl
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Creates a new ACL entry on the specified object.",
+	//   "httpMethod": "POST",
+	//   "id": "storage.objectAccessControls.insert",
+	//   "parameterOrder": [
+	//     "bucket",
+	//     "object"
+	//   ],
+	//   "parameters": {
+	//     "bucket": {
+	//       "description": "Name of a bucket.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "generation": {
+	//       "description": "If present, selects a specific revision of this object (as opposed to the latest version, the default).",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "object": {
+	//       "description": "Name of the object.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "b/{bucket}/o/{object}/acl",
+	//   "request": {
+	//     "$ref": "ObjectAccessControl"
+	//   },
+	//   "response": {
+	//     "$ref": "ObjectAccessControl"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/devstorage.full_control"
+	//   ]
+	// }
+
+}
+
+// method id "storage.objectAccessControls.list":
+
+type ObjectAccessControlsListCall struct {
+	s      *Service
+	bucket string
+	object string
+	opt_   map[string]interface{}
+}
+
+// List: Retrieves ACL entries on the specified object.
+func (r *ObjectAccessControlsService) List(bucket string, object string) *ObjectAccessControlsListCall {
+	c := &ObjectAccessControlsListCall{s: r.s, opt_: make(map[string]interface{})}
+	c.bucket = bucket
+	c.object = object
+	return c
+}
+
+// Generation sets the optional parameter "generation": If present,
+// selects a specific revision of this object (as opposed to the latest
+// version, the default).
+func (c *ObjectAccessControlsListCall) Generation(generation int64) *ObjectAccessControlsListCall {
+	c.opt_["generation"] = generation
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ObjectAccessControlsListCall) Fields(s ...googleapi.Field) *ObjectAccessControlsListCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *ObjectAccessControlsListCall) Do() (*ObjectAccessControls, error) {
+	var body io.Reader = nil
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["generation"]; ok {
+		params.Set("generation", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "b/{bucket}/o/{object}/acl")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"bucket": c.bucket,
+		"object": c.object,
+	})
+	req.Header.Set("User-Agent", c.s.userAgent())
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	var ret *ObjectAccessControls
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Retrieves ACL entries on the specified object.",
+	//   "httpMethod": "GET",
+	//   "id": "storage.objectAccessControls.list",
+	//   "parameterOrder": [
+	//     "bucket",
+	//     "object"
+	//   ],
+	//   "parameters": {
+	//     "bucket": {
+	//       "description": "Name of a bucket.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "generation": {
+	//       "description": "If present, selects a specific revision of this object (as opposed to the latest version, the default).",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "object": {
+	//       "description": "Name of the object.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "b/{bucket}/o/{object}/acl",
+	//   "response": {
+	//     "$ref": "ObjectAccessControls"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/devstorage.full_control"
+	//   ]
+	// }
+
+}
+
+// method id "storage.objectAccessControls.patch":
+
+type ObjectAccessControlsPatchCall struct {
+	s                   *Service
+	bucket              string
+	object              string
+	entity              string
+	objectaccesscontrol *ObjectAccessControl
+	opt_                map[string]interface{}
+}
+
+// Patch: Updates an ACL entry on the specified object. This method
+// supports patch semantics.
+func (r *ObjectAccessControlsService) Patch(bucket string, object string, entity string, objectaccesscontrol *ObjectAccessControl) *ObjectAccessControlsPatchCall {
+	c := &ObjectAccessControlsPatchCall{s: r.s, opt_: make(map[string]interface{})}
+	c.bucket = bucket
+	c.object = object
+	c.entity = entity
+	c.objectaccesscontrol = objectaccesscontrol
+	return c
+}
+
+// Generation sets the optional parameter "generation": If present,
+// selects a specific revision of this object (as opposed to the latest
+// version, the default).
+func (c *ObjectAccessControlsPatchCall) Generation(generation int64) *ObjectAccessControlsPatchCall {
+	c.opt_["generation"] = generation
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ObjectAccessControlsPatchCall) Fields(s ...googleapi.Field) *ObjectAccessControlsPatchCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *ObjectAccessControlsPatchCall) Do() (*ObjectAccessControl, error) {
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.objectaccesscontrol)
+	if err != nil {
+		return nil, err
+	}
+	ctype := "application/json"
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["generation"]; ok {
+		params.Set("generation", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "b/{bucket}/o/{object}/acl/{entity}")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("PATCH", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"bucket": c.bucket,
+		"object": c.object,
+		"entity": c.entity,
+	})
+	req.Header.Set("Content-Type", ctype)
+	req.Header.Set("User-Agent", c.s.userAgent())
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	var ret *ObjectAccessControl
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Updates an ACL entry on the specified object. This method supports patch semantics.",
+	//   "httpMethod": "PATCH",
+	//   "id": "storage.objectAccessControls.patch",
+	//   "parameterOrder": [
+	//     "bucket",
+	//     "object",
+	//     "entity"
+	//   ],
+	//   "parameters": {
+	//     "bucket": {
+	//       "description": "Name of a bucket.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "entity": {
+	//       "description": "The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId, group-emailAddress, allUsers, or allAuthenticatedUsers.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "generation": {
+	//       "description": "If present, selects a specific revision of this object (as opposed to the latest version, the default).",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "object": {
+	//       "description": "Name of the object.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "b/{bucket}/o/{object}/acl/{entity}",
+	//   "request": {
+	//     "$ref": "ObjectAccessControl"
+	//   },
+	//   "response": {
+	//     "$ref": "ObjectAccessControl"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/devstorage.full_control"
+	//   ]
+	// }
+
+}
+
+// method id "storage.objectAccessControls.update":
+
+type ObjectAccessControlsUpdateCall struct {
+	s                   *Service
+	bucket              string
+	object              string
+	entity              string
+	objectaccesscontrol *ObjectAccessControl
+	opt_                map[string]interface{}
+}
+
+// Update: Updates an ACL entry on the specified object.
+func (r *ObjectAccessControlsService) Update(bucket string, object string, entity string, objectaccesscontrol *ObjectAccessControl) *ObjectAccessControlsUpdateCall {
+	c := &ObjectAccessControlsUpdateCall{s: r.s, opt_: make(map[string]interface{})}
+	c.bucket = bucket
+	c.object = object
+	c.entity = entity
+	c.objectaccesscontrol = objectaccesscontrol
+	return c
+}
+
+// Generation sets the optional parameter "generation": If present,
+// selects a specific revision of this object (as opposed to the latest
+// version, the default).
+func (c *ObjectAccessControlsUpdateCall) Generation(generation int64) *ObjectAccessControlsUpdateCall {
+	c.opt_["generation"] = generation
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ObjectAccessControlsUpdateCall) Fields(s ...googleapi.Field) *ObjectAccessControlsUpdateCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *ObjectAccessControlsUpdateCall) Do() (*ObjectAccessControl, error) {
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.objectaccesscontrol)
+	if err != nil {
+		return nil, err
+	}
+	ctype := "application/json"
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["generation"]; ok {
+		params.Set("generation", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "b/{bucket}/o/{object}/acl/{entity}")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("PUT", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"bucket": c.bucket,
+		"object": c.object,
+		"entity": c.entity,
+	})
+	req.Header.Set("Content-Type", ctype)
+	req.Header.Set("User-Agent", c.s.userAgent())
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	var ret *ObjectAccessControl
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Updates an ACL entry on the specified object.",
+	//   "httpMethod": "PUT",
+	//   "id": "storage.objectAccessControls.update",
+	//   "parameterOrder": [
+	//     "bucket",
+	//     "object",
+	//     "entity"
+	//   ],
+	//   "parameters": {
+	//     "bucket": {
+	//       "description": "Name of a bucket.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "entity": {
+	//       "description": "The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId, group-emailAddress, allUsers, or allAuthenticatedUsers.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "generation": {
+	//       "description": "If present, selects a specific revision of this object (as opposed to the latest version, the default).",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "object": {
+	//       "description": "Name of the object.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "b/{bucket}/o/{object}/acl/{entity}",
+	//   "request": {
+	//     "$ref": "ObjectAccessControl"
+	//   },
+	//   "response": {
+	//     "$ref": "ObjectAccessControl"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/devstorage.full_control"
+	//   ]
+	// }
+
+}
+
+// method id "storage.objects.compose":
+
+type ObjectsComposeCall struct {
+	s                 *Service
+	destinationBucket string
+	destinationObject string
+	composerequest    *ComposeRequest
+	opt_              map[string]interface{}
+}
+
+// Compose: Concatenates a list of existing objects into a new object in
+// the same bucket.
+func (r *ObjectsService) Compose(destinationBucket string, destinationObject string, composerequest *ComposeRequest) *ObjectsComposeCall {
+	c := &ObjectsComposeCall{s: r.s, opt_: make(map[string]interface{})}
+	c.destinationBucket = destinationBucket
+	c.destinationObject = destinationObject
+	c.composerequest = composerequest
+	return c
+}
+
+// DestinationPredefinedAcl sets the optional parameter
+// "destinationPredefinedAcl": Apply a predefined set of access controls
+// to the destination object.
+//
+// Possible values:
+//   "authenticatedRead" - Object owner gets OWNER access, and
+// allAuthenticatedUsers get READER access.
+//   "bucketOwnerFullControl" - Object owner gets OWNER access, and
+// project team owners get OWNER access.
+//   "bucketOwnerRead" - Object owner gets OWNER access, and project
+// team owners get READER access.
+//   "private" - Object owner gets OWNER access.
+//   "projectPrivate" - Object owner gets OWNER access, and project team
+// members get access according to their roles.
+//   "publicRead" - Object owner gets OWNER access, and allUsers get
+// READER access.
+func (c *ObjectsComposeCall) DestinationPredefinedAcl(destinationPredefinedAcl string) *ObjectsComposeCall {
+	c.opt_["destinationPredefinedAcl"] = destinationPredefinedAcl
+	return c
+}
+
+// IfGenerationMatch sets the optional parameter "ifGenerationMatch":
+// Makes the operation conditional on whether the object's current
+// generation matches the given value.
+func (c *ObjectsComposeCall) IfGenerationMatch(ifGenerationMatch int64) *ObjectsComposeCall {
+	c.opt_["ifGenerationMatch"] = ifGenerationMatch
+	return c
+}
+
+// IfMetagenerationMatch sets the optional parameter
+// "ifMetagenerationMatch": Makes the operation conditional on whether
+// the object's current metageneration matches the given value.
+func (c *ObjectsComposeCall) IfMetagenerationMatch(ifMetagenerationMatch int64) *ObjectsComposeCall {
+	c.opt_["ifMetagenerationMatch"] = ifMetagenerationMatch
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ObjectsComposeCall) Fields(s ...googleapi.Field) *ObjectsComposeCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *ObjectsComposeCall) Do() (*Object, error) {
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.composerequest)
+	if err != nil {
+		return nil, err
+	}
+	ctype := "application/json"
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["destinationPredefinedAcl"]; ok {
+		params.Set("destinationPredefinedAcl", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifGenerationMatch"]; ok {
+		params.Set("ifGenerationMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifMetagenerationMatch"]; ok {
+		params.Set("ifMetagenerationMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "b/{destinationBucket}/o/{destinationObject}/compose")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"destinationBucket": c.destinationBucket,
+		"destinationObject": c.destinationObject,
+	})
+	req.Header.Set("Content-Type", ctype)
+	req.Header.Set("User-Agent", c.s.userAgent())
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	var ret *Object
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Concatenates a list of existing objects into a new object in the same bucket.",
+	//   "httpMethod": "POST",
+	//   "id": "storage.objects.compose",
+	//   "parameterOrder": [
+	//     "destinationBucket",
+	//     "destinationObject"
+	//   ],
+	//   "parameters": {
+	//     "destinationBucket": {
+	//       "description": "Name of the bucket in which to store the new object.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "destinationObject": {
+	//       "description": "Name of the new object.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "destinationPredefinedAcl": {
+	//       "description": "Apply a predefined set of access controls to the destination object.",
+	//       "enum": [
+	//         "authenticatedRead",
+	//         "bucketOwnerFullControl",
+	//         "bucketOwnerRead",
+	//         "private",
+	//         "projectPrivate",
+	//         "publicRead"
+	//       ],
+	//       "enumDescriptions": [
+	//         "Object owner gets OWNER access, and allAuthenticatedUsers get READER access.",
+	//         "Object owner gets OWNER access, and project team owners get OWNER access.",
+	//         "Object owner gets OWNER access, and project team owners get READER access.",
+	//         "Object owner gets OWNER access.",
+	//         "Object owner gets OWNER access, and project team members get access according to their roles.",
+	//         "Object owner gets OWNER access, and allUsers get READER access."
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifGenerationMatch": {
+	//       "description": "Makes the operation conditional on whether the object's current generation matches the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifMetagenerationMatch": {
+	//       "description": "Makes the operation conditional on whether the object's current metageneration matches the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "b/{destinationBucket}/o/{destinationObject}/compose",
+	//   "request": {
+	//     "$ref": "ComposeRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "Object"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/devstorage.full_control",
+	//     "https://www.googleapis.com/auth/devstorage.read_write"
+	//   ],
+	//   "supportsMediaDownload": true
+	// }
+
+}
+
+// method id "storage.objects.copy":
+
+type ObjectsCopyCall struct {
+	s                 *Service
+	sourceBucket      string
+	sourceObject      string
+	destinationBucket string
+	destinationObject string
+	object            *Object
+	opt_              map[string]interface{}
+}
+
+// Copy: Copies a source object to a destination object. Optionally
+// overrides metadata.
+func (r *ObjectsService) Copy(sourceBucket string, sourceObject string, destinationBucket string, destinationObject string, object *Object) *ObjectsCopyCall {
+	c := &ObjectsCopyCall{s: r.s, opt_: make(map[string]interface{})}
+	c.sourceBucket = sourceBucket
+	c.sourceObject = sourceObject
+	c.destinationBucket = destinationBucket
+	c.destinationObject = destinationObject
+	c.object = object
+	return c
+}
+
+// DestinationPredefinedAcl sets the optional parameter
+// "destinationPredefinedAcl": Apply a predefined set of access controls
+// to the destination object.
+//
+// Possible values:
+//   "authenticatedRead" - Object owner gets OWNER access, and
+// allAuthenticatedUsers get READER access.
+//   "bucketOwnerFullControl" - Object owner gets OWNER access, and
+// project team owners get OWNER access.
+//   "bucketOwnerRead" - Object owner gets OWNER access, and project
+// team owners get READER access.
+//   "private" - Object owner gets OWNER access.
+//   "projectPrivate" - Object owner gets OWNER access, and project team
+// members get access according to their roles.
+//   "publicRead" - Object owner gets OWNER access, and allUsers get
+// READER access.
+func (c *ObjectsCopyCall) DestinationPredefinedAcl(destinationPredefinedAcl string) *ObjectsCopyCall {
+	c.opt_["destinationPredefinedAcl"] = destinationPredefinedAcl
+	return c
+}
+
+// IfGenerationMatch sets the optional parameter "ifGenerationMatch":
+// Makes the operation conditional on whether the destination object's
+// current generation matches the given value.
+func (c *ObjectsCopyCall) IfGenerationMatch(ifGenerationMatch int64) *ObjectsCopyCall {
+	c.opt_["ifGenerationMatch"] = ifGenerationMatch
+	return c
+}
+
+// IfGenerationNotMatch sets the optional parameter
+// "ifGenerationNotMatch": Makes the operation conditional on whether
+// the destination object's current generation does not match the given
+// value.
+func (c *ObjectsCopyCall) IfGenerationNotMatch(ifGenerationNotMatch int64) *ObjectsCopyCall {
+	c.opt_["ifGenerationNotMatch"] = ifGenerationNotMatch
+	return c
+}
+
+// IfMetagenerationMatch sets the optional parameter
+// "ifMetagenerationMatch": Makes the operation conditional on whether
+// the destination object's current metageneration matches the given
+// value.
+func (c *ObjectsCopyCall) IfMetagenerationMatch(ifMetagenerationMatch int64) *ObjectsCopyCall {
+	c.opt_["ifMetagenerationMatch"] = ifMetagenerationMatch
+	return c
+}
+
+// IfMetagenerationNotMatch sets the optional parameter
+// "ifMetagenerationNotMatch": Makes the operation conditional on
+// whether the destination object's current metageneration does not
+// match the given value.
+func (c *ObjectsCopyCall) IfMetagenerationNotMatch(ifMetagenerationNotMatch int64) *ObjectsCopyCall {
+	c.opt_["ifMetagenerationNotMatch"] = ifMetagenerationNotMatch
+	return c
+}
+
+// IfSourceGenerationMatch sets the optional parameter
+// "ifSourceGenerationMatch": Makes the operation conditional on whether
+// the source object's generation matches the given value.
+func (c *ObjectsCopyCall) IfSourceGenerationMatch(ifSourceGenerationMatch int64) *ObjectsCopyCall {
+	c.opt_["ifSourceGenerationMatch"] = ifSourceGenerationMatch
+	return c
+}
+
+// IfSourceGenerationNotMatch sets the optional parameter
+// "ifSourceGenerationNotMatch": Makes the operation conditional on
+// whether the source object's generation does not match the given
+// value.
+func (c *ObjectsCopyCall) IfSourceGenerationNotMatch(ifSourceGenerationNotMatch int64) *ObjectsCopyCall {
+	c.opt_["ifSourceGenerationNotMatch"] = ifSourceGenerationNotMatch
+	return c
+}
+
+// IfSourceMetagenerationMatch sets the optional parameter
+// "ifSourceMetagenerationMatch": Makes the operation conditional on
+// whether the source object's current metageneration matches the given
+// value.
+func (c *ObjectsCopyCall) IfSourceMetagenerationMatch(ifSourceMetagenerationMatch int64) *ObjectsCopyCall {
+	c.opt_["ifSourceMetagenerationMatch"] = ifSourceMetagenerationMatch
+	return c
+}
+
+// IfSourceMetagenerationNotMatch sets the optional parameter
+// "ifSourceMetagenerationNotMatch": Makes the operation conditional on
+// whether the source object's current metageneration does not match the
+// given value.
+func (c *ObjectsCopyCall) IfSourceMetagenerationNotMatch(ifSourceMetagenerationNotMatch int64) *ObjectsCopyCall {
+	c.opt_["ifSourceMetagenerationNotMatch"] = ifSourceMetagenerationNotMatch
+	return c
+}
+
+// Projection sets the optional parameter "projection": Set of
+// properties to return. Defaults to noAcl, unless the object resource
+// specifies the acl property, when it defaults to full.
+//
+// Possible values:
+//   "full" - Include all properties.
+//   "noAcl" - Omit the acl property.
+func (c *ObjectsCopyCall) Projection(projection string) *ObjectsCopyCall {
+	c.opt_["projection"] = projection
+	return c
+}
+
+// SourceGeneration sets the optional parameter "sourceGeneration": If
+// present, selects a specific revision of the source object (as opposed
+// to the latest version, the default).
+func (c *ObjectsCopyCall) SourceGeneration(sourceGeneration int64) *ObjectsCopyCall {
+	c.opt_["sourceGeneration"] = sourceGeneration
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ObjectsCopyCall) Fields(s ...googleapi.Field) *ObjectsCopyCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *ObjectsCopyCall) Do() (*Object, error) {
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.object)
+	if err != nil {
+		return nil, err
+	}
+	ctype := "application/json"
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["destinationPredefinedAcl"]; ok {
+		params.Set("destinationPredefinedAcl", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifGenerationMatch"]; ok {
+		params.Set("ifGenerationMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifGenerationNotMatch"]; ok {
+		params.Set("ifGenerationNotMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifMetagenerationMatch"]; ok {
+		params.Set("ifMetagenerationMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifMetagenerationNotMatch"]; ok {
+		params.Set("ifMetagenerationNotMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifSourceGenerationMatch"]; ok {
+		params.Set("ifSourceGenerationMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifSourceGenerationNotMatch"]; ok {
+		params.Set("ifSourceGenerationNotMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifSourceMetagenerationMatch"]; ok {
+		params.Set("ifSourceMetagenerationMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifSourceMetagenerationNotMatch"]; ok {
+		params.Set("ifSourceMetagenerationNotMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["projection"]; ok {
+		params.Set("projection", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["sourceGeneration"]; ok {
+		params.Set("sourceGeneration", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "b/{sourceBucket}/o/{sourceObject}/copyTo/b/{destinationBucket}/o/{destinationObject}")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"sourceBucket":      c.sourceBucket,
+		"sourceObject":      c.sourceObject,
+		"destinationBucket": c.destinationBucket,
+		"destinationObject": c.destinationObject,
+	})
+	req.Header.Set("Content-Type", ctype)
+	req.Header.Set("User-Agent", c.s.userAgent())
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	var ret *Object
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Copies a source object to a destination object. Optionally overrides metadata.",
+	//   "httpMethod": "POST",
+	//   "id": "storage.objects.copy",
+	//   "parameterOrder": [
+	//     "sourceBucket",
+	//     "sourceObject",
+	//     "destinationBucket",
+	//     "destinationObject"
+	//   ],
+	//   "parameters": {
+	//     "destinationBucket": {
+	//       "description": "Name of the bucket in which to store the new object. Overrides the provided object metadata's bucket value, if any.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "destinationObject": {
+	//       "description": "Name of the new object. Required when the object metadata is not otherwise provided. Overrides the object metadata's name value, if any.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "destinationPredefinedAcl": {
+	//       "description": "Apply a predefined set of access controls to the destination object.",
+	//       "enum": [
+	//         "authenticatedRead",
+	//         "bucketOwnerFullControl",
+	//         "bucketOwnerRead",
+	//         "private",
+	//         "projectPrivate",
+	//         "publicRead"
+	//       ],
+	//       "enumDescriptions": [
+	//         "Object owner gets OWNER access, and allAuthenticatedUsers get READER access.",
+	//         "Object owner gets OWNER access, and project team owners get OWNER access.",
+	//         "Object owner gets OWNER access, and project team owners get READER access.",
+	//         "Object owner gets OWNER access.",
+	//         "Object owner gets OWNER access, and project team members get access according to their roles.",
+	//         "Object owner gets OWNER access, and allUsers get READER access."
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifGenerationMatch": {
+	//       "description": "Makes the operation conditional on whether the destination object's current generation matches the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifGenerationNotMatch": {
+	//       "description": "Makes the operation conditional on whether the destination object's current generation does not match the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifMetagenerationMatch": {
+	//       "description": "Makes the operation conditional on whether the destination object's current metageneration matches the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifMetagenerationNotMatch": {
+	//       "description": "Makes the operation conditional on whether the destination object's current metageneration does not match the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifSourceGenerationMatch": {
+	//       "description": "Makes the operation conditional on whether the source object's generation matches the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifSourceGenerationNotMatch": {
+	//       "description": "Makes the operation conditional on whether the source object's generation does not match the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifSourceMetagenerationMatch": {
+	//       "description": "Makes the operation conditional on whether the source object's current metageneration matches the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifSourceMetagenerationNotMatch": {
+	//       "description": "Makes the operation conditional on whether the source object's current metageneration does not match the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "projection": {
+	//       "description": "Set of properties to return. Defaults to noAcl, unless the object resource specifies the acl property, when it defaults to full.",
+	//       "enum": [
+	//         "full",
+	//         "noAcl"
+	//       ],
+	//       "enumDescriptions": [
+	//         "Include all properties.",
+	//         "Omit the acl property."
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "sourceBucket": {
+	//       "description": "Name of the bucket in which to find the source object.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "sourceGeneration": {
+	//       "description": "If present, selects a specific revision of the source object (as opposed to the latest version, the default).",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "sourceObject": {
+	//       "description": "Name of the source object.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "b/{sourceBucket}/o/{sourceObject}/copyTo/b/{destinationBucket}/o/{destinationObject}",
+	//   "request": {
+	//     "$ref": "Object"
+	//   },
+	//   "response": {
+	//     "$ref": "Object"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/devstorage.full_control",
+	//     "https://www.googleapis.com/auth/devstorage.read_write"
+	//   ],
+	//   "supportsMediaDownload": true
+	// }
+
+}
+
+// method id "storage.objects.delete":
+
+type ObjectsDeleteCall struct {
+	s      *Service
+	bucket string
+	object string
+	opt_   map[string]interface{}
+}
+
+// Delete: Deletes an object and its metadata. Deletions are permanent
+// if versioning is not enabled for the bucket, or if the generation
+// parameter is used.
+func (r *ObjectsService) Delete(bucket string, object string) *ObjectsDeleteCall {
+	c := &ObjectsDeleteCall{s: r.s, opt_: make(map[string]interface{})}
+	c.bucket = bucket
+	c.object = object
+	return c
+}
+
+// Generation sets the optional parameter "generation": If present,
+// permanently deletes a specific revision of this object (as opposed to
+// the latest version, the default).
+func (c *ObjectsDeleteCall) Generation(generation int64) *ObjectsDeleteCall {
+	c.opt_["generation"] = generation
+	return c
+}
+
+// IfGenerationMatch sets the optional parameter "ifGenerationMatch":
+// Makes the operation conditional on whether the object's current
+// generation matches the given value.
+func (c *ObjectsDeleteCall) IfGenerationMatch(ifGenerationMatch int64) *ObjectsDeleteCall {
+	c.opt_["ifGenerationMatch"] = ifGenerationMatch
+	return c
+}
+
+// IfGenerationNotMatch sets the optional parameter
+// "ifGenerationNotMatch": Makes the operation conditional on whether
+// the object's current generation does not match the given value.
+func (c *ObjectsDeleteCall) IfGenerationNotMatch(ifGenerationNotMatch int64) *ObjectsDeleteCall {
+	c.opt_["ifGenerationNotMatch"] = ifGenerationNotMatch
+	return c
+}
+
+// IfMetagenerationMatch sets the optional parameter
+// "ifMetagenerationMatch": Makes the operation conditional on whether
+// the object's current metageneration matches the given value.
+func (c *ObjectsDeleteCall) IfMetagenerationMatch(ifMetagenerationMatch int64) *ObjectsDeleteCall {
+	c.opt_["ifMetagenerationMatch"] = ifMetagenerationMatch
+	return c
+}
+
+// IfMetagenerationNotMatch sets the optional parameter
+// "ifMetagenerationNotMatch": Makes the operation conditional on
+// whether the object's current metageneration does not match the given
+// value.
+func (c *ObjectsDeleteCall) IfMetagenerationNotMatch(ifMetagenerationNotMatch int64) *ObjectsDeleteCall {
+	c.opt_["ifMetagenerationNotMatch"] = ifMetagenerationNotMatch
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ObjectsDeleteCall) Fields(s ...googleapi.Field) *ObjectsDeleteCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *ObjectsDeleteCall) Do() error {
+	var body io.Reader = nil
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["generation"]; ok {
+		params.Set("generation", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifGenerationMatch"]; ok {
+		params.Set("ifGenerationMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifGenerationNotMatch"]; ok {
+		params.Set("ifGenerationNotMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifMetagenerationMatch"]; ok {
+		params.Set("ifMetagenerationMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifMetagenerationNotMatch"]; ok {
+		params.Set("ifMetagenerationNotMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "b/{bucket}/o/{object}")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("DELETE", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"bucket": c.bucket,
+		"object": c.object,
+	})
+	req.Header.Set("User-Agent", c.s.userAgent())
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return err
+	}
+	return nil
+	// {
+	//   "description": "Deletes an object and its metadata. Deletions are permanent if versioning is not enabled for the bucket, or if the generation parameter is used.",
+	//   "httpMethod": "DELETE",
+	//   "id": "storage.objects.delete",
+	//   "parameterOrder": [
+	//     "bucket",
+	//     "object"
+	//   ],
+	//   "parameters": {
+	//     "bucket": {
+	//       "description": "Name of the bucket in which the object resides.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "generation": {
+	//       "description": "If present, permanently deletes a specific revision of this object (as opposed to the latest version, the default).",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifGenerationMatch": {
+	//       "description": "Makes the operation conditional on whether the object's current generation matches the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifGenerationNotMatch": {
+	//       "description": "Makes the operation conditional on whether the object's current generation does not match the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifMetagenerationMatch": {
+	//       "description": "Makes the operation conditional on whether the object's current metageneration matches the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifMetagenerationNotMatch": {
+	//       "description": "Makes the operation conditional on whether the object's current metageneration does not match the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "object": {
+	//       "description": "Name of the object.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "b/{bucket}/o/{object}",
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/devstorage.full_control",
+	//     "https://www.googleapis.com/auth/devstorage.read_write"
+	//   ]
+	// }
+
+}
+
+// method id "storage.objects.get":
+
+type ObjectsGetCall struct {
+	s      *Service
+	bucket string
+	object string
+	opt_   map[string]interface{}
+}
+
+// Get: Retrieves an object or its metadata.
+func (r *ObjectsService) Get(bucket string, object string) *ObjectsGetCall {
+	c := &ObjectsGetCall{s: r.s, opt_: make(map[string]interface{})}
+	c.bucket = bucket
+	c.object = object
+	return c
+}
+
+// Generation sets the optional parameter "generation": If present,
+// selects a specific revision of this object (as opposed to the latest
+// version, the default).
+func (c *ObjectsGetCall) Generation(generation int64) *ObjectsGetCall {
+	c.opt_["generation"] = generation
+	return c
+}
+
+// IfGenerationMatch sets the optional parameter "ifGenerationMatch":
+// Makes the operation conditional on whether the object's generation
+// matches the given value.
+func (c *ObjectsGetCall) IfGenerationMatch(ifGenerationMatch int64) *ObjectsGetCall {
+	c.opt_["ifGenerationMatch"] = ifGenerationMatch
+	return c
+}
+
+// IfGenerationNotMatch sets the optional parameter
+// "ifGenerationNotMatch": Makes the operation conditional on whether
+// the object's generation does not match the given value.
+func (c *ObjectsGetCall) IfGenerationNotMatch(ifGenerationNotMatch int64) *ObjectsGetCall {
+	c.opt_["ifGenerationNotMatch"] = ifGenerationNotMatch
+	return c
+}
+
+// IfMetagenerationMatch sets the optional parameter
+// "ifMetagenerationMatch": Makes the operation conditional on whether
+// the object's current metageneration matches the given value.
+func (c *ObjectsGetCall) IfMetagenerationMatch(ifMetagenerationMatch int64) *ObjectsGetCall {
+	c.opt_["ifMetagenerationMatch"] = ifMetagenerationMatch
+	return c
+}
+
+// IfMetagenerationNotMatch sets the optional parameter
+// "ifMetagenerationNotMatch": Makes the operation conditional on
+// whether the object's current metageneration does not match the given
+// value.
+func (c *ObjectsGetCall) IfMetagenerationNotMatch(ifMetagenerationNotMatch int64) *ObjectsGetCall {
+	c.opt_["ifMetagenerationNotMatch"] = ifMetagenerationNotMatch
+	return c
+}
+
+// Projection sets the optional parameter "projection": Set of
+// properties to return. Defaults to noAcl.
+//
+// Possible values:
+//   "full" - Include all properties.
+//   "noAcl" - Omit the acl property.
+func (c *ObjectsGetCall) Projection(projection string) *ObjectsGetCall {
+	c.opt_["projection"] = projection
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ObjectsGetCall) Fields(s ...googleapi.Field) *ObjectsGetCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *ObjectsGetCall) Do() (*Object, error) {
+	var body io.Reader = nil
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["generation"]; ok {
+		params.Set("generation", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifGenerationMatch"]; ok {
+		params.Set("ifGenerationMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifGenerationNotMatch"]; ok {
+		params.Set("ifGenerationNotMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifMetagenerationMatch"]; ok {
+		params.Set("ifMetagenerationMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifMetagenerationNotMatch"]; ok {
+		params.Set("ifMetagenerationNotMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["projection"]; ok {
+		params.Set("projection", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "b/{bucket}/o/{object}")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"bucket": c.bucket,
+		"object": c.object,
+	})
+	req.Header.Set("User-Agent", c.s.userAgent())
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	var ret *Object
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Retrieves an object or its metadata.",
+	//   "httpMethod": "GET",
+	//   "id": "storage.objects.get",
+	//   "parameterOrder": [
+	//     "bucket",
+	//     "object"
+	//   ],
+	//   "parameters": {
+	//     "bucket": {
+	//       "description": "Name of the bucket in which the object resides.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "generation": {
+	//       "description": "If present, selects a specific revision of this object (as opposed to the latest version, the default).",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifGenerationMatch": {
+	//       "description": "Makes the operation conditional on whether the object's generation matches the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifGenerationNotMatch": {
+	//       "description": "Makes the operation conditional on whether the object's generation does not match the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifMetagenerationMatch": {
+	//       "description": "Makes the operation conditional on whether the object's current metageneration matches the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifMetagenerationNotMatch": {
+	//       "description": "Makes the operation conditional on whether the object's current metageneration does not match the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "object": {
+	//       "description": "Name of the object.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "projection": {
+	//       "description": "Set of properties to return. Defaults to noAcl.",
+	//       "enum": [
+	//         "full",
+	//         "noAcl"
+	//       ],
+	//       "enumDescriptions": [
+	//         "Include all properties.",
+	//         "Omit the acl property."
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "b/{bucket}/o/{object}",
+	//   "response": {
+	//     "$ref": "Object"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/devstorage.full_control",
+	//     "https://www.googleapis.com/auth/devstorage.read_only",
+	//     "https://www.googleapis.com/auth/devstorage.read_write"
+	//   ],
+	//   "supportsMediaDownload": true
+	// }
+
+}
+
+// method id "storage.objects.insert":
+
+type ObjectsInsertCall struct {
+	s          *Service
+	bucket     string
+	object     *Object
+	opt_       map[string]interface{}
+	media_     io.Reader
+	resumable_ googleapi.SizeReaderAt
+	mediaType_ string
+	ctx_       context.Context
+	protocol_  string
+}
+
+// Insert: Stores a new object and metadata.
+func (r *ObjectsService) Insert(bucket string, object *Object) *ObjectsInsertCall {
+	c := &ObjectsInsertCall{s: r.s, opt_: make(map[string]interface{})}
+	c.bucket = bucket
+	c.object = object
+	return c
+}
+
+// ContentEncoding sets the optional parameter "contentEncoding": If
+// set, sets the contentEncoding property of the final object to this
+// value. Setting this parameter is equivalent to setting the
+// contentEncoding metadata property. This can be useful when uploading
+// an object with uploadType=media to indicate the encoding of the
+// content being uploaded.
+func (c *ObjectsInsertCall) ContentEncoding(contentEncoding string) *ObjectsInsertCall {
+	c.opt_["contentEncoding"] = contentEncoding
+	return c
+}
+
+// IfGenerationMatch sets the optional parameter "ifGenerationMatch":
+// Makes the operation conditional on whether the object's current
+// generation matches the given value.
+func (c *ObjectsInsertCall) IfGenerationMatch(ifGenerationMatch int64) *ObjectsInsertCall {
+	c.opt_["ifGenerationMatch"] = ifGenerationMatch
+	return c
+}
+
+// IfGenerationNotMatch sets the optional parameter
+// "ifGenerationNotMatch": Makes the operation conditional on whether
+// the object's current generation does not match the given value.
+func (c *ObjectsInsertCall) IfGenerationNotMatch(ifGenerationNotMatch int64) *ObjectsInsertCall {
+	c.opt_["ifGenerationNotMatch"] = ifGenerationNotMatch
+	return c
+}
+
+// IfMetagenerationMatch sets the optional parameter
+// "ifMetagenerationMatch": Makes the operation conditional on whether
+// the object's current metageneration matches the given value.
+func (c *ObjectsInsertCall) IfMetagenerationMatch(ifMetagenerationMatch int64) *ObjectsInsertCall {
+	c.opt_["ifMetagenerationMatch"] = ifMetagenerationMatch
+	return c
+}
+
+// IfMetagenerationNotMatch sets the optional parameter
+// "ifMetagenerationNotMatch": Makes the operation conditional on
+// whether the object's current metageneration does not match the given
+// value.
+func (c *ObjectsInsertCall) IfMetagenerationNotMatch(ifMetagenerationNotMatch int64) *ObjectsInsertCall {
+	c.opt_["ifMetagenerationNotMatch"] = ifMetagenerationNotMatch
+	return c
+}
+
+// Name sets the optional parameter "name": Name of the object. Required
+// when the object metadata is not otherwise provided. Overrides the
+// object metadata's name value, if any.
+func (c *ObjectsInsertCall) Name(name string) *ObjectsInsertCall {
+	c.opt_["name"] = name
+	return c
+}
+
+// PredefinedAcl sets the optional parameter "predefinedAcl": Apply a
+// predefined set of access controls to this object.
+//
+// Possible values:
+//   "authenticatedRead" - Object owner gets OWNER access, and
+// allAuthenticatedUsers get READER access.
+//   "bucketOwnerFullControl" - Object owner gets OWNER access, and
+// project team owners get OWNER access.
+//   "bucketOwnerRead" - Object owner gets OWNER access, and project
+// team owners get READER access.
+//   "private" - Object owner gets OWNER access.
+//   "projectPrivate" - Object owner gets OWNER access, and project team
+// members get access according to their roles.
+//   "publicRead" - Object owner gets OWNER access, and allUsers get
+// READER access.
+func (c *ObjectsInsertCall) PredefinedAcl(predefinedAcl string) *ObjectsInsertCall {
+	c.opt_["predefinedAcl"] = predefinedAcl
+	return c
+}
+
+// Projection sets the optional parameter "projection": Set of
+// properties to return. Defaults to noAcl, unless the object resource
+// specifies the acl property, when it defaults to full.
+//
+// Possible values:
+//   "full" - Include all properties.
+//   "noAcl" - Omit the acl property.
+func (c *ObjectsInsertCall) Projection(projection string) *ObjectsInsertCall {
+	c.opt_["projection"] = projection
+	return c
+}
+
+// Media specifies the media to upload in a single chunk.
+// At most one of Media and ResumableMedia may be set.
+func (c *ObjectsInsertCall) Media(r io.Reader) *ObjectsInsertCall {
+	c.media_ = r
+	c.protocol_ = "multipart"
+	return c
+}
+
+// ResumableMedia specifies the media to upload in chunks and can be cancelled with ctx.
+// At most one of Media and ResumableMedia may be set.
+// mediaType identifies the MIME media type of the upload, such as "image/png".
+// If mediaType is "", it will be auto-detected.
+func (c *ObjectsInsertCall) ResumableMedia(ctx context.Context, r io.ReaderAt, size int64, mediaType string) *ObjectsInsertCall {
+	c.ctx_ = ctx
+	c.resumable_ = io.NewSectionReader(r, 0, size)
+	c.mediaType_ = mediaType
+	c.protocol_ = "resumable"
+	return c
+}
+
+// ProgressUpdater provides a callback function that will be called after every chunk.
+// It should be a low-latency function in order to not slow down the upload operation.
+// This should only be called when using ResumableMedia (as opposed to Media).
+func (c *ObjectsInsertCall) ProgressUpdater(pu googleapi.ProgressUpdater) *ObjectsInsertCall {
+	c.opt_["progressUpdater"] = pu
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ObjectsInsertCall) Fields(s ...googleapi.Field) *ObjectsInsertCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *ObjectsInsertCall) Do() (*Object, error) {
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.object)
+	if err != nil {
+		return nil, err
+	}
+	ctype := "application/json"
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["contentEncoding"]; ok {
+		params.Set("contentEncoding", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifGenerationMatch"]; ok {
+		params.Set("ifGenerationMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifGenerationNotMatch"]; ok {
+		params.Set("ifGenerationNotMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifMetagenerationMatch"]; ok {
+		params.Set("ifMetagenerationMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifMetagenerationNotMatch"]; ok {
+		params.Set("ifMetagenerationNotMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["name"]; ok {
+		params.Set("name", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["predefinedAcl"]; ok {
+		params.Set("predefinedAcl", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["projection"]; ok {
+		params.Set("projection", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "b/{bucket}/o")
+	var progressUpdater_ googleapi.ProgressUpdater
+	if v, ok := c.opt_["progressUpdater"]; ok {
+		if pu, ok := v.(googleapi.ProgressUpdater); ok {
+			progressUpdater_ = pu
+		}
+	}
+	if c.media_ != nil || c.resumable_ != nil {
+		urls = strings.Replace(urls, "https://www.googleapis.com/", "https://www.googleapis.com/upload/", 1)
+		params.Set("uploadType", c.protocol_)
+	}
+	urls += "?" + params.Encode()
+	if c.protocol_ != "resumable" {
+		var cancel func()
+		cancel, _ = googleapi.ConditionallyIncludeMedia(c.media_, &body, &ctype)
+		if cancel != nil {
+			defer cancel()
+		}
+	}
+	req, _ := http.NewRequest("POST", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"bucket": c.bucket,
+	})
+	if c.protocol_ == "resumable" {
+		if c.mediaType_ == "" {
+			c.mediaType_ = googleapi.DetectMediaType(c.resumable_)
+		}
+		req.Header.Set("X-Upload-Content-Type", c.mediaType_)
+		req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	} else {
+		req.Header.Set("Content-Type", ctype)
+	}
+	req.Header.Set("User-Agent", c.s.userAgent())
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	if c.protocol_ == "resumable" {
+		loc := res.Header.Get("Location")
+		rx := &googleapi.ResumableUpload{
+			Client:        c.s.client,
+			UserAgent:     c.s.userAgent(),
+			URI:           loc,
+			Media:         c.resumable_,
+			MediaType:     c.mediaType_,
+			ContentLength: c.resumable_.Size(),
+			Callback:      progressUpdater_,
+		}
+		res, err = rx.Upload(c.ctx_)
+		if err != nil {
+			return nil, err
+		}
+		defer res.Body.Close()
+	}
+	var ret *Object
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Stores a new object and metadata.",
+	//   "httpMethod": "POST",
+	//   "id": "storage.objects.insert",
+	//   "mediaUpload": {
+	//     "accept": [
+	//       "*/*"
+	//     ],
+	//     "protocols": {
+	//       "resumable": {
+	//         "multipart": true,
+	//         "path": "/resumable/upload/storage/v1/b/{bucket}/o"
+	//       },
+	//       "simple": {
+	//         "multipart": true,
+	//         "path": "/upload/storage/v1/b/{bucket}/o"
+	//       }
+	//     }
+	//   },
+	//   "parameterOrder": [
+	//     "bucket"
+	//   ],
+	//   "parameters": {
+	//     "bucket": {
+	//       "description": "Name of the bucket in which to store the new object. Overrides the provided object metadata's bucket value, if any.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "contentEncoding": {
+	//       "description": "If set, sets the contentEncoding property of the final object to this value. Setting this parameter is equivalent to setting the contentEncoding metadata property. This can be useful when uploading an object with uploadType=media to indicate the encoding of the content being uploaded.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifGenerationMatch": {
+	//       "description": "Makes the operation conditional on whether the object's current generation matches the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifGenerationNotMatch": {
+	//       "description": "Makes the operation conditional on whether the object's current generation does not match the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifMetagenerationMatch": {
+	//       "description": "Makes the operation conditional on whether the object's current metageneration matches the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifMetagenerationNotMatch": {
+	//       "description": "Makes the operation conditional on whether the object's current metageneration does not match the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "name": {
+	//       "description": "Name of the object. Required when the object metadata is not otherwise provided. Overrides the object metadata's name value, if any.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "predefinedAcl": {
+	//       "description": "Apply a predefined set of access controls to this object.",
+	//       "enum": [
+	//         "authenticatedRead",
+	//         "bucketOwnerFullControl",
+	//         "bucketOwnerRead",
+	//         "private",
+	//         "projectPrivate",
+	//         "publicRead"
+	//       ],
+	//       "enumDescriptions": [
+	//         "Object owner gets OWNER access, and allAuthenticatedUsers get READER access.",
+	//         "Object owner gets OWNER access, and project team owners get OWNER access.",
+	//         "Object owner gets OWNER access, and project team owners get READER access.",
+	//         "Object owner gets OWNER access.",
+	//         "Object owner gets OWNER access, and project team members get access according to their roles.",
+	//         "Object owner gets OWNER access, and allUsers get READER access."
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "projection": {
+	//       "description": "Set of properties to return. Defaults to noAcl, unless the object resource specifies the acl property, when it defaults to full.",
+	//       "enum": [
+	//         "full",
+	//         "noAcl"
+	//       ],
+	//       "enumDescriptions": [
+	//         "Include all properties.",
+	//         "Omit the acl property."
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "b/{bucket}/o",
+	//   "request": {
+	//     "$ref": "Object"
+	//   },
+	//   "response": {
+	//     "$ref": "Object"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/devstorage.full_control",
+	//     "https://www.googleapis.com/auth/devstorage.read_write"
+	//   ],
+	//   "supportsMediaDownload": true,
+	//   "supportsMediaUpload": true
+	// }
+
+}
+
+// method id "storage.objects.list":
+
+type ObjectsListCall struct {
+	s      *Service
+	bucket string
+	opt_   map[string]interface{}
+}
+
+// List: Retrieves a list of objects matching the criteria.
+func (r *ObjectsService) List(bucket string) *ObjectsListCall {
+	c := &ObjectsListCall{s: r.s, opt_: make(map[string]interface{})}
+	c.bucket = bucket
+	return c
+}
+
+// Delimiter sets the optional parameter "delimiter": Returns results in
+// a directory-like mode. items will contain only objects whose names,
+// aside from the prefix, do not contain delimiter. Objects whose names,
+// aside from the prefix, contain delimiter will have their name,
+// truncated after the delimiter, returned in prefixes. Duplicate
+// prefixes are omitted.
+func (c *ObjectsListCall) Delimiter(delimiter string) *ObjectsListCall {
+	c.opt_["delimiter"] = delimiter
+	return c
+}
+
+// MaxResults sets the optional parameter "maxResults": Maximum number
+// of items plus prefixes to return. As duplicate prefixes are omitted,
+// fewer total results may be returned than requested. The default value
+// of this parameter is 1,000 items.
+func (c *ObjectsListCall) MaxResults(maxResults int64) *ObjectsListCall {
+	c.opt_["maxResults"] = maxResults
+	return c
+}
+
+// PageToken sets the optional parameter "pageToken": A
+// previously-returned page token representing part of the larger set of
+// results to view.
+func (c *ObjectsListCall) PageToken(pageToken string) *ObjectsListCall {
+	c.opt_["pageToken"] = pageToken
+	return c
+}
+
+// Prefix sets the optional parameter "prefix": Filter results to
+// objects whose names begin with this prefix.
+func (c *ObjectsListCall) Prefix(prefix string) *ObjectsListCall {
+	c.opt_["prefix"] = prefix
+	return c
+}
+
+// Projection sets the optional parameter "projection": Set of
+// properties to return. Defaults to noAcl.
+//
+// Possible values:
+//   "full" - Include all properties.
+//   "noAcl" - Omit the acl property.
+func (c *ObjectsListCall) Projection(projection string) *ObjectsListCall {
+	c.opt_["projection"] = projection
+	return c
+}
+
+// Versions sets the optional parameter "versions": If true, lists all
+// versions of an object as distinct results. The default is false. For
+// more information, see Object Versioning.
+func (c *ObjectsListCall) Versions(versions bool) *ObjectsListCall {
+	c.opt_["versions"] = versions
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ObjectsListCall) Fields(s ...googleapi.Field) *ObjectsListCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *ObjectsListCall) Do() (*Objects, error) {
+	var body io.Reader = nil
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["delimiter"]; ok {
+		params.Set("delimiter", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["maxResults"]; ok {
+		params.Set("maxResults", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["pageToken"]; ok {
+		params.Set("pageToken", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["prefix"]; ok {
+		params.Set("prefix", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["projection"]; ok {
+		params.Set("projection", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["versions"]; ok {
+		params.Set("versions", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "b/{bucket}/o")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"bucket": c.bucket,
+	})
+	req.Header.Set("User-Agent", c.s.userAgent())
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	var ret *Objects
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Retrieves a list of objects matching the criteria.",
+	//   "httpMethod": "GET",
+	//   "id": "storage.objects.list",
+	//   "parameterOrder": [
+	//     "bucket"
+	//   ],
+	//   "parameters": {
+	//     "bucket": {
+	//       "description": "Name of the bucket in which to look for objects.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "delimiter": {
+	//       "description": "Returns results in a directory-like mode. items will contain only objects whose names, aside from the prefix, do not contain delimiter. Objects whose names, aside from the prefix, contain delimiter will have their name, truncated after the delimiter, returned in prefixes. Duplicate prefixes are omitted.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "maxResults": {
+	//       "description": "Maximum number of items plus prefixes to return. As duplicate prefixes are omitted, fewer total results may be returned than requested. The default value of this parameter is 1,000 items.",
+	//       "format": "uint32",
+	//       "location": "query",
+	//       "minimum": "0",
+	//       "type": "integer"
+	//     },
+	//     "pageToken": {
+	//       "description": "A previously-returned page token representing part of the larger set of results to view.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "prefix": {
+	//       "description": "Filter results to objects whose names begin with this prefix.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "projection": {
+	//       "description": "Set of properties to return. Defaults to noAcl.",
+	//       "enum": [
+	//         "full",
+	//         "noAcl"
+	//       ],
+	//       "enumDescriptions": [
+	//         "Include all properties.",
+	//         "Omit the acl property."
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "versions": {
+	//       "description": "If true, lists all versions of an object as distinct results. The default is false. For more information, see Object Versioning.",
+	//       "location": "query",
+	//       "type": "boolean"
+	//     }
+	//   },
+	//   "path": "b/{bucket}/o",
+	//   "response": {
+	//     "$ref": "Objects"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/devstorage.full_control",
+	//     "https://www.googleapis.com/auth/devstorage.read_only",
+	//     "https://www.googleapis.com/auth/devstorage.read_write"
+	//   ],
+	//   "supportsSubscription": true
+	// }
+
+}
+
+// method id "storage.objects.patch":
+
+type ObjectsPatchCall struct {
+	s       *Service
+	bucket  string
+	object  string
+	object2 *Object
+	opt_    map[string]interface{}
+}
+
+// Patch: Updates an object's metadata. This method supports patch
+// semantics.
+func (r *ObjectsService) Patch(bucket string, object string, object2 *Object) *ObjectsPatchCall {
+	c := &ObjectsPatchCall{s: r.s, opt_: make(map[string]interface{})}
+	c.bucket = bucket
+	c.object = object
+	c.object2 = object2
+	return c
+}
+
+// Generation sets the optional parameter "generation": If present,
+// selects a specific revision of this object (as opposed to the latest
+// version, the default).
+func (c *ObjectsPatchCall) Generation(generation int64) *ObjectsPatchCall {
+	c.opt_["generation"] = generation
+	return c
+}
+
+// IfGenerationMatch sets the optional parameter "ifGenerationMatch":
+// Makes the operation conditional on whether the object's current
+// generation matches the given value.
+func (c *ObjectsPatchCall) IfGenerationMatch(ifGenerationMatch int64) *ObjectsPatchCall {
+	c.opt_["ifGenerationMatch"] = ifGenerationMatch
+	return c
+}
+
+// IfGenerationNotMatch sets the optional parameter
+// "ifGenerationNotMatch": Makes the operation conditional on whether
+// the object's current generation does not match the given value.
+func (c *ObjectsPatchCall) IfGenerationNotMatch(ifGenerationNotMatch int64) *ObjectsPatchCall {
+	c.opt_["ifGenerationNotMatch"] = ifGenerationNotMatch
+	return c
+}
+
+// IfMetagenerationMatch sets the optional parameter
+// "ifMetagenerationMatch": Makes the operation conditional on whether
+// the object's current metageneration matches the given value.
+func (c *ObjectsPatchCall) IfMetagenerationMatch(ifMetagenerationMatch int64) *ObjectsPatchCall {
+	c.opt_["ifMetagenerationMatch"] = ifMetagenerationMatch
+	return c
+}
+
+// IfMetagenerationNotMatch sets the optional parameter
+// "ifMetagenerationNotMatch": Makes the operation conditional on
+// whether the object's current metageneration does not match the given
+// value.
+func (c *ObjectsPatchCall) IfMetagenerationNotMatch(ifMetagenerationNotMatch int64) *ObjectsPatchCall {
+	c.opt_["ifMetagenerationNotMatch"] = ifMetagenerationNotMatch
+	return c
+}
+
+// PredefinedAcl sets the optional parameter "predefinedAcl": Apply a
+// predefined set of access controls to this object.
+//
+// Possible values:
+//   "authenticatedRead" - Object owner gets OWNER access, and
+// allAuthenticatedUsers get READER access.
+//   "bucketOwnerFullControl" - Object owner gets OWNER access, and
+// project team owners get OWNER access.
+//   "bucketOwnerRead" - Object owner gets OWNER access, and project
+// team owners get READER access.
+//   "private" - Object owner gets OWNER access.
+//   "projectPrivate" - Object owner gets OWNER access, and project team
+// members get access according to their roles.
+//   "publicRead" - Object owner gets OWNER access, and allUsers get
+// READER access.
+func (c *ObjectsPatchCall) PredefinedAcl(predefinedAcl string) *ObjectsPatchCall {
+	c.opt_["predefinedAcl"] = predefinedAcl
+	return c
+}
+
+// Projection sets the optional parameter "projection": Set of
+// properties to return. Defaults to full.
+//
+// Possible values:
+//   "full" - Include all properties.
+//   "noAcl" - Omit the acl property.
+func (c *ObjectsPatchCall) Projection(projection string) *ObjectsPatchCall {
+	c.opt_["projection"] = projection
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ObjectsPatchCall) Fields(s ...googleapi.Field) *ObjectsPatchCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *ObjectsPatchCall) Do() (*Object, error) {
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.object2)
+	if err != nil {
+		return nil, err
+	}
+	ctype := "application/json"
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["generation"]; ok {
+		params.Set("generation", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifGenerationMatch"]; ok {
+		params.Set("ifGenerationMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifGenerationNotMatch"]; ok {
+		params.Set("ifGenerationNotMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifMetagenerationMatch"]; ok {
+		params.Set("ifMetagenerationMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifMetagenerationNotMatch"]; ok {
+		params.Set("ifMetagenerationNotMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["predefinedAcl"]; ok {
+		params.Set("predefinedAcl", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["projection"]; ok {
+		params.Set("projection", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "b/{bucket}/o/{object}")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("PATCH", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"bucket": c.bucket,
+		"object": c.object,
+	})
+	req.Header.Set("Content-Type", ctype)
+	req.Header.Set("User-Agent", c.s.userAgent())
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	var ret *Object
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Updates an object's metadata. This method supports patch semantics.",
+	//   "httpMethod": "PATCH",
+	//   "id": "storage.objects.patch",
+	//   "parameterOrder": [
+	//     "bucket",
+	//     "object"
+	//   ],
+	//   "parameters": {
+	//     "bucket": {
+	//       "description": "Name of the bucket in which the object resides.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "generation": {
+	//       "description": "If present, selects a specific revision of this object (as opposed to the latest version, the default).",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifGenerationMatch": {
+	//       "description": "Makes the operation conditional on whether the object's current generation matches the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifGenerationNotMatch": {
+	//       "description": "Makes the operation conditional on whether the object's current generation does not match the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifMetagenerationMatch": {
+	//       "description": "Makes the operation conditional on whether the object's current metageneration matches the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifMetagenerationNotMatch": {
+	//       "description": "Makes the operation conditional on whether the object's current metageneration does not match the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "object": {
+	//       "description": "Name of the object.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "predefinedAcl": {
+	//       "description": "Apply a predefined set of access controls to this object.",
+	//       "enum": [
+	//         "authenticatedRead",
+	//         "bucketOwnerFullControl",
+	//         "bucketOwnerRead",
+	//         "private",
+	//         "projectPrivate",
+	//         "publicRead"
+	//       ],
+	//       "enumDescriptions": [
+	//         "Object owner gets OWNER access, and allAuthenticatedUsers get READER access.",
+	//         "Object owner gets OWNER access, and project team owners get OWNER access.",
+	//         "Object owner gets OWNER access, and project team owners get READER access.",
+	//         "Object owner gets OWNER access.",
+	//         "Object owner gets OWNER access, and project team members get access according to their roles.",
+	//         "Object owner gets OWNER access, and allUsers get READER access."
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "projection": {
+	//       "description": "Set of properties to return. Defaults to full.",
+	//       "enum": [
+	//         "full",
+	//         "noAcl"
+	//       ],
+	//       "enumDescriptions": [
+	//         "Include all properties.",
+	//         "Omit the acl property."
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "b/{bucket}/o/{object}",
+	//   "request": {
+	//     "$ref": "Object"
+	//   },
+	//   "response": {
+	//     "$ref": "Object"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/devstorage.full_control",
+	//     "https://www.googleapis.com/auth/devstorage.read_write"
+	//   ]
+	// }
+
+}
+
+// method id "storage.objects.rewrite":
+
+type ObjectsRewriteCall struct {
+	s                 *Service
+	sourceBucket      string
+	sourceObject      string
+	destinationBucket string
+	destinationObject string
+	object            *Object
+	opt_              map[string]interface{}
+}
+
+// Rewrite: Rewrites a source object to a destination object. Optionally
+// overrides metadata.
+func (r *ObjectsService) Rewrite(sourceBucket string, sourceObject string, destinationBucket string, destinationObject string, object *Object) *ObjectsRewriteCall {
+	c := &ObjectsRewriteCall{s: r.s, opt_: make(map[string]interface{})}
+	c.sourceBucket = sourceBucket
+	c.sourceObject = sourceObject
+	c.destinationBucket = destinationBucket
+	c.destinationObject = destinationObject
+	c.object = object
+	return c
+}
+
+// DestinationPredefinedAcl sets the optional parameter
+// "destinationPredefinedAcl": Apply a predefined set of access controls
+// to the destination object.
+//
+// Possible values:
+//   "authenticatedRead" - Object owner gets OWNER access, and
+// allAuthenticatedUsers get READER access.
+//   "bucketOwnerFullControl" - Object owner gets OWNER access, and
+// project team owners get OWNER access.
+//   "bucketOwnerRead" - Object owner gets OWNER access, and project
+// team owners get READER access.
+//   "private" - Object owner gets OWNER access.
+//   "projectPrivate" - Object owner gets OWNER access, and project team
+// members get access according to their roles.
+//   "publicRead" - Object owner gets OWNER access, and allUsers get
+// READER access.
+func (c *ObjectsRewriteCall) DestinationPredefinedAcl(destinationPredefinedAcl string) *ObjectsRewriteCall {
+	c.opt_["destinationPredefinedAcl"] = destinationPredefinedAcl
+	return c
+}
+
+// IfGenerationMatch sets the optional parameter "ifGenerationMatch":
+// Makes the operation conditional on whether the destination object's
+// current generation matches the given value.
+func (c *ObjectsRewriteCall) IfGenerationMatch(ifGenerationMatch int64) *ObjectsRewriteCall {
+	c.opt_["ifGenerationMatch"] = ifGenerationMatch
+	return c
+}
+
+// IfGenerationNotMatch sets the optional parameter
+// "ifGenerationNotMatch": Makes the operation conditional on whether
+// the destination object's current generation does not match the given
+// value.
+func (c *ObjectsRewriteCall) IfGenerationNotMatch(ifGenerationNotMatch int64) *ObjectsRewriteCall {
+	c.opt_["ifGenerationNotMatch"] = ifGenerationNotMatch
+	return c
+}
+
+// IfMetagenerationMatch sets the optional parameter
+// "ifMetagenerationMatch": Makes the operation conditional on whether
+// the destination object's current metageneration matches the given
+// value.
+func (c *ObjectsRewriteCall) IfMetagenerationMatch(ifMetagenerationMatch int64) *ObjectsRewriteCall {
+	c.opt_["ifMetagenerationMatch"] = ifMetagenerationMatch
+	return c
+}
+
+// IfMetagenerationNotMatch sets the optional parameter
+// "ifMetagenerationNotMatch": Makes the operation conditional on
+// whether the destination object's current metageneration does not
+// match the given value.
+func (c *ObjectsRewriteCall) IfMetagenerationNotMatch(ifMetagenerationNotMatch int64) *ObjectsRewriteCall {
+	c.opt_["ifMetagenerationNotMatch"] = ifMetagenerationNotMatch
+	return c
+}
+
+// IfSourceGenerationMatch sets the optional parameter
+// "ifSourceGenerationMatch": Makes the operation conditional on whether
+// the source object's generation matches the given value.
+func (c *ObjectsRewriteCall) IfSourceGenerationMatch(ifSourceGenerationMatch int64) *ObjectsRewriteCall {
+	c.opt_["ifSourceGenerationMatch"] = ifSourceGenerationMatch
+	return c
+}
+
+// IfSourceGenerationNotMatch sets the optional parameter
+// "ifSourceGenerationNotMatch": Makes the operation conditional on
+// whether the source object's generation does not match the given
+// value.
+func (c *ObjectsRewriteCall) IfSourceGenerationNotMatch(ifSourceGenerationNotMatch int64) *ObjectsRewriteCall {
+	c.opt_["ifSourceGenerationNotMatch"] = ifSourceGenerationNotMatch
+	return c
+}
+
+// IfSourceMetagenerationMatch sets the optional parameter
+// "ifSourceMetagenerationMatch": Makes the operation conditional on
+// whether the source object's current metageneration matches the given
+// value.
+func (c *ObjectsRewriteCall) IfSourceMetagenerationMatch(ifSourceMetagenerationMatch int64) *ObjectsRewriteCall {
+	c.opt_["ifSourceMetagenerationMatch"] = ifSourceMetagenerationMatch
+	return c
+}
+
+// IfSourceMetagenerationNotMatch sets the optional parameter
+// "ifSourceMetagenerationNotMatch": Makes the operation conditional on
+// whether the source object's current metageneration does not match the
+// given value.
+func (c *ObjectsRewriteCall) IfSourceMetagenerationNotMatch(ifSourceMetagenerationNotMatch int64) *ObjectsRewriteCall {
+	c.opt_["ifSourceMetagenerationNotMatch"] = ifSourceMetagenerationNotMatch
+	return c
+}
+
+// MaxBytesRewrittenPerCall sets the optional parameter
+// "maxBytesRewrittenPerCall": The maximum number of bytes that will be
+// rewritten per rewrite request. Most callers shouldn't need to specify
+// this parameter - it is primarily in place to support testing. If
+// specified the value must be an integral multiple of 1 MiB (1048576).
+// Also, this only applies to requests where the source and destination
+// span locations and/or storage classes. Finally, this value must not
+// change across rewrite calls else you'll get an error that the
+// rewriteToken is invalid.
+func (c *ObjectsRewriteCall) MaxBytesRewrittenPerCall(maxBytesRewrittenPerCall int64) *ObjectsRewriteCall {
+	c.opt_["maxBytesRewrittenPerCall"] = maxBytesRewrittenPerCall
+	return c
+}
+
+// Projection sets the optional parameter "projection": Set of
+// properties to return. Defaults to noAcl, unless the object resource
+// specifies the acl property, when it defaults to full.
+//
+// Possible values:
+//   "full" - Include all properties.
+//   "noAcl" - Omit the acl property.
+func (c *ObjectsRewriteCall) Projection(projection string) *ObjectsRewriteCall {
+	c.opt_["projection"] = projection
+	return c
+}
+
+// RewriteToken sets the optional parameter "rewriteToken": Include this
+// field (from the previous rewrite response) on each rewrite request
+// after the first one, until the rewrite response 'done' flag is true.
+// Calls that provide a rewriteToken can omit all other request fields,
+// but if included those fields must match the values provided in the
+// first rewrite request.
+func (c *ObjectsRewriteCall) RewriteToken(rewriteToken string) *ObjectsRewriteCall {
+	c.opt_["rewriteToken"] = rewriteToken
+	return c
+}
+
+// SourceGeneration sets the optional parameter "sourceGeneration": If
+// present, selects a specific revision of the source object (as opposed
+// to the latest version, the default).
+func (c *ObjectsRewriteCall) SourceGeneration(sourceGeneration int64) *ObjectsRewriteCall {
+	c.opt_["sourceGeneration"] = sourceGeneration
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ObjectsRewriteCall) Fields(s ...googleapi.Field) *ObjectsRewriteCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *ObjectsRewriteCall) Do() (*RewriteResponse, error) {
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.object)
+	if err != nil {
+		return nil, err
+	}
+	ctype := "application/json"
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["destinationPredefinedAcl"]; ok {
+		params.Set("destinationPredefinedAcl", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifGenerationMatch"]; ok {
+		params.Set("ifGenerationMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifGenerationNotMatch"]; ok {
+		params.Set("ifGenerationNotMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifMetagenerationMatch"]; ok {
+		params.Set("ifMetagenerationMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifMetagenerationNotMatch"]; ok {
+		params.Set("ifMetagenerationNotMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifSourceGenerationMatch"]; ok {
+		params.Set("ifSourceGenerationMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifSourceGenerationNotMatch"]; ok {
+		params.Set("ifSourceGenerationNotMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifSourceMetagenerationMatch"]; ok {
+		params.Set("ifSourceMetagenerationMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifSourceMetagenerationNotMatch"]; ok {
+		params.Set("ifSourceMetagenerationNotMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["maxBytesRewrittenPerCall"]; ok {
+		params.Set("maxBytesRewrittenPerCall", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["projection"]; ok {
+		params.Set("projection", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["rewriteToken"]; ok {
+		params.Set("rewriteToken", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["sourceGeneration"]; ok {
+		params.Set("sourceGeneration", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "b/{sourceBucket}/o/{sourceObject}/rewriteTo/b/{destinationBucket}/o/{destinationObject}")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"sourceBucket":      c.sourceBucket,
+		"sourceObject":      c.sourceObject,
+		"destinationBucket": c.destinationBucket,
+		"destinationObject": c.destinationObject,
+	})
+	req.Header.Set("Content-Type", ctype)
+	req.Header.Set("User-Agent", c.s.userAgent())
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	var ret *RewriteResponse
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Rewrites a source object to a destination object. Optionally overrides metadata.",
+	//   "httpMethod": "POST",
+	//   "id": "storage.objects.rewrite",
+	//   "parameterOrder": [
+	//     "sourceBucket",
+	//     "sourceObject",
+	//     "destinationBucket",
+	//     "destinationObject"
+	//   ],
+	//   "parameters": {
+	//     "destinationBucket": {
+	//       "description": "Name of the bucket in which to store the new object. Overrides the provided object metadata's bucket value, if any.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "destinationObject": {
+	//       "description": "Name of the new object. Required when the object metadata is not otherwise provided. Overrides the object metadata's name value, if any.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "destinationPredefinedAcl": {
+	//       "description": "Apply a predefined set of access controls to the destination object.",
+	//       "enum": [
+	//         "authenticatedRead",
+	//         "bucketOwnerFullControl",
+	//         "bucketOwnerRead",
+	//         "private",
+	//         "projectPrivate",
+	//         "publicRead"
+	//       ],
+	//       "enumDescriptions": [
+	//         "Object owner gets OWNER access, and allAuthenticatedUsers get READER access.",
+	//         "Object owner gets OWNER access, and project team owners get OWNER access.",
+	//         "Object owner gets OWNER access, and project team owners get READER access.",
+	//         "Object owner gets OWNER access.",
+	//         "Object owner gets OWNER access, and project team members get access according to their roles.",
+	//         "Object owner gets OWNER access, and allUsers get READER access."
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifGenerationMatch": {
+	//       "description": "Makes the operation conditional on whether the destination object's current generation matches the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifGenerationNotMatch": {
+	//       "description": "Makes the operation conditional on whether the destination object's current generation does not match the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifMetagenerationMatch": {
+	//       "description": "Makes the operation conditional on whether the destination object's current metageneration matches the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifMetagenerationNotMatch": {
+	//       "description": "Makes the operation conditional on whether the destination object's current metageneration does not match the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifSourceGenerationMatch": {
+	//       "description": "Makes the operation conditional on whether the source object's generation matches the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifSourceGenerationNotMatch": {
+	//       "description": "Makes the operation conditional on whether the source object's generation does not match the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifSourceMetagenerationMatch": {
+	//       "description": "Makes the operation conditional on whether the source object's current metageneration matches the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifSourceMetagenerationNotMatch": {
+	//       "description": "Makes the operation conditional on whether the source object's current metageneration does not match the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "maxBytesRewrittenPerCall": {
+	//       "description": "The maximum number of bytes that will be rewritten per rewrite request. Most callers shouldn't need to specify this parameter - it is primarily in place to support testing. If specified the value must be an integral multiple of 1 MiB (1048576). Also, this only applies to requests where the source and destination span locations and/or storage classes. Finally, this value must not change across rewrite calls else you'll get an error that the rewriteToken is invalid.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "projection": {
+	//       "description": "Set of properties to return. Defaults to noAcl, unless the object resource specifies the acl property, when it defaults to full.",
+	//       "enum": [
+	//         "full",
+	//         "noAcl"
+	//       ],
+	//       "enumDescriptions": [
+	//         "Include all properties.",
+	//         "Omit the acl property."
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "rewriteToken": {
+	//       "description": "Include this field (from the previous rewrite response) on each rewrite request after the first one, until the rewrite response 'done' flag is true. Calls that provide a rewriteToken can omit all other request fields, but if included those fields must match the values provided in the first rewrite request.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "sourceBucket": {
+	//       "description": "Name of the bucket in which to find the source object.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "sourceGeneration": {
+	//       "description": "If present, selects a specific revision of the source object (as opposed to the latest version, the default).",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "sourceObject": {
+	//       "description": "Name of the source object.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "b/{sourceBucket}/o/{sourceObject}/rewriteTo/b/{destinationBucket}/o/{destinationObject}",
+	//   "request": {
+	//     "$ref": "Object"
+	//   },
+	//   "response": {
+	//     "$ref": "RewriteResponse"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/devstorage.full_control",
+	//     "https://www.googleapis.com/auth/devstorage.read_write"
+	//   ]
+	// }
+
+}
+
+// method id "storage.objects.update":
+
+type ObjectsUpdateCall struct {
+	s       *Service
+	bucket  string
+	object  string
+	object2 *Object
+	opt_    map[string]interface{}
+}
+
+// Update: Updates an object's metadata.
+func (r *ObjectsService) Update(bucket string, object string, object2 *Object) *ObjectsUpdateCall {
+	c := &ObjectsUpdateCall{s: r.s, opt_: make(map[string]interface{})}
+	c.bucket = bucket
+	c.object = object
+	c.object2 = object2
+	return c
+}
+
+// Generation sets the optional parameter "generation": If present,
+// selects a specific revision of this object (as opposed to the latest
+// version, the default).
+func (c *ObjectsUpdateCall) Generation(generation int64) *ObjectsUpdateCall {
+	c.opt_["generation"] = generation
+	return c
+}
+
+// IfGenerationMatch sets the optional parameter "ifGenerationMatch":
+// Makes the operation conditional on whether the object's current
+// generation matches the given value.
+func (c *ObjectsUpdateCall) IfGenerationMatch(ifGenerationMatch int64) *ObjectsUpdateCall {
+	c.opt_["ifGenerationMatch"] = ifGenerationMatch
+	return c
+}
+
+// IfGenerationNotMatch sets the optional parameter
+// "ifGenerationNotMatch": Makes the operation conditional on whether
+// the object's current generation does not match the given value.
+func (c *ObjectsUpdateCall) IfGenerationNotMatch(ifGenerationNotMatch int64) *ObjectsUpdateCall {
+	c.opt_["ifGenerationNotMatch"] = ifGenerationNotMatch
+	return c
+}
+
+// IfMetagenerationMatch sets the optional parameter
+// "ifMetagenerationMatch": Makes the operation conditional on whether
+// the object's current metageneration matches the given value.
+func (c *ObjectsUpdateCall) IfMetagenerationMatch(ifMetagenerationMatch int64) *ObjectsUpdateCall {
+	c.opt_["ifMetagenerationMatch"] = ifMetagenerationMatch
+	return c
+}
+
+// IfMetagenerationNotMatch sets the optional parameter
+// "ifMetagenerationNotMatch": Makes the operation conditional on
+// whether the object's current metageneration does not match the given
+// value.
+func (c *ObjectsUpdateCall) IfMetagenerationNotMatch(ifMetagenerationNotMatch int64) *ObjectsUpdateCall {
+	c.opt_["ifMetagenerationNotMatch"] = ifMetagenerationNotMatch
+	return c
+}
+
+// PredefinedAcl sets the optional parameter "predefinedAcl": Apply a
+// predefined set of access controls to this object.
+//
+// Possible values:
+//   "authenticatedRead" - Object owner gets OWNER access, and
+// allAuthenticatedUsers get READER access.
+//   "bucketOwnerFullControl" - Object owner gets OWNER access, and
+// project team owners get OWNER access.
+//   "bucketOwnerRead" - Object owner gets OWNER access, and project
+// team owners get READER access.
+//   "private" - Object owner gets OWNER access.
+//   "projectPrivate" - Object owner gets OWNER access, and project team
+// members get access according to their roles.
+//   "publicRead" - Object owner gets OWNER access, and allUsers get
+// READER access.
+func (c *ObjectsUpdateCall) PredefinedAcl(predefinedAcl string) *ObjectsUpdateCall {
+	c.opt_["predefinedAcl"] = predefinedAcl
+	return c
+}
+
+// Projection sets the optional parameter "projection": Set of
+// properties to return. Defaults to full.
+//
+// Possible values:
+//   "full" - Include all properties.
+//   "noAcl" - Omit the acl property.
+func (c *ObjectsUpdateCall) Projection(projection string) *ObjectsUpdateCall {
+	c.opt_["projection"] = projection
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ObjectsUpdateCall) Fields(s ...googleapi.Field) *ObjectsUpdateCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *ObjectsUpdateCall) Do() (*Object, error) {
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.object2)
+	if err != nil {
+		return nil, err
+	}
+	ctype := "application/json"
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["generation"]; ok {
+		params.Set("generation", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifGenerationMatch"]; ok {
+		params.Set("ifGenerationMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifGenerationNotMatch"]; ok {
+		params.Set("ifGenerationNotMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifMetagenerationMatch"]; ok {
+		params.Set("ifMetagenerationMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["ifMetagenerationNotMatch"]; ok {
+		params.Set("ifMetagenerationNotMatch", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["predefinedAcl"]; ok {
+		params.Set("predefinedAcl", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["projection"]; ok {
+		params.Set("projection", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "b/{bucket}/o/{object}")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("PUT", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"bucket": c.bucket,
+		"object": c.object,
+	})
+	req.Header.Set("Content-Type", ctype)
+	req.Header.Set("User-Agent", c.s.userAgent())
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	var ret *Object
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Updates an object's metadata.",
+	//   "httpMethod": "PUT",
+	//   "id": "storage.objects.update",
+	//   "parameterOrder": [
+	//     "bucket",
+	//     "object"
+	//   ],
+	//   "parameters": {
+	//     "bucket": {
+	//       "description": "Name of the bucket in which the object resides.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "generation": {
+	//       "description": "If present, selects a specific revision of this object (as opposed to the latest version, the default).",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifGenerationMatch": {
+	//       "description": "Makes the operation conditional on whether the object's current generation matches the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifGenerationNotMatch": {
+	//       "description": "Makes the operation conditional on whether the object's current generation does not match the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifMetagenerationMatch": {
+	//       "description": "Makes the operation conditional on whether the object's current metageneration matches the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "ifMetagenerationNotMatch": {
+	//       "description": "Makes the operation conditional on whether the object's current metageneration does not match the given value.",
+	//       "format": "int64",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "object": {
+	//       "description": "Name of the object.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "predefinedAcl": {
+	//       "description": "Apply a predefined set of access controls to this object.",
+	//       "enum": [
+	//         "authenticatedRead",
+	//         "bucketOwnerFullControl",
+	//         "bucketOwnerRead",
+	//         "private",
+	//         "projectPrivate",
+	//         "publicRead"
+	//       ],
+	//       "enumDescriptions": [
+	//         "Object owner gets OWNER access, and allAuthenticatedUsers get READER access.",
+	//         "Object owner gets OWNER access, and project team owners get OWNER access.",
+	//         "Object owner gets OWNER access, and project team owners get READER access.",
+	//         "Object owner gets OWNER access.",
+	//         "Object owner gets OWNER access, and project team members get access according to their roles.",
+	//         "Object owner gets OWNER access, and allUsers get READER access."
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "projection": {
+	//       "description": "Set of properties to return. Defaults to full.",
+	//       "enum": [
+	//         "full",
+	//         "noAcl"
+	//       ],
+	//       "enumDescriptions": [
+	//         "Include all properties.",
+	//         "Omit the acl property."
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "b/{bucket}/o/{object}",
+	//   "request": {
+	//     "$ref": "Object"
+	//   },
+	//   "response": {
+	//     "$ref": "Object"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/devstorage.full_control",
+	//     "https://www.googleapis.com/auth/devstorage.read_write"
+	//   ],
+	//   "supportsMediaDownload": true
+	// }
+
+}
+
+// method id "storage.objects.watchAll":
+
+type ObjectsWatchAllCall struct {
+	s       *Service
+	bucket  string
+	channel *Channel
+	opt_    map[string]interface{}
+}
+
+// WatchAll: Watch for changes on all objects in a bucket.
+func (r *ObjectsService) WatchAll(bucket string, channel *Channel) *ObjectsWatchAllCall {
+	c := &ObjectsWatchAllCall{s: r.s, opt_: make(map[string]interface{})}
+	c.bucket = bucket
+	c.channel = channel
+	return c
+}
+
+// Delimiter sets the optional parameter "delimiter": Returns results in
+// a directory-like mode. items will contain only objects whose names,
+// aside from the prefix, do not contain delimiter. Objects whose names,
+// aside from the prefix, contain delimiter will have their name,
+// truncated after the delimiter, returned in prefixes. Duplicate
+// prefixes are omitted.
+func (c *ObjectsWatchAllCall) Delimiter(delimiter string) *ObjectsWatchAllCall {
+	c.opt_["delimiter"] = delimiter
+	return c
+}
+
+// MaxResults sets the optional parameter "maxResults": Maximum number
+// of items plus prefixes to return. As duplicate prefixes are omitted,
+// fewer total results may be returned than requested. The default value
+// of this parameter is 1,000 items.
+func (c *ObjectsWatchAllCall) MaxResults(maxResults int64) *ObjectsWatchAllCall {
+	c.opt_["maxResults"] = maxResults
+	return c
+}
+
+// PageToken sets the optional parameter "pageToken": A
+// previously-returned page token representing part of the larger set of
+// results to view.
+func (c *ObjectsWatchAllCall) PageToken(pageToken string) *ObjectsWatchAllCall {
+	c.opt_["pageToken"] = pageToken
+	return c
+}
+
+// Prefix sets the optional parameter "prefix": Filter results to
+// objects whose names begin with this prefix.
+func (c *ObjectsWatchAllCall) Prefix(prefix string) *ObjectsWatchAllCall {
+	c.opt_["prefix"] = prefix
+	return c
+}
+
+// Projection sets the optional parameter "projection": Set of
+// properties to return. Defaults to noAcl.
+//
+// Possible values:
+//   "full" - Include all properties.
+//   "noAcl" - Omit the acl property.
+func (c *ObjectsWatchAllCall) Projection(projection string) *ObjectsWatchAllCall {
+	c.opt_["projection"] = projection
+	return c
+}
+
+// Versions sets the optional parameter "versions": If true, lists all
+// versions of an object as distinct results. The default is false. For
+// more information, see Object Versioning.
+func (c *ObjectsWatchAllCall) Versions(versions bool) *ObjectsWatchAllCall {
+	c.opt_["versions"] = versions
+	return c
+}
+
+// Fields allows partial responses to be retrieved.
+// See https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ObjectsWatchAllCall) Fields(s ...googleapi.Field) *ObjectsWatchAllCall {
+	c.opt_["fields"] = googleapi.CombineFields(s)
+	return c
+}
+
+func (c *ObjectsWatchAllCall) Do() (*Channel, error) {
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.channel)
+	if err != nil {
+		return nil, err
+	}
+	ctype := "application/json"
+	params := make(url.Values)
+	params.Set("alt", "json")
+	if v, ok := c.opt_["delimiter"]; ok {
+		params.Set("delimiter", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["maxResults"]; ok {
+		params.Set("maxResults", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["pageToken"]; ok {
+		params.Set("pageToken", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["prefix"]; ok {
+		params.Set("prefix", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["projection"]; ok {
+		params.Set("projection", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["versions"]; ok {
+		params.Set("versions", fmt.Sprintf("%v", v))
+	}
+	if v, ok := c.opt_["fields"]; ok {
+		params.Set("fields", fmt.Sprintf("%v", v))
+	}
+	urls := googleapi.ResolveRelative(c.s.BasePath, "b/{bucket}/o/watch")
+	urls += "?" + params.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	googleapi.Expand(req.URL, map[string]string{
+		"bucket": c.bucket,
+	})
+	req.Header.Set("Content-Type", ctype)
+	req.Header.Set("User-Agent", c.s.userAgent())
+	res, err := c.s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	var ret *Channel
+	if err := json.NewDecoder(res.Body).Decode(&ret); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Watch for changes on all objects in a bucket.",
+	//   "httpMethod": "POST",
+	//   "id": "storage.objects.watchAll",
+	//   "parameterOrder": [
+	//     "bucket"
+	//   ],
+	//   "parameters": {
+	//     "bucket": {
+	//       "description": "Name of the bucket in which to look for objects.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "delimiter": {
+	//       "description": "Returns results in a directory-like mode. items will contain only objects whose names, aside from the prefix, do not contain delimiter. Objects whose names, aside from the prefix, contain delimiter will have their name, truncated after the delimiter, returned in prefixes. Duplicate prefixes are omitted.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "maxResults": {
+	//       "description": "Maximum number of items plus prefixes to return. As duplicate prefixes are omitted, fewer total results may be returned than requested. The default value of this parameter is 1,000 items.",
+	//       "format": "uint32",
+	//       "location": "query",
+	//       "minimum": "0",
+	//       "type": "integer"
+	//     },
+	//     "pageToken": {
+	//       "description": "A previously-returned page token representing part of the larger set of results to view.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "prefix": {
+	//       "description": "Filter results to objects whose names begin with this prefix.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "projection": {
+	//       "description": "Set of properties to return. Defaults to noAcl.",
+	//       "enum": [
+	//         "full",
+	//         "noAcl"
+	//       ],
+	//       "enumDescriptions": [
+	//         "Include all properties.",
+	//         "Omit the acl property."
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "versions": {
+	//       "description": "If true, lists all versions of an object as distinct results. The default is false. For more information, see Object Versioning.",
+	//       "location": "query",
+	//       "type": "boolean"
+	//     }
+	//   },
+	//   "path": "b/{bucket}/o/watch",
+	//   "request": {
+	//     "$ref": "Channel",
+	//     "parameterName": "resource"
+	//   },
+	//   "response": {
+	//     "$ref": "Channel"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/devstorage.full_control",
+	//     "https://www.googleapis.com/auth/devstorage.read_only",
+	//     "https://www.googleapis.com/auth/devstorage.read_write"
+	//   ],
+	//   "supportsSubscription": true
+	// }
+
+}

--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/util/storage"
 )
 
 // Interface is an abstract, pluggable interface for cloud providers.
@@ -37,6 +38,8 @@ type Interface interface {
 	Clusters() (Clusters, bool)
 	// Routes returns a routes interface along with whether the interface is supported.
 	Routes() (Routes, bool)
+	// Storage returns a storage interface along with whether the interface is supported.
+	Storage() (storage.Interface, bool)
 	// ProviderName returns the cloud provider ID.
 	ProviderName() string
 	// ScrubDNS provides an opportunity for cloud-provider-specific code to process DNS settings for pods.

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/util/storage"
 
 	"github.com/golang/glog"
 )
@@ -2108,4 +2109,8 @@ func (s *AWSCloud) addFilters(filters []*ec2.Filter) []*ec2.Filter {
 		filters = append(filters, newEc2Filter("tag:"+k, v))
 	}
 	return filters
+}
+
+func (s *AWSCloud) Storage() (storage.Interface, bool) {
+	return nil, false
 }

--- a/pkg/cloudprovider/providers/fake/fake.go
+++ b/pkg/cloudprovider/providers/fake/fake.go
@@ -19,12 +19,15 @@ package fake
 import (
 	"errors"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net"
 	"regexp"
 	"sync"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/cloudprovider"
+	"k8s.io/kubernetes/pkg/util"
 )
 
 const ProviderName = "fake"
@@ -59,6 +62,7 @@ type FakeCloud struct {
 	Balancers     map[string]FakeBalancer
 	UpdateCalls   []FakeUpdateBalancerCall
 	RouteMap      map[string]*FakeRoute
+	Uploads       map[string][]byte
 	Lock          sync.Mutex
 	cloudprovider.Zone
 }
@@ -247,5 +251,18 @@ func (f *FakeCloud) DeleteRoute(clusterName string, route *cloudprovider.Route) 
 		return f.Err
 	}
 	delete(f.RouteMap, name)
+	return nil
+}
+
+func (f *FakeCloud) Storage() (storage.Interface, error) {
+	return f, nil
+}
+
+func (f *FakeCloud) UploadBlob(blobName string, stream io.Reader) error {
+	data, err := ioutil.ReadAll(stream)
+	if err != nil {
+		return err
+	}
+	f.Uploads[blobName] = data
 	return nil
 }

--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -31,7 +31,9 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	utilerrors "k8s.io/kubernetes/pkg/util/errors"
+	"k8s.io/kubernetes/pkg/util/exec"
 	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/util/storage"
 	"k8s.io/kubernetes/pkg/util/wait"
 
 	"github.com/golang/glog"
@@ -41,6 +43,7 @@ import (
 	compute "google.golang.org/api/compute/v1"
 	container "google.golang.org/api/container/v1beta1"
 	"google.golang.org/api/googleapi"
+	gcs_storage "google.golang.org/api/storage/v1"
 	"google.golang.org/cloud/compute/metadata"
 )
 
@@ -64,6 +67,7 @@ const (
 type GCECloud struct {
 	service          *compute.Service
 	containerService *container.Service
+	storageService   *gcs_storage.Service
 	projectID        string
 	zone             string
 	instanceID       string
@@ -82,6 +86,12 @@ type Config struct {
 
 func init() {
 	cloudprovider.RegisterCloudProvider(ProviderName, func(config io.Reader) (cloudprovider.Interface, error) { return newGCECloud(config) })
+}
+
+// returns true if we are running on a GCE VM
+func onGCE() bool {
+	addrs, err := net.LookupHost("metadata.google.internal")
+	return err == nil && len(addrs) > 0
 }
 
 func getProjectAndZone() (string, string, error) {
@@ -135,27 +145,33 @@ func getNetworkName() (string, error) {
 
 // newGCECloud creates a new instance of GCECloud.
 func newGCECloud(config io.Reader) (*GCECloud, error) {
-	projectID, zone, err := getProjectAndZone()
+	var projectID, zone, instanceID, externalID, networkURL string
+	var err error
+	if onGCE() {
+		if projectID, zone, err = getProjectAndZone(); err != nil {
+			return nil, err
+		}
+		if instanceID, err = getInstanceID(); err != nil {
+			return nil, err
+		}
+		if externalID, err = getCurrentExternalID(); err != nil {
+			return nil, err
+		}
+		var networkName string
+		if networkName, err = getNetworkName(); err != nil {
+			return nil, err
+		}
+		networkURL = gceNetworkURL(projectID, networkName)
+	} else {
+		gcloud := &GCloud{exec.New()}
+		if projectID, zone, err = gcloud.getProjectAndZone(); err != nil {
+			return nil, err
+		}
+	}
+	tokenSource, err := google.DefaultTokenSource(oauth2.NoContext)
 	if err != nil {
 		return nil, err
 	}
-	// TODO: if we want to use this on a machine that doesn't have the http://metadata server
-	// e.g. on a user's machine (not VM) somewhere, we need to have an alternative for
-	// instance id lookup.
-	instanceID, err := getInstanceID()
-	if err != nil {
-		return nil, err
-	}
-	externalID, err := getCurrentExternalID()
-	if err != nil {
-		return nil, err
-	}
-	networkName, err := getNetworkName()
-	if err != nil {
-		return nil, err
-	}
-	networkURL := gceNetworkURL(projectID, networkName)
-	tokenSource := google.ComputeTokenSource("")
 	if config != nil {
 		var cfg Config
 		if err := gcfg.ReadInto(&cfg, config); err != nil {
@@ -185,9 +201,14 @@ func newGCECloud(config io.Reader) (*GCECloud, error) {
 	if err != nil {
 		return nil, err
 	}
+	storageSvc, err := gcs_storage.New(client)
+	if err != nil {
+		return nil, err
+	}
 	return &GCECloud{
 		service:          svc,
 		containerService: containerSvc,
+		storageService:   storageSvc,
 		projectID:        projectID,
 		zone:             zone,
 		instanceID:       instanceID,
@@ -663,6 +684,9 @@ func (gce *GCECloud) updateFirewall(name, region, ipAddress string, ports []*api
 }
 
 func (gce *GCECloud) firewallObject(name, region, ipAddress string, ports []*api.ServicePort, hosts []string) (*compute.Firewall, error) {
+	if len(gce.networkURL) == 0 {
+		return nil, fmt.Errorf("unknown network")
+	}
 	allowedPorts := make([]string, len(ports))
 	for ix := range ports {
 		allowedPorts[ix] = strconv.Itoa(ports[ix].Port)
@@ -1369,6 +1393,9 @@ func (gce *GCECloud) NodeAddresses(_ string) ([]api.NodeAddress, error) {
 }
 
 func (gce *GCECloud) isCurrentInstance(instance string) bool {
+	if len(gce.instanceID) == 0 {
+		return false
+	}
 	return gce.instanceID == canonicalizeInstanceName(instance)
 }
 
@@ -1424,6 +1451,9 @@ func truncateClusterName(clusterName string) string {
 }
 
 func (gce *GCECloud) ListRoutes(clusterName string) ([]*cloudprovider.Route, error) {
+	if len(gce.networkURL) == 0 {
+		return nil, fmt.Errorf("unknown network")
+	}
 	listCall := gce.service.Routes.List(gce.projectID)
 
 	prefix := truncateClusterName(clusterName)
@@ -1458,6 +1488,9 @@ func gceNetworkURL(project, network string) string {
 }
 
 func (gce *GCECloud) CreateRoute(clusterName string, nameHint string, route *cloudprovider.Route) error {
+	if len(gce.networkURL) == 0 {
+		return fmt.Errorf("unknown network")
+	}
 	routeName := truncateClusterName(clusterName) + "-" + nameHint
 
 	instanceName := canonicalizeInstanceName(route.TargetInstance)
@@ -1495,6 +1528,9 @@ func (gce *GCECloud) GetZone() (cloudprovider.Zone, error) {
 }
 
 func (gce *GCECloud) AttachDisk(diskName string, readOnly bool) error {
+	if len(gce.instanceID) == 0 {
+		return fmt.Errorf("current instance id is unknown.")
+	}
 	disk, err := gce.getDisk(diskName)
 	if err != nil {
 		return err
@@ -1514,6 +1550,9 @@ func (gce *GCECloud) AttachDisk(diskName string, readOnly bool) error {
 }
 
 func (gce *GCECloud) DetachDisk(devicePath string) error {
+	if len(gce.instanceID) == 0 {
+		return fmt.Errorf("current instance id is unknown.")
+	}
 	detachOp, err := gce.service.Instances.DetachDisk(gce.projectID, gce.zone, gce.instanceID, devicePath).Do()
 	if err != nil {
 		return err
@@ -1563,4 +1602,27 @@ func (gce *GCECloud) ListClusters() ([]string, error) {
 
 func (gce *GCECloud) Master(clusterName string) (string, error) {
 	return "k8s-" + clusterName + "-master.internal", nil
+}
+
+func (s *GCECloud) Storage() (storage.Interface, bool) {
+	return s, true
+}
+
+func (s *GCECloud) UploadBlob(blobName string, stream io.Reader) error {
+	parts := strings.SplitN(blobName, "/", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid blobName: expected at least <bucket>/<file> saw %s", blobName)
+	}
+	bucket := parts[0]
+	file := parts[1]
+	_, err := s.storageService.Buckets.Get(bucket).Do()
+	if err != nil && isHTTPErrorCode(err, http.StatusNotFound) {
+		_, err = s.storageService.Buckets.Insert(s.projectID, &gcs_storage.Bucket{Name: bucket}).Do()
+	}
+	if err != nil {
+		return err
+	}
+	object := &gcs_storage.Object{Name: file}
+	_, err = s.storageService.Objects.Insert(bucket, object).Media(stream).Do()
+	return err
 }

--- a/pkg/cloudprovider/providers/gce/gcloud.go
+++ b/pkg/cloudprovider/providers/gce/gcloud.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gce
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"strings"
+
+	"k8s.io/kubernetes/pkg/util/exec"
+)
+
+// GCloud knows how to use the gcloud command line tool to discover things about the GCE environment
+type GCloud struct {
+	e exec.Interface
+}
+
+func (g *GCloud) getProjectAndZone() (string, string, error) {
+	data, err := g.e.Command("gcloud", "config", "list").CombinedOutput()
+	if err != nil {
+		return "", "", err
+	}
+
+	// Ugh, this isn't the best parser, but gcfg is too picky and requires all fields to be
+	// present which is brittle.
+	scanner := bufio.NewScanner(bytes.NewBuffer(data))
+	project := ""
+	zone := ""
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		// skip sections
+		if strings.HasPrefix(line, "[") {
+			continue
+		}
+		// skip things w/o '='
+		if strings.Index(line, "=") == -1 {
+			continue
+		}
+
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			return "", "", fmt.Errorf("unexpected format: %s", line)
+		}
+		property := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+		switch property {
+		case "project":
+			project = value
+		case "zone":
+			zone = value
+		}
+	}
+	return project, zone, nil
+}

--- a/pkg/cloudprovider/providers/mesos/mesos.go
+++ b/pkg/cloudprovider/providers/mesos/mesos.go
@@ -28,6 +28,7 @@ import (
 	"golang.org/x/net/context"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/cloudprovider"
+	"k8s.io/kubernetes/pkg/util/storage"
 )
 
 const (
@@ -275,4 +276,8 @@ func (c *MesosCloud) NodeAddresses(name string) ([]api.NodeAddress, error) {
 		return nil, err
 	}
 	return []api.NodeAddress{{Type: api.NodeLegacyHostIP, Address: ip.String()}}, nil
+}
+
+func (s *MesosCloud) Storage() (storage.Interface, bool) {
+	return nil, false
 }

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/cloudprovider"
+	"k8s.io/kubernetes/pkg/util/storage"
 )
 
 const ProviderName = "openstack"
@@ -925,4 +926,8 @@ func (os *OpenStack) getComputeIDbyHostname(cClient *gophercloud.ServiceClient) 
 		}
 	}
 	return "", fmt.Errorf("No server found matching hostname: %s", hostname)
+}
+
+func (s *OpenStack) Storage() (storage.Interface, bool) {
+	return nil, false
 }

--- a/pkg/cloudprovider/providers/ovirt/ovirt.go
+++ b/pkg/cloudprovider/providers/ovirt/ovirt.go
@@ -32,6 +32,7 @@ import (
 	"github.com/scalingdata/gcfg"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/cloudprovider"
+	"k8s.io/kubernetes/pkg/util/storage"
 )
 
 const ProviderName = "ovirt"
@@ -283,4 +284,8 @@ func (v *OVirtCloud) CurrentNodeName(hostname string) (string, error) {
 
 func (v *OVirtCloud) AddSSHKeyToAllInstances(user string, keyData []byte) error {
 	return errors.New("unimplemented")
+}
+
+func (s *OVirtCloud) Storage() (storage.Interface, bool) {
+	return nil, false
 }

--- a/pkg/cloudprovider/providers/rackspace/rackspace.go
+++ b/pkg/cloudprovider/providers/rackspace/rackspace.go
@@ -34,6 +34,7 @@ import (
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/cloudprovider"
+	"k8s.io/kubernetes/pkg/util/storage"
 )
 
 const ProviderName = "rackspace"
@@ -385,4 +386,8 @@ func (os *Rackspace) GetZone() (cloudprovider.Zone, error) {
 	glog.V(1).Infof("Current zone is %v", os.region)
 
 	return cloudprovider.Zone{Region: os.region}, nil
+}
+
+func (s *Rackspace) Storage() (storage.Interface, bool) {
+	return nil, false
 }

--- a/pkg/cloudprovider/providers/vagrant/vagrant.go
+++ b/pkg/cloudprovider/providers/vagrant/vagrant.go
@@ -29,6 +29,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/cloudprovider"
+	"k8s.io/kubernetes/pkg/util/storage"
 )
 
 const ProviderName = "vagrant"
@@ -269,4 +270,8 @@ func (v *VagrantCloud) List(filter string) ([]string, error) {
 	}
 
 	return instances, nil
+}
+
+func (s *VagrantCloud) Storage() (storage.Interface, bool) {
+	return nil, false
 }

--- a/pkg/util/storage/doc.go
+++ b/pkg/util/storage/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package storage implements functions related to storing things out onto storage devices
+package storage

--- a/pkg/util/storage/storage.go
+++ b/pkg/util/storage/storage.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"io"
+)
+
+type Interface interface {
+	UploadBlob(blobName string, stream io.Reader) error
+}


### PR DESCRIPTION
This is necessary so that we can use kubectl to automatically upload local files that containers can just use.

Related to https://github.com/kubernetes/kubernetes/pull/15926

See https://github.com/kubernetes/kubernetes/pull/16010 for usage of Storage
