### PR TITLE
Update annotation only if apply already called.

### DIFF
--- a/pkg/kubectl/apply.go
+++ b/pkg/kubectl/apply.go
@@ -163,16 +163,25 @@ func GetModifiedConfiguration(info *resource.Info, annotate bool) ([]byte, error
 	return modified, nil
 }
 
+// If the last applied configuration annotation is already present, then
 // UpdateApplyAnnotation gets the modified configuration of the object,
 // without embedding it again, and then sets it on the object as the annotation.
+// Otherwise, it does nothing.
 func UpdateApplyAnnotation(info *resource.Info) error {
-	modified, err := GetModifiedConfiguration(info, false)
+	original, err := GetOriginalConfiguration(info)
 	if err != nil {
 		return err
 	}
 
-	if err := SetOriginalConfiguration(info, modified); err != nil {
-		return err
+	if len(original) > 0 {
+		modified, err := GetModifiedConfiguration(info, false)
+		if err != nil {
+			return err
+		}
+
+		if err := SetOriginalConfiguration(info, modified); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This PR addresses #15878. It makes a minor change to pkg/kubectl/apply.go to update the last applied configuration annotation used by kubectl apply if and only if it is already present. The only way to create the annotation in the first place, now, is to use kubectl apply.
