### PR TITLE
Preload aws-sdk-go godep for 1.1 branch

### DIFF
--- a/hack/verify-godeps.sh
+++ b/hack/verify-godeps.sh
@@ -59,6 +59,9 @@ go get -u github.com/tools/godep 2>/dev/null
 go install github.com/tools/godep 2>/dev/null
 GODEP="${_tmpdir}/bin/godep"
 
+echo "Preloading aws-sdk-go godep - see https://github.com/kubernetes/kubernetes/issues/16238"
+preload-dep github.com/aws aws-sdk-go v0.9.9
+
 # fill out that nice clean place with the kube godeps
 echo "Starting to download all kubernetes godeps. This takes a while"
 


### PR DESCRIPTION
See #16238 - this just fixes it for 1.1 branch so we can get some godep bumps in e..g #16193 

/cc @eparis @justinsb @dchen1107 
