### PR TITLE
Standardized test image Makefile targets

### DIFF
--- a/test/images/dnsutils/Makefile
+++ b/test/images/dnsutils/Makefile
@@ -1,8 +1,13 @@
-all:
-	@echo "try 'make image' or 'make push'"
+# This image does not tag
+#TAG =
+PREFIX = gcr.io/google_containers
+
+all: push
 
 image:
-	docker build -t gcr.io/google_containers/dnsutils .
+	docker build -t $(PREFIX)/dnsutils .
 
-push:
-	gcloud docker push gcr.io/google_containers/dnsutils
+push: image
+	gcloud docker push $(PREFIX)/dnsutils
+
+clean:

--- a/test/images/entrypoint-tester/Makefile
+++ b/test/images/entrypoint-tester/Makefile
@@ -1,15 +1,16 @@
-all: push
-
 TAG = 0.1
+PREFIX = kubernetes
+
+all: push
 
 ep: ep.go
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' ./ep.go
 
 image: ep
-	sudo docker build -t kubernetes/eptest:$(TAG) .
+	sudo docker build -t $(PREFIX)/eptest:$(TAG) .
 
 push: image
-	sudo docker push kubernetes/eptest:$(TAG)
+	sudo docker push $(PREFIX)/eptest:$(TAG)
 
 clean:
 	rm -f ep

--- a/test/images/goproxy/Makefile
+++ b/test/images/goproxy/Makefile
@@ -1,15 +1,16 @@
-all: push
-
 TAG = 0.1
+PREFIX = gcr.io/google_containers
+
+all: push
 
 goproxy: goproxy.go
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' ./goproxy.go
 
 image: goproxy
-	docker build -t gcr.io/google_containers/goproxy:$(TAG) .
+	docker build -t $(PREFIX)/goproxy:$(TAG) .
 
 push: image
-	gcloud docker push gcr.io/google_containers/goproxy:$(TAG)
+	gcloud docker push $(PREFIX)/goproxy:$(TAG)
 
 clean:
 	rm -f goproxy

--- a/test/images/jessie-dnsutils/Makefile
+++ b/test/images/jessie-dnsutils/Makefile
@@ -1,8 +1,13 @@
-all:
-	@echo "try 'make image' or 'make push'"
+# This image does not tag
+#TAG =
+PREFIX = gcr.io/google_containers
+
+all: push
 
 image:
-	docker build -t gcr.io/google_containers/jessie-dnsutils .
+	docker build -t $(PREFIX)/jessie-dnsutils .
 
-push:
-	gcloud docker push gcr.io/google_containers/jessie-dnsutils
+push: image
+	gcloud docker push $(PREFIX)/jessie-dnsutils
+
+clean:

--- a/test/images/mount-tester-user/Makefile
+++ b/test/images/mount-tester-user/Makefile
@@ -1,9 +1,12 @@
+TAG = 0.3
+PREFIX = gcr.io/google_containers
+
 all: push
 
-TAG = 0.3
-
 image:
-	sudo docker build -t gcr.io/google_containers/mounttest-user:$(TAG) .
+	sudo docker build -t $(PREFIX)/mounttest-user:$(TAG) .
 
 push: image
-	gcloud docker push gcr.io/google_containers/mounttest-user:$(TAG)
+	gcloud docker push $(PREFIX)/mounttest-user:$(TAG)
+
+clean:

--- a/test/images/mount-tester/Makefile
+++ b/test/images/mount-tester/Makefile
@@ -1,15 +1,16 @@
-all: push
-
 TAG = 0.5
+PREFIX = gcr.io/google_containers
+
+all: push
 
 mt: mt.go
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' ./mt.go
 
 image: mt
-	sudo docker build -t gcr.io/google_containers/mounttest:$(TAG) .
+	sudo docker build -t $(PREFIX)/mounttest:$(TAG) .
 
 push: image
-	gcloud docker push gcr.io/google_containers/mounttest:$(TAG)
+	gcloud docker push $(PREFIX)/mounttest:$(TAG)
 
 clean:
 	rm -f mt

--- a/test/images/network-tester/Makefile
+++ b/test/images/network-tester/Makefile
@@ -1,16 +1,18 @@
-all: push
-
-# Set this to the *next* version to prevent accidentally overwriting the existing image.
 TAG = 1.6
+PREFIX = gcr.io/google_containers
+
+all: push
 
 webserver: webserver.go
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' ./webserver.go
 
-container: webserver
-	docker build -t gcr.io/google_containers/nettest:$(TAG) .
+container: image
 
-push: container
-	gcloud docker push gcr.io/google_containers/nettest:$(TAG)
+image: webserver
+	docker build -t $(PREFIX)/nettest:$(TAG) .
+
+push: image
+	gcloud docker push $(PREFIX)/nettest:$(TAG)
 
 clean:
 	rm -f webserver

--- a/test/images/port-forward-tester/Makefile
+++ b/test/images/port-forward-tester/Makefile
@@ -1,15 +1,16 @@
-all: push
-
 TAG = 1.0
