### PR TITLE
WIP: improve experience to make secrets

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -308,4 +308,5 @@ terminated-pod-gc-threshold
 reconcile-cidr
 register-schedulable
 repair-malformed-updates
-
+from-file
+from-literal

--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/golang/glog"
 	cmdconfig "k8s.io/kubernetes/pkg/kubectl/cmd/config"
+	cmdsecret "k8s.io/kubernetes/pkg/kubectl/cmd/secret"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/util"
 
@@ -177,6 +178,7 @@ Find more information at https://github.com/kubernetes/kubernetes.`,
 	cmds.AddCommand(NewCmdExplain(f, out))
 	cmds.AddCommand(NewCmdConvert(f, out))
 
+	cmds.AddCommand(cmdsecret.NewCmdSecret(f, out))
 	return cmds
 }
 

--- a/pkg/kubectl/cmd/cmd_test.go
+++ b/pkg/kubectl/cmd/cmd_test.go
@@ -198,6 +198,7 @@ func NewAPIFactory() (*cmdutil.Factory, *testFactory, runtime.Codec) {
 		"service/v1":   kubectl.ServiceGeneratorV1{},
 		"service/v2":   kubectl.ServiceGeneratorV2{},
 		"service/test": testServiceGenerator{},
+		"secret/v1":    kubectl.SecretGeneratorV1{},
 	}
 	f := &cmdutil.Factory{
 		Object: func() (meta.RESTMapper, runtime.ObjectTyper) {

--- a/pkg/kubectl/cmd/secret/make.go
+++ b/pkg/kubectl/cmd/secret/make.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package secret
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+	"k8s.io/kubernetes/pkg/kubectl"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/kubectl/resource"
+)
+
+const (
+	makeLong = `
+Create a secret based on a file, directory, or specified literal value
+
+Key files can be specified using their file path, in which case a default name will be given to them, or optionally 
+with a name and file path, in which case the given name will be used. Specifying a directory will create a secret 
+using with all valid keys in that directory.
+`
+
+	makeExample = `  // Create a new secret named my-secret with keys for each file in folder bar
+  $ kubectl secret make my-secret --from-file=path/to/bar
+
+  // Create a new secret named my-secret with specified keys instead of names on disk
+  $ kubectl secret make my-secret --from-file=ssh-privatekey=~/.ssh/id_rsa --from-file=ssh-publickey=~/.ssh/id_rsa.pub
+
+  // Create a new secret named my-secret with key1=supersecret and key2=topsecret
+  $ kubectl secret make my-secret --from-literal=key1=supersecret --from-literal=key2=topsecret`
+)
+
+// TODO: --quiet -q to suppress warnings on ignored files
+func NewCmdMakeSecret(f *cmdutil.Factory, cmdOut io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "make NAME [--from-file=[key=]source] [--from-literal=key1=value1] [--dry-run=bool]",
+		Short:   "Make a secret from a local file, directory or literal value.",
+		Long:    makeLong,
+		Example: makeExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			err := MakeSecret(f, cmdOut, cmd, args)
+			cmdutil.CheckErr(err)
+		},
+	}
+	cmdutil.AddPrinterFlags(cmd)
+	cmd.Flags().String("generator", "", "The name of the API generator to use.  If not specified, default to secret/v1")
+	cmd.Flags().StringSlice("from-file", []string{}, "Key files can be specified using their file path, in which case a default name will be given to them, or optionally with a name and file path, in which case the given name will be used.  Specifying a directory will iterate each named file in the directory that is a valid secret key.")
+	cmd.Flags().StringSlice("from-literal", []string{}, "Specify a key and literal value to insert in secret (i.e. mykey=somevalue)")
+	cmd.Flags().String("type", "", "The type of secret to make")
+	cmd.Flags().Bool("dry-run", false, "If true, only print the object that would be sent, without sending it.")
+	return cmd
+}
+
+func MakeSecret(f *cmdutil.Factory, cmdOut io.Writer, cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return cmdutil.UsageError(cmd, "NAME is required for make")
+	}
+
+	namespace, _, err := f.DefaultNamespace()
+	if err != nil {
+		return err
+	}
+
+	generatorName := cmdutil.GetFlagString(cmd, "generator")
+	if len(generatorName) == 0 {
+		generatorName = "secret/v1"
+	}
+	generator, found := f.Generator(generatorName)
+	if !found {
+		return cmdutil.UsageError(cmd, fmt.Sprintf("Generator: %s not found.", generatorName))
+	}
+	names := generator.ParamNames()
+	params := kubectl.MakeParams(cmd, names)
+	params["name"] = args[0]
+	if len(args) > 1 {
+		params["args"] = args[1:]
+	}
+
+	params["from-file"] = cmdutil.GetFlagStringSlice(cmd, "from-file")
+	params["from-literal"] = cmdutil.GetFlagStringSlice(cmd, "from-literal")
+
+	err = kubectl.ValidateParams(names, params)
+	if err != nil {
+		return err
+	}
+
+	obj, err := generator.Generate(params)
+	if err != nil {
+		return err
+	}
+
+	mapper, typer := f.Object()
+	version, kind, err := typer.ObjectVersionAndKind(obj)
+	if err != nil {
+		return err
+	}
+
+	mapping, err := mapper.RESTMapping(kind, version)
+	if err != nil {
+		return err
+	}
+	client, err := f.RESTClient(mapping)
+	if err != nil {
+		return err
+	}
+
+	// TODO: extract this flag to a central location, when such a location exists.
+	if !cmdutil.GetFlagBool(cmd, "dry-run") {
+		resourceMapper := &resource.Mapper{ObjectTyper: typer, RESTMapper: mapper, ClientMapper: f.ClientMapperForCommand()}
+		info, err := resourceMapper.InfoForObject(obj)
+		if err != nil {
+			return err
+		}
+
+		// Serialize the configuration into an annotation.
+		if err := kubectl.UpdateApplyAnnotation(info); err != nil {
+			return err
+		}
+
+		// Serialize the object with the annotation applied.
+		data, err := mapping.Codec.Encode(info.Object)
+		if err != nil {
+			return err
+		}
+
+		obj, err = resource.NewHelper(client, mapping).Create(namespace, false, data)
+		if err != nil {
+			return err
+		}
+	}
+	outputFormat := cmdutil.GetFlagString(cmd, "output")
+	if outputFormat != "" {
+		return f.PrintObject(cmd, obj, cmdOut)
+	}
+	cmdutil.PrintSuccess(mapper, false, cmdOut, mapping.Resource, args[0], "created")
+	return nil
+}

