### PR TITLE
put generated definitions/operations.html under release version folder

### DIFF
--- a/_tools/release_docs/api-reference-process.go
+++ b/_tools/release_docs/api-reference-process.go
@@ -99,7 +99,7 @@ func nitFix(filename string) error {
 
 // move the definitions.html and operations.html to _includes, with name like
 // extensions-v1beta1-definitions.html.
-func moveHTML(filePath string, outputDir string) error {
+func moveHTML(filePath string, version string, outputDir string) error {
 	dirs := strings.Split(filePath, "/")
 	var i int
 	for i = 0; i < len(dirs); i++ {
@@ -111,7 +111,11 @@ func moveHTML(filePath string, outputDir string) error {
 		return fmt.Errorf("failed to find fold \"api-reference\"\n")
 	}
 	fileName := strings.Join(dirs[i+1:], "-")
-	return os.Rename(filePath, outputDir+"/../_includes/"+fileName)
+	// version is needed to eliminate conflicts among releases.
+	if err := os.MkdirAll(outputDir+"/../_includes/"+version, 0766); err != nil {
+		return err
+	}
+	return os.Rename(filePath, outputDir+"/../_includes/"+version+"/"+fileName)
 }
 
 func processHTML(filePath string, version string, outputDir string) error {
@@ -124,7 +128,7 @@ func processHTML(filePath string, version string, outputDir string) error {
 	if err := fixLinks(filePath, version); err != nil {
 		return err
 	}
-	if err := moveHTML(filePath, outputDir); err != nil {
+	if err := moveHTML(filePath, version, outputDir); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
For example, /docs/api-reference/extensions/v1beta/definitions.html will be copied to  
_includes/v1.1/extensions-v1beta1-definitions.html in gh-pages.

Fix https://github.com/kubernetes/kubernetes/pull/15876#issuecomment-150695826
