### PR TITLE
Fixes to kubekins test-image, add makefile

### DIFF
--- a/hack/jenkins/gotest-dockerized.sh
+++ b/hack/jenkins/gotest-dockerized.sh
@@ -24,11 +24,23 @@ export REPO_DIR=${REPO_DIR:-$(pwd)}
 # Produce a JUnit-style XML test report for Jenkins.
 export KUBE_JUNIT_REPORT_DIR=${WORKSPACE}/_artifacts
 
-# Run the kubekins container, mapping in docker (so we can launch containers)
-# and the repo directory
-docker run -v /var/run/docker.sock:/var/run/docker.sock \
+# Run the kubekins container, mapping in docker (so we can launch containers),
+# the repo directory, and the artifacts output directory.
+#
+# Note: We pass in the absolute path to the repo on the host as an env var incase
+# any tests that get run need to launch containers that also map volumes.
+# This is required because if you do
+#
+# $ docker run -v $PATH:/container/path ...
+#
+# From _inside_ a container that has the host's docker mapped in, the $PATH
+# provided must be resolvable on the *HOST*, not the container.
+
+docker run --rm=true \
+  -v /var/run/docker.sock:/var/run/docker.sock \
   -v "$(which docker)":/bin/docker \
   -v "${REPO_DIR}":/go/src/k8s.io/kubernetes \
   -v "${KUBE_JUNIT_REPORT_DIR}":/workspace/artifacts \
-  -it kubekins-test \
-  bash -c "cd kubernetes && /workspace/run.sh"
+  --env REPO_DIR="${REPO_DIR}" \
+  -it gcr.io/google_containers/kubekins-test:0.1 \
+  bash -c "cd kubernetes && ./hack/jenkins/test-dockerized.sh"

--- a/hack/jenkins/test-image/Dockerfile
+++ b/hack/jenkins/test-image/Dockerfile
@@ -16,16 +16,17 @@
 # unit and integration tests
 
 FROM golang:1.4
-MAINTAINER  jeff lowdermilk <jeffml@google.com>
+MAINTAINER  Jeff Lowdermilk <jeffml@google.com>
 
 ENV KUBE_TEST_API_VERSIONS  v1,extensions/v1beta1
 ENV KUBE_TEST_ETCD_PREFIXES registry
 ENV WORKSPACE               /workspace
+ENV TERM                    xterm
 
 WORKDIR /workspace
-ADD run.sh ./
 
 RUN apt-get -o Acquire::Check-Valid-Until=false update && apt-get install -y rsync
+RUN apt-get install -y file
 RUN mkdir -p /go/src/k8s.io/kubernetes
 RUN ln -s /go/src/k8s.io/kubernetes /workspace/kubernetes
 

--- a/hack/jenkins/test-image/Makefile
+++ b/hack/jenkins/test-image/Makefile
@@ -1,0 +1,13 @@
+all: push
+
+TAG = 0.1
+
+container:
+	docker build -t gcr.io/google_containers/kubekins-test .
+	docker tag gcr.io/google_containers/kubekins-test gcr.io/google_containers/kubekins-test:$(TAG)
+
+push: container
+	gcloud docker push gcr.io/google_containers/kubekins-test # Push image tagged as latest to repository
+	gcloud docker push gcr.io/google_containers/kubekins-test:$(TAG) # Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
+
+clean:

--- a/hack/update-api-reference-docs.sh
+++ b/hack/update-api-reference-docs.sh
@@ -22,14 +22,15 @@ set -o nounset
 set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
-DEFAULT_OUTPUT_PATH="$PWD/${KUBE_ROOT}/docs/api-reference"
+REPO_DIR=${REPO_DIR:-"${PWD}/${KUBE_ROOT}"}
+DEFAULT_OUTPUT_PATH="${REPO_DIR}/docs/api-reference"
 OUTPUT=${1:-${DEFAULT_OUTPUT_PATH}}
 
 echo "Generating api reference docs at ${OUTPUT}"
 
 V1_PATH="${OUTPUT}/v1/"
 V1BETA1_PATH="${OUTPUT}/extensions/v1beta1"
-SWAGGER_PATH="$PWD/${KUBE_ROOT}/api/swagger-spec/"
+SWAGGER_PATH="${REPO_DIR}/api/swagger-spec/"
 
 echo "Reading swagger spec from: ${SWAGGER_PATH}"
 

--- a/hack/verify-api-reference-docs.sh
+++ b/hack/verify-api-reference-docs.sh
@@ -26,11 +26,19 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 kube::golang::setup_env
 
 API_REFERENCE_DOCS_ROOT="${KUBE_ROOT}/docs/api-reference"
+# Use REPO_DIR if provided so we can set it to the host-resolvable path
+# to the repo root if we are running this script from a container with
+# docker mounted in as a volume.
+# We pass the host output dir to update-api-reference-docs.sh, but use
+# the regular one to compute diff (they will be the same if running this
+# test on the host, potentially different if running in a container).
+REPO_DIR=${REPO_DIR:-"${KUBE_ROOT}"}
+HOST_OUTPUT_DIR="${REPO_DIR}/_tmp/api-reference"
 TMP_OUTPUT_DIR="${KUBE_ROOT}/_tmp/api-reference"
 TMP_ROOT="${KUBE_ROOT}/_tmp"
 
 # Generate API reference docs in tmp.
-"./hack/update-api-reference-docs.sh" "${TMP_OUTPUT_DIR}"
+"./hack/update-api-reference-docs.sh" "${HOST_OUTPUT_DIR}"
 
 echo "diffing ${API_REFERENCE_DOCS_ROOT} against freshly generated docs"
 ret=0


### PR DESCRIPTION
Fix issues, address comments from #16140. Also, closes #14781

@ixdy, to answer "why separate gotest-pr.sh"; tests run in container as root, so build/test output files in the workspace get owned by root as well. This requires extra cleanup steps I didn't want to reproduce for the `kubernetes-test-go` job, but I can if you think it's worth doing.
