### PR TITLE
Disable google cloud monitoring sinks in heapster by default.

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -58,7 +58,7 @@ ALLOCATE_NODE_CIDRS=true
 #   google         - Heapster, Google Cloud Monitoring, and Google Cloud Logging
 #   googleinfluxdb - Enable influxdb and google (except GCM)
 #   standalone     - Heapster only. Metrics available via Heapster REST API.
-ENABLE_CLUSTER_MONITORING="${KUBE_ENABLE_CLUSTER_MONITORING:-googleinfluxdb}"
+ENABLE_CLUSTER_MONITORING="${KUBE_ENABLE_CLUSTER_MONITORING:-influxdb}"
 
 # Optional: Enable node logging.
 ENABLE_NODE_LOGGING="${KUBE_ENABLE_NODE_LOGGING:-true}"
@@ -94,6 +94,7 @@ if [[ "${ENABLE_NODE_AUTOSCALER}" == "true" ]]; then
   AUTOSCALER_MIN_NODES="${KUBE_AUTOSCALER_MIN_NODES:-1}"
   AUTOSCALER_MAX_NODES="${KUBE_AUTOSCALER_MAX_NODES:-${NUM_MINIONS}}"
   TARGET_NODE_UTILIZATION="${KUBE_TARGET_NODE_UTILIZATION:-0.7}"
+  ENABLE_CLUSTER_MONITORING=googleinfluxdb
 fi
 
 # Optional: Enable deployment experimental feature, not ready for production use.


### PR DESCRIPTION
Expected to fix #16201

cc @mikedanese @dchen1107 @mwielgus @piosz 
