### PR TITLE
Fixes for update-api-reference-docs.sh

### DIFF
--- a/hack/update-all.sh
+++ b/hack/update-all.sh
@@ -45,7 +45,9 @@ BASH_TARGETS="codecgen
 	generated-deep-copies 
 	generated-docs 
 	generated-swagger-docs 
-	swagger-spec"
+	swagger-spec
+	api-reference-docs"
+
 
 for t in $BASH_TARGETS
 do

--- a/hack/update-api-reference-docs.sh
+++ b/hack/update-api-reference-docs.sh
@@ -36,11 +36,11 @@ echo "Reading swagger spec from: ${SWAGGER_PATH}"
 mkdir -p $V1_PATH
 mkdir -p $V1BETA1_PATH
 
-docker run -v $V1_PATH:/output -v ${SWAGGER_PATH}:/swagger-source gcr.io/google_containers/gen-swagger-docs:v3 \
+docker run --rm -v $V1_PATH:/output:z -v ${SWAGGER_PATH}:/swagger-source:z gcr.io/google_containers/gen-swagger-docs:v3 \
     v1 \
     https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/api/v1/register.go
 
-docker run -v $V1BETA1_PATH:/output -v ${SWAGGER_PATH}:/swagger-source gcr.io/google_containers/gen-swagger-docs:v3 \
+docker run --rm -v $V1BETA1_PATH:/output:z -v ${SWAGGER_PATH}:/swagger-source:z gcr.io/google_containers/gen-swagger-docs:v3 \
     v1beta1 \
     https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/apis/extensions/v1beta1/register.go
 


### PR DESCRIPTION
Update to @pmorie's original PR #16125

Beyond the work paul already did this includes
- `:z` added to volume mounts
- `--rm` added to `docker run`
