### PR TITLE
Revert "Improved HPA e2e to test stability of the scale decision"

### DIFF
--- a/test/e2e/autoscaling_utils.go
+++ b/test/e2e/autoscaling_utils.go
@@ -231,17 +231,6 @@ func (rc *ResourceConsumer) WaitForReplicas(desiredReplicas int) {
 	Failf("timeout waiting %v for pods size to be %d", timeout, desiredReplicas)
 }
 
-func (rc *ResourceConsumer) EnsureDesiredReplicas(desiredReplicas int, timeout time.Duration) {
-	for start := time.Now(); time.Since(start) < timeout; time.Sleep(10 * time.Second) {
-		actual := rc.GetReplicas()
-		if desiredReplicas != actual {
-			Failf("Number of replicas has changed: expected %v, got %v", desiredReplicas, actual)
-		}
-		Logf("Number of replicas is as expected")
-	}
-	Logf("Number of replicas was stable over %v", timeout)
-}
-
 func (rc *ResourceConsumer) CleanUp() {
 	By(fmt.Sprintf("Removing consuming RC %s", rc.name))
 	rc.stopCPU <- 0

--- a/test/e2e/horizontal_pod_autoscaling.go
+++ b/test/e2e/horizontal_pod_autoscaling.go
@@ -17,8 +17,6 @@ limitations under the License.
 package e2e
 
 import (
-	"time"
-
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 
@@ -26,9 +24,8 @@ import (
 )
 
 const (
-	kind             = "replicationController"
-	subresource      = "scale"
-	stabilityTimeout = 10 * time.Minute
+	kind        = "replicationController"
+	subresource = "scale"
 )
 
 var _ = Describe("Horizontal pod autoscaling", func() {
@@ -41,7 +38,6 @@ var _ = Describe("Horizontal pod autoscaling", func() {
 		defer rc.CleanUp()
 		createCPUHorizontalPodAutoscaler(rc, 20)
 		rc.WaitForReplicas(3)
-		rc.EnsureDesiredReplicas(3, stabilityTimeout)
 		rc.ConsumeCPU(700)
 		rc.WaitForReplicas(5)
 	})
@@ -51,7 +47,6 @@ var _ = Describe("Horizontal pod autoscaling", func() {
 		defer rc.CleanUp()
 		createCPUHorizontalPodAutoscaler(rc, 30)
 		rc.WaitForReplicas(3)
-		rc.EnsureDesiredReplicas(3, stabilityTimeout)
 		rc.ConsumeCPU(100)
 		rc.WaitForReplicas(1)
 	})


### PR DESCRIPTION
Reverts kubernetes/kubernetes#16156

The test failed in autoscaling suite run 1496, @jszczepkowski is working on fix
