### PR TITLE
Change resource "ingress" to "ingresses" in URL path and kubectl

### DIFF
--- a/api/swagger-spec/v1beta1.json
+++ b/api/swagger-spec/v1beta1.json
@@ -728,7 +728,7 @@
     ]
    },
    {
-    "path": "/apis/extensions/v1beta1/namespaces/{namespace}/ingress",
+    "path": "/apis/extensions/v1beta1/namespaces/{namespace}/ingresses",
     "description": "API at /apis/extensions/v1beta1",
     "operations": [
      {
@@ -856,7 +856,7 @@
     ]
    },
    {
-    "path": "/apis/extensions/v1beta1/watch/namespaces/{namespace}/ingress",
+    "path": "/apis/extensions/v1beta1/watch/namespaces/{namespace}/ingresses",
     "description": "API at /apis/extensions/v1beta1",
     "operations": [
      {
@@ -939,7 +939,7 @@
     ]
    },
    {
-    "path": "/apis/extensions/v1beta1/namespaces/{namespace}/ingress/{name}",
+    "path": "/apis/extensions/v1beta1/namespaces/{namespace}/ingresses/{name}",
     "description": "API at /apis/extensions/v1beta1",
     "operations": [
      {
@@ -1151,7 +1151,7 @@
     ]
    },
    {
-    "path": "/apis/extensions/v1beta1/watch/namespaces/{namespace}/ingress/{name}",
+    "path": "/apis/extensions/v1beta1/watch/namespaces/{namespace}/ingresses/{name}",
     "description": "API at /apis/extensions/v1beta1",
     "operations": [
      {
@@ -1242,7 +1242,7 @@
     ]
    },
    {
-    "path": "/apis/extensions/v1beta1/ingress",
+    "path": "/apis/extensions/v1beta1/ingresses",
     "description": "API at /apis/extensions/v1beta1",
     "operations": [
      {
@@ -1317,7 +1317,7 @@
     ]
    },
    {
-    "path": "/apis/extensions/v1beta1/watch/ingress",
+    "path": "/apis/extensions/v1beta1/watch/ingresses",
     "description": "API at /apis/extensions/v1beta1",
     "operations": [
      {
@@ -1392,7 +1392,7 @@
     ]
    },
    {
-    "path": "/apis/extensions/v1beta1/namespaces/{namespace}/ingress/{name}/status",
+    "path": "/apis/extensions/v1beta1/namespaces/{namespace}/ingresses/{name}/status",
     "description": "API at /apis/extensions/v1beta1",
     "operations": [
      {

--- a/pkg/api/meta/restmapper.go
+++ b/pkg/api/meta/restmapper.go
@@ -142,12 +142,12 @@ func KindToResource(kind string, mixedCase bool) (plural, singular string) {
 	} else {
 		singular = strings.ToLower(kind)
 	}
-	if strings.HasSuffix(singular, "status") {
-		plural = singular + "es"
+	if strings.HasSuffix(singular, "endpoints") {
+		plural = singular
 	} else {
 		switch string(singular[len(singular)-1]) {
 		case "s":
-			plural = singular
+			plural = singular + "es"
 		case "y":
 			plural = strings.TrimSuffix(singular, "y") + "ies"
 		default:

--- a/pkg/api/meta/restmapper_test.go
+++ b/pkg/api/meta/restmapper_test.go
@@ -153,11 +153,12 @@ func TestKindToResource(t *testing.T) {
 		{Kind: "ReplicationController", MixedCase: true, Plural: "replicationControllers", Singular: "replicationController"},
 		{Kind: "ReplicationController", MixedCase: false, Plural: "replicationcontrollers", Singular: "replicationcontroller"},
 
+		// Add "ies" when ending with "y"
 		{Kind: "ImageRepository", MixedCase: true, Plural: "imageRepositories", Singular: "imageRepository"},
-
+		// Add "es" when ending with "s"
+		{Kind: "miss", MixedCase: false, Plural: "misses", Singular: "miss"},
+		// Add "s" otherwise
 		{Kind: "lowercase", MixedCase: false, Plural: "lowercases", Singular: "lowercase"},
-		// Don't add extra s if the original object is already plural
-		{Kind: "lowercases", MixedCase: false, Plural: "lowercases", Singular: "lowercases"},
 	}
 	for i, testCase := range testCases {
 		plural, singular := KindToResource(testCase.Kind, testCase.MixedCase)

--- a/pkg/client/unversioned/client_test.go
+++ b/pkg/client/unversioned/client_test.go
@@ -284,7 +284,7 @@ func TestGetServerResources(t *testing.T) {
 		GroupVersion: "extensions/v1",
 		APIResources: []unversioned.APIResource{
 			{"deployments", true},
-			{"ingress", true},
+			{"ingresses", true},
 			{"jobs", true},
 		},
 	}

--- a/pkg/client/unversioned/ingress.go
+++ b/pkg/client/unversioned/ingress.go
@@ -54,42 +54,42 @@ func newIngress(c *ExtensionsClient, namespace string) *ingress {
 // List returns a list of ingress that match the label and field selectors.
 func (c *ingress) List(label labels.Selector, field fields.Selector) (result *extensions.IngressList, err error) {
 	result = &extensions.IngressList{}
-	err = c.r.Get().Namespace(c.ns).Resource("ingress").LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
+	err = c.r.Get().Namespace(c.ns).Resource("ingresses").LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
 	return
 }
 
 // Get returns information about a particular ingress.
 func (c *ingress) Get(name string) (result *extensions.Ingress, err error) {
 	result = &extensions.Ingress{}
-	err = c.r.Get().Namespace(c.ns).Resource("ingress").Name(name).Do().Into(result)
+	err = c.r.Get().Namespace(c.ns).Resource("ingresses").Name(name).Do().Into(result)
 	return
 }
 
 // Create creates a new ingress.
 func (c *ingress) Create(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
 	result = &extensions.Ingress{}
-	err = c.r.Post().Namespace(c.ns).Resource("ingress").Body(ingress).Do().Into(result)
+	err = c.r.Post().Namespace(c.ns).Resource("ingresses").Body(ingress).Do().Into(result)
 	return
 }
 
 // Update updates an existing ingress.
 func (c *ingress) Update(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
 	result = &extensions.Ingress{}
-	err = c.r.Put().Namespace(c.ns).Resource("ingress").Name(ingress.Name).Body(ingress).Do().Into(result)
+	err = c.r.Put().Namespace(c.ns).Resource("ingresses").Name(ingress.Name).Body(ingress).Do().Into(result)
 	return
 }
 
 // Delete deletes a ingress, returns error if one occurs.
 func (c *ingress) Delete(name string, options *api.DeleteOptions) (err error) {
 	if options == nil {
-		return c.r.Delete().Namespace(c.ns).Resource("ingress").Name(name).Do().Error()
+		return c.r.Delete().Namespace(c.ns).Resource("ingresses").Name(name).Do().Error()
 	}
 
 	body, err := api.Scheme.EncodeToVersion(options, c.r.APIVersion())
 	if err != nil {
 		return err
 	}
-	return c.r.Delete().Namespace(c.ns).Resource("ingress").Name(name).Body(body).Do().Error()
+	return c.r.Delete().Namespace(c.ns).Resource("ingresses").Name(name).Body(body).Do().Error()
 }
 
 // Watch returns a watch.Interface that watches the requested ingress.
@@ -97,7 +97,7 @@ func (c *ingress) Watch(label labels.Selector, field fields.Selector, opts api.L
 	return c.r.Get().
 		Prefix("watch").
 		Namespace(c.ns).
-		Resource("ingress").
+		Resource("ingresses").
 		Param("resourceVersion", opts.ResourceVersion).
 		TimeoutSeconds(TimeoutFromListOptions(opts)).
 		LabelsSelectorParam(label).
@@ -108,6 +108,6 @@ func (c *ingress) Watch(label labels.Selector, field fields.Selector, opts api.L
 // UpdateStatus takes the name of the ingress and the new status.  Returns the server's representation of the ingress, and an error, if it occurs.
 func (c *ingress) UpdateStatus(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
 	result = &extensions.Ingress{}
-	err = c.r.Put().Namespace(c.ns).Resource("ingress").Name(ingress.Name).SubResource("status").Body(ingress).Do().Into(result)
+	err = c.r.Put().Namespace(c.ns).Resource("ingresses").Name(ingress.Name).SubResource("status").Body(ingress).Do().Into(result)
 	return
 }

--- a/pkg/client/unversioned/ingress_test.go
+++ b/pkg/client/unversioned/ingress_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func getIngressResourceName() string {
-	return "ingress"
+	return "ingresses"
 }
 
 func TestListIngress(t *testing.T) {

--- a/pkg/client/unversioned/testclient/fake_ingress.go
+++ b/pkg/client/unversioned/testclient/fake_ingress.go
@@ -32,7 +32,7 @@ type FakeIngress struct {
 }
 
 func (c *FakeIngress) Get(name string) (*extensions.Ingress, error) {
-	obj, err := c.Fake.Invokes(NewGetAction("ingress", c.Namespace, name), &extensions.Ingress{})
+	obj, err := c.Fake.Invokes(NewGetAction("ingresses", c.Namespace, name), &extensions.Ingress{})
 	if obj == nil {
 		return nil, err
 	}
@@ -41,7 +41,7 @@ func (c *FakeIngress) Get(name string) (*extensions.Ingress, error) {
 }
 
 func (c *FakeIngress) List(label labels.Selector, fields fields.Selector) (*extensions.IngressList, error) {
-	obj, err := c.Fake.Invokes(NewListAction("ingress", c.Namespace, label, nil), &extensions.IngressList{})
+	obj, err := c.Fake.Invokes(NewListAction("ingresses", c.Namespace, label, nil), &extensions.IngressList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -50,7 +50,7 @@ func (c *FakeIngress) List(label labels.Selector, fields fields.Selector) (*exte
 }
 
 func (c *FakeIngress) Create(ingress *extensions.Ingress) (*extensions.Ingress, error) {
-	obj, err := c.Fake.Invokes(NewCreateAction("ingress", c.Namespace, ingress), ingress)
+	obj, err := c.Fake.Invokes(NewCreateAction("ingresses", c.Namespace, ingress), ingress)
 	if obj == nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func (c *FakeIngress) Create(ingress *extensions.Ingress) (*extensions.Ingress, 
 }
 
 func (c *FakeIngress) Update(ingress *extensions.Ingress) (*extensions.Ingress, error) {
-	obj, err := c.Fake.Invokes(NewUpdateAction("ingress", c.Namespace, ingress), ingress)
+	obj, err := c.Fake.Invokes(NewUpdateAction("ingresses", c.Namespace, ingress), ingress)
 	if obj == nil {
 		return nil, err
 	}
@@ -68,16 +68,16 @@ func (c *FakeIngress) Update(ingress *extensions.Ingress) (*extensions.Ingress, 
 }
 
 func (c *FakeIngress) Delete(name string, options *api.DeleteOptions) error {
-	_, err := c.Fake.Invokes(NewDeleteAction("ingress", c.Namespace, name), &extensions.Ingress{})
+	_, err := c.Fake.Invokes(NewDeleteAction("ingresses", c.Namespace, name), &extensions.Ingress{})
 	return err
 }
 
 func (c *FakeIngress) Watch(label labels.Selector, field fields.Selector, opts api.ListOptions) (watch.Interface, error) {
-	return c.Fake.InvokesWatch(NewWatchAction("ingress", c.Namespace, label, field, opts))
+	return c.Fake.InvokesWatch(NewWatchAction("ingresses", c.Namespace, label, field, opts))
 }
 
 func (c *FakeIngress) UpdateStatus(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
-	obj, err := c.Fake.Invokes(NewUpdateSubresourceAction("ingress", "status", c.Namespace, ingress), ingress)
+	obj, err := c.Fake.Invokes(NewUpdateSubresourceAction("ingresses", "status", c.Namespace, ingress), ingress)
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -205,7 +205,7 @@ func deleteAllContent(kubeClient client.Interface, versions *unversioned.APIVers
 				return estimate, err
 			}
 		}
-		if containsResource(resources, "ingress") {
+		if containsResource(resources, "ingresses") {
 			err = deleteIngress(kubeClient.Extensions(), namespace)
 			if err != nil {
 				return estimate, err

--- a/pkg/controller/namespace/namespace_controller_test.go
+++ b/pkg/controller/namespace/namespace_controller_test.go
@@ -92,7 +92,7 @@ func testSyncNamespaceThatIsTerminating(t *testing.T, versions *unversioned.APIV
 
 	if containsVersion(versions, "extensions/v1beta1") {
 		resources := []unversioned.APIResource{}
-		for _, resource := range []string{"daemonsets", "deployments", "jobs", "horizontalpodautoscalers", "ingress"} {
+		for _, resource := range []string{"daemonsets", "deployments", "jobs", "horizontalpodautoscalers", "ingresses"} {
 			resources = append(resources, unversioned.APIResource{Name: resource})
 		}
 		mockClient.Resources = map[string]*unversioned.APIResourceList{
@@ -128,7 +128,7 @@ func testSyncNamespaceThatIsTerminating(t *testing.T, versions *unversioned.APIV
 			strings.Join([]string{"list", "deployments", ""}, "-"),
 			strings.Join([]string{"list", "jobs", ""}, "-"),
 			strings.Join([]string{"list", "horizontalpodautoscalers", ""}, "-"),
-			strings.Join([]string{"list", "ingress", ""}, "-"),
+			strings.Join([]string{"list", "ingresses", ""}, "-"),
 			strings.Join([]string{"get", "resource", ""}, "-"),
 		)
 	}

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -108,7 +108,7 @@ func expandResourceShortcut(resource string) string {
 		"rc":     "replicationcontrollers",
 		"ds":     "daemonsets",
 		"svc":    "services",
-		"ing":    "ingress",
+		"ing":    "ingresses",
 	}
 	if expanded, ok := shortForms[resource]; ok {
 		return expanded

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -1033,7 +1033,7 @@ func (m *Master) thirdpartyapi(group, kind, version string) *apiserver.APIGroupV
 // experimental returns the resources and codec for the experimental api
 func (m *Master) experimental(c *Config) *apiserver.APIGroupVersion {
 	// All resources except these are disabled by default.
-	enabledResources := utilsets.NewString("jobs", "horizontalpodautoscalers", "ingress")
+	enabledResources := utilsets.NewString("jobs", "horizontalpodautoscalers", "ingresses")
 	resourceOverrides := m.apiGroupVersionOverrides["extensions/v1beta1"].ResourceOverrides
 	isEnabled := func(resource string) bool {
 		// Check if the resource has been overriden.
@@ -1088,10 +1088,10 @@ func (m *Master) experimental(c *Config) *apiserver.APIGroupVersion {
 		storage["jobs"] = jobStorage
 		storage["jobs/status"] = jobStatusStorage
 	}
-	if isEnabled("ingress") {
-		ingressStorage, ingressStatusStorage := ingressetcd.NewREST(dbClient("ingress"))
-		storage["ingress"] = ingressStorage
-		storage["ingress/status"] = ingressStatusStorage
+	if isEnabled("ingresses") {
+		ingressStorage, ingressStatusStorage := ingressetcd.NewREST(dbClient("ingresses"))
+		storage["ingresses"] = ingressStorage
+		storage["ingresses/status"] = ingressStatusStorage
 	}
 
 	extensionsGroup := latest.GroupOrDie("extensions")

--- a/pkg/registry/ingress/etcd/etcd.go
+++ b/pkg/registry/ingress/etcd/etcd.go
@@ -62,7 +62,7 @@ func NewREST(s storage.Interface) (*REST, *StatusREST) {
 		PredicateFunc: func(label labels.Selector, field fields.Selector) generic.Matcher {
 			return ingress.MatchIngress(label, field)
 		},
-		EndpointName: "ingress",
+		EndpointName: "ingresses",
 
 		// Used to validate controller creation
 		CreateStrategy: ingress.Strategy,


### PR DESCRIPTION
Fixes #16070

Now you can do:

``` console
$ kubectl get ing
$ kubectl get ingress
$ kubectl get ingresses
```

or visit `http://<master>/apis/extensions/v1beta1/ingresses`

cc @bgrant0607 @bprashanth @thockin @kubernetes/kubectl @kubernetes/kube-api 
