### PR TITLE
add a version flag to the release tool

### DIFF
--- a/_tools/import_docs.sh
+++ b/_tools/import_docs.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 # This is a hack to import from a branch and call it a versioned snapshot.
 
+VERSION=v1.0
 OUTDIR=v1.0
 REPORT_TAG=v1.0.1
 BRANCH=release-1.0
@@ -20,7 +21,7 @@ tmpdir=docs.$RANDOM
 echo fetching upstream
 git fetch upstream
 go build ./_tools/release_docs
-./release_docs --branch ${BRANCH} --output-dir $tmpdir >/dev/null
+./release_docs --branch ${BRANCH} --output-dir $tmpdir --version $VERSION >/dev/null
 rm ./release_docs
 
 echo removing old

--- a/_tools/release_docs/api-reference-process.go
+++ b/_tools/release_docs/api-reference-process.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"regexp"
 	"strings"
 
@@ -67,9 +66,9 @@ func stripHTML(filename string) error {
 
 // replace http://releases.k8s.io/HEAD/docs/xxx.md with
 // http://kubernetes.io/v1.0/docs/xxx.html
-func fixLinks(fileName, outputDir string) error {
+func fixLinks(fileName, version string) error {
 	mdRE := regexp.MustCompile(`http://releases.k8s.io/HEAD/docs(.*?\.)md`)
-	repl := []byte("http://kubernetes.io/" + path.Base(outputDir) + "/docs" + "${1}" + "html")
+	repl := []byte("http://kubernetes.io/" + version + "/docs" + "${1}" + "html")
 	file, err := ioutil.ReadFile(fileName)
 	if err != nil {
 		return err
@@ -115,14 +114,14 @@ func moveHTML(filePath string, outputDir string) error {
 	return os.Rename(filePath, outputDir+"/../_includes/"+fileName)
 }
 
-func processHTML(filePath string, outputDir string) error {
+func processHTML(filePath string, version string, outputDir string) error {
 	if err := stripHTML(filePath); err != nil {
 		return err
 	}
 	if err := nitFix(filePath); err != nil {
 		return err
 	}
-	if err := fixLinks(filePath, outputDir); err != nil {
+	if err := fixLinks(filePath, version); err != nil {
 		return err
 	}
 	if err := moveHTML(filePath, outputDir); err != nil {

--- a/_tools/release_docs/main.go
+++ b/_tools/release_docs/main.go
@@ -36,8 +36,9 @@ import (
 var (
 	branch       = flag.String("branch", "", "The git branch from which to pull docs. (e.g. release-1.0, master).")
 	outputDir    = flag.String("output-dir", "", "The directory in which to save results.")
-	remote       = flag.String("remote", "upstream", "The name of the remote repo from which to pull docs.")
-	apiReference = flag.Bool("apiReference", true, "Whether update api reference")
+	version      = flag.String("version", "", "The release version. It should be the same as the version segment in the URL, e.g., when importing docs that will be hosted at k8s.io/v1.0/, the version flag should be \"v1.0\".")
+	remote       = flag.String("remote", "upstream", "Optional: The name of the remote repo from which to pull docs.")
+	apiReference = flag.Bool("apiReference", true, "Optional: Whether update api reference")
 
 	subdirs = []string{"docs", "examples"}
 )
@@ -396,6 +397,10 @@ func main() {
 		fmt.Println("You must specify an output dir with --output-dir.")
 		os.Exit(1)
 	}
+	if len(*version) == 0 {
+		fmt.Println("You must specify the release version with --version.")
+		os.Exit(1)
+	}
 
 	if err := checkCWD(); err != nil {
 		fmt.Printf("Could not find the kubernetes root: %v\n", err)
@@ -431,7 +436,7 @@ func main() {
 
 			if *apiReference && !info.IsDir() && (info.Name() == "definitions.html" || info.Name() == "operations.html") {
 				fmt.Printf("Processing %s\n", path)
-				err := processHTML(path, *outputDir)
+				err := processHTML(path, *version, *outputDir)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
My code in the release tool had wrong assumption that outputDir == release version, which is not true. This PR explicitly adds a release version flag.

@nikhiljindal @RichieEscarez 
