### PR TITLE
Automated cherry pick of #14191 #14882 upstream release 1.0

### DIFF
--- a/pkg/proxy/proxier.go
+++ b/pkg/proxy/proxier.go
@@ -133,7 +133,7 @@ func NewProxier(loadBalancer LoadBalancer, listenIP net.IP, iptables iptables.In
 
 	err = setRLimit(64 * 1000)
 	if err != nil {
-		return nil, fmt.Errorf("failed to set open file handler limit", err)
+		return nil, fmt.Errorf("failed to set open file handler limit: %v", err)
 	}
 
 	proxyPorts := newPortAllocator(pr)


### PR DESCRIPTION
Bring the kube-proxy rlimit fix into 1.0.x