--- a/pkg/kubectl/cmd/secret/make_dockercfg.go
+++ b/pkg/kubectl/cmd/secret/make_dockercfg.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package secret
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+	"k8s.io/kubernetes/pkg/kubectl"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/kubectl/resource"
+)
+
+const (
+	makeDockercfgLong = `
+Create a new dockercfg secret
+
+Dockercfg secrets are used to authenticate against Docker registries.
+
+When using the Docker command line to push images, you can authenticate to a given registry by running
+  'docker login DOCKER_REGISTRY_SERVER --username=DOCKER_USER --password=DOCKER_PASSWORD --email=DOCKER_EMAIL'.
+That produces a ~/.dockercfg file that is used by subsequent 'docker push' and 'docker pull' commands to
+authenticate to the registry.
+
+When creating applications, you may have a Docker registry that requires authentication.  In order for the
+nodes to pull images on your behalf, they have to have the credentials.  You can provide this information
+by creating a dockercfg secret and attaching it to your service account.`
+
+	makeDockercfgExample = `  // If you don't already have a .dockercfg file, you can create a dockercfg secret directly by using:
+  $ kubectl secret make-dockercfg my-secret --docker-server=DOCKER_REGISTRY_SERVER --docker-username=DOCKER_USER --docker-password=DOCKER_PASSWORD --docker-email=DOCKER_EMAIL
+
+  // If you do already have a .dockercfg file, you can create a dockercfg secret by using:
+  $ kubectl secret make-dockercfg my-secret -f path/to/.dockercfg`
+)
+
+func NewCmdMakeDockercfgSecret(f *cmdutil.Factory, cmdOut io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "make-dockercfg NAME [-f path/to/.dockercfg] [--docker-server=DOCKER_REGISTRY_SERVER --docker-username=DOCKER_USER --docker-password=DOCKER_PASSWORD --docker-email=DOCKER_EMAIL] [--dry-run=bool]",
+		Short:   "Make a secret for use against Docker registries.",
+		Long:    makeDockercfgLong,
+		Example: makeDockercfgExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			err := MakeDockercfgSecret(f, cmdOut, cmd, args)
+			cmdutil.CheckErr(err)
+		},
+	}
+	cmdutil.AddPrinterFlags(cmd)
+	cmd.Flags().String("generator", "", "The name of the API generator to use.  If not specified, default to secret/v1")
+	cmd.Flags().String("docker-username", "", "Username for Docker registry authentication")
+	cmd.Flags().String("docker-password", "", "Password for Docker registry authentication")
+	cmd.Flags().String("docker-email", "", "Email for Docker registry")
+	cmd.Flags().String("docker-server", "https://index.docker.io/v1/", "Server location for Docker registry")
+	cmd.Flags().Bool("dry-run", false, "If true, only print the object that would be sent, without sending it.")
+	return cmd
+}
+
+func MakeDockercfgSecret(f *cmdutil.Factory, cmdOut io.Writer, cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return cmdutil.UsageError(cmd, "NAME is required for make")
+	}
+
+	namespace, _, err := f.DefaultNamespace()
+	if err != nil {
+		return err
+	}
+
+	generatorName := cmdutil.GetFlagString(cmd, "generator")
+	if len(generatorName) == 0 {
+		generatorName = "secret/v1"
+	}
+	generator, found := f.Generator(generatorName)
+	if !found {
+		return cmdutil.UsageError(cmd, fmt.Sprintf("Generator: %s not found.", generatorName))
+	}
+	names := generator.ParamNames()
+	params := kubectl.MakeParams(cmd, names)
+	params["name"] = args[0]
+	if len(args) > 1 {
+		params["args"] = args[1:]
+	}
+
+	err = kubectl.ValidateParams(names, params)
+	if err != nil {
+		return err
+	}
+
+	obj, err := generator.Generate(params)
+	if err != nil {
+		return err
+	}
+
+	mapper, typer := f.Object()
+	version, kind, err := typer.ObjectVersionAndKind(obj)
+	if err != nil {
+		return err
+	}
+
+	mapping, err := mapper.RESTMapping(kind, version)
+	if err != nil {
+		return err
+	}
+	client, err := f.RESTClient(mapping)
+	if err != nil {
+		return err
+	}
+
+	// TODO: extract this flag to a central location, when such a location exists.
+	if !cmdutil.GetFlagBool(cmd, "dry-run") {
+		resourceMapper := &resource.Mapper{ObjectTyper: typer, RESTMapper: mapper, ClientMapper: f.ClientMapperForCommand()}
+		info, err := resourceMapper.InfoForObject(obj)
+		if err != nil {
+			return err
+		}
+
+		// Serialize the configuration into an annotation.
+		if err := kubectl.UpdateApplyAnnotation(info); err != nil {
+			return err
+		}
+
+		// Serialize the object with the annotation applied.
+		data, err := mapping.Codec.Encode(info.Object)
+		if err != nil {
+			return err
+		}
+
+		obj, err = resource.NewHelper(client, mapping).Create(namespace, false, data)
+		if err != nil {
+			return err
+		}
+	}
+	outputFormat := cmdutil.GetFlagString(cmd, "output")
+	if outputFormat != "" {
+		return f.PrintObject(cmd, obj, cmdOut)
+	}
+	cmdutil.PrintSuccess(mapper, false, cmdOut, mapping.Resource, args[0], "created")
+	return nil
+}