+PREFIX = gcr.io/google_containers
+
+all: push
 
 portforwardtester: portforwardtester.go
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' ./portforwardtester.go
 
 image: portforwardtester
-	docker build -t gcr.io/google_containers/portforwardtester:$(TAG) .
+	docker build -t $(PREFIX)/portforwardtester:$(TAG) .
 
 push: image
-	gcloud docker push gcr.io/google_containers/portforwardtester:$(TAG)
+	gcloud docker push $(PREFIX)/portforwardtester:$(TAG)
 
 clean:
 	rm -f portforwardtester

--- a/test/images/porter/Makefile
+++ b/test/images/porter/Makefile
@@ -2,10 +2,12 @@
 #
 # `make porter` will build porter.
 # `make tag` will suggest a tag.
-# `make container` will build a container-- you must supply a tag.
-# `make push` will push the container-- you must supply a tag.
+# `make image` will build an image-- you must supply a tag.
+# `make push` will push the image-- you must supply a tag.
 
-REPO ?= gcr.io/google_containers
+# This image does not tag in the normal way
+# TAG =
+PREFIX = gcr.io/google_containers
 SUGGESTED_TAG = $(shell git rev-parse --verify HEAD)
 
 porter: porter.go
@@ -17,13 +19,15 @@ tag:
 	@echo "or"
 	@echo "$$ make push TAG=$(SUGGESTED_TAG)"
 
-container:
+container: image
+
+image:
 	$(if $(TAG),,$(error TAG is not defined. Use 'make tag' after committing changes to see a suggestion))
-	docker build -t $(REPO)/porter:$(TAG) .
+	docker build -t $(PREFIX)/porter:$(TAG) .
 
 push:
 	$(if $(TAG),,$(error TAG is not defined. Use 'make tag' after committing changes to see a suggestion))
-	gcloud docker push $(REPO)/porter:$(TAG)
+	gcloud docker push $(PREFIX)/porter:$(TAG)
 
 clean:
 	rm -f porter

--- a/test/images/resource-consumer/Makefile
+++ b/test/images/resource-consumer/Makefile
@@ -1,16 +1,22 @@
-all: clean consumer
-
 TAG = beta
+PREFIX = gcr.io/google_containers
+
+all: clean consumer
 
 consumer:
 	CGO_ENABLED=0 godep go build -a -installsuffix cgo --ldflags '-w' -o consume-cpu/consume-cpu ./consume-cpu/consume_cpu.go
 	CGO_ENABLED=0 godep go build -a -installsuffix cgo --ldflags '-w' -o consumer .
 
-container:
-	sudo docker build -t gcr.io/google_containers/resource_consumer:$(TAG) .	
+container: image
+
+image:
+	sudo docker build -t $(PREFIX)/resource_consumer:$(TAG) .
 
 run_container:
-	docker run --publish=8080:8080 gcr.io/google_containers/resource_consumer:$(TAG)
+	docker run --publish=8080:8080 $(PREFIX)/resource_consumer:$(TAG)
+
+push:
+	@echo "This image is not meant to be pushed."
 
 clean:
 	rm -f consumer

--- a/test/images/volumes-tester/ceph/Makefile
+++ b/test/images/volumes-tester/ceph/Makefile
@@ -1,13 +1,16 @@
+TAG = 0.1
+PREFIX = gcr.io/google_containers
+
 all: push
 
-TAG = 0.1
+container: image
 
-container:
-	docker build -t gcr.io/google_containers/volume-ceph . # Build new image and automatically tag it as latest
-	docker tag gcr.io/google_containers/volume-ceph gcr.io/google_containers/volume-ceph:$(TAG)  # Add the version tag to the latest image 
+image:
+	docker build -t $(PREFIX)/volume-ceph . # Build new image and automatically tag it as latest
+	docker tag $(PREFIX)/volume-ceph $(PREFIX)/volume-ceph:$(TAG)  # Add the version tag to the latest image
 
-push: container
-	gcloud docker push gcr.io/google_containers/volume-ceph # Push image tagged as latest to repository
-	gcloud docker push gcr.io/google_containers/volume-ceph:$(TAG) # Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
+push: image
+	gcloud docker push $(PREFIX)/volume-ceph # Push image tagged as latest to repository
+	gcloud docker push $(PREFIX)/volume-ceph:$(TAG) # Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
 
 clean:

--- a/test/images/volumes-tester/gluster/Makefile
+++ b/test/images/volumes-tester/gluster/Makefile
@@ -1,13 +1,16 @@
+TAG = 0.2
+PREFIX = gcr.io/google_containers
+
 all: push
 
-TAG = 0.2
+container: image
 
-container:
-	docker build -t gcr.io/google_containers/volume-gluster . # Build new image and automatically tag it as latest
-	docker tag gcr.io/google_containers/volume-gluster gcr.io/google_containers/volume-gluster:$(TAG)  # Add the version tag to the latest image 
+image:
+	docker build -t $(PREFIX)/volume-gluster . # Build new image and automatically tag it as latest
+	docker tag $(PREFIX)/volume-gluster $(PREFIX)/volume-gluster:$(TAG)  # Add the version tag to the latest image 
 
