### PR TITLE
Ignore error when discovering server supported groupVersions and resources

### DIFF
--- a/pkg/client/unversioned/client_test.go
+++ b/pkg/client/unversioned/client_test.go
@@ -271,6 +271,76 @@ func TestGetServerVersion(t *testing.T) {
 	}
 }
 
+func TestGetServerGroupsWithV1Server(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		var obj interface{}
+		switch req.URL.Path {
+		case "/api":
+			obj = &unversioned.APIVersions{
+				Versions: []string{
+					"v1",
+				},
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		output, err := json.Marshal(obj)
+		if err != nil {
+			t.Errorf("unexpected encoding error: %v", err)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(output)
+	}))
+	client := NewOrDie(&Config{Host: server.URL})
+	// ServerGroups should not return an error even if server returns error at /api and /apis
+	apiGroupList, err := client.Discovery().ServerGroups()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	groupVersions := ExtractGroupVersions(apiGroupList)
+	if !reflect.DeepEqual(groupVersions, []string{"v1"}) {
+		t.Errorf("expected: %q, got: %q", []string{"v1"}, groupVersions)
+	}
+}
+
+func TestGetServerResourcesWithV1Server(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		var obj interface{}
+		switch req.URL.Path {
+		case "/api":
+			obj = &unversioned.APIVersions{
+				Versions: []string{
+					"v1",
+				},
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		output, err := json.Marshal(obj)
+		if err != nil {
+			t.Errorf("unexpected encoding error: %v", err)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(output)
+	}))
+	client := NewOrDie(&Config{Host: server.URL})
+	// ServerResources should not return an error even if server returns error at /api/v1.
+	resourceMap, err := client.Discovery().ServerResources()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if _, found := resourceMap["v1"]; !found {
+		t.Errorf("missing v1 in resource map")
+	}
+
+}
+
 func TestGetServerResources(t *testing.T) {
 	stable := unversioned.APIResourceList{
 		GroupVersion: "v1",

--- a/pkg/client/unversioned/helper.go
+++ b/pkg/client/unversioned/helper.go
@@ -416,6 +416,31 @@ func RESTClientFor(config *Config) (*RESTClient, error) {
 	return client, nil
 }
 
+// UnversionedRESTClientFor is the same as RESTClientFor, except that it allows
+// the config.Version to be empty.
+func UnversionedRESTClientFor(config *Config) (*RESTClient, error) {
+	if config.Codec == nil {
+		return nil, fmt.Errorf("Codec is required when initializing a RESTClient")
+	}
+
+	baseURL, err := defaultServerUrlFor(config)
+	if err != nil {
+		return nil, err
+	}
+
+	client := NewRESTClient(baseURL, config.Version, config.Codec, config.QPS, config.Burst)
+
+	transport, err := TransportFor(config)
+	if err != nil {
+		return nil, err
+	}
+
+	if transport != http.DefaultTransport {
+		client.Client = &http.Client{Transport: transport}
+	}
+	return client, nil
+}
+
 var (
 	// tlsTransports stores reusable round trippers with custom TLSClientConfig options
 	tlsTransports = map[string]*http.Transport{}

--- a/pkg/conversion/decode.go
+++ b/pkg/conversion/decode.go
@@ -19,6 +19,7 @@ package conversion
 import (
 	"errors"
 	"fmt"
+
 	"github.com/ugorji/go/codec"
 )
 


### PR DESCRIPTION
First two commits are #15973.

Let the Discovery Client ignore error when discovering server supported groupVersions

fixes @bgrant0607's comment https://github.com/kubernetes/kubernetes/pull/15796#discussion_r42576181.

This one needs to be cherry-picked.

supersede #16066

cc @liggitt @jlowdermilk