--- a/pkg/kubectl/cmd/secret/secret.go
+++ b/pkg/kubectl/cmd/secret/secret.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package secret
+
+import (
+	"io"
+
+	"github.com/spf13/cobra"
+
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+)
+
+const (
+	secretsLong = `
+Store secret artifacts.
+
+Secrets are used to store confidential information that should not be contained inside of an image.
+They are commonly used to hold things like keys for authentication to other internal systems.`
+)
+
+func NewCmdSecret(f *cmdutil.Factory, out io.Writer) *cobra.Command {
+	// Parent command to which all subcommands are added.
+	cmds := &cobra.Command{
+		Use:   "secret SUBCOMMAND",
+		Short: "Store secret artifacts.",
+		Long:  secretsLong,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Help()
+		},
+	}
+
+	cmds.AddCommand(NewCmdMakeSecret(f, out))
+	cmds.AddCommand(NewCmdMakeDockercfgSecret(f, out))
+
+	return cmds
+}

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -109,6 +109,7 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 		"service/v1":                      kubectl.ServiceGeneratorV1{},
 		"service/v2":                      kubectl.ServiceGeneratorV2{},
 		"horizontalpodautoscaler/v1beta1": kubectl.HorizontalPodAutoscalerV1Beta1{},
+		"secret/v1":                       kubectl.SecretGeneratorV1{},
 	}
 
 	clientConfig := optionalClientConfig

