### PR TITLE
Update tutorial about kubectl expose

### DIFF
--- a/docs/getting-started-guides/docker-multinode/testing.md
+++ b/docs/getting-started-guides/docker-multinode/testing.md
@@ -63,17 +63,22 @@ now run `docker ps` you should see nginx running.  You may need to wait a few mi
 kubectl expose rc nginx --port=80
 ```
 
-This should print:
-
-```console
-NAME         CLUSTER_IP       EXTERNAL_IP       PORT(S)                SELECTOR     AGE
-nginx        10.179.240.1     <none>            80/TCP                 run=nginx    8d
-```
-
-Hit the webserver:
+Run the following command to obtain the IP of this service we just created. There are two IPs, the first one is internal (CLUSTER_IP), and the second one is the external load-balanced IP.
 
 ```sh
-curl <insert-ip-from-above-here>
+kubectl get svc nginx
+```
+
+Alternatively, you can obtain only the first IP (CLUSTER_IP) by running:
+
+```sh
+kubectl get svc nginx --template={{.spec.clusterIP}}
+```
+
+Hit the webserver with the first IP (CLUSTER_IP):
+
+```sh
+curl <insert-cluster-ip-here>
 ```
 
 Note that you will need run this curl command on your boot2docker VM if you are running on OS X.

--- a/docs/getting-started-guides/docker.md
+++ b/docs/getting-started-guides/docker.md
@@ -178,23 +178,22 @@ Now run `docker ps` you should see nginx running.  You may need to wait a few mi
 kubectl expose rc nginx --port=80
 ```
 
-This should print:
-
-```console
-NAME      LABELS      SELECTOR    IP(S)     PORT(S)
-nginx     run=nginx   run=nginx             80/TCP
-```
-
-If `IP(S)` is blank run the following command to obtain it. Know issue [#10836](https://github.com/kubernetes/kubernetes/issues/10836)
+Run the following command to obtain the IP of this service we just created. There are two IPs, the first one is internal (CLUSTER_IP), and the second one is the external load-balanced IP.
 
 ```sh
 kubectl get svc nginx
 ```
 
-Hit the webserver:
+Alternatively, you can obtain only the first IP (CLUSTER_IP) by running:
 
 ```sh
-curl <insert-ip-from-above-here>
+kubectl get svc nginx --template={{.spec.clusterIP}}
+```
+
+Hit the webserver with the first IP (CLUSTER_IP):
+
+```sh
+curl <insert-cluster-ip-here>
 ```
 
 Note that you will need run this curl command on your boot2docker VM if you are running on OS X.

--- a/docs/user-guide/debugging-services.md
+++ b/docs/user-guide/debugging-services.md
@@ -209,8 +209,7 @@ walk-through - you can use your own `Service`'s details here.
 
 ```console
 $ kubectl expose rc hostnames --port=80 --target-port=9376
-NAME              CLUSTER_IP       EXTERNAL_IP       PORT(S)       SELECTOR               AGE
-hostnames         10.0.0.1         <none>            80/TCP        run=hostnames          1h
+service "hostnames" exposed
 ```
 
 And read it back, just to be sure:

--- a/docs/user-guide/horizontal-pod-autoscaling/README.md
+++ b/docs/user-guide/horizontal-pod-autoscaling/README.md
@@ -82,8 +82,7 @@ If load balancers are not supported (e.g.: on Vagrant), we can expose php-apache
 
 ```console
 $ kubectl expose rc php-apache --port=80 --type=ClusterIP
-NAME         LABELS           SELECTOR         IP(S)     PORT(S)
-php-apache   run=php-apache   run=php-apache             80/TCP
+service "php-apache" exposed
 
 $ kubectl cluster-info | grep master
 Kubernetes master is running at https://146.148.6.215

--- a/docs/user-guide/quick-start.md
+++ b/docs/user-guide/quick-start.md
@@ -76,8 +76,7 @@ Through integration with some cloud providers (for example Google Compute Engine
 
 ```console
 $ kubectl expose rc my-nginx --port=80 --type=LoadBalancer
-NAME         CLUSTER_IP       EXTERNAL_IP       PORT(S)                SELECTOR     AGE
-my-nginx     10.179.240.1     <none>            80/TCP                 run=nginx    8d
+service "my-nginx" exposed
 ```
 
 To find the public IP address assigned to your application, execute:


### PR DESCRIPTION
Fixes #16239. 

Since the output of `kubectl expose` is changed (refer to 13187), update related documents to reduce confusion. 

@kubernetes/kubectl @kubernetes/goog-ux 
