### PR TITLE
Automated cherry pick of #16219 upstream release 1.1

### DIFF
--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -39,6 +39,8 @@ type Interface interface {
 	Routes() (Routes, bool)
 	// ProviderName returns the cloud provider ID.
 	ProviderName() string
+	// ScrubDNS provides an opportunity for cloud-provider-specific code to process DNS settings for pods.
+	ScrubDNS(nameservers, searches []string) (nsOut, srchOut []string)
 }
 
 // Clusters is an abstract, pluggable interface for clusters of containers.

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -589,6 +589,11 @@ func (aws *AWSCloud) ProviderName() string {
 	return ProviderName
 }
 
+// ScrubDNS filters DNS settings for pods.
+func (aws *AWSCloud) ScrubDNS(nameservers, searches []string) (nsOut, srchOut []string) {
+	return nameservers, searches
+}
+
 // TCPLoadBalancer returns an implementation of TCPLoadBalancer for Amazon Web Services.
 func (s *AWSCloud) TCPLoadBalancer() (cloudprovider.TCPLoadBalancer, bool) {
 	return s, true

--- a/pkg/cloudprovider/providers/fake/fake.go
+++ b/pkg/cloudprovider/providers/fake/fake.go
@@ -94,6 +94,11 @@ func (f *FakeCloud) ProviderName() string {
 	return ProviderName
 }
 
+// ScrubDNS filters DNS settings for pods.
+func (f *FakeCloud) ScrubDNS(nameservers, searches []string) (nsOut, srchOut []string) {
+	return nameservers, searches
+}
+
 // TCPLoadBalancer returns a fake implementation of TCPLoadBalancer.
 // Actually it just returns f itself.
 func (f *FakeCloud) TCPLoadBalancer() (cloudprovider.TCPLoadBalancer, bool) {

--- a/pkg/cloudprovider/providers/gce/gce_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_test.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package gce_cloud
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestGetRegion(t *testing.T) {
 	gce := &GCECloud{
@@ -121,6 +124,42 @@ func TestComparingHostURLs(t *testing.T) {
 			t.Errorf("expected link1 and link2 to be equal, got %s and %s", link1, link2)
 		} else if !test.expectEqual && link1 == link2 {
 			t.Errorf("expected link1 and link2 not to be equal, got %s and %s", link1, link2)
+		}
+	}
+}
+
+func TestScrubDNS(t *testing.T) {
+	tcs := []struct {
+		nameserversIn  []string
+		searchesIn     []string
+		nameserversOut []string
+		searchesOut    []string
+	}{
+		{
+			nameserversIn:  []string{"1.2.3.4", "5.6.7.8"},
+			nameserversOut: []string{"1.2.3.4", "5.6.7.8"},
+		},
+		{
+			searchesIn:  []string{"c.prj.internal.", "12345678910.google.internal.", "google.internal."},
+			searchesOut: []string{"c.prj.internal.", "google.internal."},
+		},
+		{
+			searchesIn:  []string{"c.prj.internal.", "12345678910.google.internal.", "zone.c.prj.internal.", "google.internal."},
+			searchesOut: []string{"c.prj.internal.", "zone.c.prj.internal.", "google.internal."},
+		},
+		{
+			searchesIn:  []string{"c.prj.internal.", "12345678910.google.internal.", "zone.c.prj.internal.", "google.internal.", "unexpected"},
+			searchesOut: []string{"c.prj.internal.", "zone.c.prj.internal.", "google.internal.", "unexpected"},
+		},
+	}
+	gce := &GCECloud{}
+	for i := range tcs {
+		n, s := gce.ScrubDNS(tcs[i].nameserversIn, tcs[i].searchesIn)
+		if !reflect.DeepEqual(n, tcs[i].nameserversOut) {
+			t.Errorf("Expected %v, got %v", tcs[i].nameserversOut, n)
+		}
+		if !reflect.DeepEqual(s, tcs[i].searchesOut) {
+			t.Errorf("Expected %v, got %v", tcs[i].searchesOut, s)
 		}
 	}
 }

--- a/pkg/cloudprovider/providers/mesos/mesos.go
+++ b/pkg/cloudprovider/providers/mesos/mesos.go
@@ -124,6 +124,11 @@ func (c *MesosCloud) ProviderName() string {
 	return ProviderName
 }
 
+// ScrubDNS filters DNS settings for pods.
+func (c *MesosCloud) ScrubDNS(nameservers, searches []string) (nsOut, srchOut []string) {
+	return nameservers, searches
+}
+
 // ListClusters lists the names of the available Mesos clusters.
 func (c *MesosCloud) ListClusters() ([]string, error) {
 	// Always returns a single cluster (this one!)

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -399,6 +399,11 @@ func (os *OpenStack) ProviderName() string {
 	return ProviderName
 }
 
+// ScrubDNS filters DNS settings for pods.
+func (os *OpenStack) ScrubDNS(nameservers, searches []string) (nsOut, srchOut []string) {
+	return nameservers, searches
+}
+
 type LoadBalancer struct {
 	network *gophercloud.ServiceClient
 	compute *gophercloud.ServiceClient

--- a/pkg/cloudprovider/providers/ovirt/ovirt.go
+++ b/pkg/cloudprovider/providers/ovirt/ovirt.go
@@ -123,6 +123,11 @@ func (v *OVirtCloud) ProviderName() string {
 	return ProviderName
 }
 
+// ScrubDNS filters DNS settings for pods.
+func (v *OVirtCloud) ScrubDNS(nameservers, searches []string) (nsOut, srchOut []string) {
+	return nameservers, searches
+}
+
 // TCPLoadBalancer returns an implementation of TCPLoadBalancer for oVirt cloud
 func (v *OVirtCloud) TCPLoadBalancer() (cloudprovider.TCPLoadBalancer, bool) {
 	return nil, false

--- a/pkg/cloudprovider/providers/rackspace/rackspace.go
+++ b/pkg/cloudprovider/providers/rackspace/rackspace.go
@@ -362,6 +362,11 @@ func (os *Rackspace) ProviderName() string {
 	return ProviderName
 }
 
+// ScrubDNS filters DNS settings for pods.
+func (os *Rackspace) ScrubDNS(nameservers, searches []string) (nsOut, srchOut []string) {
+	return nameservers, searches
+}
+
 func (os *Rackspace) TCPLoadBalancer() (cloudprovider.TCPLoadBalancer, bool) {
 	return nil, false
 }

--- a/pkg/cloudprovider/providers/vagrant/vagrant.go
+++ b/pkg/cloudprovider/providers/vagrant/vagrant.go
@@ -91,6 +91,11 @@ func (v *VagrantCloud) ProviderName() string {
 	return ProviderName
 }
 
+// ScrubDNS filters DNS settings for pods.
+func (v *VagrantCloud) ScrubDNS(nameservers, searches []string) (nsOut, srchOut []string) {
+	return nameservers, searches
+}
+
 // TCPLoadBalancer returns an implementation of TCPLoadBalancer for Vagrant cloud.
 func (v *VagrantCloud) TCPLoadBalancer() (cloudprovider.TCPLoadBalancer, bool) {
 	return nil, false

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1135,7 +1135,7 @@ func (kl *Kubelet) getClusterDNS(pod *api.Pod) ([]string, []string, error) {
 		}
 		defer f.Close()
 
-		hostDNS, hostSearch, err = parseResolvConf(f)
+		hostDNS, hostSearch, err = kl.parseResolvConf(f)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -1172,7 +1172,20 @@ func (kl *Kubelet) getClusterDNS(pod *api.Pod) ([]string, []string, error) {
 }
 
 // Returns the list of DNS servers and DNS search domains.
-func parseResolvConf(reader io.Reader) (nameservers []string, searches []string, err error) {
+func (kl *Kubelet) parseResolvConf(reader io.Reader) (nameservers []string, searches []string, err error) {
+	var scrubber dnsScrubber
+	if kl.cloud != nil {
+		scrubber = kl.cloud
+	}
+	return parseResolvConf(reader, scrubber)
+}
+
+// A helper for testing.
+type dnsScrubber interface {
+	ScrubDNS(nameservers, searches []string) (nsOut, srchOut []string)
+}
+
+func parseResolvConf(reader io.Reader, dnsScrubber dnsScrubber) (nameservers []string, searches []string, err error) {
 	file, err := ioutil.ReadAll(reader)
 	if err != nil {
 		return nil, nil, err
@@ -1200,6 +1213,11 @@ func parseResolvConf(reader io.Reader) (nameservers []string, searches []string,
 		if fields[0] == "search" {
 			searches = fields[1:]
 		}
+	}
+
+	// Give the cloud-provider a chance to post-process DNS settings.
+	if dnsScrubber != nil {
+		nameservers, searches = dnsScrubber.ScrubDNS(nameservers, searches)
 	}
 	return nameservers, searches, nil
 }


### PR DESCRIPTION
This is for 1.1

Add a cloud-provider hook to scrub DNS for pods 

GCE needs this hook and it seems general enough to include.
