### PR TITLE
Fix AWS EBS detach operation.

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -916,6 +916,23 @@ func (self *awsInstance) releaseMountDevice(volumeID string, mountDevice string)
 	delete(self.deviceMappings, mountDevice)
 }
 
+func (self *awsInstance) releaseMountDeviceByVolume(volumeID string) {
+	self.mutex.Lock()
+	defer self.mutex.Unlock()
+
+	// Sequentially find 'device', whose self.deviceMappings[device] == volumeID
+	// AWS supports only 40 attached EBS volumes, we probably do not need to
+	// over-optimize with maps and such.
+	for device, existingVolumeID := range self.deviceMappings {
+		if existingVolumeID == volumeID {
+			glog.V(2).Infof("Releasing mount device mapping: %s -> volume %s", device, volumeID)
+			delete(self.deviceMappings, device)
+			return
+		}
+	}
+	glog.Errorf("releaseMountDeviceByVolume on non-allocated volume %s", volumeID)
+}
+
 type awsDisk struct {
 	ec2 EC2
 
@@ -1170,6 +1187,7 @@ func (aws *AWSCloud) DetachDisk(instanceName string, diskName string) error {
 		return err
 	}
 
+	awsInstance.releaseMountDeviceByVolume(disk.awsID)
 	return err
 }
 


### PR DESCRIPTION
Remove the record about attached EBS when detach completes, otherwise
subsequent attach of the same volume never completes.

Fixes #15073
