### PR TITLE
[WIP]  Add wmftoolsenforcer admission controller

### DIFF
--- a/cmd/kube-apiserver/app/plugins.go
+++ b/cmd/kube-apiserver/app/plugins.go
@@ -35,4 +35,5 @@ import (
 	_ "k8s.io/kubernetes/plugin/pkg/admission/resourcequota"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/securitycontext/scdeny"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/serviceaccount"
+	_ "k8s.io/kubernetes/plugin/pkg/admission/wmftoolsenforcer"
 )

--- a/plugin/pkg/admission/wmftoolsenforcer/admission.go
+++ b/plugin/pkg/admission/wmftoolsenforcer/admission.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wmftoolsenforcer
+
+import (
+	"io"
+	"strconv"
+	"time"
+
+	"k8s.io/kubernetes/pkg/admission"
+	"k8s.io/kubernetes/pkg/api"
+	apierrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/client/cache"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+func init() {
+	admission.RegisterPlugin("UidEnforcer", func(client client.Interface, config io.Reader) (admission.Interface, error) {
+		return NewUidEnforcer(client), nil
+	})
+}
+
+// plugin contains the client used by the uidenforcer admin controller
+type plugin struct {
+	*admission.Handler
+	client client.Interface
+	store  cache.Store
+}
+
+// NewSecurityContextDeny creates a new instance of the SecurityContextDeny admission controller
+func NewUidEnforcer(client client.Interface) admission.Interface {
+	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	reflector := cache.NewReflector(
+		&cache.ListWatch{
+			ListFunc: func() (runtime.Object, error) {
+				return client.Namespaces().List(labels.Everything(), fields.Everything())
+			},
+			WatchFunc: func(options api.ListOptions) (watch.Interface, error) {
+				return client.Namespaces().Watch(labels.Everything(), fields.Everything(), options)
+			},
+		},
+		&api.Namespace{},
+		store,
+		5*time.Minute,
+	)
+	reflector.Run()
+	return &plugin{
+		Handler: admission.NewHandler(admission.Create, admission.Update),
+		client:  client,
+		store:   store,
+	}
+}
+
+// This will verify the following:
+//  - Not a namespace modification from a namespaced user for their own namespace
+//  - User object has a numeric uid
+//  - Namespace object has an annotation called RunAsUser that's an integer
+//
+// If after all this there's no SecurityContext on each Container with a RunAsUser set to the same RunAsUser, it'll be set
+func (p *plugin) Admit(a admission.Attributes) (err error) {
+	if a.GetResource() != string(api.ResourcePods) && a.GetResource() != "namespace" {
+		return nil
+	}
+
+	// HACK: This should probably be a separate AdmissionController
+	hackNamespace, ok := a.GetObject().(*api.Namespace)
+	if ok {
+		user := a.GetUserInfo()
+		if user == nil {
+			return apierrors.NewBadRequest("uidenforcer admission controller can not be used if there is no user set")
+		}
+
+		// This is a namespace!
+		// We hope only users can directly change this!
+		// So namespaced users can not affect other namespaces, but can change the
+		// annotations on their own namespace. let's deny that
+		if hackNamespace.Name == user.GetName() {
+			return apierrors.NewBadRequest("Can not modify users' own namespace")
+		}
+		return nil
+	}
+
+	pod, ok := a.GetObject().(*api.Pod)
+	if !ok {
+		return apierrors.NewBadRequest("Resource was marked with kind Pod but was unable to be converted")
+	}
+
+	namespaceObj, exists, err := p.store.Get(&api.Namespace{
+		ObjectMeta: api.ObjectMeta{
+			Name:      a.GetNamespace(),
+			Namespace: "",
+		},
+	})
+
+	if !exists {
+		return apierrors.NewBadRequest("Namespace " + a.GetNamespace() + " not found")
+	}
+
+	if err != nil {
+		return apierrors.NewBadRequest("Everything must be in a namespace!")
+	}
+	namespace := namespaceObj.(*api.Namespace)
+
+	if _, ok := namespace.Annotations["RunAsUser"]; !ok {
+		return apierrors.NewBadRequest("Namespace does not have a RunAsUser annotation!")
+	}
+
+	for i := 0; i < len(pod.Spec.Containers); i++ {
+		container := &pod.Spec.Containers[i]
+		uid, ok := strconv.ParseInt(namespace.Annotations["RunAsUser"], 10, 32)
+		if ok == nil {
+			if container.SecurityContext == nil {
+				container.SecurityContext = &api.SecurityContext{
+					RunAsUser: &uid,
+				}
+			} else {
+				container.SecurityContext.RunAsUser = &uid
+			}
+		} else {
+			return apierrors.NewBadRequest("Namespace's RunAsUser not an integer")
+		}
+	}
+	return nil
+}

