### PR TITLE
Cherry pick of 15813: Fix races in ClusterDns e2e test

### DIFF
--- a/test/e2e/examples.go
+++ b/test/e2e/examples.go
@@ -516,7 +516,13 @@ var _ = Describe("Examples e2e", func() {
 			for _, ns := range namespaces {
 				newKubectlCommand("create", "-f", "-", getNsCmdFlag(ns)).withStdinData(updatedPodYaml).exec()
 			}
-			// remember that we cannot wait for the pods to be running because our pods terminate by themselves.
+
+			// wait until the pods have been scheduler, i.e. are not Pending anymore. Remember
+			// that we cannot wait for the pods to be running because our pods terminate by themselves.
+			for _, ns := range namespaces {
+				err := waitForPodNotPending(c, ns.Name, frontendPodName)
+				expectNoError(err)
+			}
 
 			// wait for pods to print their result
 			for _, ns := range namespaces {

--- a/test/e2e/kube-ui.go
+++ b/test/e2e/kube-ui.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/util/wait"
 
 	. "github.com/onsi/ginkgo"
@@ -30,7 +31,7 @@ import (
 var _ = Describe("kube-ui", func() {
 	const (
 		uiServiceName = "kube-ui"
-		uiRcName      = uiServiceName
+		uiAppName     = uiServiceName
 		uiNamespace   = api.NamespaceSystem
 
 		serverStartTimeout = 1 * time.Minute
@@ -44,7 +45,8 @@ var _ = Describe("kube-ui", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Checking to make sure the kube-ui pods are running")
-		err = waitForRCPodsRunning(f.Client, uiNamespace, uiRcName)
+		selector := labels.SelectorFromSet(labels.Set(map[string]string{"k8s-app": uiAppName}))
+		err = waitForPodsWithLabelRunning(f.Client, uiNamespace, selector)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Checking to make sure we get a response from the kube-ui.")

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1447,6 +1447,9 @@ func waitForRCPodsRunning(c *client.Client, ns, rcName string) error {
 waitLoop:
 	for start := time.Now(); time.Since(start) < 10*time.Minute; time.Sleep(5 * time.Second) {
 		pods := podStore.List()
+		if len(pods) == 0 {
+			continue waitLoop
+		}
 		for _, p := range pods {
 			if p.Status.Phase != api.PodRunning {
 				continue waitLoop


### PR DESCRIPTION
This is important for 1.1 because it fixes a conformance test and should be part of the next conformance test tag.
