### PR TITLE
New "archived doc set" notice. To be applied to the v1.0 doc set when v1.1 GAs

### DIFF
--- a/_includes/archivedocnotice.html
+++ b/_includes/archivedocnotice.html
@@ -1,0 +1,4 @@
+<div>
+	<br/>
+	<p style="text-align:center; border-style:ridge; border-width:2px; border-color:red">This is an archived version of the documentation. <a href="http://kubernetes.io/docs">View the latest version here.</a></p>
+</div>

--- a/_sass/_documents.scss
+++ b/_sass/_documents.scss
@@ -1,4 +1,5 @@
 #docbanner{
+    padding-top:10px;
     overflow: hidden;
 }
 .bodywrapper {


### PR DESCRIPTION
This is just the notice that when we are ready to GA v1.1, will get added during the doc build to all the v1.0 pages.

The link in the notice uses our generic "/docs" URL so it always points to our latest doc set (controlled by the ...docs/index.md file in gh-pages). 

Note: This file is not integrated into the build yet but looks like this (will show at the top of every v1.0 page):
![image](https://cloud.githubusercontent.com/assets/11762685/10698931/485b0ef8-7968-11e5-810e-28968a2f328c.png)

In this PR ive also added some padding to the top of the doc banner (to add separation/whitespace between the notice)
![image](https://cloud.githubusercontent.com/assets/11762685/10699217/1132ea16-796a-11e5-8686-fe2b08e25df3.png)

FYI:
I will open a separate PR to enable/integrate this notice into the build (for v1.0 docs) so that it can be held onto and later merged for GA.
The specific steps include: 
- Updating the docs/index.md redirect to point to v1.1
- Adding "{% include archivedocnotice.html%}" to the "Content body" section in the _layouts/docwithnav.html file

@mansoorj @brendandburns 
