### PR TITLE
MESOS mesos/docker: bump mesosslave image version

### DIFF
--- a/cluster/mesos/docker/docker-compose.yml
+++ b/cluster/mesos/docker/docker-compose.yml
@@ -29,7 +29,7 @@ mesosmaster1:
 mesosslave:
   hostname: mesosslave
   privileged: true
-  image: mesosphere/mesos-slave-dind:mesos-0.24.0_dind-0.2_docker-1.8.2_ubuntu-14.04.3
+  image: mesosphere/mesos-slave-dind:0.2.2_mesos-0.24.0_docker-1.8.2_ubuntu-14.04.3
   ports: [ "10248","10249" ]
   entrypoint:
   - bash


### PR DESCRIPTION
Bump the mesos-slave-dind image version in the docker-compose template of the mesos cluster. The 0.2.2 image fixes a bash syntax error in wrapdocker: https://github.com/mesosphere/mesos-slave-dind/pull/3