-push: container
-	gcloud docker push gcr.io/google_containers/volume-gluster # Push image tagged as latest to repository
-	gcloud docker push gcr.io/google_containers/volume-gluster:$(TAG) # Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
+push: image
+	gcloud docker push $(PREFIX)/volume-gluster # Push image tagged as latest to repository
+	gcloud docker push $(PREFIX)/volume-gluster:$(TAG) # Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
 
 clean:

--- a/test/images/volumes-tester/iscsi/Makefile
+++ b/test/images/volumes-tester/iscsi/Makefile
@@ -1,12 +1,15 @@
+TAG = 0.1
+PREFIX = gcr.io/google_containers
+
 all: push
 
-TAG = 0.1
+container: image
 
-container:
+image:
 	# Build new image and automatically tag it as latest
-	docker build -t gcr.io/google_containers/volume-iscsi .
+	docker build -t $(PREFIX)/volume-iscsi .
 	# Add the version tag to the latest image
-	docker tag gcr.io/google_containers/volume-iscsi gcr.io/google_containers/volume-iscsi:$(TAG)
+	docker tag $(PREFIX)/volume-iscsi $(PREFIX)/volume-iscsi:$(TAG)
 
 block:
 	# Create block.tar.gz with ext2 block device with index.html inside.
@@ -15,8 +18,10 @@ block:
 	# Run as root!
 	./create_block.sh
 
-push: container
+push: image
 	# Push image tagged as latest to repository
-	gcloud docker push gcr.io/google_containers/volume-iscsi
+	gcloud docker push $(PREFIX)/volume-iscsi
 	# Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
-	gcloud docker push gcr.io/google_containers/volume-iscsi:$(TAG)
+	gcloud docker push $(PREFIX)/volume-iscsi:$(TAG)
+
+clean:

--- a/test/images/volumes-tester/nfs/Makefile
+++ b/test/images/volumes-tester/nfs/Makefile
@@ -1,13 +1,16 @@
+TAG = 0.4
+PREFIX = gcr.io/google_containers
+
 all: push
 
-TAG = 0.4
+container: image
 
-container:
-	docker build -t gcr.io/google_containers/volume-nfs . # Build new image and automatically tag it as latest
-	docker tag gcr.io/google_containers/volume-nfs gcr.io/google_containers/volume-nfs:$(TAG) # Add the version tag to the latest image 
+image:
+	docker build -t $(PREFIX)/volume-nfs . # Build new image and automatically tag it as latest
+	docker tag $(PREFIX)/volume-nfs $(PREFIX)/volume-nfs:$(TAG) # Add the version tag to the latest image
 
-push: container
-	gcloud docker push gcr.io/google_containers/volume-nfs # Push image tagged as latest to repository
-	gcloud docker push gcr.io/google_containers/volume-nfs:$(TAG) # Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
+push: image
+	gcloud docker push $(PREFIX)/volume-nfs # Push image tagged as latest to repository
+	gcloud docker push $(PREFIX)/volume-nfs:$(TAG) # Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
 
 clean:

--- a/test/images/volumes-tester/rbd/Makefile
+++ b/test/images/volumes-tester/rbd/Makefile
@@ -1,12 +1,15 @@
+TAG = 0.1
+PREFIX = gcr.io/google_containers
+
 all: push
 
-TAG = 0.1
+container: image
 
-container:
+image:
 	# Build new image and automatically tag it as latest
-	docker build -t gcr.io/google_containers/volume-rbd .
+	docker build -t $(PREFIX)/volume-rbd .
 	# Add the version tag to the latest image 
-	docker tag gcr.io/google_containers/volume-rbd gcr.io/google_containers/volume-rbd:$(TAG)
+	docker tag $(PREFIX)/volume-rbd $(PREFIX)/volume-rbd:$(TAG)
 
 block:
 	# Create block.tar.gz with ext2 block device with index.html inside.
@@ -15,8 +18,10 @@ block:
 	# Run as root!
 	./create_block.sh
 
-push: container
+push: image
 	# Push image tagged as latest to repository
-	gcloud docker push gcr.io/google_containers/volume-rbd
+	gcloud docker push $(PREFIX)/volume-rbd
 	# Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
-	gcloud docker push gcr.io/google_containers/volume-rbd:$(TAG)
+	gcloud docker push $(PREFIX)/volume-rbd:$(TAG)
+
+clean:


### PR DESCRIPTION
### Updates

`Makefile`s under `test/e2e/` now always support:
- **all**: The default target
- **clean**: Always present even if there is nothing to do
- **image**: Creation of an image
- **push**: Pushes the image to a repository

If a `Makefile` previously used `container` a forward target to `image` is created to retain backwards compatability.

For builds with tags a `TAG` variable has been added. 

All builds have a new variable called `PREFIX` which holds the repository prefix. With few exceptions this is `gcr.io/google_containers`.
### Special Case: porter/Makefile

This build was significantly different. Minor modifications have been made to bring it close to a standard but much of it's specialty has been left alone. This includes how it tags.
