### PR TITLE
Dockerfile for jenkins build/test

### DIFF
--- a/hack/jenkins/gotest-pr.sh
+++ b/hack/jenkins/gotest-pr.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+export REPO_DIR=${REPO_DIR:-$(pwd)}
+
+# Produce a JUnit-style XML test report for Jenkins.
+export KUBE_JUNIT_REPORT_DIR=${WORKSPACE}/_artifacts
+
+# Run the kubekins container, mapping in docker (so we can launch containers)
+# and the repo directory
+docker run -v /var/run/docker.sock:/var/run/docker.sock \
+  -v "$(which docker)":/bin/docker \
+  -v "${REPO_DIR}":/go/src/k8s.io/kubernetes \
+  -v "${KUBE_JUNIT_REPORT_DIR}":/workspace/artifacts \
+  -it kubekins-test \
+  bash -c "cd kubernetes && /workspace/run.sh"

--- a/hack/jenkins/test-image/Dockerfile
+++ b/hack/jenkins/test-image/Dockerfile
@@ -1,0 +1,32 @@
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file creates a build environment for building and running kubernetes
+# unit and integration tests
+
+FROM golang:1.4
+MAINTAINER  jeff lowdermilk <jeffml@google.com>
+
+ENV KUBE_TEST_API_VERSIONS  v1,extensions/v1beta1
+ENV KUBE_TEST_ETCD_PREFIXES registry
+ENV WORKSPACE               /workspace
+
+WORKDIR /workspace
+ADD run.sh ./
+
+RUN apt-get -o Acquire::Check-Valid-Until=false update && apt-get install -y rsync
+RUN mkdir -p /go/src/k8s.io/kubernetes
+RUN ln -s /go/src/k8s.io/kubernetes /workspace/kubernetes
+
+RUN /bin/bash

--- a/hack/jenkins/test-image/run.sh
+++ b/hack/jenkins/test-image/run.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Copyright 2015 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+export PATH=${GOPATH}/bin:${PWD}/third_party/etcd:/usr/local/go/bin:${PATH}
+
+./hack/install-etcd.sh
+go get -u github.com/jstemmer/go-junit-report
+go get golang.org/x/tools/cmd/cover
+go get github.com/mattn/goveralls
+go get github.com/tools/godep
+go get github.com/jstemmer/go-junit-report
+
+# Enable the Go race detector.
+export KUBE_RACE=-race
+# Disable coverage report
+export KUBE_COVER="n"
+# Produce a JUnit-style XML test report for Jenkins.
+export KUBE_JUNIT_REPORT_DIR=${WORKSPACE}/artifacts
+# Save the verbose stdout as well.
+export KUBE_KEEP_VERBOSE_TEST_OUTPUT=y
+export KUBE_GOVERALLS_BIN="${GOPATH}/bin/goveralls"
+export KUBE_TIMEOUT='-timeout 300s'
+export KUBE_COVERPROCS=8
+export KUBE_INTEGRATION_TEST_MAX_CONCURRENCY=4
+export LOG_LEVEL=4
+
+./hack/verify-gofmt.sh
+./hack/verify-boilerplate.sh
+./hack/verify-description.sh
+./hack/verify-flags-underscore.py
+./hack/verify-generated-conversions.sh
+./hack/verify-generated-deep-copies.sh
+./hack/verify-generated-docs.sh
+./hack/verify-generated-swagger-docs.sh
+./hack/verify-swagger-spec.sh
+./hack/verify-linkcheck.sh
+
+./hack/test-go.sh -- -p=2
+./hack/test-cmd.sh
+./hack/test-integration.sh
+./hack/test-update-storage-objects.sh
+
+


### PR DESCRIPTION
To allow jenkins to run unit/cmd/integration tests in a container, mapping in a repo dir and a test artifact output dir. Ref #14781

cc @ixdy
