### PR TITLE
Fixed resetting last scale time in HPA status.

### DIFF
--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -160,6 +160,7 @@ func (a *HorizontalController) reconcileAutoscaler(hpa extensions.HorizontalPodA
 		CurrentReplicas:                 currentReplicas,
 		DesiredReplicas:                 desiredReplicas,
 		CurrentCPUUtilizationPercentage: currentUtilization,
+		LastScaleTime:                   hpa.Status.LastScaleTime,
 	}
 	if rescale {
 		now := unversioned.NewTime(now)


### PR DESCRIPTION
Fixed resetting last scale time in HPA status. Fixes #16275.