--- a/plugin/pkg/admission/wmftoolsenforcer/admission.go
+++ b/plugin/pkg/admission/wmftoolsenforcer/admission.go
@@ -113,7 +113,7 @@ func (p *plugin) Admit(a admission.Attributes) (err error) {
 					RunAsUser: &uid,
 				}
 			} else {
-				container.SecurityContext.RunAsUser = &uid
+				return apierrors.NewBadRequest("Must have an empty SecuriyContext to pass!")
 			}
 		} else {
 			return apierrors.NewBadRequest("Namespace's RunAsUser not an integer")

--- a/plugin/pkg/admission/wmftoolsenforcer/admission.go
+++ b/plugin/pkg/admission/wmftoolsenforcer/admission.go
@@ -45,7 +45,7 @@ type plugin struct {
 	store  cache.Store
 }
 
-// NewSecurityContextDeny creates a new instance of the SecurityContextDeny admission controller
+// NewUidEnforcer creates a new instance of the UidEnforcer admission controller
 func NewUidEnforcer(client client.Interface) admission.Interface {
 	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
 	reflector := cache.NewReflector(

--- a/plugin/pkg/admission/wmftoolsenforcer/admission_test.go
+++ b/plugin/pkg/admission/wmftoolsenforcer/admission_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wmftoolsenforcer
+
+import (
+	"strconv"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/admission"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/cache"
+	"k8s.io/kubernetes/pkg/client/unversioned/testclient"
+)
+
+func validPod(name string, numContainers int) api.Pod {
+	pod := api.Pod{ObjectMeta: api.ObjectMeta{Name: name, Namespace: "test"},
+		Spec: api.PodSpec{},
+	}
+	pod.Spec.Containers = make([]api.Container, 0, numContainers)
+	for i := 0; i < numContainers; i++ {
+		pod.Spec.Containers = append(pod.Spec.Containers, api.Container{
+			Image: "foo:V" + strconv.Itoa(i),
+		})
+	}
+	return pod
+}
+
+func TestNoRunUser(t *testing.T) {
+	client := testclient.NewSimpleFake()
+	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	testPod := validPod("test", 2)
+
+	namespace := &api.Namespace{
+		ObjectMeta: api.ObjectMeta{
+			Name: testPod.Namespace,
+		},
+	}
+	store.Add(namespace)
+
+	handler := &plugin{
+		client: client,
+		store:  store,
+	}
+
+	err := handler.Admit(admission.NewAttributesRecord(&testPod, "Pod", testPod.Namespace, testPod.Name, "pods", "", admission.Update, nil))
+	if err == nil {
+		t.Errorf("Expected admission to fail but it passed!")
+	}
+}
+
+func TestPodWithUID(t *testing.T) {
+	client := testclient.NewSimpleFake()
+	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	testPod := validPod("test", 2)
+
+	namespace := &api.Namespace{
+		ObjectMeta: api.ObjectMeta{
+			Name: testPod.Namespace,
+			Annotations: map[string]string{
+				"RunAsUser": "100",
+			},
+		},
+	}
+	store.Add(namespace)
+
+	handler := &plugin{
+		client: client,
+		store:  store,
+	}
+
+	err := handler.Admit(admission.NewAttributesRecord(&testPod, "Pod", testPod.Namespace, testPod.Name, "pods", "", admission.Update, nil))
+	if err != nil {
+		t.Errorf("%+v", err)
+	}
+
+	for _, v := range testPod.Spec.Containers {
+		if v.SecurityContext != nil {
+			if *v.SecurityContext.RunAsUser != 100 {
+				t.Errorf("WTF!")
+			}
+		} else {
+			t.Errorf("Uh, no SecurityContext!")
+		}
+	}
+}


### PR DESCRIPTION
 Enforces that:

```
  - All namespaces have a RunAsUser annotation
  - Pods in a namespace will have RunAsUser set in all the containers
    to the RunAsUser annotation
```

This wouldn't ever be merged, see https://github.com/kubernetes/kubernetes/pull/16250#issuecomment-155553224 for rationale. This is here for review.
