### PR TITLE
remove the type keyword of constant variables

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -142,15 +142,15 @@ type ObjectMeta struct {
 
 const (
 	// NamespaceDefault means the object is in the default namespace which is applied when not specified by clients
-	NamespaceDefault string = "default"
+	NamespaceDefault = "default"
 	// NamespaceAll is the default argument to specify on a context when you want to list or filter resources across all namespaces
-	NamespaceAll string = ""
+	NamespaceAll = ""
 	// NamespaceNone is the argument for a context when there is no namespace.
-	NamespaceNone string = ""
+	NamespaceNone = ""
 	// NamespaceSystem is the system namespace where we place system components.
-	NamespaceSystem string = "kube-system"
+	NamespaceSystem = "kube-system"
 	// TerminationMessagePathDefault means the default path to capture the application termination message running in a container
-	TerminationMessagePathDefault string = "/dev/termination-log"
+	TerminationMessagePathDefault = "/dev/termination-log"
 )
 
 // Volume represents a named volume in a pod that may be accessed by any containers in the pod.

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -181,9 +181,9 @@ type ObjectMeta struct {
 
 const (
 	// NamespaceDefault means the object is in the default namespace which is applied when not specified by clients
-	NamespaceDefault string = "default"
+	NamespaceDefault = "default"
 	// NamespaceAll is the default argument to specify on a context when you want to list or filter resources across all namespaces
-	NamespaceAll string = ""
+	NamespaceAll = ""
 )
 
 // Volume represents a named volume in a pod that may be accessed by any container in the pod.
@@ -896,7 +896,7 @@ type ResourceRequirements struct {
 
 const (
 	// TerminationMessagePathDefault means the default path to capture the application termination message running in a container
-	TerminationMessagePathDefault string = "/dev/termination-log"
+	TerminationMessagePathDefault = "/dev/termination-log"
 )
 
 // A single application container that you want to run within a pod.

--- a/pkg/apiserver/authz.go
+++ b/pkg/apiserver/authz.go
@@ -57,9 +57,9 @@ func NewAlwaysDenyAuthorizer() authorizer.Authorizer {
 }
 
 const (
-	ModeAlwaysAllow string = "AlwaysAllow"
-	ModeAlwaysDeny  string = "AlwaysDeny"
-	ModeABAC        string = "ABAC"
+	ModeAlwaysAllow = "AlwaysAllow"
+	ModeAlwaysDeny  = "AlwaysDeny"
+	ModeABAC        = "ABAC"
 )
 
 // Keep this list in sync with constant list above.

--- a/pkg/client/unversioned/debugging.go
+++ b/pkg/client/unversioned/debugging.go
@@ -80,12 +80,12 @@ type DebuggingRoundTripper struct {
 }
 
 const (
-	JustURL         string = "url"
-	URLTiming       string = "urltiming"
-	CurlCommand     string = "curlcommand"
-	RequestHeaders  string = "requestheaders"
-	ResponseStatus  string = "responsestatus"
-	ResponseHeaders string = "responseheaders"
+	JustURL         = "url"
+	URLTiming       = "urltiming"
+	CurlCommand     = "curlcommand"
+	RequestHeaders  = "requestheaders"
+	ResponseStatus  = "responsestatus"
+	ResponseHeaders = "responseheaders"
 )
 
 func NewDebuggingRoundTripper(rt http.RoundTripper, levels ...string) *DebuggingRoundTripper {

--- a/pkg/kubectl/resource/visitor.go
+++ b/pkg/kubectl/resource/visitor.go
@@ -35,8 +35,8 @@ import (
 )
 
 const (
-	constSTDINstr       string = "STDIN"
-	stopValidateMessage        = "if you choose to ignore these errors, turn validation off with --validate=false"
+	constSTDINstr       = "STDIN"
+	stopValidateMessage = "if you choose to ignore these errors, turn validation off with --validate=false"
 )
 
 // Visitor lets clients walk a list of resources.

--- a/pkg/kubelet/qos/memory_policy.go
+++ b/pkg/kubelet/qos/memory_policy.go
@@ -21,9 +21,9 @@ import (
 )
 
 const (
-	PodInfraOOMAdj       int = -999
-	KubeletOOMScoreAdj   int = -999
-	KubeProxyOOMScoreAdj int = -999
+	PodInfraOOMAdj       = -999
+	KubeletOOMScoreAdj   = -999
+	KubeProxyOOMScoreAdj = -999
 )
 
 // isMemoryBestEffort returns true if the container's memory requirements are best-effort.

--- a/pkg/registry/ingress/etcd/etcd.go
+++ b/pkg/registry/ingress/etcd/etcd.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	IngressPath string = "/ingress"
+	IngressPath = "/ingress"
 )
 
 // rest implements a RESTStorage for replication controllers against etcd

--- a/pkg/securitycontext/types.go
+++ b/pkg/securitycontext/types.go
@@ -37,9 +37,9 @@ type SecurityContextProvider interface {
 }
 
 const (
-	dockerLabelUser    string = "label:user"
-	dockerLabelRole    string = "label:role"
-	dockerLabelType    string = "label:type"
-	dockerLabelLevel   string = "label:level"
-	dockerLabelDisable string = "label:disable"
+	dockerLabelUser    = "label:user"
+	dockerLabelRole    = "label:role"
+	dockerLabelType    = "label:type"
+	dockerLabelLevel   = "label:level"
+	dockerLabelDisable = "label:disable"
 )

--- a/pkg/util/cache.go
+++ b/pkg/util/cache.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	shardsCount int = 32
+	shardsCount = 32
 )
 
 type Cache []*cacheShard

--- a/pkg/util/cache_test.go
+++ b/pkg/util/cache_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	maxTestCacheSize int = shardsCount * 2
+	maxTestCacheSize = shardsCount * 2
 )
 
 func ExpectEntry(t *testing.T, cache Cache, index uint64, expectedValue interface{}) {

--- a/pkg/util/iptables/iptables.go
+++ b/pkg/util/iptables/iptables.go
@@ -94,10 +94,10 @@ const (
 )
 
 const (
-	cmdIptablesSave    string = "iptables-save"
-	cmdIptablesRestore string = "iptables-restore"
-	cmdIptables        string = "iptables"
-	cmdIp6tables       string = "ip6tables"
+	cmdIptablesSave    = "iptables-save"
+	cmdIptablesRestore = "iptables-restore"
+	cmdIptables        = "iptables"
+	cmdIp6tables       = "ip6tables"
 )
 
 // Option flag for Restore

--- a/pkg/version/verflag/verflag.go
+++ b/pkg/version/verflag/verflag.go
@@ -35,7 +35,7 @@ const (
 	VersionRaw   versionValue = 2
 )
 
-const strRawVersion string = "raw"
+const strRawVersion = "raw"
 
 func (v *versionValue) IsBoolFlag() bool {
 	return true


### PR DESCRIPTION
In general coding style, if defining a constant variable, we often have two ways: 
- dropping the type keyword: such as `string` `int` and so on .Likethis:

``` golang
const (
    Added     = "ADDED"
    Modified  = "MODIFIED"
    Deleted   = "DELETED"
    Error       = "ERROR"
)
```
- Or, giving alias names for type keywords. Like this:

``` golang
type EventType string
const (
    Added    EventType = "ADDED"
    Modified EventType = "MODIFIED"
    Deleted  EventType = "DELETED"
    Error    EventType = "ERROR"
)
```
