### PR TITLE
Load or generate auth from kubeconfig on kube-up

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -681,7 +681,7 @@ function kube-up {
 
   ensure-iam-profiles
 
-  gen-kube-basicauth
+  load-or-gen-kube-basicauth
 
   if [[ ! -f "$AWS_SSH_KEY" ]]; then
     ssh-keygen -f "$AWS_SSH_KEY" -N ''

--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -116,7 +116,7 @@ function clear-kubeconfig() {
   "${kubectl}" config unset "contexts.${CONTEXT}"
 
   local current
-  current=$("${kubectl}" config view -o template --template='{{ index . "current-context" }}')
+  current=$("${kubectl}" config view -o jsonpath='{.current-context}')
   if [[ "${current}" == "${CONTEXT}" ]]; then
     "${kubectl}" config unset current-context
   fi
@@ -136,6 +136,7 @@ function tear_down_alive_resources() {
 # Gets username, password for the current-context in kubeconfig, if they exist.
 # Assumed vars:
 #   KUBECONFIG  # if unset, defaults to global
+#   KUBE_CONTEXT  # if unset, defaults to current-context
 #
 # Vars set:
 #   KUBE_USER
@@ -145,21 +146,14 @@ function tear_down_alive_resources() {
 # the current-context user does not exist or contain basicauth entries.
 function get-kubeconfig-basicauth() {
   export KUBECONFIG=${KUBECONFIG:-$DEFAULT_KUBECONFIG}
-  # Templates to safely extract the username,password for the current-context
-  # user.  The long chain of 'with' commands avoids indexing nil if any of the
-  # entries ("current-context", "contexts"."current-context", "users", etc)
-  # is missing.
-  # Note: we save dot ('.') to $root because the 'with' action overrides it.
-  # See http://golang.org/pkg/text/template/.
-  local username='{{$dot := .}}{{with $ctx := index $dot "current-context"}}{{range $element := (index $dot "contexts")}}{{ if eq .name $ctx }}{{ with $user := .context.user }}{{range $element := (index $dot "users")}}{{ if eq .name $user }}{{ index . "user" "username" }}{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}'
-  local password='{{$dot := .}}{{with $ctx := index $dot "current-context"}}{{range $element := (index $dot "contexts")}}{{ if eq .name $ctx }}{{ with $user := .context.user }}{{range $element := (index $dot "users")}}{{ if eq .name $user }}{{ index . "user" "password" }}{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}'
-  KUBE_USER=$("${KUBE_ROOT}/cluster/kubectl.sh" config view -o template --template="${username}")
-  KUBE_PASSWORD=$("${KUBE_ROOT}/cluster/kubectl.sh" config view -o template --template="${password}")
-  # Handle empty/missing username|password
-  if [[ "${KUBE_USER}" == '<no value>' || "$KUBE_PASSWORD" == '<no value>' ]]; then
-    KUBE_USER=''
-    KUBE_PASSWORD=''
+
+  local cc="current-context"
+  if [[ ! -z "${KUBE_CONTEXT:-}" ]]; then
+    cc="${KUBE_CONTEXT}"
   fi
+  local user=$("${KUBE_ROOT}/cluster/kubectl.sh" config view -o jsonpath="{.contexts[?(@.name == \"${cc}\")].context.user}")
+  KUBE_USER=$("${KUBE_ROOT}/cluster/kubectl.sh" config view -o jsonpath="{.users[?(@.name == \"${user}\")].user.username}")
+  KUBE_PASSWORD=$("${KUBE_ROOT}/cluster/kubectl.sh" config view -o jsonpath="{.users[?(@.name == \"${user}\")].user.password}")
 }
 
 # Generate basic auth user and password.
@@ -175,6 +169,7 @@ function gen-kube-basicauth() {
 # Get the bearer token for the current-context in kubeconfig if one exists.
 # Assumed vars:
 #   KUBECONFIG  # if unset, defaults to global
+#   KUBE_CONTEXT  # if unset, defaults to current-context
 #
 # Vars set:
 #   KUBE_BEARER_TOKEN
@@ -183,18 +178,13 @@ function gen-kube-basicauth() {
 # current-context user does not exist or contain a bearer token entry.
 function get-kubeconfig-bearertoken() {
   export KUBECONFIG=${KUBECONFIG:-$DEFAULT_KUBECONFIG}
-  # Template to safely extract the token for the current-context user.
-  # The long chain of 'with' commands avoids indexing nil if any of the
-  # entries ("current-context", "contexts"."current-context", "users", etc)
-  # is missing.
-  # Note: we save dot ('.') to $root because the 'with' action overrides it.
-  # See http://golang.org/pkg/text/template/.
-  local token='{{$dot := .}}{{with $ctx := index $dot "current-context"}}{{range $element := (index $dot "contexts")}}{{ if eq .name $ctx }}{{ with $user := .context.user }}{{range $element := (index $dot "users")}}{{ if eq .name $user }}{{ index . "user" "token" }}{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}'
-  KUBE_BEARER_TOKEN=$("${KUBE_ROOT}/cluster/kubectl.sh" config view -o template --template="${token}")
-  # Handle empty/missing token
-  if [[ "${KUBE_BEARER_TOKEN}" == '<no value>' ]]; then
-    KUBE_BEARER_TOKEN=''
+
+  local cc="current-context"
+  if [[ ! -z "${KUBE_CONTEXT:-}" ]]; then
+    cc="${KUBE_CONTEXT}"
   fi
+  local user=$("${KUBE_ROOT}/cluster/kubectl.sh" config view -o jsonpath="{.contexts[?(@.name == \"${cc}\")].context.user}")
+  KUBE_BEARER_TOKEN=$("${KUBE_ROOT}/cluster/kubectl.sh" config view -o jsonpath="{.users[?(@.name == \"${user}\")].user.token}")
 }
 
 # Generate bearer token.
@@ -205,10 +195,31 @@ function gen-kube-bearertoken() {
     KUBE_BEARER_TOKEN=$(dd if=/dev/urandom bs=128 count=1 2>/dev/null | base64 | tr -d "=+/" | dd bs=32 count=1 2>/dev/null)
 }
 
+
+function load-or-gen-kube-basicauth() {
+  if [[ ! -z "${KUBE_CONTEXT:-}" ]]; then
+    get-kubeconfig-basicauth
+  fi
+
+  if [[ -z "${KUBE_USER:-}" || -z "${KUBE_PASSWORD:-}" ]]; then
+    gen-kube-basicauth
+  fi
+}
+
+function load-or-gen-kube-bearertoken() {
+  if [[ ! -z "${KUBE_CONTEXT:-}" ]]; then
+    get-kubeconfig-bearertoken
+  fi
+  if [[ -z "${KUBE_BEARER_TOKEN:-}" ]]; then
+    gen-kube-bearertoken
+  fi
+}
+
 # Get the master IP for the current-context in kubeconfig if one exists.
 #
 # Assumed vars:
 #   KUBECONFIG  # if unset, defaults to global
+#   KUBE_CONTEXT  # if unset, defaults to current-context
 #
 # Vars set:
 #   KUBE_MASTER_URL
@@ -217,18 +228,13 @@ function gen-kube-bearertoken() {
 # current-context user does not exist or contain a server entry.
 function detect-master-from-kubeconfig() {
   export KUBECONFIG=${KUBECONFIG:-$DEFAULT_KUBECONFIG}
-  # Template to safely extract the server for the current-context cluster.
-  # The long chain of 'with' commands avoids indexing nil if any of the
-  # entries ("current-context", "contexts"."current-context", "users", etc)
-  # is missing.
-  # Note: we save dot ('.') to $root because the 'with' action overrides it.
-  # See http://golang.org/pkg/text/template/.
-  local server_tpl='{{$dot := .}}{{with $ctx := index $dot "current-context"}}{{range $element := (index $dot "contexts")}}{{ if eq .name $ctx }}{{ with $cluster := .context.cluster }}{{range $element := (index $dot "clusters")}}{{ if eq .name $cluster }}{{ index . "cluster" "server" }}{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}'
-  KUBE_MASTER_URL=$("${KUBE_ROOT}/cluster/kubectl.sh" config view -o template --template="${server_tpl}")
-  # Handle empty/missing server
-  if [[ "${KUBE_MASTER_URL}" == '<no value>' ]]; then
-    KUBE_MASTER_URL=''
+
+  local cc="current-context"
+  if [[ ! -z "${KUBE_CONTEXT:-}" ]]; then
+    cc="${KUBE_CONTEXT}"
   fi
+  local cluster=$("${KUBE_ROOT}/cluster/kubectl.sh" config view -o jsonpath="{.contexts[?(@.name == \"${cc}\")].context.cluster}")
+  KUBE_MASTER_URL=$("${KUBE_ROOT}/cluster/kubectl.sh" config view -o jsonpath="{.clusters[?(@.name == \"${cluster}\")].cluster.server}")
 }
 
 # Sets KUBE_VERSION variable to the proper version number (e.g. "v1.0.6",

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -575,8 +575,8 @@ function kube-up {
   ensure-temp-dir
   detect-project
 
-  gen-kube-basicauth
-  gen-kube-bearertoken
+  load-or-gen-kube-basicauth
+  load-or-gen-kube-bearertoken
 
   # Make sure we have the tar files staged on Google Storage
   find-release-tars

--- a/cluster/libvirt-coreos/util.sh
+++ b/cluster/libvirt-coreos/util.sh
@@ -183,7 +183,7 @@ function wait-cluster-readiness {
 function kube-up {
   detect-master
   detect-nodes
-  gen-kube-bearertoken
+  load-or-gen-kube-bearertoken
   initialize-pool keep_base_image
   initialize-network
 

--- a/cluster/rackspace/util.sh
+++ b/cluster/rackspace/util.sh
@@ -274,7 +274,7 @@ kube-up() {
   KUBE_TEMP=$(mktemp -d -t kubernetes.XXXXXX)
   trap "rm -rf ${KUBE_TEMP}" EXIT
 
-  gen-kube-basicauth
+  load-or-gen-kube-basicauth
   python2.7 $(dirname $0)/../third_party/htpasswd/htpasswd.py -b -c ${KUBE_TEMP}/htpasswd $KUBE_USER $KUBE_PASSWORD
   HTPASSWD=$(cat ${KUBE_TEMP}/htpasswd)
 

--- a/cluster/ubuntu/util.sh
+++ b/cluster/ubuntu/util.sh
@@ -339,7 +339,7 @@ function kube-up() {
   source "${KUBE_ROOT}/cluster/common.sh"
 
   # set kubernetes user and password
-  gen-kube-basicauth
+  load-or-gen-kube-basicauth
 
   create-kubeconfig
 }

--- a/cluster/vagrant/util.sh
+++ b/cluster/vagrant/util.sh
@@ -297,7 +297,7 @@ function verify-cluster {
 
 # Instantiate a kubernetes cluster
 function kube-up {
-  gen-kube-basicauth
+  load-or-gen-kube-basicauth
   get-tokens
   create-provision-scripts
 

--- a/cluster/vsphere/util.sh
+++ b/cluster/vsphere/util.sh
@@ -225,7 +225,7 @@ function kube-up {
 
   ensure-temp-dir
 
-  gen-kube-basicauth
+  load-or-gen-kube-basicauth
   python "${KUBE_ROOT}/third_party/htpasswd/htpasswd.py" \
     -b -c "${KUBE_TEMP}/htpasswd" "$KUBE_USER" "$KUBE_PASSWORD"
   local htpasswd


### PR DESCRIPTION
Allow loading existing auth from kubeconfig on kube-up if a valid KUBE_CONTEXT is specified, instead of always generating fresh auth (basic or token) when creating a new
cluster. Supports use case in #14335

Also updated functions in `common.sh` to use jsonpath to extract values from kubeconfig (instead of soon-to-be-deprecated go-template).
