### PR TITLE
Add an option to not delete a namespace after e2e test

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -59,6 +59,7 @@ cpu-percent
 default-container-cpu-limit
 default-container-mem-limit
 delay-shutdown
+delete-namespace
 deleting-pods-burst
 deleting-pods-qps
 deployment-label-key

--- a/test/e2e/docker_containers.go
+++ b/test/e2e/docker_containers.go
@@ -17,33 +17,21 @@ limitations under the License.
 package e2e
 
 import (
-	"time"
-
 	"k8s.io/kubernetes/pkg/api"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/util"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Docker Containers", func() {
+	framework := NewFramework("containers")
 	var c *client.Client
 	var ns string
 
 	BeforeEach(func() {
-		var err error
-		c, err = loadClient()
-		Expect(err).NotTo(HaveOccurred())
-		ns_, err := createTestingNS("containers", c)
-		ns = ns_.Name
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	AfterEach(func() {
-		if err := deleteNS(c, ns, 5*time.Minute /* namespace deletion timeout */); err != nil {
-			Failf("Couldn't delete ns %s", err)
-		}
+		c = framework.Client
+		ns = framework.Namespace.Name
 	})
 
 	It("should use the image defaults if command and args are blank [Conformance]", func() {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -82,6 +82,7 @@ func init() {
 	flag.StringVar(&testContext.UpgradeTarget, "upgrade-target", "ci/latest", "Version to upgrade to (e.g. 'release/stable', 'release/latest', 'ci/latest', '0.19.1', '0.19.1-669-gabac8c8') if doing an upgrade test.")
 	flag.StringVar(&testContext.PrometheusPushGateway, "prom-push-gateway", "", "The URL to prometheus gateway, so that metrics can be pushed during e2es and scraped by prometheus. Typically something like 127.0.0.1:9091.")
 	flag.BoolVar(&testContext.VerifyServiceAccount, "e2e-verify-service-account", true, "If true tests will verify the service account before running.")
+	flag.BoolVar(&testContext.DeleteNamespace, "delete-namespace", true, "If true tests will delete namespace after completion. It is only designed to make debugging easier, DO NOT turn it off by default.")
 }
 
 func TestE2E(t *testing.T) {

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -100,14 +100,18 @@ func (f *Framework) afterEach() {
 		Failf("All nodes should be ready after test, %v", err)
 	}
 
-	By(fmt.Sprintf("Destroying namespace %q for this suite.", f.Namespace.Name))
+	if testContext.DeleteNamespace {
+		By(fmt.Sprintf("Destroying namespace %q for this suite.", f.Namespace.Name))
 
-	timeout := 5 * time.Minute
-	if f.NamespaceDeletionTimeout != 0 {
-		timeout = f.NamespaceDeletionTimeout
-	}
-	if err := deleteNS(f.Client, f.Namespace.Name, timeout); err != nil {
-		Failf("Couldn't delete ns %q: %s", f.Namespace.Name, err)
+		timeout := 5 * time.Minute
+		if f.NamespaceDeletionTimeout != 0 {
+			timeout = f.NamespaceDeletionTimeout
+		}
+		if err := deleteNS(f.Client, f.Namespace.Name, timeout); err != nil {
+			Failf("Couldn't delete ns %q: %s", f.Namespace.Name, err)
+		}
+	} else {
+		Logf("Found DeleteNamespace=false, skipping namespace deletion!")
 	}
 	// Paranoia-- prevent reuse!
 	f.Namespace = nil

--- a/test/e2e/host_path.go
+++ b/test/e2e/host_path.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"time"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/latest"
@@ -28,35 +27,21 @@ import (
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 //TODO : Consolidate this code with the code for emptyDir.
 //This will require some smart.
 var _ = Describe("hostPath", func() {
-	var (
-		c         *client.Client
-		namespace *api.Namespace
-	)
+	framework := NewFramework("hostpath")
+	var c *client.Client
+	var namespace *api.Namespace
 
 	BeforeEach(func() {
-		var err error
-		c, err = loadClient()
-		Expect(err).NotTo(HaveOccurred())
-
-		By("Building a namespace api object")
-		namespace, err = createTestingNS("hostpath", c)
-		Expect(err).NotTo(HaveOccurred())
+		c = framework.Client
+		namespace = framework.Namespace
 
 		//cleanup before running the test.
 		_ = os.Remove("/tmp/test-file")
-	})
-
-	AfterEach(func() {
-		By(fmt.Sprintf("Destroying namespace for this suite %v", namespace.Name))
-		if err := deleteNS(c, namespace.Name, 5*time.Minute /* namespace deletion timeout */); err != nil {
-			Failf("Couldn't delete ns %s", err)
-		}
 	})
 
 	It("should give a volume the correct mode [Conformance]", func() {

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -76,23 +76,12 @@ var proxyRegexp = regexp.MustCompile("Starting to serve on 127.0.0.1:([0-9]+)")
 
 var _ = Describe("Kubectl client", func() {
 	defer GinkgoRecover()
+	framework := NewFramework("kubectl")
 	var c *client.Client
 	var ns string
-	var testingNs *api.Namespace
 	BeforeEach(func() {
-		var err error
-		c, err = loadClient()
-		expectNoError(err)
-		testingNs, err = createTestingNS("kubectl", c)
-		Expect(err).NotTo(HaveOccurred())
-		ns = testingNs.Name
-	})
-
-	AfterEach(func() {
-		By(fmt.Sprintf("Destroying namespace for this suite %v", ns))
-		if err := deleteNS(c, ns, 5*time.Minute /* namespace deletion timeout */); err != nil {
-			Failf("Couldn't delete ns %s", err)
-		}
+		c = framework.Client
+		ns = framework.Namespace.Name
 	})
 
 	Describe("Update Demo", func() {

--- a/test/e2e/persistent_volumes.go
+++ b/test/e2e/persistent_volumes.go
@@ -17,7 +17,6 @@ limitations under the License.
 package e2e
 
 import (
-	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -33,23 +32,13 @@ import (
 // the test needs privileged containers, which are disabled by default.
 // Run the test with "go run hack/e2e.go ... --ginkgo.focus=PersistentVolume"
 var _ = Describe("[Skipped] persistentVolumes", func() {
+	framework := NewFramework("pv")
 	var c *client.Client
 	var ns string
 
 	BeforeEach(func() {
-		var err error
-		c, err = loadClient()
-		Expect(err).NotTo(HaveOccurred())
-		ns_, err := createTestingNS("pv", c)
-		ns = ns_.Name
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	AfterEach(func() {
-		By(fmt.Sprintf("Destroying namespace for this suite %v", ns))
-		if err := deleteNS(c, ns, 5*time.Minute /* namespace deletion timeout */); err != nil {
-			Failf("Couldn't delete ns %s", err)
-		}
+		c = framework.Client
+		ns = framework.Namespace.Name
 	})
 
 	It("PersistentVolume", func() {

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -54,13 +54,17 @@ var _ = Describe("Services", func() {
 	})
 
 	AfterEach(func() {
-		for _, ns := range extraNamespaces {
-			By(fmt.Sprintf("Destroying namespace %v", ns))
-			if err := deleteNS(c, ns, 5*time.Minute /* namespace deletion timeout */); err != nil {
-				Failf("Couldn't delete namespace %s: %s", ns, err)
+		if testContext.DeleteNamespace {
+			for _, ns := range extraNamespaces {
+				By(fmt.Sprintf("Destroying namespace %v", ns))
+				if err := deleteNS(c, ns, 5*time.Minute /* namespace deletion timeout */); err != nil {
+					Failf("Couldn't delete namespace %s: %s", ns, err)
+				}
 			}
+			extraNamespaces = nil
+		} else {
+			Logf("Found DeleteNamespace=false, skipping namespace deletion!")
 		}
-		extraNamespaces = nil
 	})
 
 	// TODO: We get coverage of TCP/UDP and multi-port services through the DNS test. We should have a simpler test for multi-port TCP here.

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -120,6 +120,7 @@ type TestContextType struct {
 	UpgradeTarget         string
 	PrometheusPushGateway string
 	VerifyServiceAccount  bool
+	DeleteNamespace       bool
 }
 
 var testContext TestContextType

--- a/test/e2e/volumes.go
+++ b/test/e2e/volumes.go
@@ -219,27 +219,18 @@ func testVolumeClient(client *client.Client, config VolumeTestConfig, volume api
 }
 
 var _ = Describe("Volumes", func() {
-	clean := true // If 'false', the test won't clear its namespace (and pods and services) upon completion. Useful for debugging.
+	framework := NewFramework("volume")
 
+	// If 'false', the test won't clear its volumes upon completion. Useful for debugging,
+	// note that namespace deletion is handled by delete-namespace flag
+	clean := true
 	// filled in BeforeEach
 	var c *client.Client
 	var namespace *api.Namespace
 
 	BeforeEach(func() {
-		var err error
-		c, err = loadClient()
-		Expect(err).NotTo(HaveOccurred())
-		By("Building a namespace api object")
-		namespace, err = createTestingNS("volume", c)
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	AfterEach(func() {
-		if clean {
-			if err := deleteNS(c, namespace.Name, 5*time.Minute /* namespace deletion timeout */); err != nil {
-				Failf("Couldn't delete ns %s", err)
-			}
-		}
+		c = framework.Client
+		namespace = framework.Namespace
 	})
 
 	////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
cc @quinton-hoole - I'm recreating my old PR that does this. In Kubemark clusters we wait for hours before namespace get deleted and first thing we do afterwards is turning down the cluster.
