### PR TITLE
Stores hash of pod manifest in mirror pod's annotation

### DIFF
--- a/pkg/kubelet/config/common.go
+++ b/pkg/kubelet/config/common.go
@@ -64,6 +64,12 @@ func applyDefaults(pod *api.Pod, source string, isFile bool, nodeName string) er
 	pod.Spec.NodeName = nodeName
 
 	pod.ObjectMeta.SelfLink = getSelfLink(pod.Name, pod.Namespace)
+
+	if pod.Annotations == nil {
+		pod.Annotations = make(map[string]string)
+	}
+	// The generated UID is the hash of the file.
+	pod.Annotations[kubetypes.ConfigHashAnnotationKey] = string(pod.UID)
 	return nil
 }
 

--- a/pkg/kubelet/config/file_test.go
+++ b/pkg/kubelet/config/file_test.go
@@ -92,10 +92,11 @@ func TestReadPodsFromFile(t *testing.T) {
 			},
 			expected: CreatePodUpdate(kubelet.SET, kubelet.FileSource, &api.Pod{
 				ObjectMeta: api.ObjectMeta{
-					Name:      "test-" + hostname,
-					UID:       "12345",
-					Namespace: "mynamespace",
-					SelfLink:  getSelfLink("test-"+hostname, "mynamespace"),
+					Name:        "test-" + hostname,
+					UID:         "12345",
+					Namespace:   "mynamespace",
+					Annotations: map[string]string{kubetypes.ConfigHashAnnotationKey: "12345"},
+					SelfLink:    getSelfLink("test-"+hostname, "mynamespace"),
 				},
 				Spec: api.PodSpec{
 					NodeName:      hostname,

--- a/pkg/kubelet/config/http_test.go
+++ b/pkg/kubelet/config/http_test.go
@@ -149,11 +149,11 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 				kubelet.HTTPSource,
 				&api.Pod{
 					ObjectMeta: api.ObjectMeta{
-						UID:       "111",
-						Name:      "foo" + "-" + hostname,
-						Namespace: "mynamespace",
-
-						SelfLink: getSelfLink("foo-"+hostname, "mynamespace"),
+						UID:         "111",
+						Name:        "foo" + "-" + hostname,
+						Namespace:   "mynamespace",
+						Annotations: map[string]string{kubetypes.ConfigHashAnnotationKey: "111"},
+						SelfLink:    getSelfLink("foo-"+hostname, "mynamespace"),
 					},
 					Spec: api.PodSpec{
 						NodeName:      hostname,
@@ -202,11 +202,11 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 				kubelet.HTTPSource,
 				&api.Pod{
 					ObjectMeta: api.ObjectMeta{
-						UID:       "111",
-						Name:      "foo" + "-" + hostname,
-						Namespace: "default",
-
-						SelfLink: getSelfLink("foo-"+hostname, kubelet.NamespaceDefault),
+						UID:         "111",
+						Name:        "foo" + "-" + hostname,
+						Namespace:   "default",
+						Annotations: map[string]string{kubetypes.ConfigHashAnnotationKey: "111"},
+						SelfLink:    getSelfLink("foo-"+hostname, kubetypes.NamespaceDefault),
 					},
 					Spec: api.PodSpec{
 						NodeName:      hostname,
@@ -222,11 +222,11 @@ func TestExtractPodsFromHTTP(t *testing.T) {
 				},
 				&api.Pod{
 					ObjectMeta: api.ObjectMeta{
-						UID:       "222",
-						Name:      "bar" + "-" + hostname,
-						Namespace: "default",
-
-						SelfLink: getSelfLink("bar-"+hostname, kubelet.NamespaceDefault),
+						UID:         "222",
+						Name:        "bar" + "-" + hostname,
+						Namespace:   "default",
+						Annotations: map[string]string{kubetypes.ConfigHashAnnotationKey: "222"},
+						SelfLink:    getSelfLink("bar-"+hostname, kubetypes.NamespaceDefault),
 					},
 					Spec: api.PodSpec{
 						NodeName:      hostname,

--- a/pkg/kubelet/pod_manager.go
+++ b/pkg/kubelet/pod_manager.go
@@ -285,7 +285,11 @@ func (pm *basicPodManager) IsMirrorPodOf(mirrorPod, pod *api.Pod) bool {
 	if pod.Name != mirrorPod.Name || pod.Namespace != mirrorPod.Namespace {
 		return false
 	}
-	return api.Semantic.DeepEqual(&pod.Spec, &mirrorPod.Spec)
+	hash, ok := getHashFromMirrorPod(mirrorPod)
+	if !ok {
+		return false
+	}
+	return hash == getPodHash(pod)
 }
 
 func podsMapToPods(UIDMap map[types.UID]*api.Pod) []*api.Pod {

--- a/pkg/kubelet/types.go
+++ b/pkg/kubelet/types.go
@@ -25,6 +25,7 @@ import (
 const ConfigSourceAnnotationKey = "kubernetes.io/config.source"
 const ConfigMirrorAnnotationKey = "kubernetes.io/config.mirror"
 const ConfigFirstSeenAnnotationKey = "kubernetes.io/config.seen"
+const ConfigHashAnnotationKey = "kubernetes.io/config.hash"
 
 // PodOperation defines what changes will be made on a pod configuration.
 type PodOperation int
@@ -48,9 +49,6 @@ const (
 	ApiserverSource = "api"
 	// Updates from all sources
 	AllSource = "*"
-
-	// Used for ConfigMirrorAnnotationKey.
-	MirrorType = "mirror"
 
 	NamespaceDefault = api.NamespaceDefault
 )


### PR DESCRIPTION
Use the hash to track whether the mirror pod is a truthful representation of
the static pod.

cc/ @yujuhong 
