### PR TITLE
HTTP Client request metrics: consolidating and adding request statuses.

### DIFF
--- a/pkg/client/metrics/metrics.go
+++ b/pkg/client/metrics/metrics.go
@@ -38,6 +38,15 @@ var (
 		},
 		[]string{"verb", "url"},
 	)
+
+	RequestResult = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: restClientSubsystem,
+			Name:      "request_status_codes",
+			Help:      "Number of http requests, partitioned by metadata",
+		},
+		[]string{"code", "method", "host"},
+	)
 )
 
 var registerMetrics sync.Once
@@ -48,6 +57,7 @@ func Register() {
 	// Register the metrics.
 	registerMetrics.Do(func() {
 		prometheus.MustRegister(RequestLatency)
+		prometheus.MustRegister(RequestResult)
 	})
 }
 


### PR DESCRIPTION
This adds the ability to graph errors (i.e. 409's 404s and so on) seen at the client level.
- Purpose: This is Related to helping diagnose #16134 and confirming backoff behaviour improvements we are working on in #16100 .  
- I also consolidated the metrics in `Do` and `DoRaw` here, because I think they are all ultimately calling the `request()` function.   Any initial thoughts @fgrzadkowski ?  
