### PR TITLE
Fix dead links to submit-queue

### DIFF
--- a/docs/devel/automation.md
+++ b/docs/devel/automation.md
@@ -46,8 +46,8 @@ In an effort to
    * maintain e2e stability
    * load test githubs label feature
 
-We have added an automated [submit-queue](https://github.com/kubernetes/contrib/tree/master/submit-queue)
-for kubernetes.
+We have added an automated [submit-queue](https://github.com/kubernetes/contrib/blob/master/mungegithub/pulls/submit-queue.go) to the
+[github "munger"](https://github.com/kubernetes/contrib/tree/master/mungegithub) for kubernetes.
 
 The submit-queue does the following:
 

--- a/docs/devel/pull-requests.md
+++ b/docs/devel/pull-requests.md
@@ -52,14 +52,14 @@ Life of a Pull Request
 
 Unless in the last few weeks of a milestone when we need to reduce churn and stabilize, we aim to be always accepting pull requests.
 
-Either the [on call](https://github.com/kubernetes/kubernetes/wiki/Kubernetes-on-call-rotation) manually or the [submit queue](https://github.com/kubernetes/contrib/tree/master/submit-queue) automatically will manage merging PRs.
+Either the [on call](https://github.com/kubernetes/kubernetes/wiki/Kubernetes-on-call-rotations) manually or the [github "munger"](https://github.com/kubernetes/contrib/tree/master/mungegithub) submit-queue plugin automatically will manage merging PRs.
 
-There are several requirements for the submit queue to work:
+There are several requirements for the submit-queue to work:
 * Author must have signed CLA ("cla: yes" label added to PR)
 * No changes can be made since last lgtm label was applied
 * k8s-bot must have reported the GCE E2E build and test steps passed (Travis, Shippable and Jenkins build)
 
-Additionally, for infrequent or new contributors, we require the on call to apply the "ok-to-merge" label manually.  This is gated by the [whitelist](https://github.com/kubernetes/contrib/tree/master/submit-queue/whitelist.txt).
+Additionally, for infrequent or new contributors, we require the on call to apply the "ok-to-merge" label manually.  This is gated by the [whitelist](https://github.com/kubernetes/contrib/blob/master/mungegithub/whitelist.txt).
 
 Automation
 ----------


### PR DESCRIPTION
- https://github.com/kubernetes/contrib/pull/122 merged submit-queue into mungegithub. This fixes links to the old submit-queue location.
- Standardized to use "submit-queue" instead of "submit queue". Just picked one since both were used.
- Fixes dead link to on-call wiki.