--- a/pkg/kubectl/secret.go
+++ b/pkg/kubectl/secret.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/validation"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+type SecretGeneratorV1 struct{}
+
+func (SecretGeneratorV1) ParamNames() []GeneratorParam {
+	return []GeneratorParam{
+		{"default-name", false},
+		{"name", true},
+		{"type", false},
+		{"from-file", false},
+		{"from-literal", false},
+	}
+}
+
+func (SecretGeneratorV1) Generate(genericParams map[string]interface{}) (runtime.Object, error) {
+	secret := &api.Secret{
+		Data: map[string][]byte{},
+	}
+
+	fromFileStrings, found := genericParams["from-file"]
+	if found {
+		if fromFileArray, isArray := fromFileStrings.([]string); isArray {
+			if err := handleFromFileSources(secret, fromFileArray); err != nil {
+				return nil, err
+			}
+			delete(genericParams, "from-file")
+		} else {
+			return nil, fmt.Errorf("expected []string, found :%v", fromFileStrings)
+		}
+	}
+	fromLiteralStrings, found := genericParams["from-literal"]
+	if found {
+		if fromLiteralArray, isArray := fromLiteralStrings.([]string); isArray {
+			if err := handleFromLiteralSources(secret, fromLiteralArray); err != nil {
+				return nil, err
+			}
+			delete(genericParams, "from-literal")
+		} else {
+			return nil, fmt.Errorf("expected []string, found :%v", fromFileStrings)
+		}
+	}
+
+	params := map[string]string{}
+	for key, value := range genericParams {
+		strVal, isString := value.(string)
+		if !isString {
+			return nil, fmt.Errorf("expected string, saw %v for '%s'", value, key)
+		}
+		params[key] = strVal
+	}
+
+	name, found := params["name"]
+	secret.Name = name
+
+	if secretType, found := params["type"]; found {
+		secret.Type = api.SecretType(secretType)
+	}
+
+	return secret, nil
+}
+
+// handleFromLiteralSources adds the specified literal source information into the provided secret
+func handleFromLiteralSources(secret *api.Secret, literalSources []string) error {
+	for _, literalSource := range literalSources {
+		keyName, value, err := parseLiteralSource(literalSource)
+		if err != nil {
+			return err
+		}
+		addKeyFromLiteralToSecret(secret, keyName, []byte(value))
+	}
+	return nil
+}
+
+// handleFromFileSources adds the specified file source information into the provided secret
+func handleFromFileSources(secret *api.Secret, fileSources []string) error {
+	for _, fileSource := range fileSources {
+		keyName, filePath, err := parseFileSource(fileSource)
+		fmt.Fprintf(os.Stderr, "FILE %v\n", filePath)
+		if err != nil {
+			return err
+		}
+		info, err := os.Stat(filePath)
+		if err != nil {
+			switch err := err.(type) {
+			case *os.PathError:
+				return fmt.Errorf("error reading %s: %v", filePath, err.Err)
+			default:
+				return fmt.Errorf("error reading %s: %v", filePath, err)
+			}
+		}
+		if info.IsDir() {
+			fmt.Fprintf(os.Stderr, "ISDIR\n")
+			if strings.Contains(fileSource, "=") {
+				return fmt.Errorf("cannot give a key name for a directory path.")
+			}
+			fileList, err := ioutil.ReadDir(filePath)
+			if err != nil {
+				return fmt.Errorf("error listing files in %s: %v", filePath, err)
+			}
+			for _, item := range fileList {
+				itemPath := path.Join(filePath, item.Name())
+				fmt.Fprintf(os.Stderr, "FILES %v\n", itemPath)
+				if !item.Mode().IsRegular() {
+					// NEED A FLAG for quiet
+					if true {
+						fmt.Fprintf(os.Stderr, "Skipping resource %s\n", itemPath)
+					}
+				} else {
+					keyName = item.Name()
+					err = addKeyFromFileToSecret(secret, keyName, itemPath)
+					if err != nil {
+						return err
+					}
+				}
+			}
+		} else {
+			fmt.Fprintf(os.Stderr, "KEY %v FILE %v\n", keyName, filePath)
+			err = addKeyFromFileToSecret(secret, keyName, filePath)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func addKeyFromFileToSecret(secret *api.Secret, keyName, filePath string) error {
+	data, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return err
+	}
+	addKeyFromLiteralToSecret(secret, keyName, data)
+	return nil
+}
+
+func addKeyFromLiteralToSecret(secret *api.Secret, keyName string, data []byte) error {
+	if !validation.IsSecretKey(keyName) {
+		return fmt.Errorf("%v is not a valid key name for a secret", keyName)
+	}
+	if _, entryExists := secret.Data[keyName]; entryExists {
+		return fmt.Errorf("cannot add key %s, another key by that name already exists: %v.", keyName, secret.Data)
+	}
+	secret.Data[keyName] = data
+	return nil
+}
+
+// parseFileSource parses the source given. Acceptable formats include:
+// source-name=source-path, where source-name will become the key name and source-path is the path to the key file
+// source-path, where source-path is a path to a file or directory, and key names will default to file names
+// Key names cannot include '='.
+func parseFileSource(source string) (keyName, filePath string, err error) {
+	numSeparators := strings.Count(source, "=")
+	switch {
+	case numSeparators == 0:
+		return path.Base(source), source, nil
+	case numSeparators == 1 && strings.HasPrefix(source, "="):
+		return "", "", fmt.Errorf("key name for file path %v missing.", strings.TrimPrefix(source, "="))
+	case numSeparators == 1 && strings.HasSuffix(source, "="):
+		return "", "", fmt.Errorf("file path for key name %v missing.", strings.TrimSuffix(source, "="))
+	case numSeparators > 1:
+		return "", "", errors.New("Key names or file paths cannot contain '='.")
+	default:
+		components := strings.Split(source, "=")
+		return components[0], components[1], nil
+	}
+}
+
+// parseLiteralSource parses the source key=val pair
+func parseLiteralSource(source string) (keyName, value string, err error) {
+	items := strings.Split(source, "=")
+	if len(items) != 2 {
+		return "", "", fmt.Errorf("invalid literal source %v, expected key=value", source)
+	}
+	return items[0], items[1], nil
+}


### PR DESCRIPTION
This is NOT ready for final code review, but is a preview of what was discussed in #4822 

The pattern here is:

```
Create an opaque secret based on a file or directory
Usage:
  kubectl secret make NAME [options]

Examples:
  // Create a new secret named my-secret with keys for each file in folder "bar"
  $ kubectl secret make my-secret --from-file=path/to/bar

  // Create a new secret named my-secret with specified keys instead of names on disk
  $ kubectl secret make my-secret --from-file=key1=~/path/to/somefile --from-file=key2=~/path/to/someotherfile

  // Create a new secret named my-secret with specified literal values
  $ kubectl secret make my-secret --from-literal=key1=value1

Create a dockercfg secret with specified options
Usage:
  kubectl secret make-dockercfg NAME [options]

Examples:
  // Create a new secret named my-secret for use with a Docker registry
  $ kubectl secret make-dockercfg my-secret --email=jdoe --password=xyz --username=jdoe
```

I think I may now prefer an alternate pattern like the following:

```
kubectl make SUBCOMMAND
kubectl make secret my-secret --from-file=path/to/bar
kubectl make secret-dockercfg my-secret --docker-server=...
kubectl make namespace my-namespace
kubectl make node my-node --
kubectl make persistent-volume my-volume --capacity=... --access-modes=...
```

Just typing the above makes me now prefer this latter format.

Structural (not code) feedback at this stage is welcome before I wrap up the PR.

@bgrant0607 @smarterclayton @thockin 
