### PR TITLE
v1.0.7

### DIFF
--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -10583,15 +10583,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"
      },
      "target": {
       "$ref": "v1.ObjectReference",
@@ -10604,15 +10604,15 @@
     "properties": {
      "name": {
       "type": "string",
-      "description": "string that identifies an object. Must be unique within a namespace; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/user-guide/identifiers.md#names"
+      "description": "string that identifies an object. Must be unique within a namespace; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/user-guide/identifiers.md#names"
      },
      "generateName": {
       "type": "string",
-      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#idempotency"
+      "description": "an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#idempotency"
      },
      "namespace": {
       "type": "string",
-      "description": "namespace of the object; must be a DNS_LABEL; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/user-guide/namespaces.md"
+      "description": "namespace of the object; must be a DNS_LABEL; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/user-guide/namespaces.md"
      },
      "selfLink": {
       "type": "string",
@@ -10620,11 +10620,11 @@
      },
      "uid": {
       "type": "string",
-      "description": "unique UUID across space and time; populated by the system; read-only; see http://releases.k8s.io/v1.0.6/docs/user-guide/identifiers.md#uids"
+      "description": "unique UUID across space and time; populated by the system; read-only; see http://releases.k8s.io/v1.0.7/docs/user-guide/identifiers.md#uids"
      },
      "resourceVersion": {
       "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#concurrency-control-and-consistency"
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#concurrency-control-and-consistency"
      },
      "generation": {
       "type": "integer",
@@ -10633,19 +10633,19 @@
      },
      "creationTimestamp": {
       "type": "string",
-      "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"
+      "description": "RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"
      },
      "deletionTimestamp": {
       "type": "string",
-      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"
+      "description": "RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"
      },
      "labels": {
       "type": "any",
-      "description": "map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services; see http://releases.k8s.io/v1.0.6/docs/user-guide/labels.md"
+      "description": "map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services; see http://releases.k8s.io/v1.0.7/docs/user-guide/labels.md"
      },
      "annotations": {
       "type": "any",
-      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects; see http://releases.k8s.io/v1.0.6/docs/user-guide/annotations.md"
+      "description": "map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects; see http://releases.k8s.io/v1.0.7/docs/user-guide/annotations.md"
      }
     }
    },
@@ -10654,19 +10654,19 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of the referent; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "kind of the referent; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "namespace": {
       "type": "string",
-      "description": "namespace of the referent; see http://releases.k8s.io/v1.0.6/docs/user-guide/namespaces.md"
+      "description": "namespace of the referent; see http://releases.k8s.io/v1.0.7/docs/user-guide/namespaces.md"
      },
      "name": {
       "type": "string",
-      "description": "name of the referent; see http://releases.k8s.io/v1.0.6/docs/user-guide/identifiers.md#names"
+      "description": "name of the referent; see http://releases.k8s.io/v1.0.7/docs/user-guide/identifiers.md#names"
      },
      "uid": {
       "type": "string",
-      "description": "uid of the referent; see http://releases.k8s.io/v1.0.6/docs/user-guide/identifiers.md#uids"
+      "description": "uid of the referent; see http://releases.k8s.io/v1.0.7/docs/user-guide/identifiers.md#uids"
      },
      "apiVersion": {
       "type": "string",
@@ -10674,7 +10674,7 @@
      },
      "resourceVersion": {
       "type": "string",
-      "description": "specific resourceVersion to which this reference is made, if any: http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#concurrency-control-and-consistency"
+      "description": "specific resourceVersion to which this reference is made, if any: http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#concurrency-control-and-consistency"
      },
      "fieldPath": {
       "type": "string",
@@ -10690,15 +10690,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
@@ -10718,7 +10718,7 @@
      },
      "resourceVersion": {
       "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#concurrency-control-and-consistency"
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#concurrency-control-and-consistency"
      }
     }
    },
@@ -10727,15 +10727,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"
      },
      "conditions": {
       "type": "array",
@@ -10779,15 +10779,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
@@ -10806,15 +10806,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"
      },
      "subsets": {
       "type": "array",
@@ -10903,19 +10903,19 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"
      },
      "status": {
       "type": "string",
-      "description": "status of the operation; either Success, or Failure; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#spec-and-status"
+      "description": "status of the operation; either Success, or Failure; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#spec-and-status"
      },
      "message": {
       "type": "string",
@@ -10945,7 +10945,7 @@
      },
      "kind": {
       "type": "string",
-      "description": "the kind attribute of the resource associated with the status StatusReason; on some operations may differ from the requested resource Kind; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "the kind attribute of the resource associated with the status StatusReason; on some operations may differ from the requested resource Kind; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "causes": {
       "type": "array",
@@ -10986,11 +10986,11 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#resources"
      },
      "gracePeriodSeconds": {
       "type": "integer",
@@ -11007,15 +11007,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
@@ -11035,15 +11035,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"
      },
      "involvedObject": {
       "$ref": "v1.ObjectReference",
@@ -11097,22 +11097,22 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
       "items": {
        "$ref": "v1.LimitRange"
       },
-      "description": "items is a list of LimitRange objects; see http://releases.k8s.io/v1.0.6/docs/design/admission_control_limit_range.md"
+      "description": "items is a list of LimitRange objects; see http://releases.k8s.io/v1.0.7/docs/design/admission_control_limit_range.md"
      }
     }
    },
@@ -11121,19 +11121,19 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1.LimitRangeSpec",
-      "description": "spec defines the limits enforced; http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#spec-and-status"
+      "description": "spec defines the limits enforced; http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -11181,22 +11181,22 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
       "items": {
        "$ref": "v1.Namespace"
       },
-      "description": "items is the list of Namespace objects in the list; see http://releases.k8s.io/v1.0.6/docs/user-guide/namespaces.md"
+      "description": "items is the list of Namespace objects in the list; see http://releases.k8s.io/v1.0.7/docs/user-guide/namespaces.md"
      }
     }
    },
@@ -11205,23 +11205,23 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1.NamespaceSpec",
-      "description": "spec defines the behavior of the Namespace; http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#spec-and-status"
+      "description": "spec defines the behavior of the Namespace; http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1.NamespaceStatus",
-      "description": "status describes the current status of a Namespace; http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#spec-and-status"
+      "description": "status describes the current status of a Namespace; http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -11233,7 +11233,7 @@
       "items": {
        "$ref": "v1.FinalizerName"
       },
-      "description": "an opaque list of values that must be empty to permanently remove object from storage; see http://releases.k8s.io/v1.0.6/docs/design/namespaces.md#finalizers"
+      "description": "an opaque list of values that must be empty to permanently remove object from storage; see http://releases.k8s.io/v1.0.7/docs/design/namespaces.md#finalizers"
      }
     }
    },
@@ -11246,7 +11246,7 @@
     "properties": {
      "phase": {
       "type": "string",
-      "description": "phase is the current lifecycle phase of the namespace; see http://releases.k8s.io/v1.0.6/docs/design/namespaces.md#phases"
+      "description": "phase is the current lifecycle phase of the namespace; see http://releases.k8s.io/v1.0.7/docs/design/namespaces.md#phases"
      }
     }
    },
@@ -11258,15 +11258,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
@@ -11282,23 +11282,23 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1.NodeSpec",
-      "description": "specification of a node; http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#spec-and-status"
+      "description": "specification of a node; http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1.NodeStatus",
-      "description": "most recently observed status of the node; populated by the system, read-only; http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#spec-and-status"
+      "description": "most recently observed status of the node; populated by the system, read-only; http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -11319,7 +11319,7 @@
      },
      "unschedulable": {
       "type": "boolean",
-      "description": "disable pod scheduling on the node; see http://releases.k8s.io/v1.0.6/docs/admin/node.md#manual-node-administration"
+      "description": "disable pod scheduling on the node; see http://releases.k8s.io/v1.0.7/docs/admin/node.md#manual-node-administration"
      }
     }
    },
@@ -11328,29 +11328,29 @@
     "properties": {
      "capacity": {
       "type": "any",
-      "description": "compute resource capacity of the node; see http://releases.k8s.io/v1.0.6/docs/user-guide/compute-resources.md"
+      "description": "compute resource capacity of the node; see http://releases.k8s.io/v1.0.7/docs/user-guide/compute-resources.md"
      },
      "phase": {
       "type": "string",
-      "description": "most recently observed lifecycle phase of the node; see http://releases.k8s.io/v1.0.6/docs/admin/node.md#node-phase"
+      "description": "most recently observed lifecycle phase of the node; see http://releases.k8s.io/v1.0.7/docs/admin/node.md#node-phase"
      },
      "conditions": {
       "type": "array",
       "items": {
        "$ref": "v1.NodeCondition"
       },
-      "description": "list of node conditions observed; see http://releases.k8s.io/v1.0.6/docs/admin/node.md#node-condition"
+      "description": "list of node conditions observed; see http://releases.k8s.io/v1.0.7/docs/admin/node.md#node-condition"
      },
      "addresses": {
       "type": "array",
       "items": {
        "$ref": "v1.NodeAddress"
       },
-      "description": "list of addresses reachable to the node; see http://releases.k8s.io/v1.0.6/docs/admin/node.md#node-addresses"
+      "description": "list of addresses reachable to the node; see http://releases.k8s.io/v1.0.7/docs/admin/node.md#node-addresses"
      },
      "nodeInfo": {
       "$ref": "v1.NodeSystemInfo",
-      "description": "set of ids/uuids to uniquely identify the node; see http://releases.k8s.io/v1.0.6/docs/admin/node.md#node-info"
+      "description": "set of ids/uuids to uniquely identify the node; see http://releases.k8s.io/v1.0.7/docs/admin/node.md#node-info"
      }
     }
    },
@@ -11456,22 +11456,22 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "standard list metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "items": {
       "type": "array",
       "items": {
        "$ref": "v1.PersistentVolumeClaim"
       },
-      "description": "a list of persistent volume claims; see http://releases.k8s.io/v1.0.6/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"
+      "description": "a list of persistent volume claims; see http://releases.k8s.io/v1.0.7/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"
      }
     }
    },
@@ -11480,23 +11480,23 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1.PersistentVolumeClaimSpec",
-      "description": "the desired characteristics of a volume; see http://releases.k8s.io/v1.0.6/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"
+      "description": "the desired characteristics of a volume; see http://releases.k8s.io/v1.0.7/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"
      },
      "status": {
       "$ref": "v1.PersistentVolumeClaimStatus",
-      "description": "the current status of a persistent volume claim; read-only; see http://releases.k8s.io/v1.0.6/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"
+      "description": "the current status of a persistent volume claim; read-only; see http://releases.k8s.io/v1.0.7/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"
      }
     }
    },
@@ -11508,11 +11508,11 @@
       "items": {
        "$ref": "v1.PersistentVolumeAccessMode"
       },
-      "description": "the desired access modes the volume should have; see http://releases.k8s.io/v1.0.6/docs/user-guide/persistent-volumes.md#access-modes-1"
+      "description": "the desired access modes the volume should have; see http://releases.k8s.io/v1.0.7/docs/user-guide/persistent-volumes.md#access-modes-1"
      },
      "resources": {
       "$ref": "v1.ResourceRequirements",
-      "description": "the desired resources the volume should have; see http://releases.k8s.io/v1.0.6/docs/user-guide/persistent-volumes.md#resources"
+      "description": "the desired resources the volume should have; see http://releases.k8s.io/v1.0.7/docs/user-guide/persistent-volumes.md#resources"
      },
      "volumeName": {
       "type": "string",
@@ -11529,11 +11529,11 @@
     "properties": {
      "limits": {
       "type": "any",
-      "description": "Maximum amount of compute resources allowed; see http://releases.k8s.io/v1.0.6/docs/design/resources.md#resource-specifications"
+      "description": "Maximum amount of compute resources allowed; see http://releases.k8s.io/v1.0.7/docs/design/resources.md#resource-specifications"
      },
      "requests": {
       "type": "any",
-      "description": "Minimum amount of resources requested; requests are honored only for persistent volumes as of now; see http://releases.k8s.io/v1.0.6/docs/design/resources.md#resource-specifications"
+      "description": "Minimum amount of resources requested; requests are honored only for persistent volumes as of now; see http://releases.k8s.io/v1.0.7/docs/design/resources.md#resource-specifications"
      }
     }
    },
@@ -11549,7 +11549,7 @@
       "items": {
        "$ref": "v1.PersistentVolumeAccessMode"
       },
-      "description": "the actual access modes the volume has; see http://releases.k8s.io/v1.0.6/docs/user-guide/persistent-volumes.md#access-modes-1"
+      "description": "the actual access modes the volume has; see http://releases.k8s.io/v1.0.7/docs/user-guide/persistent-volumes.md#access-modes-1"
      },
      "capacity": {
       "type": "any",
@@ -11562,22 +11562,22 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "standard list metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "items": {
       "type": "array",
       "items": {
        "$ref": "v1.PersistentVolume"
       },
-      "description": "list of persistent volumes; see http://releases.k8s.io/v1.0.6/docs/user-guide/persistent-volumes.md"
+      "description": "list of persistent volumes; see http://releases.k8s.io/v1.0.7/docs/user-guide/persistent-volumes.md"
      }
     }
    },
@@ -11586,23 +11586,23 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1.PersistentVolumeSpec",
-      "description": "specification of a persistent volume as provisioned by an administrator; see http://releases.k8s.io/v1.0.6/docs/user-guide/persistent-volumes.md#persistent-volumes"
+      "description": "specification of a persistent volume as provisioned by an administrator; see http://releases.k8s.io/v1.0.7/docs/user-guide/persistent-volumes.md#persistent-volumes"
      },
      "status": {
       "$ref": "v1.PersistentVolumeStatus",
-      "description": "current status of a persistent volume; populated by the system, read-only; see http://releases.k8s.io/v1.0.6/docs/user-guide/persistent-volumes.md#persistent-volumes"
+      "description": "current status of a persistent volume; populated by the system, read-only; see http://releases.k8s.io/v1.0.7/docs/user-guide/persistent-volumes.md#persistent-volumes"
      }
     }
    },
@@ -11611,31 +11611,31 @@
     "properties": {
      "capacity": {
       "type": "any",
-      "description": "a description of the persistent volume's resources and capacityr; see http://releases.k8s.io/v1.0.6/docs/user-guide/persistent-volumes.md#capacity"
+      "description": "a description of the persistent volume's resources and capacityr; see http://releases.k8s.io/v1.0.7/docs/user-guide/persistent-volumes.md#capacity"
      },
      "gcePersistentDisk": {
       "$ref": "v1.GCEPersistentDiskVolumeSource",
-      "description": "GCE disk resource provisioned by an admin; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#gcepersistentdisk"
+      "description": "GCE disk resource provisioned by an admin; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#gcepersistentdisk"
      },
      "awsElasticBlockStore": {
       "$ref": "v1.AWSElasticBlockStoreVolumeSource",
-      "description": "AWS disk resource provisioned by an admin; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#awselasticblockstore"
+      "description": "AWS disk resource provisioned by an admin; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#awselasticblockstore"
      },
      "hostPath": {
       "$ref": "v1.HostPathVolumeSource",
-      "description": "a HostPath provisioned by a developer or tester; for develment use only; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#hostpath"
+      "description": "a HostPath provisioned by a developer or tester; for develment use only; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#hostpath"
      },
      "glusterfs": {
       "$ref": "v1.GlusterfsVolumeSource",
-      "description": "Glusterfs volume resource provisioned by an admin; see http://releases.k8s.io/v1.0.6/examples/glusterfs/README.md"
+      "description": "Glusterfs volume resource provisioned by an admin; see http://releases.k8s.io/v1.0.7/examples/glusterfs/README.md"
      },
      "nfs": {
       "$ref": "v1.NFSVolumeSource",
-      "description": "NFS volume resource provisioned by an admin; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#nfs"
+      "description": "NFS volume resource provisioned by an admin; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#nfs"
      },
      "rbd": {
       "$ref": "v1.RBDVolumeSource",
-      "description": "rados block volume that will be mounted on the host machine; see http://releases.k8s.io/v1.0.6/examples/rbd/README.md"
+      "description": "rados block volume that will be mounted on the host machine; see http://releases.k8s.io/v1.0.7/examples/rbd/README.md"
      },
      "iscsi": {
       "$ref": "v1.ISCSIVolumeSource",
@@ -11646,15 +11646,15 @@
       "items": {
        "$ref": "v1.PersistentVolumeAccessMode"
       },
-      "description": "all ways the volume can be mounted; see http://releases.k8s.io/v1.0.6/docs/user-guide/persistent-volumes.md#access-modes"
+      "description": "all ways the volume can be mounted; see http://releases.k8s.io/v1.0.7/docs/user-guide/persistent-volumes.md#access-modes"
      },
      "claimRef": {
       "$ref": "v1.ObjectReference",
-      "description": "when bound, a reference to the bound claim; see http://releases.k8s.io/v1.0.6/docs/user-guide/persistent-volumes.md#binding"
+      "description": "when bound, a reference to the bound claim; see http://releases.k8s.io/v1.0.7/docs/user-guide/persistent-volumes.md#binding"
      },
      "persistentVolumeReclaimPolicy": {
       "type": "string",
-      "description": "what happens to a volume when released from its claim; Valid options are Retain (default) and Recycle.  Recyling must be supported by the volume plugin underlying this persistent volume. See http://releases.k8s.io/v1.0.6/docs/user-guide/persistent-volumes.md#recycling-policy"
+      "description": "what happens to a volume when released from its claim; Valid options are Retain (default) and Recycle.  Recyling must be supported by the volume plugin underlying this persistent volume. See http://releases.k8s.io/v1.0.7/docs/user-guide/persistent-volumes.md#recycling-policy"
      }
     }
    },
@@ -11667,20 +11667,20 @@
     "properties": {
      "pdName": {
       "type": "string",
-      "description": "unique name of the PD resource in GCE; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#gcepersistentdisk"
+      "description": "unique name of the PD resource in GCE; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#gcepersistentdisk"
      },
      "fsType": {
       "type": "string",
-      "description": "file system type to mount, such as ext4, xfs, ntfs; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#gcepersistentdisk"
+      "description": "file system type to mount, such as ext4, xfs, ntfs; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#gcepersistentdisk"
      },
      "partition": {
       "type": "integer",
       "format": "int32",
-      "description": "partition on the disk to mount (e.g., '1' for /dev/sda1); if omitted the plain device name (e.g., /dev/sda) will be mounted; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#gcepersistentdisk"
+      "description": "partition on the disk to mount (e.g., '1' for /dev/sda1); if omitted the plain device name (e.g., /dev/sda) will be mounted; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#gcepersistentdisk"
      },
      "readOnly": {
       "type": "boolean",
-      "description": "read-only if true, read-write otherwise (false or unspecified); see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#gcepersistentdisk"
+      "description": "read-only if true, read-write otherwise (false or unspecified); see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#gcepersistentdisk"
      }
     }
    },
@@ -11693,20 +11693,20 @@
     "properties": {
      "volumeID": {
       "type": "string",
-      "description": "unique id of the PD resource in AWS; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#awselasticblockstore"
+      "description": "unique id of the PD resource in AWS; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#awselasticblockstore"
      },
      "fsType": {
       "type": "string",
-      "description": "file system type to mount, such as ext4, xfs, ntfs; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#awselasticblockstore"
+      "description": "file system type to mount, such as ext4, xfs, ntfs; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#awselasticblockstore"
      },
      "partition": {
       "type": "integer",
       "format": "int32",
-      "description": "partition on the disk to mount (e.g., '1' for /dev/sda1); if omitted the plain device name (e.g., /dev/sda) will be mounted; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#awselasticblockstore"
+      "description": "partition on the disk to mount (e.g., '1' for /dev/sda1); if omitted the plain device name (e.g., /dev/sda) will be mounted; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#awselasticblockstore"
      },
      "readOnly": {
       "type": "boolean",
-      "description": "read-only if true, read-write otherwise (false or unspecified); see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#awselasticblockstore"
+      "description": "read-only if true, read-write otherwise (false or unspecified); see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#awselasticblockstore"
      }
     }
    },
@@ -11718,7 +11718,7 @@
     "properties": {
      "path": {
       "type": "string",
-      "description": "path of the directory on the host; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#hostpath"
+      "description": "path of the directory on the host; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#hostpath"
      }
     }
    },
@@ -11731,15 +11731,15 @@
     "properties": {
      "endpoints": {
       "type": "string",
-      "description": "gluster hosts endpoints name; see http://releases.k8s.io/v1.0.6/examples/glusterfs/README.md#create-a-pod"
+      "description": "gluster hosts endpoints name; see http://releases.k8s.io/v1.0.7/examples/glusterfs/README.md#create-a-pod"
      },
      "path": {
       "type": "string",
-      "description": "path to gluster volume; see http://releases.k8s.io/v1.0.6/examples/glusterfs/README.md#create-a-pod"
+      "description": "path to gluster volume; see http://releases.k8s.io/v1.0.7/examples/glusterfs/README.md#create-a-pod"
      },
      "readOnly": {
       "type": "boolean",
-      "description": "glusterfs volume to be mounted with read-only permissions; see http://releases.k8s.io/v1.0.6/examples/glusterfs/README.md#create-a-pod"
+      "description": "glusterfs volume to be mounted with read-only permissions; see http://releases.k8s.io/v1.0.7/examples/glusterfs/README.md#create-a-pod"
      }
     }
    },
@@ -11752,15 +11752,15 @@
     "properties": {
      "server": {
       "type": "string",
-      "description": "the hostname or IP address of the NFS server; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#nfs"
+      "description": "the hostname or IP address of the NFS server; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#nfs"
      },
      "path": {
       "type": "string",
-      "description": "the path that is exported by the NFS server; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#nfs"
+      "description": "the path that is exported by the NFS server; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#nfs"
      },
      "readOnly": {
       "type": "boolean",
-      "description": "forces the NFS export to be mounted with read-only permissions; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#nfs"
+      "description": "forces the NFS export to be mounted with read-only permissions; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#nfs"
      }
     }
    },
@@ -11780,35 +11780,35 @@
       "items": {
        "type": "string"
       },
-      "description": "a collection of Ceph monitors; see http://releases.k8s.io/v1.0.6/examples/rbd/README.md#how-to-use-it"
+      "description": "a collection of Ceph monitors; see http://releases.k8s.io/v1.0.7/examples/rbd/README.md#how-to-use-it"
      },
      "image": {
       "type": "string",
-      "description": "rados image name; see http://releases.k8s.io/v1.0.6/examples/rbd/README.md#how-to-use-it"
+      "description": "rados image name; see http://releases.k8s.io/v1.0.7/examples/rbd/README.md#how-to-use-it"
      },
      "fsType": {
       "type": "string",
-      "description": "file system type to mount, such as ext4, xfs, ntfs; see http://releases.k8s.io/v1.0.6/examples/rbd/README.md#how-to-use-it"
+      "description": "file system type to mount, such as ext4, xfs, ntfs; see http://releases.k8s.io/v1.0.7/examples/rbd/README.md#how-to-use-it"
      },
      "pool": {
       "type": "string",
-      "description": "rados pool name; default is rbd; optional; see http://releases.k8s.io/v1.0.6/examples/rbd/README.md#how-to-use-it"
+      "description": "rados pool name; default is rbd; optional; see http://releases.k8s.io/v1.0.7/examples/rbd/README.md#how-to-use-it"
      },
      "user": {
       "type": "string",
-      "description": "rados user name; default is admin; optional; see http://releases.k8s.io/v1.0.6/examples/rbd/README.md#how-to-use-it"
+      "description": "rados user name; default is admin; optional; see http://releases.k8s.io/v1.0.7/examples/rbd/README.md#how-to-use-it"
      },
      "keyring": {
       "type": "string",
-      "description": "keyring is the path to key ring for rados user; default is /etc/ceph/keyring; optional; see http://releases.k8s.io/v1.0.6/examples/rbd/README.md#how-to-use-it"
+      "description": "keyring is the path to key ring for rados user; default is /etc/ceph/keyring; optional; see http://releases.k8s.io/v1.0.7/examples/rbd/README.md#how-to-use-it"
      },
      "secretRef": {
       "$ref": "v1.LocalObjectReference",
-      "description": "name of a secret to authenticate the RBD user; if provided overrides keyring; optional; see http://releases.k8s.io/v1.0.6/examples/rbd/README.md#how-to-use-it"
+      "description": "name of a secret to authenticate the RBD user; if provided overrides keyring; optional; see http://releases.k8s.io/v1.0.7/examples/rbd/README.md#how-to-use-it"
      },
      "readOnly": {
       "type": "boolean",
-      "description": "rbd volume to be mounted with read-only permissions; see http://releases.k8s.io/v1.0.6/examples/rbd/README.md#how-to-use-it"
+      "description": "rbd volume to be mounted with read-only permissions; see http://releases.k8s.io/v1.0.7/examples/rbd/README.md#how-to-use-it"
      }
     }
    },
@@ -11817,7 +11817,7 @@
     "properties": {
      "name": {
       "type": "string",
-      "description": "name of the referent; see http://releases.k8s.io/v1.0.6/docs/user-guide/identifiers.md#names"
+      "description": "name of the referent; see http://releases.k8s.io/v1.0.7/docs/user-guide/identifiers.md#names"
      }
     }
    },
@@ -11858,7 +11858,7 @@
     "properties": {
      "phase": {
       "type": "string",
-      "description": "the current phase of a persistent volume; see http://releases.k8s.io/v1.0.6/docs/user-guide/persistent-volumes.md#phase"
+      "description": "the current phase of a persistent volume; see http://releases.k8s.io/v1.0.7/docs/user-guide/persistent-volumes.md#phase"
      },
      "message": {
       "type": "string",
@@ -11878,22 +11878,22 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "standard list metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "items": {
       "type": "array",
       "items": {
        "$ref": "v1.Pod"
       },
-      "description": "list of pods; see http://releases.k8s.io/v1.0.6/docs/user-guide/pods.md"
+      "description": "list of pods; see http://releases.k8s.io/v1.0.7/docs/user-guide/pods.md"
      }
     }
    },
@@ -11902,23 +11902,23 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1.PodSpec",
-      "description": "specification of the desired behavior of the pod; http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#spec-and-status"
+      "description": "specification of the desired behavior of the pod; http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1.PodStatus",
-      "description": "most recently observed status of the pod; populated by the system, read-only; http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#spec-and-status"
+      "description": "most recently observed status of the pod; populated by the system, read-only; http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -11933,18 +11933,18 @@
       "items": {
        "$ref": "v1.Volume"
       },
-      "description": "list of volumes that can be mounted by containers belonging to the pod; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md"
+      "description": "list of volumes that can be mounted by containers belonging to the pod; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md"
      },
      "containers": {
       "type": "array",
       "items": {
        "$ref": "v1.Container"
       },
-      "description": "list of containers belonging to the pod; cannot be updated; containers cannot currently be added or removed; there must be at least one container in a Pod; see http://releases.k8s.io/v1.0.6/docs/user-guide/containers.md"
+      "description": "list of containers belonging to the pod; cannot be updated; containers cannot currently be added or removed; there must be at least one container in a Pod; see http://releases.k8s.io/v1.0.7/docs/user-guide/containers.md"
      },
      "restartPolicy": {
       "type": "string",
-      "description": "restart policy for all containers within the pod; one of Always, OnFailure, Never; defaults to Always; see http://releases.k8s.io/v1.0.6/docs/user-guide/pod-states.md#restartpolicy"
+      "description": "restart policy for all containers within the pod; one of Always, OnFailure, Never; defaults to Always; see http://releases.k8s.io/v1.0.7/docs/user-guide/pod-states.md#restartpolicy"
      },
      "terminationGracePeriodSeconds": {
       "type": "integer",
@@ -11961,11 +11961,11 @@
      },
      "nodeSelector": {
       "type": "any",
-      "description": "selector which must match a node's labels for the pod to be scheduled on that node; see http://releases.k8s.io/v1.0.6/docs/user-guide/node-selection/README.md"
+      "description": "selector which must match a node's labels for the pod to be scheduled on that node; see http://releases.k8s.io/v1.0.7/docs/user-guide/node-selection/README.md"
      },
      "serviceAccountName": {
       "type": "string",
-      "description": "name of the ServiceAccount to use to run this pod; see http://releases.k8s.io/v1.0.6/docs/user-guide/service-accounts.md"
+      "description": "name of the ServiceAccount to use to run this pod; see http://releases.k8s.io/v1.0.7/docs/user-guide/service-accounts.md"
      },
      "serviceAccount": {
       "type": "string",
@@ -11984,7 +11984,7 @@
       "items": {
        "$ref": "v1.LocalObjectReference"
       },
-      "description": "list of references to secrets in the same namespace available for pulling the container images; see http://releases.k8s.io/v1.0.6/docs/user-guide/images.md#specifying-imagepullsecrets-on-a-pod"
+      "description": "list of references to secrets in the same namespace available for pulling the container images; see http://releases.k8s.io/v1.0.7/docs/user-guide/images.md#specifying-imagepullsecrets-on-a-pod"
      }
     }
    },
@@ -11996,23 +11996,23 @@
     "properties": {
      "name": {
       "type": "string",
-      "description": "volume name; must be a DNS_LABEL and unique within the pod; see http://releases.k8s.io/v1.0.6/docs/user-guide/identifiers.md#names"
+      "description": "volume name; must be a DNS_LABEL and unique within the pod; see http://releases.k8s.io/v1.0.7/docs/user-guide/identifiers.md#names"
      },
      "hostPath": {
       "$ref": "v1.HostPathVolumeSource",
-      "description": "pre-existing host file or directory; generally for privileged system daemons or other agents tied to the host; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#hostpath"
+      "description": "pre-existing host file or directory; generally for privileged system daemons or other agents tied to the host; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#hostpath"
      },
      "emptyDir": {
       "$ref": "v1.EmptyDirVolumeSource",
-      "description": "temporary directory that shares a pod's lifetime; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#emptydir"
+      "description": "temporary directory that shares a pod's lifetime; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#emptydir"
      },
      "gcePersistentDisk": {
       "$ref": "v1.GCEPersistentDiskVolumeSource",
-      "description": "GCE disk resource attached to the host machine on demand; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#gcepersistentdisk"
+      "description": "GCE disk resource attached to the host machine on demand; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#gcepersistentdisk"
      },
      "awsElasticBlockStore": {
       "$ref": "v1.AWSElasticBlockStoreVolumeSource",
-      "description": "AWS disk resource attached to the host machine on demand; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#awselasticblockstore"
+      "description": "AWS disk resource attached to the host machine on demand; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#awselasticblockstore"
      },
      "gitRepo": {
       "$ref": "v1.GitRepoVolumeSource",
@@ -12020,27 +12020,27 @@
      },
      "secret": {
       "$ref": "v1.SecretVolumeSource",
-      "description": "secret to populate volume; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#secrets"
+      "description": "secret to populate volume; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#secrets"
      },
      "nfs": {
       "$ref": "v1.NFSVolumeSource",
-      "description": "NFS volume that will be mounted in the host machine; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#nfs"
+      "description": "NFS volume that will be mounted in the host machine; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#nfs"
      },
      "iscsi": {
       "$ref": "v1.ISCSIVolumeSource",
-      "description": "iSCSI disk attached to host machine on demand; see http://releases.k8s.io/v1.0.6/examples/iscsi/README.md"
+      "description": "iSCSI disk attached to host machine on demand; see http://releases.k8s.io/v1.0.7/examples/iscsi/README.md"
      },
      "glusterfs": {
       "$ref": "v1.GlusterfsVolumeSource",
-      "description": "Glusterfs volume that will be mounted on the host machine; see http://releases.k8s.io/v1.0.6/examples/glusterfs/README.md"
+      "description": "Glusterfs volume that will be mounted on the host machine; see http://releases.k8s.io/v1.0.7/examples/glusterfs/README.md"
      },
      "persistentVolumeClaim": {
       "$ref": "v1.PersistentVolumeClaimVolumeSource",
-      "description": "a reference to a PersistentVolumeClaim in the same namespace; see http://releases.k8s.io/v1.0.6/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"
+      "description": "a reference to a PersistentVolumeClaim in the same namespace; see http://releases.k8s.io/v1.0.7/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"
      },
      "rbd": {
       "$ref": "v1.RBDVolumeSource",
-      "description": "rados block volume that will be mounted on the host machine; see http://releases.k8s.io/v1.0.6/examples/rbd/README.md"
+      "description": "rados block volume that will be mounted on the host machine; see http://releases.k8s.io/v1.0.7/examples/rbd/README.md"
      }
     }
    },
@@ -12049,7 +12049,7 @@
     "properties": {
      "medium": {
       "type": "string",
-      "description": "type of storage used to back the volume; must be an empty string (default) or Memory; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#emptydir"
+      "description": "type of storage used to back the volume; must be an empty string (default) or Memory; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#emptydir"
      }
     }
    },
@@ -12078,7 +12078,7 @@
     "properties": {
      "secretName": {
       "type": "string",
-      "description": "secretName is the name of a secret in the pod's namespace; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#secrets"
+      "description": "secretName is the name of a secret in the pod's namespace; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#secrets"
      }
     }
    },
@@ -12090,7 +12090,7 @@
     "properties": {
      "claimName": {
       "type": "string",
-      "description": "the name of the claim in the same namespace to be mounted as a volume; see http://releases.k8s.io/v1.0.6/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"
+      "description": "the name of the claim in the same namespace to be mounted as a volume; see http://releases.k8s.io/v1.0.7/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"
      },
      "readOnly": {
       "type": "boolean",
@@ -12110,21 +12110,21 @@
      },
      "image": {
       "type": "string",
-      "description": "Docker image name; see http://releases.k8s.io/v1.0.6/docs/user-guide/images.md"
+      "description": "Docker image name; see http://releases.k8s.io/v1.0.7/docs/user-guide/images.md"
      },
      "command": {
       "type": "array",
       "items": {
        "type": "string"
       },
-      "description": "entrypoint array; not executed within a shell; the docker image's entrypoint is used if this is not provided; cannot be updated; variable references $(VAR_NAME) are expanded using the container's environment variables; if a variable cannot be resolved, the reference in the input string will be unchanged; the $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME) ; escaped references will never be expanded, regardless of whether the variable exists or not; see http://releases.k8s.io/v1.0.6/docs/user-guide/containers.md#containers-and-commands"
+      "description": "entrypoint array; not executed within a shell; the docker image's entrypoint is used if this is not provided; cannot be updated; variable references $(VAR_NAME) are expanded using the container's environment variables; if a variable cannot be resolved, the reference in the input string will be unchanged; the $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME) ; escaped references will never be expanded, regardless of whether the variable exists or not; see http://releases.k8s.io/v1.0.7/docs/user-guide/containers.md#containers-and-commands"
      },
      "args": {
       "type": "array",
       "items": {
        "type": "string"
       },
-      "description": "command array; the docker image's cmd is used if this is not provided; arguments to the entrypoint; cannot be updated; variable references $(VAR_NAME) are expanded using the container's environment variables; if a variable cannot be resolved, the reference in the input string will be unchanged; the $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME) ; escaped references will never be expanded, regardless of whether the variable exists or not; see http://releases.k8s.io/v1.0.6/docs/user-guide/containers.md#containers-and-commands"
+      "description": "command array; the docker image's cmd is used if this is not provided; arguments to the entrypoint; cannot be updated; variable references $(VAR_NAME) are expanded using the container's environment variables; if a variable cannot be resolved, the reference in the input string will be unchanged; the $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME) ; escaped references will never be expanded, regardless of whether the variable exists or not; see http://releases.k8s.io/v1.0.7/docs/user-guide/containers.md#containers-and-commands"
      },
      "workingDir": {
       "type": "string",
@@ -12146,7 +12146,7 @@
      },
      "resources": {
       "$ref": "v1.ResourceRequirements",
-      "description": "Compute Resources required by this container; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/user-guide/compute-resources.md"
+      "description": "Compute Resources required by this container; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/user-guide/compute-resources.md"
      },
      "volumeMounts": {
       "type": "array",
@@ -12157,11 +12157,11 @@
      },
      "livenessProbe": {
       "$ref": "v1.Probe",
-      "description": "periodic probe of container liveness; container will be restarted if the probe fails; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/user-guide/pod-states.md#container-probes"
+      "description": "periodic probe of container liveness; container will be restarted if the probe fails; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/user-guide/pod-states.md#container-probes"
      },
      "readinessProbe": {
       "$ref": "v1.Probe",
-      "description": "periodic probe of container service readiness; container will be removed from service endpoints if the probe fails; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/user-guide/pod-states.md#container-probes"
+      "description": "periodic probe of container service readiness; container will be removed from service endpoints if the probe fails; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/user-guide/pod-states.md#container-probes"
      },
      "lifecycle": {
       "$ref": "v1.Lifecycle",
@@ -12173,11 +12173,11 @@
      },
      "imagePullPolicy": {
       "type": "string",
-      "description": "image pull policy; one of Always, Never, IfNotPresent; defaults to Always if :latest tag is specified, or IfNotPresent otherwise; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/user-guide/images.md#updating-images"
+      "description": "image pull policy; one of Always, Never, IfNotPresent; defaults to Always if :latest tag is specified, or IfNotPresent otherwise; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/user-guide/images.md#updating-images"
      },
      "securityContext": {
       "$ref": "v1.SecurityContext",
-      "description": "security options the pod should run with; see http://releases.k8s.io/v1.0.6/docs/design/security_context.md"
+      "description": "security options the pod should run with; see http://releases.k8s.io/v1.0.7/docs/design/security_context.md"
      }
     }
    },
@@ -12298,12 +12298,12 @@
      "initialDelaySeconds": {
       "type": "integer",
       "format": "int64",
-      "description": "number of seconds after the container has started before liveness probes are initiated; see http://releases.k8s.io/v1.0.6/docs/user-guide/pod-states.md#container-probes"
+      "description": "number of seconds after the container has started before liveness probes are initiated; see http://releases.k8s.io/v1.0.7/docs/user-guide/pod-states.md#container-probes"
      },
      "timeoutSeconds": {
       "type": "integer",
       "format": "int64",
-      "description": "number of seconds after which liveness probes timeout; defaults to 1 second; see http://releases.k8s.io/v1.0.6/docs/user-guide/pod-states.md#container-probes"
+      "description": "number of seconds after which liveness probes timeout; defaults to 1 second; see http://releases.k8s.io/v1.0.7/docs/user-guide/pod-states.md#container-probes"
      }
     }
    },
@@ -12360,11 +12360,11 @@
     "properties": {
      "postStart": {
       "$ref": "v1.Handler",
-      "description": "called immediately after a container is started; if the handler fails, the container is terminated and restarted according to its restart policy; other management of the container blocks until the hook completes; see http://releases.k8s.io/v1.0.6/docs/user-guide/container-environment.md#hook-details"
+      "description": "called immediately after a container is started; if the handler fails, the container is terminated and restarted according to its restart policy; other management of the container blocks until the hook completes; see http://releases.k8s.io/v1.0.7/docs/user-guide/container-environment.md#hook-details"
      },
      "preStop": {
       "$ref": "v1.Handler",
-      "description": "called before a container is terminated; the container is terminated after the handler completes; other management of the container blocks until the hook completes; see http://releases.k8s.io/v1.0.6/docs/user-guide/container-environment.md#hook-details"
+      "description": "called before a container is terminated; the container is terminated after the handler completes; other management of the container blocks until the hook completes; see http://releases.k8s.io/v1.0.7/docs/user-guide/container-environment.md#hook-details"
      }
     }
    },
@@ -12390,20 +12390,20 @@
     "properties": {
      "capabilities": {
       "$ref": "v1.Capabilities",
-      "description": "the linux capabilites that should be added or removed; see http://releases.k8s.io/v1.0.6/docs/design/security_context.md#security-context"
+      "description": "the linux capabilites that should be added or removed; see http://releases.k8s.io/v1.0.7/docs/design/security_context.md#security-context"
      },
      "privileged": {
       "type": "boolean",
-      "description": "run the container in privileged mode; see http://releases.k8s.io/v1.0.6/docs/design/security_context.md#security-context"
+      "description": "run the container in privileged mode; see http://releases.k8s.io/v1.0.7/docs/design/security_context.md#security-context"
      },
      "seLinuxOptions": {
       "$ref": "v1.SELinuxOptions",
-      "description": "options that control the SELinux labels applied; see http://releases.k8s.io/v1.0.6/docs/design/security_context.md#security-context"
+      "description": "options that control the SELinux labels applied; see http://releases.k8s.io/v1.0.7/docs/design/security_context.md#security-context"
      },
      "runAsUser": {
       "type": "integer",
       "format": "int64",
-      "description": "the user id that runs the first process in the container; see http://releases.k8s.io/v1.0.6/docs/design/security_context.md#security-context"
+      "description": "the user id that runs the first process in the container; see http://releases.k8s.io/v1.0.7/docs/design/security_context.md#security-context"
      }
     }
    },
@@ -12435,19 +12435,19 @@
     "properties": {
      "user": {
       "type": "string",
-      "description": "the user label to apply to the container; see http://releases.k8s.io/v1.0.6/docs/user-guide/labels.md"
+      "description": "the user label to apply to the container; see http://releases.k8s.io/v1.0.7/docs/user-guide/labels.md"
      },
      "role": {
       "type": "string",
-      "description": "the role label to apply to the container; see http://releases.k8s.io/v1.0.6/docs/user-guide/labels.md"
+      "description": "the role label to apply to the container; see http://releases.k8s.io/v1.0.7/docs/user-guide/labels.md"
      },
      "type": {
       "type": "string",
-      "description": "the type label to apply to the container; see http://releases.k8s.io/v1.0.6/docs/user-guide/labels.md"
+      "description": "the type label to apply to the container; see http://releases.k8s.io/v1.0.7/docs/user-guide/labels.md"
      },
      "level": {
       "type": "string",
-      "description": "the level label to apply to the container; see http://releases.k8s.io/v1.0.6/docs/user-guide/labels.md"
+      "description": "the level label to apply to the container; see http://releases.k8s.io/v1.0.7/docs/user-guide/labels.md"
      }
     }
    },
@@ -12456,14 +12456,14 @@
     "properties": {
      "phase": {
       "type": "string",
-      "description": "current condition of the pod; see http://releases.k8s.io/v1.0.6/docs/user-guide/pod-states.md#pod-phase"
+      "description": "current condition of the pod; see http://releases.k8s.io/v1.0.7/docs/user-guide/pod-states.md#pod-phase"
      },
      "conditions": {
       "type": "array",
       "items": {
        "$ref": "v1.PodCondition"
       },
-      "description": "current service state of pod; see http://releases.k8s.io/v1.0.6/docs/user-guide/pod-states.md#pod-conditions"
+      "description": "current service state of pod; see http://releases.k8s.io/v1.0.7/docs/user-guide/pod-states.md#pod-conditions"
      },
      "message": {
       "type": "string",
@@ -12490,7 +12490,7 @@
       "items": {
        "$ref": "v1.ContainerStatus"
       },
-      "description": "list of container statuses; see http://releases.k8s.io/v1.0.6/docs/user-guide/pod-states.md#container-statuses"
+      "description": "list of container statuses; see http://releases.k8s.io/v1.0.7/docs/user-guide/pod-states.md#container-statuses"
      }
     }
    },
@@ -12503,11 +12503,11 @@
     "properties": {
      "type": {
       "type": "string",
-      "description": "kind of the condition, currently only Ready; see http://releases.k8s.io/v1.0.6/docs/user-guide/pod-states.md#pod-conditions"
+      "description": "kind of the condition, currently only Ready; see http://releases.k8s.io/v1.0.7/docs/user-guide/pod-states.md#pod-conditions"
      },
      "status": {
       "type": "string",
-      "description": "status of the condition, one of True, False, Unknown; see http://releases.k8s.io/v1.0.6/docs/user-guide/pod-states.md#pod-conditions"
+      "description": "status of the condition, one of True, False, Unknown; see http://releases.k8s.io/v1.0.7/docs/user-guide/pod-states.md#pod-conditions"
      }
     }
    },
@@ -12544,7 +12544,7 @@
      },
      "image": {
       "type": "string",
-      "description": "image of the container; see http://releases.k8s.io/v1.0.6/docs/user-guide/images.md"
+      "description": "image of the container; see http://releases.k8s.io/v1.0.7/docs/user-guide/images.md"
      },
      "imageID": {
       "type": "string",
@@ -12552,7 +12552,7 @@
      },
      "containerID": {
       "type": "string",
-      "description": "container's ID in the format 'docker://\u003ccontainer_id\u003e'; see http://releases.k8s.io/v1.0.6/docs/user-guide/container-environment.md#container-information"
+      "description": "container's ID in the format 'docker://\u003ccontainer_id\u003e'; see http://releases.k8s.io/v1.0.7/docs/user-guide/container-environment.md#container-information"
      }
     }
    },
@@ -12637,15 +12637,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
@@ -12661,19 +12661,19 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"
      },
      "template": {
       "$ref": "v1.PodTemplateSpec",
-      "description": "the template of the desired behavior of the pod; http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#spec-and-status"
+      "description": "the template of the desired behavior of the pod; http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -12682,11 +12682,11 @@
     "properties": {
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1.PodSpec",
-      "description": "specification of the desired behavior of the pod; http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#spec-and-status"
+      "description": "specification of the desired behavior of the pod; http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -12698,22 +12698,22 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
       "items": {
        "$ref": "v1.ReplicationController"
       },
-      "description": "list of replication controllers; see http://releases.k8s.io/v1.0.6/docs/user-guide/replication-controller.md"
+      "description": "list of replication controllers; see http://releases.k8s.io/v1.0.7/docs/user-guide/replication-controller.md"
      }
     }
    },
@@ -12722,23 +12722,23 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1.ReplicationControllerSpec",
-      "description": "specification of the desired behavior of the replication controller; http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#spec-and-status"
+      "description": "specification of the desired behavior of the replication controller; http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1.ReplicationControllerStatus",
-      "description": "most recently observed status of the replication controller; populated by the system, read-only; http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#spec-and-status"
+      "description": "most recently observed status of the replication controller; populated by the system, read-only; http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -12748,15 +12748,15 @@
      "replicas": {
       "type": "integer",
       "format": "int32",
-      "description": "number of replicas desired; defaults to 1; see http://releases.k8s.io/v1.0.6/docs/user-guide/replication-controller.md#what-is-a-replication-controller"
+      "description": "number of replicas desired; defaults to 1; see http://releases.k8s.io/v1.0.7/docs/user-guide/replication-controller.md#what-is-a-replication-controller"
      },
      "selector": {
       "type": "any",
-      "description": "label keys and values that must match in order to be controlled by this replication controller, if empty defaulted to labels on Pod template; see http://releases.k8s.io/v1.0.6/docs/user-guide/labels.md#label-selectors"
+      "description": "label keys and values that must match in order to be controlled by this replication controller, if empty defaulted to labels on Pod template; see http://releases.k8s.io/v1.0.7/docs/user-guide/labels.md#label-selectors"
      },
      "template": {
       "$ref": "v1.PodTemplateSpec",
-      "description": "object that describes the pod that will be created if insufficient replicas are detected; takes precendence over templateRef; see http://releases.k8s.io/v1.0.6/docs/user-guide/replication-controller.md#pod-template"
+      "description": "object that describes the pod that will be created if insufficient replicas are detected; takes precendence over templateRef; see http://releases.k8s.io/v1.0.7/docs/user-guide/replication-controller.md#pod-template"
      }
     }
    },
@@ -12769,7 +12769,7 @@
      "replicas": {
       "type": "integer",
       "format": "int32",
-      "description": "most recently oberved number of replicas; see http://releases.k8s.io/v1.0.6/docs/user-guide/replication-controller.md#what-is-a-replication-controller"
+      "description": "most recently oberved number of replicas; see http://releases.k8s.io/v1.0.7/docs/user-guide/replication-controller.md#what-is-a-replication-controller"
      },
      "observedGeneration": {
       "type": "integer",
@@ -12786,22 +12786,22 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
       "items": {
        "$ref": "v1.ResourceQuota"
       },
-      "description": "items is a list of ResourceQuota objects; see http://releases.k8s.io/v1.0.6/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota"
+      "description": "items is a list of ResourceQuota objects; see http://releases.k8s.io/v1.0.7/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota"
      }
     }
    },
@@ -12810,23 +12810,23 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1.ResourceQuotaSpec",
-      "description": "spec defines the desired quota; http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#spec-and-status"
+      "description": "spec defines the desired quota; http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1.ResourceQuotaStatus",
-      "description": "status defines the actual enforced quota and current usage; http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#spec-and-status"
+      "description": "status defines the actual enforced quota and current usage; http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -12835,7 +12835,7 @@
     "properties": {
      "hard": {
       "type": "any",
-      "description": "hard is the set of desired hard limits for each named resource; see http://releases.k8s.io/v1.0.6/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota"
+      "description": "hard is the set of desired hard limits for each named resource; see http://releases.k8s.io/v1.0.7/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota"
      }
     }
    },
@@ -12844,7 +12844,7 @@
     "properties": {
      "hard": {
       "type": "any",
-      "description": "hard is the set of enforced hard limits for each named resource; see http://releases.k8s.io/v1.0.6/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota"
+      "description": "hard is the set of enforced hard limits for each named resource; see http://releases.k8s.io/v1.0.7/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota"
      },
      "used": {
       "type": "any",
@@ -12860,22 +12860,22 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
       "items": {
        "$ref": "v1.Secret"
       },
-      "description": "items is a list of secret objects; see http://releases.k8s.io/v1.0.6/docs/user-guide/secrets.md"
+      "description": "items is a list of secret objects; see http://releases.k8s.io/v1.0.7/docs/user-guide/secrets.md"
      }
     }
    },
@@ -12884,15 +12884,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"
      },
      "data": {
       "type": "any",
@@ -12912,22 +12912,22 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
       "items": {
        "$ref": "v1.ServiceAccount"
       },
-      "description": "list of ServiceAccounts; see http://releases.k8s.io/v1.0.6/docs/user-guide/service-accounts.md#service-accounts"
+      "description": "list of ServiceAccounts; see http://releases.k8s.io/v1.0.7/docs/user-guide/service-accounts.md#service-accounts"
      }
     }
    },
@@ -12936,29 +12936,29 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"
      },
      "secrets": {
       "type": "array",
       "items": {
        "$ref": "v1.ObjectReference"
       },
-      "description": "list of secrets that can be used by pods running as this service account; see http://releases.k8s.io/v1.0.6/docs/user-guide/secrets.md"
+      "description": "list of secrets that can be used by pods running as this service account; see http://releases.k8s.io/v1.0.7/docs/user-guide/secrets.md"
      },
      "imagePullSecrets": {
       "type": "array",
       "items": {
        "$ref": "v1.LocalObjectReference"
       },
-      "description": "list of references to secrets in the same namespace available for pulling container images; see http://releases.k8s.io/v1.0.6/docs/user-guide/secrets.md#manually-specifying-an-imagepullsecret"
+      "description": "list of references to secrets in the same namespace available for pulling container images; see http://releases.k8s.io/v1.0.7/docs/user-guide/secrets.md#manually-specifying-an-imagepullsecret"
      }
     }
    },
@@ -12970,15 +12970,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
@@ -12994,23 +12994,23 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"
+      "description": "kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#resources"
+      "description": "version of the schema the object should have; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1.ServiceSpec",
-      "description": "specification of the desired behavior of the service; http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#spec-and-status"
+      "description": "specification of the desired behavior of the service; http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1.ServiceStatus",
-      "description": "most recently observed status of the service; populated by the system, read-only; http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#spec-and-status"
+      "description": "most recently observed status of the service; populated by the system, read-only; http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -13025,19 +13025,19 @@
       "items": {
        "$ref": "v1.ServicePort"
       },
-      "description": "ports exposed by the service; see http://releases.k8s.io/v1.0.6/docs/user-guide/services.md#virtual-ips-and-service-proxies"
+      "description": "ports exposed by the service; see http://releases.k8s.io/v1.0.7/docs/user-guide/services.md#virtual-ips-and-service-proxies"
      },
      "selector": {
       "type": "any",
-      "description": "label keys and values that must match in order to receive traffic for this service; if empty, all pods are selected, if not specified, endpoints must be manually specified; see http://releases.k8s.io/v1.0.6/docs/user-guide/services.md#overview"
+      "description": "label keys and values that must match in order to receive traffic for this service; if empty, all pods are selected, if not specified, endpoints must be manually specified; see http://releases.k8s.io/v1.0.7/docs/user-guide/services.md#overview"
      },
      "clusterIP": {
       "type": "string",
-      "description": "IP address of the service; usually assigned by the system; if specified, it will be allocated to the service if unused or else creation of the service will fail; cannot be updated; 'None' can be specified for a headless service when proxying is not required; see http://releases.k8s.io/v1.0.6/docs/user-guide/services.md#virtual-ips-and-service-proxies"
+      "description": "IP address of the service; usually assigned by the system; if specified, it will be allocated to the service if unused or else creation of the service will fail; cannot be updated; 'None' can be specified for a headless service when proxying is not required; see http://releases.k8s.io/v1.0.7/docs/user-guide/services.md#virtual-ips-and-service-proxies"
      },
      "type": {
       "type": "string",
-      "description": "type of this service; must be ClusterIP, NodePort, or LoadBalancer; defaults to ClusterIP; see http://releases.k8s.io/v1.0.6/docs/user-guide/services.md#external-services"
+      "description": "type of this service; must be ClusterIP, NodePort, or LoadBalancer; defaults to ClusterIP; see http://releases.k8s.io/v1.0.7/docs/user-guide/services.md#external-services"
      },
      "deprecatedPublicIPs": {
       "type": "array",
@@ -13048,7 +13048,7 @@
      },
      "sessionAffinity": {
       "type": "string",
-      "description": "enable client IP based session affinity; must be ClientIP or None; defaults to None; see http://releases.k8s.io/v1.0.6/docs/user-guide/services.md#virtual-ips-and-service-proxies"
+      "description": "enable client IP based session affinity; must be ClientIP or None; defaults to None; see http://releases.k8s.io/v1.0.7/docs/user-guide/services.md#virtual-ips-and-service-proxies"
      }
     }
    },
@@ -13074,12 +13074,12 @@
      },
      "targetPort": {
       "type": "string",
-      "description": "number or name of the port to access on the pods targeted by the service; defaults to the service port; number must be in the range 1 to 65535; name must be an IANA_SVC_NAME; see http://releases.k8s.io/v1.0.6/docs/user-guide/services.md#defining-a-service"
+      "description": "number or name of the port to access on the pods targeted by the service; defaults to the service port; number must be in the range 1 to 65535; name must be an IANA_SVC_NAME; see http://releases.k8s.io/v1.0.7/docs/user-guide/services.md#defining-a-service"
      },
      "nodePort": {
       "type": "integer",
       "format": "int32",
-      "description": "the port on each node on which this service is exposed when type=NodePort or LoadBalancer; usually assigned by the system; if specified, it will be allocated to the service if unused or else creation of the service will fail; see http://releases.k8s.io/v1.0.6/docs/user-guide/services.md#type--nodeport"
+      "description": "the port on each node on which this service is exposed when type=NodePort or LoadBalancer; usually assigned by the system; if specified, it will be allocated to the service if unused or else creation of the service will fail; see http://releases.k8s.io/v1.0.7/docs/user-guide/services.md#type--nodeport"
      }
     }
    },

--- a/api/swagger-spec/v1beta3.json
+++ b/api/swagger-spec/v1beta3.json
@@ -10591,7 +10591,7 @@
      },
      "metadata": {
       "$ref": "v1beta3.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"
      },
      "target": {
       "$ref": "v1beta3.ObjectReference",
@@ -10624,7 +10624,7 @@
      },
      "resourceVersion": {
       "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://releases.k8s.io/v1.0.6/docs/api-conventions.md#concurrency-control-and-consistency"
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://releases.k8s.io/v1.0.7/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "generation": {
       "type": "integer",
@@ -10674,7 +10674,7 @@
      },
      "resourceVersion": {
       "type": "string",
-      "description": "specific resourceVersion to which this reference is made, if any: http://releases.k8s.io/v1.0.6/docs/api-conventions.md#concurrency-control-and-consistency"
+      "description": "specific resourceVersion to which this reference is made, if any: http://releases.k8s.io/v1.0.7/docs/api-conventions.md#concurrency-control-and-consistency"
      },
      "fieldPath": {
       "type": "string",
@@ -10698,7 +10698,7 @@
      },
      "metadata": {
       "$ref": "v1beta3.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
@@ -10718,7 +10718,7 @@
      },
      "resourceVersion": {
       "type": "string",
-      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://releases.k8s.io/v1.0.6/docs/api-conventions.md#concurrency-control-and-consistency"
+      "description": "string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://releases.k8s.io/v1.0.7/docs/api-conventions.md#concurrency-control-and-consistency"
      }
     }
    },
@@ -10735,7 +10735,7 @@
      },
      "metadata": {
       "$ref": "v1beta3.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"
      },
      "conditions": {
       "type": "array",
@@ -10787,7 +10787,7 @@
      },
      "metadata": {
       "$ref": "v1beta3.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
@@ -10814,7 +10814,7 @@
      },
      "metadata": {
       "$ref": "v1beta3.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"
      },
      "subsets": {
       "type": "array",
@@ -10911,7 +10911,7 @@
      },
      "metadata": {
       "$ref": "v1beta3.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"
      },
      "status": {
       "type": "string",
@@ -11012,7 +11012,7 @@
      },
      "metadata": {
       "$ref": "v1beta3.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
@@ -11040,7 +11040,7 @@
      },
      "metadata": {
       "$ref": "v1beta3.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"
      },
      "involvedObject": {
       "$ref": "v1beta3.ObjectReference",
@@ -11102,7 +11102,7 @@
      },
      "metadata": {
       "$ref": "v1beta3.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
@@ -11126,11 +11126,11 @@
      },
      "metadata": {
       "$ref": "v1beta3.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1beta3.LimitRangeSpec",
-      "description": "spec defines the limits enforced; http://releases.k8s.io/v1.0.6/docs/api-conventions.md#spec-and-status"
+      "description": "spec defines the limits enforced; http://releases.k8s.io/v1.0.7/docs/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -11186,7 +11186,7 @@
      },
      "metadata": {
       "$ref": "v1beta3.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
@@ -11210,15 +11210,15 @@
      },
      "metadata": {
       "$ref": "v1beta3.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1beta3.NamespaceSpec",
-      "description": "spec defines the behavior of the Namespace; http://releases.k8s.io/v1.0.6/docs/api-conventions.md#spec-and-status"
+      "description": "spec defines the behavior of the Namespace; http://releases.k8s.io/v1.0.7/docs/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1beta3.NamespaceStatus",
-      "description": "status describes the current status of a Namespace; http://releases.k8s.io/v1.0.6/docs/api-conventions.md#spec-and-status"
+      "description": "status describes the current status of a Namespace; http://releases.k8s.io/v1.0.7/docs/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -11263,7 +11263,7 @@
      },
      "metadata": {
       "$ref": "v1beta3.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
@@ -11287,15 +11287,15 @@
      },
      "metadata": {
       "$ref": "v1beta3.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1beta3.NodeSpec",
-      "description": "specification of a node; http://releases.k8s.io/v1.0.6/docs/api-conventions.md#spec-and-status"
+      "description": "specification of a node; http://releases.k8s.io/v1.0.7/docs/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1beta3.NodeStatus",
-      "description": "most recently observed status of the node; populated by the system, read-only; http://releases.k8s.io/v1.0.6/docs/api-conventions.md#spec-and-status"
+      "description": "most recently observed status of the node; populated by the system, read-only; http://releases.k8s.io/v1.0.7/docs/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -11325,7 +11325,7 @@
     "properties": {
      "capacity": {
       "type": "any",
-      "description": "compute resource capacity of the node; http://releases.k8s.io/v1.0.6/docs/resources.md"
+      "description": "compute resource capacity of the node; http://releases.k8s.io/v1.0.7/docs/resources.md"
      },
      "phase": {
       "type": "string",
@@ -11461,7 +11461,7 @@
      },
      "metadata": {
       "$ref": "v1beta3.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#types-kinds"
+      "description": "standard list metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#types-kinds"
      },
      "items": {
       "type": "array",
@@ -11485,7 +11485,7 @@
      },
      "metadata": {
       "$ref": "v1beta3.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1beta3.PersistentVolumeClaimSpec",
@@ -11567,7 +11567,7 @@
      },
      "metadata": {
       "$ref": "v1beta3.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#types-kinds"
+      "description": "standard list metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#types-kinds"
      },
      "items": {
       "type": "array",
@@ -11591,7 +11591,7 @@
      },
      "metadata": {
       "$ref": "v1beta3.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1beta3.PersistentVolumeSpec",
@@ -11883,7 +11883,7 @@
      },
      "metadata": {
       "$ref": "v1beta3.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#types-kinds"
+      "description": "standard list metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#types-kinds"
      },
      "items": {
       "type": "array",
@@ -11907,15 +11907,15 @@
      },
      "metadata": {
       "$ref": "v1beta3.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1beta3.PodSpec",
-      "description": "specification of the desired behavior of the pod; http://releases.k8s.io/v1.0.6/docs/api-conventions.md#spec-and-status"
+      "description": "specification of the desired behavior of the pod; http://releases.k8s.io/v1.0.7/docs/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1beta3.PodStatus",
-      "description": "most recently observed status of the pod; populated by the system, read-only; http://releases.k8s.io/v1.0.6/docs/api-conventions.md#spec-and-status"
+      "description": "most recently observed status of the pod; populated by the system, read-only; http://releases.k8s.io/v1.0.7/docs/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -12643,7 +12643,7 @@
      },
      "metadata": {
       "$ref": "v1beta3.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
@@ -12667,11 +12667,11 @@
      },
      "metadata": {
       "$ref": "v1beta3.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"
      },
      "template": {
       "$ref": "v1beta3.PodTemplateSpec",
-      "description": "the template of the desired behavior of the pod; http://releases.k8s.io/v1.0.6/docs/api-conventions.md#spec-and-status"
+      "description": "the template of the desired behavior of the pod; http://releases.k8s.io/v1.0.7/docs/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -12680,11 +12680,11 @@
     "properties": {
      "metadata": {
       "$ref": "v1beta3.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1beta3.PodSpec",
-      "description": "specification of the desired behavior of the pod; http://releases.k8s.io/v1.0.6/docs/api-conventions.md#spec-and-status"
+      "description": "specification of the desired behavior of the pod; http://releases.k8s.io/v1.0.7/docs/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -12704,7 +12704,7 @@
      },
      "metadata": {
       "$ref": "v1beta3.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
@@ -12728,15 +12728,15 @@
      },
      "metadata": {
       "$ref": "v1beta3.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1beta3.ReplicationControllerSpec",
-      "description": "specification of the desired behavior of the replication controller; http://releases.k8s.io/v1.0.6/docs/api-conventions.md#spec-and-status"
+      "description": "specification of the desired behavior of the replication controller; http://releases.k8s.io/v1.0.7/docs/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1beta3.ReplicationControllerStatus",
-      "description": "most recently observed status of the replication controller; populated by the system, read-only; http://releases.k8s.io/v1.0.6/docs/api-conventions.md#spec-and-status"
+      "description": "most recently observed status of the replication controller; populated by the system, read-only; http://releases.k8s.io/v1.0.7/docs/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -12792,7 +12792,7 @@
      },
      "metadata": {
       "$ref": "v1beta3.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
@@ -12816,15 +12816,15 @@
      },
      "metadata": {
       "$ref": "v1beta3.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1beta3.ResourceQuotaSpec",
-      "description": "spec defines the desired quota; http://releases.k8s.io/v1.0.6/docs/api-conventions.md#spec-and-status"
+      "description": "spec defines the desired quota; http://releases.k8s.io/v1.0.7/docs/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1beta3.ResourceQuotaStatus",
-      "description": "status defines the actual enforced quota and current usage; http://releases.k8s.io/v1.0.6/docs/api-conventions.md#spec-and-status"
+      "description": "status defines the actual enforced quota and current usage; http://releases.k8s.io/v1.0.7/docs/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -12866,7 +12866,7 @@
      },
      "metadata": {
       "$ref": "v1beta3.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
@@ -12890,7 +12890,7 @@
      },
      "metadata": {
       "$ref": "v1beta3.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"
      },
      "data": {
       "type": "any",
@@ -12918,7 +12918,7 @@
      },
      "metadata": {
       "$ref": "v1beta3.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
@@ -12942,7 +12942,7 @@
      },
      "metadata": {
       "$ref": "v1beta3.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"
      },
      "secrets": {
       "type": "array",
@@ -12976,7 +12976,7 @@
      },
      "metadata": {
       "$ref": "v1beta3.ListMeta",
-      "description": "standard list metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"
+      "description": "standard list metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
@@ -13000,15 +13000,15 @@
      },
      "metadata": {
       "$ref": "v1beta3.ObjectMeta",
-      "description": "standard object metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"
+      "description": "standard object metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1beta3.ServiceSpec",
-      "description": "specification of the desired behavior of the service; http://releases.k8s.io/v1.0.6/docs/api-conventions.md#spec-and-status"
+      "description": "specification of the desired behavior of the service; http://releases.k8s.io/v1.0.7/docs/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1beta3.ServiceStatus",
-      "description": "most recently observed status of the service; populated by the system, read-only; http://releases.k8s.io/v1.0.6/docs/api-conventions.md#spec-and-status"
+      "description": "most recently observed status of the service; populated by the system, read-only; http://releases.k8s.io/v1.0.7/docs/api-conventions.md#spec-and-status"
      }
     }
    },

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -1,6 +1,6 @@
 # build the hyperkube image.
 
-VERSION=v0.18.2
+VERSION=v1.0.7
 
 all:
 	cp ../../saltbase/salt/helpers/safe_format_and_mount .

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 
 <!-- END MUNGE: UNVERSIONED_WARNING -->
 
-# Kubernetes Documentation: releases.k8s.io/v1.0.6
+# Kubernetes Documentation: releases.k8s.io/v1.0.7
 
 * The [User's guide](user-guide/README.md) is for anyone who wants to run programs and
   services on an existing Kubernetes cluster.

--- a/docs/admin/authorization.md
+++ b/docs/admin/authorization.md
@@ -85,7 +85,7 @@ To permit an action Policy with an unset namespace applies regardless of namespa
  3. Kubelet can read and write events: `{"user":"kubelet", "resource": "events"}`
  4. Bob can just read pods in namespace "projectCaribou": `{"user":"bob", "resource": "pods", "readonly": true, "ns": "projectCaribou"}`
 
-[Complete file example](http://releases.k8s.io/v1.0.6/pkg/auth/authorizer/abac/example_policy_file.jsonl)
+[Complete file example](http://releases.k8s.io/v1.0.7/pkg/auth/authorizer/abac/example_policy_file.jsonl)
 
 ## Plugin Development
 

--- a/docs/admin/cluster-components.md
+++ b/docs/admin/cluster-components.md
@@ -69,17 +69,17 @@ selects a node for them to run on.
 Addons are pods and services that implement cluster features. They don't run on
 the master VM, but currently the default setup scripts that make the API calls
 to create these pods and services does run on the master VM. See:
-[kube-master-addons](http://releases.k8s.io/v1.0.6/cluster/saltbase/salt/kube-master-addons/kube-master-addons.sh)
+[kube-master-addons](http://releases.k8s.io/v1.0.7/cluster/saltbase/salt/kube-master-addons/kube-master-addons.sh)
 
 Addon objects are created in the "kube-system" namespace.
 
 Example addons are:
-* [DNS](http://releases.k8s.io/v1.0.6/cluster/addons/dns/) provides cluster local DNS.
-* [kube-ui](http://releases.k8s.io/v1.0.6/cluster/addons/kube-ui/) provides a graphical UI for the
+* [DNS](http://releases.k8s.io/v1.0.7/cluster/addons/dns/) provides cluster local DNS.
+* [kube-ui](http://releases.k8s.io/v1.0.7/cluster/addons/kube-ui/) provides a graphical UI for the
   cluster.
-* [fluentd-elasticsearch](http://releases.k8s.io/v1.0.6/cluster/addons/fluentd-elasticsearch/) provides
-  log storage. Also see the [gcp version](http://releases.k8s.io/v1.0.6/cluster/addons/fluentd-gcp/).
-* [cluster-monitoring](http://releases.k8s.io/v1.0.6/cluster/addons/cluster-monitoring/) provides
+* [fluentd-elasticsearch](http://releases.k8s.io/v1.0.7/cluster/addons/fluentd-elasticsearch/) provides
+  log storage. Also see the [gcp version](http://releases.k8s.io/v1.0.7/cluster/addons/fluentd-gcp/).
+* [cluster-monitoring](http://releases.k8s.io/v1.0.7/cluster/addons/cluster-monitoring/) provides
   monitoring for the cluster.
 
 ## Node components

--- a/docs/admin/cluster-large.md
+++ b/docs/admin/cluster-large.md
@@ -13,7 +13,7 @@ At v1.0, Kubernetes supports clusters up to 100 nodes with 30 pods per node and 
 
 A cluster is a set of nodes (physical or virtual machines) running Kubernetes agents, managed by a "master" (the cluster-level control plane).
 
-Normally the number of nodes in a cluster is controlled by the the value `NUM_MINIONS` in the platform-specific `config-default.sh` file (for example, see [GCE's `config-default.sh`](http://releases.k8s.io/v1.0.6/cluster/gce/config-default.sh)).
+Normally the number of nodes in a cluster is controlled by the the value `NUM_MINIONS` in the platform-specific `config-default.sh` file (for example, see [GCE's `config-default.sh`](http://releases.k8s.io/v1.0.7/cluster/gce/config-default.sh)).
 
 Simply changing that value to something very large, however, may cause the setup script to fail for many cloud providers. A GCE deployment, for example, will run in to quota issues and fail to bring the cluster up.
 
@@ -54,15 +54,15 @@ These limits, however, are based on data collected from addons running on 4-node
 
 To avoid running into cluster addon resource issues, when creating a cluster with many nodes, consider the following:
 * Scale memory and CPU limits for each of the following addons, if used, along with the size of cluster (there is one replica of each handling the entire cluster so memory and CPU usage tends to grow proportionally with size/load on cluster):
-  * Heapster ([GCM/GCL backed](http://releases.k8s.io/v1.0.6/cluster/addons/cluster-monitoring/google/heapster-controller.yaml), [InfluxDB backed](http://releases.k8s.io/v1.0.6/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml), [InfluxDB/GCL backed](http://releases.k8s.io/v1.0.6/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml), [standalone](http://releases.k8s.io/v1.0.6/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml))
-  * [InfluxDB and Grafana](http://releases.k8s.io/v1.0.6/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml)
-  * [skydns, kube2sky, and dns etcd](http://releases.k8s.io/v1.0.6/cluster/addons/dns/skydns-rc.yaml.in)
-  * [Kibana](http://releases.k8s.io/v1.0.6/cluster/addons/fluentd-elasticsearch/kibana-controller.yaml)
+  * Heapster ([GCM/GCL backed](http://releases.k8s.io/v1.0.7/cluster/addons/cluster-monitoring/google/heapster-controller.yaml), [InfluxDB backed](http://releases.k8s.io/v1.0.7/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml), [InfluxDB/GCL backed](http://releases.k8s.io/v1.0.7/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml), [standalone](http://releases.k8s.io/v1.0.7/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml))
+  * [InfluxDB and Grafana](http://releases.k8s.io/v1.0.7/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml)
+  * [skydns, kube2sky, and dns etcd](http://releases.k8s.io/v1.0.7/cluster/addons/dns/skydns-rc.yaml.in)
+  * [Kibana](http://releases.k8s.io/v1.0.7/cluster/addons/fluentd-elasticsearch/kibana-controller.yaml)
 * Scale number of replicas for the following addons, if used, along with the size of cluster (there are multiple replicas of each so increasing replicas should help handle increased load, but, since load per replica also increases slightly, also consider increasing CPU/memory limits):
-  * [elasticsearch](http://releases.k8s.io/v1.0.6/cluster/addons/fluentd-elasticsearch/es-controller.yaml)
+  * [elasticsearch](http://releases.k8s.io/v1.0.7/cluster/addons/fluentd-elasticsearch/es-controller.yaml)
 * Increase memory and CPU limits sligthly for each of the following addons, if used, along with the size of cluster (there is one replica per node but CPU/memory usage increases slightly along with cluster load/size as well):
-  * [FluentD with ElasticSearch Plugin](http://releases.k8s.io/v1.0.6/cluster/saltbase/salt/fluentd-es/fluentd-es.yaml)
-  * [FluentD with GCP Plugin](http://releases.k8s.io/v1.0.6/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml)
+  * [FluentD with ElasticSearch Plugin](http://releases.k8s.io/v1.0.7/cluster/saltbase/salt/fluentd-es/fluentd-es.yaml)
+  * [FluentD with GCP Plugin](http://releases.k8s.io/v1.0.7/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml)
 
 For directions on how to detect if addon containers are hitting resource limits, see the [Troubleshooting section of Compute Resources](../user-guide/compute-resources.md#troubleshooting).
 

--- a/docs/admin/dns.md
+++ b/docs/admin/dns.md
@@ -5,7 +5,7 @@
 
 # DNS Integration with Kubernetes
 
-As of Kubernetes 0.8, DNS is offered as a [cluster add-on](http://releases.k8s.io/v1.0.6/cluster/addons/README.md).
+As of Kubernetes 0.8, DNS is offered as a [cluster add-on](http://releases.k8s.io/v1.0.7/cluster/addons/README.md).
 If enabled, a DNS Pod and Service will be scheduled on the cluster, and the kubelets will be
 configured to tell individual containers to use the DNS Service's IP to resolve DNS names.
 
@@ -40,7 +40,7 @@ time.
 
 ## For more information
 
-See [the docs for the DNS cluster addon](http://releases.k8s.io/v1.0.6/cluster/addons/dns/README.md).
+See [the docs for the DNS cluster addon](http://releases.k8s.io/v1.0.7/cluster/addons/dns/README.md).
 
 
 <!-- BEGIN MUNGE: IS_VERSIONED -->

--- a/docs/admin/etcd.md
+++ b/docs/admin/etcd.md
@@ -27,7 +27,7 @@ to reduce downtime in case of corruption.
 ## Default configuration
 
 The default setup scripts use kubelet's file-based static pods feature to run etcd in a
-[pod](http://releases.k8s.io/v1.0.6/cluster/saltbase/salt/etcd/etcd.manifest). This manifest should only
+[pod](http://releases.k8s.io/v1.0.7/cluster/saltbase/salt/etcd/etcd.manifest). This manifest should only
 be run on master VMs. The default location that kubelet scans for manifests is
 `/etc/kubernetes/manifests/`.
 

--- a/docs/admin/high-availability.md
+++ b/docs/admin/high-availability.md
@@ -79,7 +79,7 @@ choices. For example, on systemd-based systems (e.g. RHEL, CentOS), you can run 
 If you are extending from a standard Kubernetes installation, the `kubelet` binary should already be present on your system.  You can run
 `which kubelet` to determine if the binary is in fact installed.  If it is not installed,
 you should install the [kubelet binary](https://storage.googleapis.com/kubernetes-release/release/v0.19.3/bin/linux/amd64/kubelet), the
-[kubelet init file](http://releases.k8s.io/v1.0.6/cluster/saltbase/salt/kubelet/initd) and [high-availability/default-kubelet](high-availability/default-kubelet)
+[kubelet init file](http://releases.k8s.io/v1.0.7/cluster/saltbase/salt/kubelet/initd) and [high-availability/default-kubelet](high-availability/default-kubelet)
 scripts.
 
 If you are using monit, you should also install the monit daemon (`apt-get install monit`) and the [high-availability/monit-kubelet](high-availability/monit-kubelet) and

--- a/docs/admin/salt.md
+++ b/docs/admin/salt.md
@@ -101,7 +101,7 @@ We should define a grains.conf key that captures more specifically what network 
 
 ## Further reading
 
-The [cluster/saltbase](http://releases.k8s.io/v1.0.6/cluster/saltbase/) tree has more details on the current SaltStack configuration.
+The [cluster/saltbase](http://releases.k8s.io/v1.0.7/cluster/saltbase/) tree has more details on the current SaltStack configuration.
 
 
 <!-- BEGIN MUNGE: IS_VERSIONED -->

--- a/docs/design/event_compression.md
+++ b/docs/design/event_compression.md
@@ -20,7 +20,7 @@ Event compression should be best effort (not guaranteed). Meaning, in the worst 
 
 ## Design
 
-Instead of a single Timestamp, each event object [contains](http://releases.k8s.io/v1.0.6/pkg/api/types.go#L1111) the following fields:
+Instead of a single Timestamp, each event object [contains](http://releases.k8s.io/v1.0.7/pkg/api/types.go#L1111) the following fields:
  * `FirstTimestamp util.Time` 
    * The date/time of the first occurrence of the event.
  * `LastTimestamp util.Time`
@@ -44,7 +44,7 @@ Each binary that generates events:
      * `event.Reason`
      * `event.Message`
    * The LRU cache is capped at 4096 events. That means if a component (e.g. kubelet) runs for a long period of time and generates tons of unique events, the previously generated events cache will not grow unchecked in memory. Instead, after 4096 unique events are generated, the oldest events are evicted from the cache.
- * When an event is generated, the previously generated events cache is checked (see [`pkg/client/record/event.go`](http://releases.k8s.io/v1.0.6/pkg/client/record/event.go)).
+ * When an event is generated, the previously generated events cache is checked (see [`pkg/client/record/event.go`](http://releases.k8s.io/v1.0.7/pkg/client/record/event.go)).
    * If the key for the new event matches the key for a previously generated event (meaning all of the above fields match between the new event and some previously generated event), then the event is considered to be a duplicate and the existing event entry is updated in etcd:
      * The new PUT (update) event API is called to update the existing event entry in etcd with the new last seen timestamp and count.
      * The event is also updated in the previously generated events cache with an incremented count, updated last seen timestamp, name, and new resource version (all required to issue a future event update).

--- a/docs/devel/cherry-picks.md
+++ b/docs/devel/cherry-picks.md
@@ -26,7 +26,7 @@ particular, they may be self-merged by the release branch owner without fanfare,
 in the case the release branch owner knows the cherry pick was already
 requested - this should not be the norm, but it may happen.
 
-[Contributor License Agreements](http://releases.k8s.io/v1.0.6/CONTRIBUTING.md) is considered implicit
+[Contributor License Agreements](http://releases.k8s.io/v1.0.7/CONTRIBUTING.md) is considered implicit
 for all code within cherry-pick pull requests, ***unless there is a large
 conflict***.
 

--- a/docs/devel/client-libraries.md
+++ b/docs/devel/client-libraries.md
@@ -7,7 +7,7 @@
 
 ### Supported
 
-   * [Go](http://releases.k8s.io/v1.0.6/pkg/client/)
+   * [Go](http://releases.k8s.io/v1.0.7/pkg/client/)
 
 ### User Contributed
 

--- a/docs/devel/development.md
+++ b/docs/devel/development.md
@@ -7,7 +7,7 @@
 
 # Releases and Official Builds
 
-Official releases are built in Docker containers.  Details are [here](http://releases.k8s.io/v1.0.6/build/README.md).  You can do simple builds and development with just a local Docker installation.  If want to build go locally outside of docker, please continue below.
+Official releases are built in Docker containers.  Details are [here](http://releases.k8s.io/v1.0.7/build/README.md).  You can do simple builds and development with just a local Docker installation.  If want to build go locally outside of docker, please continue below.
 
 ## Go development environment
 
@@ -296,7 +296,7 @@ The conformance test runs a subset of the e2e-tests against a manually-created c
 require support for up/push/down and other operations.  To run a conformance test, you need to know the
 IP of the master for your cluster and the authorization arguments to use.  The conformance test is
 intended to run against a cluster at a specific binary release of Kubernetes.
-See [conformance-test.sh](http://releases.k8s.io/v1.0.6/hack/conformance-test.sh).
+See [conformance-test.sh](http://releases.k8s.io/v1.0.7/hack/conformance-test.sh).
 
 ## Testing out flaky tests
 

--- a/docs/devel/getting-builds.md
+++ b/docs/devel/getting-builds.md
@@ -5,7 +5,7 @@
 
 # Getting Kubernetes Builds
 
-You can use [hack/get-build.sh](http://releases.k8s.io/v1.0.6/hack/get-build.sh) to or use as a reference on how to get the most recent builds with curl. With `get-build.sh` you can grab the most recent stable build, the most recent release candidate, or the most recent build to pass our ci and gce e2e tests (essentially a nightly build).
+You can use [hack/get-build.sh](http://releases.k8s.io/v1.0.7/hack/get-build.sh) to or use as a reference on how to get the most recent builds with curl. With `get-build.sh` you can grab the most recent stable build, the most recent release candidate, or the most recent build to pass our ci and gce e2e tests (essentially a nightly build).
 
 ```console
 usage:

--- a/docs/devel/scheduler.md
+++ b/docs/devel/scheduler.md
@@ -25,30 +25,30 @@ divided by the node's capacity).
 Finally, the node with the highest priority is chosen
 (or, if there are multiple such nodes, then one of them is chosen at random). The code
 for this main scheduling loop is in the function `Schedule()` in
-[plugin/pkg/scheduler/generic_scheduler.go](http://releases.k8s.io/v1.0.6/plugin/pkg/scheduler/generic_scheduler.go)
+[plugin/pkg/scheduler/generic_scheduler.go](http://releases.k8s.io/v1.0.7/plugin/pkg/scheduler/generic_scheduler.go)
 
 ## Scheduler extensibility
 
 The scheduler is extensible: the cluster administrator can choose which of the pre-defined
 scheduling policies to apply, and can add new ones. The built-in predicates and priorities are
-defined in [plugin/pkg/scheduler/algorithm/predicates/predicates.go](http://releases.k8s.io/v1.0.6/plugin/pkg/scheduler/algorithm/predicates/predicates.go) and
-[plugin/pkg/scheduler/algorithm/priorities/priorities.go](http://releases.k8s.io/v1.0.6/plugin/pkg/scheduler/algorithm/priorities/priorities.go), respectively.
+defined in [plugin/pkg/scheduler/algorithm/predicates/predicates.go](http://releases.k8s.io/v1.0.7/plugin/pkg/scheduler/algorithm/predicates/predicates.go) and
+[plugin/pkg/scheduler/algorithm/priorities/priorities.go](http://releases.k8s.io/v1.0.7/plugin/pkg/scheduler/algorithm/priorities/priorities.go), respectively.
 The policies that are applied when scheduling can be chosen in one of two ways. Normally,
 the policies used are selected by the functions `defaultPredicates()` and `defaultPriorities()` in
-[plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go](http://releases.k8s.io/v1.0.6/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go).
+[plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go](http://releases.k8s.io/v1.0.7/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go).
 However, the choice of policies
 can be overridden by passing the command-line flag `--policy-config-file` to the scheduler, pointing to a JSON
 file specifying which scheduling policies to use. See
 [examples/scheduler-policy-config.json](../../examples/scheduler-policy-config.json) for an example
 config file. (Note that the config file format is versioned; the API is defined in
-[plugin/pkg/scheduler/api](http://releases.k8s.io/v1.0.6/plugin/pkg/scheduler/api/)).
+[plugin/pkg/scheduler/api](http://releases.k8s.io/v1.0.7/plugin/pkg/scheduler/api/)).
 Thus to add a new scheduling policy, you should modify predicates.go or priorities.go,
 and either register the policy in `defaultPredicates()` or `defaultPriorities()`, or use a policy config file.
 
 ## Exploring the code
 
 If you want to get a global picture of how the scheduler works, you can start in
-[plugin/cmd/kube-scheduler/app/server.go](http://releases.k8s.io/v1.0.6/plugin/cmd/kube-scheduler/app/server.go)
+[plugin/cmd/kube-scheduler/app/server.go](http://releases.k8s.io/v1.0.7/plugin/cmd/kube-scheduler/app/server.go)
 
 
 <!-- BEGIN MUNGE: IS_VERSIONED -->

--- a/docs/devel/scheduler_algorithm.md
+++ b/docs/devel/scheduler_algorithm.md
@@ -18,7 +18,7 @@ The purpose of filtering the nodes is to filter out the nodes that do not meet c
 - `PodSelectorMatches`: Check if the labels of the node match the labels specified in the Pod's `nodeSelector` field ([Here](../user-guide/node-selection/) is an example of how to use `nodeSelector` field).
 - `CheckNodeLabelPresence`: Check if all the specified labels exist on a node or not, regardless of the value. 
 
-The details of the above predicates can be found in [plugin/pkg/scheduler/algorithm/predicates/predicates.go](http://releases.k8s.io/v1.0.6/plugin/pkg/scheduler/algorithm/predicates/predicates.go). All predicates mentioned above can be used in combination to perform a sophisticated filtering policy. Kubernetes uses some, but not all, of these predicates by default. You can see which ones are used by default in [plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go](http://releases.k8s.io/v1.0.6/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go).
+The details of the above predicates can be found in [plugin/pkg/scheduler/algorithm/predicates/predicates.go](http://releases.k8s.io/v1.0.7/plugin/pkg/scheduler/algorithm/predicates/predicates.go). All predicates mentioned above can be used in combination to perform a sophisticated filtering policy. Kubernetes uses some, but not all, of these predicates by default. You can see which ones are used by default in [plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go](http://releases.k8s.io/v1.0.7/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go).
 
 ## Ranking the nodes
 
@@ -36,7 +36,7 @@ Currently, Kubernetes scheduler provides some practical priority functions, incl
 - `CalculateSpreadPriority`: Spread Pods by minimizing the number of Pods belonging to the same service on the same node.
 - `CalculateAntiAffinityPriority`: Spread Pods by minimizing the number of Pods belonging to the same service on nodes with the same value for a particular label.
 
-The details of the above priority functions can be found in [plugin/pkg/scheduler/algorithm/priorities](http://releases.k8s.io/v1.0.6/plugin/pkg/scheduler/algorithm/priorities/). Kubernetes uses some, but not all, of these priority functions by default. You can see which ones are used by default in [plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go](http://releases.k8s.io/v1.0.6/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go). Similar as predicates, you can combine the above priority functions and assign weight factors (positive number) to them as you want (check [scheduler.md](scheduler.md) for how to customize).
+The details of the above priority functions can be found in [plugin/pkg/scheduler/algorithm/priorities](http://releases.k8s.io/v1.0.7/plugin/pkg/scheduler/algorithm/priorities/). Kubernetes uses some, but not all, of these priority functions by default. You can see which ones are used by default in [plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go](http://releases.k8s.io/v1.0.7/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go). Similar as predicates, you can combine the above priority functions and assign weight factors (positive number) to them as you want (check [scheduler.md](scheduler.md) for how to customize).
 
 
 <!-- BEGIN MUNGE: IS_VERSIONED -->

--- a/docs/getting-started-guides/aws.md
+++ b/docs/getting-started-guides/aws.md
@@ -35,16 +35,16 @@ export KUBERNETES_PROVIDER=aws; wget -q -O - https://get.k8s.io | bash
 export KUBERNETES_PROVIDER=aws; curl -sS https://get.k8s.io | bash
 ```
 
-NOTE: This script calls [cluster/kube-up.sh](http://releases.k8s.io/v1.0.6/cluster/kube-up.sh)
-which in turn calls [cluster/aws/util.sh](http://releases.k8s.io/v1.0.6/cluster/aws/util.sh)
-using [cluster/aws/config-default.sh](http://releases.k8s.io/v1.0.6/cluster/aws/config-default.sh).
+NOTE: This script calls [cluster/kube-up.sh](http://releases.k8s.io/v1.0.7/cluster/kube-up.sh)
+which in turn calls [cluster/aws/util.sh](http://releases.k8s.io/v1.0.7/cluster/aws/util.sh)
+using [cluster/aws/config-default.sh](http://releases.k8s.io/v1.0.7/cluster/aws/config-default.sh).
 
 This process takes about 5 to 10 minutes. Once the cluster is up, the IP addresses of your master and node(s) will be printed,
 as well as information about the default services running in the cluster (monitoring, logging, dns). User credentials and security
 tokens are written in `~/.kube/kubeconfig`, they will be necessary to use the CLI or the HTTP Basic Auth.
 
 By default, the script will provision a new VPC and a 4 node k8s cluster in us-west-2a (Oregon) with `t2.micro` instances running on Ubuntu.
-You can override the variables defined in [config-default.sh](http://releases.k8s.io/v1.0.6/cluster/aws/config-default.sh) to change this behavior as follows:
+You can override the variables defined in [config-default.sh](http://releases.k8s.io/v1.0.7/cluster/aws/config-default.sh) to change this behavior as follows:
 
 ```bash
 export KUBE_AWS_ZONE=eu-west-1c

--- a/docs/getting-started-guides/binary_release.md
+++ b/docs/getting-started-guides/binary_release.md
@@ -25,7 +25,7 @@ cd kubernetes
 make release
 ```
 
-For more details on the release process see the [`build/` directory](http://releases.k8s.io/v1.0.6/build/)
+For more details on the release process see the [`build/` directory](http://releases.k8s.io/v1.0.7/build/)
 
 
 <!-- BEGIN MUNGE: IS_VERSIONED -->

--- a/docs/getting-started-guides/gce.md
+++ b/docs/getting-started-guides/gce.md
@@ -58,7 +58,7 @@ wget -q -O - https://get.k8s.io | bash
 
 Once this command completes, you will have a master VM and four worker VMs, running as a Kubernetes cluster.
 
-By default, some containers will already be running on your cluster. Containers like `kibana` and `elasticsearch` provide [logging](logging.md), while `heapster` provides [monitoring](http://releases.k8s.io/v1.0.6/cluster/addons/cluster-monitoring/README.md) services.
+By default, some containers will already be running on your cluster. Containers like `kibana` and `elasticsearch` provide [logging](logging.md), while `heapster` provides [monitoring](http://releases.k8s.io/v1.0.7/cluster/addons/cluster-monitoring/README.md) services.
 
 The script run by the commands above creates a cluster with the name/prefix "kubernetes". It defines one specific cluster config, so you can't run it more than once.
 

--- a/docs/getting-started-guides/logging.md
+++ b/docs/getting-started-guides/logging.md
@@ -124,7 +124,7 @@ We’ve lost the log lines from the first invocation of the container in this po
 
 When a Kubernetes cluster is created with logging to Google Cloud Logging enabled, the system creates a pod called `fluentd-cloud-logging` on each node of the cluster to collect Docker container logs. These pods were shown at the start of this blog article in the response to the first get pods command.
 
-This log collection pod has a specification which looks something like this [fluentd-gcp.yaml](http://releases.k8s.io/v1.0.6/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml):
+This log collection pod has a specification which looks something like this [fluentd-gcp.yaml](http://releases.k8s.io/v1.0.7/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml):
 
 ```yaml
 apiVersion: v1
@@ -201,7 +201,7 @@ $ cat 21\:00\:00_21\:59\:59_S0.json | jq '.structPayload.log'
 ...
 ```
 
-This page has touched briefly on the underlying mechanisms that support gathering cluster level logs on a Kubernetes deployment. The approach here only works for gathering the standard output and standard error output of the processes running in the pod’s containers. To gather other logs that are stored in files one can use a sidecar container to gather the required files as described at the page [Collecting log files within containers with Fluentd](http://releases.k8s.io/v1.0.6/contrib/logging/fluentd-sidecar-gcp/README.md) and sending them to the Google Cloud Logging service.
+This page has touched briefly on the underlying mechanisms that support gathering cluster level logs on a Kubernetes deployment. The approach here only works for gathering the standard output and standard error output of the processes running in the pod’s containers. To gather other logs that are stored in files one can use a sidecar container to gather the required files as described at the page [Collecting log files within containers with Fluentd](http://releases.k8s.io/v1.0.7/contrib/logging/fluentd-sidecar-gcp/README.md) and sending them to the Google Cloud Logging service.
 
 Some of the material in this section also appears in the blog article [Cluster Level Logging with Kubernetes](http://blog.kubernetes.io/2015/06/cluster-level-logging-with-kubernetes.html).
 

--- a/docs/getting-started-guides/scratch.md
+++ b/docs/getting-started-guides/scratch.md
@@ -825,7 +825,7 @@ At this point you should be able to run through one of the basic examples, such 
 
 ### Running the Conformance Test
 
-You may want to try to run the [Conformance test](http://releases.k8s.io/v1.0.6/hack/conformance-test.sh).  Any failures may give a hint as to areas that need more attention.
+You may want to try to run the [Conformance test](http://releases.k8s.io/v1.0.7/hack/conformance-test.sh).  Any failures may give a hint as to areas that need more attention.
 
 ### Networking
 

--- a/docs/user-guide/accessing-the-cluster.md
+++ b/docs/user-guide/accessing-the-cluster.md
@@ -120,7 +120,7 @@ with future high-availability support.
 
 There are [client libraries](../devel/client-libraries.md) for accessing the API
 from several languages.  The Kubernetes project-supported
-[Go](http://releases.k8s.io/v1.0.6/pkg/client/)
+[Go](http://releases.k8s.io/v1.0.7/pkg/client/)
 client library can use the same [kubeconfig file](kubeconfig-file.md)
 as the kubectl CLI does to locate and authenticate to the apiserver.  
 

--- a/docs/user-guide/compute-resources.md
+++ b/docs/user-guide/compute-resources.md
@@ -117,7 +117,7 @@ To determine if a container cannot be scheduled or is being killed due to resour
 
 The resource usage of a pod is reported as part of the Pod status.
 
-If [optional monitoring](http://releases.k8s.io/v1.0.6/cluster/addons/cluster-monitoring/README.md) is configured for your cluster,
+If [optional monitoring](http://releases.k8s.io/v1.0.7/cluster/addons/cluster-monitoring/README.md) is configured for your cluster,
 then pod resource usage can be retrieved from the monitoring system.
 
 ## Troubleshooting

--- a/docs/user-guide/connecting-applications.md
+++ b/docs/user-guide/connecting-applications.md
@@ -133,7 +133,7 @@ You should now be able to curl the nginx Service on `10.0.116.146:80` from any n
 
 ## Accessing the Service
 
-Kubernetes supports 2 primary modes of finding a Service - environment variables and DNS. The former works out of the box while the latter requires the [kube-dns cluster addon](http://releases.k8s.io/v1.0.6/cluster/addons/dns/README.md).
+Kubernetes supports 2 primary modes of finding a Service - environment variables and DNS. The former works out of the box while the latter requires the [kube-dns cluster addon](http://releases.k8s.io/v1.0.7/cluster/addons/dns/README.md).
 
 ### Environment Variables
 
@@ -172,7 +172,7 @@ kube-dns   <none>       k8s-app=kube-dns     10.0.0.10   53/UDP
                                                          53/TCP
 ```
 
-If it isn’t running, you can [enable it](http://releases.k8s.io/v1.0.6/cluster/addons/dns/README.md#how-do-i-configure-it). The rest of this section will assume you have a Service with a long lived ip (nginxsvc), and a dns server that has assigned a name to that ip (the kube-dns cluster addon), so you can talk to the Service from any pod in your cluster using standard methods (e.g. gethostbyname). Let’s create another pod to test this:
+If it isn’t running, you can [enable it](http://releases.k8s.io/v1.0.7/cluster/addons/dns/README.md#how-do-i-configure-it). The rest of this section will assume you have a Service with a long lived ip (nginxsvc), and a dns server that has assigned a name to that ip (the kube-dns cluster addon), so you can talk to the Service from any pod in your cluster using standard methods (e.g. gethostbyname). Let’s create another pod to test this:
 
 ```yaml
 $ cat curlpod.yaml

--- a/docs/user-guide/container-environment.md
+++ b/docs/user-guide/container-environment.md
@@ -55,7 +55,7 @@ FOO_SERVICE_HOST=<the host the service is running on>
 FOO_SERVICE_PORT=<the port the service is running on>
 ```
 
-Services have dedicated IP address, and are also surfaced to the container via DNS (If [DNS addon](http://releases.k8s.io/v1.0.6/cluster/addons/dns/) is enabled).  Of course DNS is still not an enumerable protocol, so we will continue to provide environment variables so that containers can do discovery.
+Services have dedicated IP address, and are also surfaced to the container via DNS (If [DNS addon](http://releases.k8s.io/v1.0.7/cluster/addons/dns/) is enabled).  Of course DNS is still not an enumerable protocol, so we will continue to provide environment variables so that containers can do discovery.
 
 ## Container Hooks
 

--- a/docs/user-guide/logging.md
+++ b/docs/user-guide/logging.md
@@ -83,7 +83,7 @@ describes how to ingest cluster level logs into Elasticsearch and view them usin
 ## Ingesting Application Log Files
 
 Cluster level logging only collects the standard output and standard error output of the applications
-running in containers. The guide [Collecting log files within containers with Fluentd](http://releases.k8s.io/v1.0.6/contrib/logging/fluentd-sidecar-gcp/README.md) explains how the log files of applications can also be ingested into Google Cloud logging.
+running in containers. The guide [Collecting log files within containers with Fluentd](http://releases.k8s.io/v1.0.7/contrib/logging/fluentd-sidecar-gcp/README.md) explains how the log files of applications can also be ingested into Google Cloud logging.
 
 ## Known issues
 

--- a/docs/user-guide/production-pods.md
+++ b/docs/user-guide/production-pods.md
@@ -178,7 +178,7 @@ spec:
 
 [Pods](pods.md) support running multiple containers co-located together. They can be used to host vertically integrated application stacks, but their primary motivation is to support auxiliary helper programs that assist the primary application. Typical examples are data pullers, data pushers, and proxies.
 
-Such containers typically need to communicate with one another, often through the file system. This can be achieved by mounting the same volume into both containers. An example of this pattern would be a web server with a [program that polls a git repository](http://releases.k8s.io/v1.0.6/contrib/git-sync/) for new updates:
+Such containers typically need to communicate with one another, often through the file system. This can be achieved by mounting the same volume into both containers. An example of this pattern would be a web server with a [program that polls a git repository](http://releases.k8s.io/v1.0.7/contrib/git-sync/) for new updates:
 
 ```yaml
 apiVersion: v1

--- a/docs/user-guide/services.md
+++ b/docs/user-guide/services.md
@@ -267,7 +267,7 @@ variables and DNS.
 When a `Pod` is run on a `Node`, the kubelet adds a set of environment variables
 for each active `Service`.  It supports both [Docker links
 compatible](https://docs.docker.com/userguide/dockerlinks/) variables (see
-[makeLinkVariables](http://releases.k8s.io/v1.0.6/pkg/kubelet/envvars/envvars.go#L49))
+[makeLinkVariables](http://releases.k8s.io/v1.0.7/pkg/kubelet/envvars/envvars.go#L49))
 and simpler `{SVCNAME}_SERVICE_HOST` and `{SVCNAME}_SERVICE_PORT` variables,
 where the Service name is upper-cased and dashes are converted to underscores.
 
@@ -292,7 +292,7 @@ variables will not be populated.  DNS does not have this restriction.
 ### DNS
 
 An optional (though strongly recommended) [cluster
-add-on](http://releases.k8s.io/v1.0.6/cluster/addons/README.md) is a DNS server.  The
+add-on](http://releases.k8s.io/v1.0.7/cluster/addons/README.md) is a DNS server.  The
 DNS server watches the Kubernetes API for new `Services` and creates a set of
 DNS records for each.  If DNS has been enabled throughout the cluster then all
 `Pods` should be able to do name resolution of `Services` automatically.

--- a/docs/user-guide/ui.md
+++ b/docs/user-guide/ui.md
@@ -18,7 +18,7 @@ kubectl create -f cluster/addons/kube-ui/kube-ui-rc.yaml --namespace=kube-system
 kubectl create -f cluster/addons/kube-ui/kube-ui-svc.yaml --namespace=kube-system
 ```
 
-Normally, this should be taken care of automatically by the [`kube-addons.sh`](http://releases.k8s.io/v1.0.6/cluster/saltbase/salt/kube-addons/kube-addons.sh) script that runs on the master.
+Normally, this should be taken care of automatically by the [`kube-addons.sh`](http://releases.k8s.io/v1.0.7/cluster/saltbase/salt/kube-addons/kube-addons.sh) script that runs on the master.
 
 ## Using the UI
 
@@ -51,7 +51,7 @@ Other views (Pods, Nodes, Replication Controllers, Services, and Events) simply 
 
 ## More Information 
 
-For more information, see the [Kubernetes UI development document](http://releases.k8s.io/v1.0.6/www/README.md) in the www directory.
+For more information, see the [Kubernetes UI development document](http://releases.k8s.io/v1.0.7/www/README.md) in the www directory.
 
 
 <!-- BEGIN MUNGE: IS_VERSIONED -->

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,7 +3,7 @@
 
 <!-- END MUNGE: UNVERSIONED_WARNING -->
 
-# Kubernetes Examples: releases.k8s.io/v1.0.6
+# Kubernetes Examples: releases.k8s.io/v1.0.7
 
 This directory contains a number of different examples of how to run
 applications with Kubernetes.

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -58,12 +58,12 @@ import (
 type TypeMeta struct {
 	// Kind is a string value representing the REST resource this object represents.
 	// Servers may infer this from the endpoint the client submits requests to.
-	Kind string `json:"kind,omitempty" description:"kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"`
+	Kind string `json:"kind,omitempty" description:"kind of object, in CamelCase; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"`
 
 	// APIVersion defines the versioned schema of this representation of an object.
 	// Servers should convert recognized schemas to the latest internal value, and
 	// may reject unrecognized values.
-	APIVersion string `json:"apiVersion,omitempty" description:"version of the schema the object should have; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#resources"`
+	APIVersion string `json:"apiVersion,omitempty" description:"version of the schema the object should have; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#resources"`
 }
 
 // ListMeta describes metadata that synthetic resources must have, including lists and
@@ -76,7 +76,7 @@ type ListMeta struct {
 	// concurrency and change monitoring endpoints.  Clients must treat these values as opaque
 	// and values may only be valid for a particular resource or set of resources. Only servers
 	// will generate resource versions.
-	ResourceVersion string `json:"resourceVersion,omitempty" description:"string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#concurrency-control-and-consistency"`
+	ResourceVersion string `json:"resourceVersion,omitempty" description:"string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#concurrency-control-and-consistency"`
 }
 
 // ObjectMeta is metadata that all persisted resources must have, which includes all objects
@@ -86,7 +86,7 @@ type ObjectMeta struct {
 	// some resources may allow a client to request the generation of an appropriate name
 	// automatically. Name is primarily intended for creation idempotence and configuration
 	// definition.
-	Name string `json:"name,omitempty" description:"string that identifies an object. Must be unique within a namespace; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/user-guide/identifiers.md#names"`
+	Name string `json:"name,omitempty" description:"string that identifies an object. Must be unique within a namespace; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/user-guide/identifiers.md#names"`
 
 	// GenerateName indicates that the name should be made unique by the server prior to persisting
 	// it. A non-empty value for the field indicates the name will be made unique (and the name
@@ -99,13 +99,13 @@ type ObjectMeta struct {
 	// generated name exists - instead, it will either return 201 Created or 500 with Reason
 	// ServerTimeout indicating a unique name could not be found in the time allotted, and the client
 	// should retry (optionally after the time indicated in the Retry-After header).
-	GenerateName string `json:"generateName,omitempty" description:"an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#idempotency"`
+	GenerateName string `json:"generateName,omitempty" description:"an optional prefix to use to generate a unique name; has the same validation rules as name; optional, and is applied only name if is not specified; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#idempotency"`
 
 	// Namespace defines the space within which name must be unique. An empty namespace is
 	// equivalent to the "default" namespace, but "default" is the canonical representation.
 	// Not all objects are required to be scoped to a namespace - the value of this field for
 	// those objects will be empty.
-	Namespace string `json:"namespace,omitempty" description:"namespace of the object; must be a DNS_LABEL; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/user-guide/namespaces.md"`
+	Namespace string `json:"namespace,omitempty" description:"namespace of the object; must be a DNS_LABEL; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/user-guide/namespaces.md"`
 
 	// SelfLink is a URL representing this object.
 	SelfLink string `json:"selfLink,omitempty" description:"URL for the object; populated by the system, read-only"`
@@ -113,13 +113,13 @@ type ObjectMeta struct {
 	// UID is the unique in time and space value for this object. It is typically generated by
 	// the server on successful creation of a resource and is not allowed to change on PUT
 	// operations.
-	UID types.UID `json:"uid,omitempty" description:"unique UUID across space and time; populated by the system; read-only; see http://releases.k8s.io/v1.0.6/docs/user-guide/identifiers.md#uids"`
+	UID types.UID `json:"uid,omitempty" description:"unique UUID across space and time; populated by the system; read-only; see http://releases.k8s.io/v1.0.7/docs/user-guide/identifiers.md#uids"`
 
 	// An opaque value that represents the version of this resource. May be used for optimistic
 	// concurrency, change detection, and the watch operation on a resource or set of resources.
 	// Clients must treat these values as opaque and values may only be valid for a particular
 	// resource or set of resources. Only servers will generate resource versions.
-	ResourceVersion string `json:"resourceVersion,omitempty" description:"string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#concurrency-control-and-consistency"`
+	ResourceVersion string `json:"resourceVersion,omitempty" description:"string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#concurrency-control-and-consistency"`
 
 	// A sequence number representing a specific generation of the desired state.
 	// Currently only implemented by replication controllers.
@@ -128,7 +128,7 @@ type ObjectMeta struct {
 	// CreationTimestamp is a timestamp representing the server time when this object was
 	// created. It is not guaranteed to be set in happens-before order across separate operations.
 	// Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-	CreationTimestamp util.Time `json:"creationTimestamp,omitempty" description:"RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"`
+	CreationTimestamp util.Time `json:"creationTimestamp,omitempty" description:"RFC 3339 date and time at which the object was created; populated by the system, read-only; null for lists; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"`
 
 	// DeletionTimestamp is the time after which this resource will be deleted. This
 	// field is set by the server when a graceful deletion is requested by the user, and is not
@@ -139,16 +139,16 @@ type ObjectMeta struct {
 	// a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination
 	// signal to the containers in the pod. Once the resource is deleted in the API, the Kubelet
 	// will send a hard termination signal to the container.
-	DeletionTimestamp *util.Time `json:"deletionTimestamp,omitempty" description:"RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"`
+	DeletionTimestamp *util.Time `json:"deletionTimestamp,omitempty" description:"RFC 3339 date and time at which the object will be deleted; populated by the system when a graceful deletion is requested, read-only; if not set, graceful deletion of the object has not been requested; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"`
 
 	// Labels are key value pairs that may be used to scope and select individual resources.
 	// TODO: replace map[string]string with labels.LabelSet type
-	Labels map[string]string `json:"labels,omitempty" description:"map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services; see http://releases.k8s.io/v1.0.6/docs/user-guide/labels.md"`
+	Labels map[string]string `json:"labels,omitempty" description:"map of string keys and values that can be used to organize and categorize objects; may match selectors of replication controllers and services; see http://releases.k8s.io/v1.0.7/docs/user-guide/labels.md"`
 
 	// Annotations are unstructured key value data stored with a resource that may be set by
 	// external tooling. They are not queryable and should be preserved when modifying
 	// objects.
-	Annotations map[string]string `json:"annotations,omitempty" description:"map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects; see http://releases.k8s.io/v1.0.6/docs/user-guide/annotations.md"`
+	Annotations map[string]string `json:"annotations,omitempty" description:"map of string keys and values that can be used by external tooling to store and retrieve arbitrary metadata about objects; see http://releases.k8s.io/v1.0.7/docs/user-guide/annotations.md"`
 }
 
 const (
@@ -162,7 +162,7 @@ const (
 type Volume struct {
 	// Required: This must be a DNS_LABEL.  Each volume in a pod must have
 	// a unique name.
-	Name string `json:"name" description:"volume name; must be a DNS_LABEL and unique within the pod; see http://releases.k8s.io/v1.0.6/docs/user-guide/identifiers.md#names"`
+	Name string `json:"name" description:"volume name; must be a DNS_LABEL and unique within the pod; see http://releases.k8s.io/v1.0.7/docs/user-guide/identifiers.md#names"`
 	// Source represents the location and type of a volume to mount.
 	// This is optional for now. If not specified, the Volume is implied to be an EmptyDir.
 	// This implied behavior is deprecated and will be removed in a future version.
@@ -178,35 +178,35 @@ type VolumeSource struct {
 	// to see the host machine. Most containers will NOT need this.
 	// TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
 	// mount host directories as read/write.
-	HostPath *HostPathVolumeSource `json:"hostPath,omitempty" description:"pre-existing host file or directory; generally for privileged system daemons or other agents tied to the host; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#hostpath"`
+	HostPath *HostPathVolumeSource `json:"hostPath,omitempty" description:"pre-existing host file or directory; generally for privileged system daemons or other agents tied to the host; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#hostpath"`
 	// EmptyDir represents a temporary directory that shares a pod's lifetime.
-	EmptyDir *EmptyDirVolumeSource `json:"emptyDir,omitempty" description:"temporary directory that shares a pod's lifetime; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#emptydir"`
+	EmptyDir *EmptyDirVolumeSource `json:"emptyDir,omitempty" description:"temporary directory that shares a pod's lifetime; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#emptydir"`
 	// GCEPersistentDisk represents a GCE Disk resource that is attached to a
 	// kubelet's host machine and then exposed to the pod.
-	GCEPersistentDisk *GCEPersistentDiskVolumeSource `json:"gcePersistentDisk,omitempty" description:"GCE disk resource attached to the host machine on demand; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#gcepersistentdisk"`
+	GCEPersistentDisk *GCEPersistentDiskVolumeSource `json:"gcePersistentDisk,omitempty" description:"GCE disk resource attached to the host machine on demand; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#gcepersistentdisk"`
 	// AWSElasticBlockStore represents an AWS Disk resource that is attached to a
 	// kubelet's host machine and then exposed to the pod.
-	AWSElasticBlockStore *AWSElasticBlockStoreVolumeSource `json:"awsElasticBlockStore,omitempty" description:"AWS disk resource attached to the host machine on demand; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#awselasticblockstore"`
+	AWSElasticBlockStore *AWSElasticBlockStoreVolumeSource `json:"awsElasticBlockStore,omitempty" description:"AWS disk resource attached to the host machine on demand; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#awselasticblockstore"`
 	// GitRepo represents a git repository at a particular revision.
 	GitRepo *GitRepoVolumeSource `json:"gitRepo,omitempty" description:"git repository at a particular revision"`
 	// Secret represents a secret that should populate this volume.
-	Secret *SecretVolumeSource `json:"secret,omitempty" description:"secret to populate volume; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#secrets"`
+	Secret *SecretVolumeSource `json:"secret,omitempty" description:"secret to populate volume; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#secrets"`
 	// NFS represents an NFS mount on the host that shares a pod's lifetime
-	NFS *NFSVolumeSource `json:"nfs,omitempty" description:"NFS volume that will be mounted in the host machine; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#nfs"`
+	NFS *NFSVolumeSource `json:"nfs,omitempty" description:"NFS volume that will be mounted in the host machine; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#nfs"`
 	// ISCSI represents an ISCSI Disk resource that is attached to a
 	// kubelet's host machine and then exposed to the pod.
-	ISCSI *ISCSIVolumeSource `json:"iscsi,omitempty" description:"iSCSI disk attached to host machine on demand; see http://releases.k8s.io/v1.0.6/examples/iscsi/README.md"`
+	ISCSI *ISCSIVolumeSource `json:"iscsi,omitempty" description:"iSCSI disk attached to host machine on demand; see http://releases.k8s.io/v1.0.7/examples/iscsi/README.md"`
 	// Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime
-	Glusterfs *GlusterfsVolumeSource `json:"glusterfs,omitempty" description:"Glusterfs volume that will be mounted on the host machine; see http://releases.k8s.io/v1.0.6/examples/glusterfs/README.md"`
+	Glusterfs *GlusterfsVolumeSource `json:"glusterfs,omitempty" description:"Glusterfs volume that will be mounted on the host machine; see http://releases.k8s.io/v1.0.7/examples/glusterfs/README.md"`
 	// PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace
-	PersistentVolumeClaim *PersistentVolumeClaimVolumeSource `json:"persistentVolumeClaim,omitempty" description:"a reference to a PersistentVolumeClaim in the same namespace; see http://releases.k8s.io/v1.0.6/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"`
+	PersistentVolumeClaim *PersistentVolumeClaimVolumeSource `json:"persistentVolumeClaim,omitempty" description:"a reference to a PersistentVolumeClaim in the same namespace; see http://releases.k8s.io/v1.0.7/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"`
 	// RBD represents a Rados Block Device mount on the host that shares a pod's lifetime
-	RBD *RBDVolumeSource `json:"rbd,omitempty" description:"rados block volume that will be mounted on the host machine; see http://releases.k8s.io/v1.0.6/examples/rbd/README.md"`
+	RBD *RBDVolumeSource `json:"rbd,omitempty" description:"rados block volume that will be mounted on the host machine; see http://releases.k8s.io/v1.0.7/examples/rbd/README.md"`
 }
 
 type PersistentVolumeClaimVolumeSource struct {
 	// ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume
-	ClaimName string `json:"claimName" description:"the name of the claim in the same namespace to be mounted as a volume; see http://releases.k8s.io/v1.0.6/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"`
+	ClaimName string `json:"claimName" description:"the name of the claim in the same namespace to be mounted as a volume; see http://releases.k8s.io/v1.0.7/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"`
 	// Optional: Defaults to false (read/write).  ReadOnly here
 	// will force the ReadOnly setting in VolumeMounts
 	ReadOnly bool `json:"readOnly,omitempty" description:"mount volume as read-only when true; default false"`
@@ -217,20 +217,20 @@ type PersistentVolumeClaimVolumeSource struct {
 type PersistentVolumeSource struct {
 	// GCEPersistentDisk represents a GCE Disk resource that is attached to a
 	// kubelet's host machine and then exposed to the pod.
-	GCEPersistentDisk *GCEPersistentDiskVolumeSource `json:"gcePersistentDisk,omitempty" description:"GCE disk resource provisioned by an admin; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#gcepersistentdisk"`
+	GCEPersistentDisk *GCEPersistentDiskVolumeSource `json:"gcePersistentDisk,omitempty" description:"GCE disk resource provisioned by an admin; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#gcepersistentdisk"`
 	// AWSElasticBlockStore represents an AWS Disk resource that is attached to a
 	// kubelet's host machine and then exposed to the pod.
-	AWSElasticBlockStore *AWSElasticBlockStoreVolumeSource `json:"awsElasticBlockStore,omitempty" description:"AWS disk resource provisioned by an admin; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#awselasticblockstore"`
+	AWSElasticBlockStore *AWSElasticBlockStoreVolumeSource `json:"awsElasticBlockStore,omitempty" description:"AWS disk resource provisioned by an admin; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#awselasticblockstore"`
 	// HostPath represents a directory on the host.
 	// This is useful for development and testing only.
 	// on-host storage is not supported in any way.
-	HostPath *HostPathVolumeSource `json:"hostPath,omitempty" description:"a HostPath provisioned by a developer or tester; for develment use only; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#hostpath"`
+	HostPath *HostPathVolumeSource `json:"hostPath,omitempty" description:"a HostPath provisioned by a developer or tester; for develment use only; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#hostpath"`
 	// Glusterfs represents a Glusterfs volume that is attached to a host and exposed to the pod
-	Glusterfs *GlusterfsVolumeSource `json:"glusterfs,omitempty" description:"Glusterfs volume resource provisioned by an admin; see http://releases.k8s.io/v1.0.6/examples/glusterfs/README.md"`
+	Glusterfs *GlusterfsVolumeSource `json:"glusterfs,omitempty" description:"Glusterfs volume resource provisioned by an admin; see http://releases.k8s.io/v1.0.7/examples/glusterfs/README.md"`
 	// NFS represents an NFS mount on the host
-	NFS *NFSVolumeSource `json:"nfs,omitempty" description:"NFS volume resource provisioned by an admin; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#nfs"`
+	NFS *NFSVolumeSource `json:"nfs,omitempty" description:"NFS volume resource provisioned by an admin; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#nfs"`
 	// RBD represents a Rados Block Device mount on the host that shares a pod's lifetime
-	RBD *RBDVolumeSource `json:"rbd,omitempty" description:"rados block volume that will be mounted on the host machine; see http://releases.k8s.io/v1.0.6/examples/rbd/README.md"`
+	RBD *RBDVolumeSource `json:"rbd,omitempty" description:"rados block volume that will be mounted on the host machine; see http://releases.k8s.io/v1.0.7/examples/rbd/README.md"`
 	// ISCSI represents an ISCSI Disk resource that is attached to a
 	// kubelet's host machine and then exposed to the pod.
 	ISCSI *ISCSIVolumeSource `json:"iscsi,omitempty" description:"an iSCSI disk resource provisioned by an admin"`
@@ -238,28 +238,28 @@ type PersistentVolumeSource struct {
 
 type PersistentVolume struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"`
 
 	// Spec defines a persistent volume owned by the cluster
-	Spec PersistentVolumeSpec `json:"spec,omitempty" description:"specification of a persistent volume as provisioned by an administrator; see http://releases.k8s.io/v1.0.6/docs/user-guide/persistent-volumes.md#persistent-volumes"`
+	Spec PersistentVolumeSpec `json:"spec,omitempty" description:"specification of a persistent volume as provisioned by an administrator; see http://releases.k8s.io/v1.0.7/docs/user-guide/persistent-volumes.md#persistent-volumes"`
 
 	// Status represents the current information about persistent volume.
-	Status PersistentVolumeStatus `json:"status,omitempty" description:"current status of a persistent volume; populated by the system, read-only; see http://releases.k8s.io/v1.0.6/docs/user-guide/persistent-volumes.md#persistent-volumes"`
+	Status PersistentVolumeStatus `json:"status,omitempty" description:"current status of a persistent volume; populated by the system, read-only; see http://releases.k8s.io/v1.0.7/docs/user-guide/persistent-volumes.md#persistent-volumes"`
 }
 
 type PersistentVolumeSpec struct {
 	// Resources represents the actual resources of the volume
-	Capacity ResourceList `json:"capacity,omitempty" description:"a description of the persistent volume's resources and capacityr; see http://releases.k8s.io/v1.0.6/docs/user-guide/persistent-volumes.md#capacity"`
+	Capacity ResourceList `json:"capacity,omitempty" description:"a description of the persistent volume's resources and capacityr; see http://releases.k8s.io/v1.0.7/docs/user-guide/persistent-volumes.md#capacity"`
 	// Source represents the location and type of a volume to mount.
 	PersistentVolumeSource `json:",inline" description:"the actual volume backing the persistent volume"`
 	// AccessModes contains all ways the volume can be mounted
-	AccessModes []PersistentVolumeAccessMode `json:"accessModes,omitempty" description:"all ways the volume can be mounted; see http://releases.k8s.io/v1.0.6/docs/user-guide/persistent-volumes.md#access-modes"`
+	AccessModes []PersistentVolumeAccessMode `json:"accessModes,omitempty" description:"all ways the volume can be mounted; see http://releases.k8s.io/v1.0.7/docs/user-guide/persistent-volumes.md#access-modes"`
 	// ClaimRef is part of a bi-directional binding between PersistentVolume and PersistentVolumeClaim.
 	// ClaimRef is expected to be non-nil when bound.
 	// claim.VolumeName is the authoritative bind between PV and PVC.
-	ClaimRef *ObjectReference `json:"claimRef,omitempty" description:"when bound, a reference to the bound claim; see http://releases.k8s.io/v1.0.6/docs/user-guide/persistent-volumes.md#binding"`
+	ClaimRef *ObjectReference `json:"claimRef,omitempty" description:"when bound, a reference to the bound claim; see http://releases.k8s.io/v1.0.7/docs/user-guide/persistent-volumes.md#binding"`
 	// Optional: what happens to a persistent volume when released from its claim.
-	PersistentVolumeReclaimPolicy PersistentVolumeReclaimPolicy `json:"persistentVolumeReclaimPolicy,omitempty" description:"what happens to a volume when released from its claim; Valid options are Retain (default) and Recycle.  Recyling must be supported by the volume plugin underlying this persistent volume. See http://releases.k8s.io/v1.0.6/docs/user-guide/persistent-volumes.md#recycling-policy"`
+	PersistentVolumeReclaimPolicy PersistentVolumeReclaimPolicy `json:"persistentVolumeReclaimPolicy,omitempty" description:"what happens to a volume when released from its claim; Valid options are Retain (default) and Recycle.  Recyling must be supported by the volume plugin underlying this persistent volume. See http://releases.k8s.io/v1.0.7/docs/user-guide/persistent-volumes.md#recycling-policy"`
 }
 
 // PersistentVolumeReclaimPolicy describes a policy for end-of-life maintenance of persistent volumes
@@ -280,7 +280,7 @@ const (
 
 type PersistentVolumeStatus struct {
 	// Phase indicates if a volume is available, bound to a claim, or released by a claim
-	Phase PersistentVolumePhase `json:"phase,omitempty" description:"the current phase of a persistent volume; see http://releases.k8s.io/v1.0.6/docs/user-guide/persistent-volumes.md#phase"`
+	Phase PersistentVolumePhase `json:"phase,omitempty" description:"the current phase of a persistent volume; see http://releases.k8s.io/v1.0.7/docs/user-guide/persistent-volumes.md#phase"`
 	// A human-readable message indicating details about why the volume is in this state.
 	Message string `json:"message,omitempty" description:"human-readable message indicating details about why the volume is in this state"`
 	// Reason is a brief CamelCase string that describes any failure and is meant for machine parsing and tidy display in the CLI
@@ -289,35 +289,35 @@ type PersistentVolumeStatus struct {
 
 type PersistentVolumeList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"`
-	Items    []PersistentVolume `json:"items,omitempty" description:"list of persistent volumes; see http://releases.k8s.io/v1.0.6/docs/user-guide/persistent-volumes.md"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"`
+	Items    []PersistentVolume `json:"items,omitempty" description:"list of persistent volumes; see http://releases.k8s.io/v1.0.7/docs/user-guide/persistent-volumes.md"`
 }
 
 // PersistentVolumeClaim is a user's request for and claim to a persistent volume
 type PersistentVolumeClaim struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"`
 
 	// Spec defines the volume requested by a pod author
-	Spec PersistentVolumeClaimSpec `json:"spec,omitempty" description:"the desired characteristics of a volume; see http://releases.k8s.io/v1.0.6/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"`
+	Spec PersistentVolumeClaimSpec `json:"spec,omitempty" description:"the desired characteristics of a volume; see http://releases.k8s.io/v1.0.7/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"`
 
 	// Status represents the current information about a claim
-	Status PersistentVolumeClaimStatus `json:"status,omitempty" description:"the current status of a persistent volume claim; read-only; see http://releases.k8s.io/v1.0.6/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"`
+	Status PersistentVolumeClaimStatus `json:"status,omitempty" description:"the current status of a persistent volume claim; read-only; see http://releases.k8s.io/v1.0.7/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"`
 }
 
 type PersistentVolumeClaimList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"`
-	Items    []PersistentVolumeClaim `json:"items,omitempty" description:"a list of persistent volume claims; see http://releases.k8s.io/v1.0.6/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"`
+	Items    []PersistentVolumeClaim `json:"items,omitempty" description:"a list of persistent volume claims; see http://releases.k8s.io/v1.0.7/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"`
 }
 
 // PersistentVolumeClaimSpec describes the common attributes of storage devices
 // and allows a Source for provider-specific attributes
 type PersistentVolumeClaimSpec struct {
 	// Contains the types of access modes required
-	AccessModes []PersistentVolumeAccessMode `json:"accessModes,omitempty" description:"the desired access modes the volume should have; see http://releases.k8s.io/v1.0.6/docs/user-guide/persistent-volumes.md#access-modes-1"`
+	AccessModes []PersistentVolumeAccessMode `json:"accessModes,omitempty" description:"the desired access modes the volume should have; see http://releases.k8s.io/v1.0.7/docs/user-guide/persistent-volumes.md#access-modes-1"`
 	// Resources represents the minimum resources required
-	Resources ResourceRequirements `json:"resources,omitempty" description:"the desired resources the volume should have; see http://releases.k8s.io/v1.0.6/docs/user-guide/persistent-volumes.md#resources"`
+	Resources ResourceRequirements `json:"resources,omitempty" description:"the desired resources the volume should have; see http://releases.k8s.io/v1.0.7/docs/user-guide/persistent-volumes.md#resources"`
 	// VolumeName is the binding reference to the PersistentVolume backing this claim
 	VolumeName string `json:"volumeName,omitempty" description:"the binding reference to the persistent volume backing this claim"`
 }
@@ -326,7 +326,7 @@ type PersistentVolumeClaimStatus struct {
 	// Phase represents the current phase of PersistentVolumeClaim
 	Phase PersistentVolumeClaimPhase `json:"phase,omitempty" description:"the current phase of the claim"`
 	// AccessModes contains all ways the volume backing the PVC can be mounted
-	AccessModes []PersistentVolumeAccessMode `json:"accessModes,omitempty" description:"the actual access modes the volume has; see http://releases.k8s.io/v1.0.6/docs/user-guide/persistent-volumes.md#access-modes-1"`
+	AccessModes []PersistentVolumeAccessMode `json:"accessModes,omitempty" description:"the actual access modes the volume has; see http://releases.k8s.io/v1.0.7/docs/user-guide/persistent-volumes.md#access-modes-1"`
 	// Represents the actual resources of the underlying volume
 	Capacity ResourceList `json:"capacity,omitempty" description:"the actual resources the volume has"`
 }
@@ -371,26 +371,26 @@ const (
 
 // HostPathVolumeSource represents bare host directory volume.
 type HostPathVolumeSource struct {
-	Path string `json:"path" description:"path of the directory on the host; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#hostpath"`
+	Path string `json:"path" description:"path of the directory on the host; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#hostpath"`
 }
 
 type EmptyDirVolumeSource struct {
 	// Optional: what type of storage medium should back this directory.
 	// The default is "" which means to use the node's default medium.
-	Medium StorageMedium `json:"medium,omitempty" description:"type of storage used to back the volume; must be an empty string (default) or Memory; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#emptydir"`
+	Medium StorageMedium `json:"medium,omitempty" description:"type of storage used to back the volume; must be an empty string (default) or Memory; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#emptydir"`
 }
 
 // GlusterfsVolumeSource represents a Glusterfs Mount that lasts the lifetime of a pod
 type GlusterfsVolumeSource struct {
 	// Required: EndpointsName is the endpoint name that details Glusterfs topology
-	EndpointsName string `json:"endpoints" description:"gluster hosts endpoints name; see http://releases.k8s.io/v1.0.6/examples/glusterfs/README.md#create-a-pod"`
+	EndpointsName string `json:"endpoints" description:"gluster hosts endpoints name; see http://releases.k8s.io/v1.0.7/examples/glusterfs/README.md#create-a-pod"`
 
 	// Required: Path is the Glusterfs volume path
-	Path string `json:"path" description:"path to gluster volume; see http://releases.k8s.io/v1.0.6/examples/glusterfs/README.md#create-a-pod"`
+	Path string `json:"path" description:"path to gluster volume; see http://releases.k8s.io/v1.0.7/examples/glusterfs/README.md#create-a-pod"`
 
 	// Optional: Defaults to false (read/write). ReadOnly here will force
 	// the Glusterfs volume to be mounted with read-only permissions
-	ReadOnly bool `json:"readOnly,omitempty" description:"glusterfs volume to be mounted with read-only permissions; see http://releases.k8s.io/v1.0.6/examples/glusterfs/README.md#create-a-pod"`
+	ReadOnly bool `json:"readOnly,omitempty" description:"glusterfs volume to be mounted with read-only permissions; see http://releases.k8s.io/v1.0.7/examples/glusterfs/README.md#create-a-pod"`
 }
 
 // StorageMedium defines ways that storage can be allocated to a volume.
@@ -399,25 +399,25 @@ type StorageMedium string
 // RBDVolumeSource represents a Rados Block Device Mount that lasts the lifetime of a pod
 type RBDVolumeSource struct {
 	// Required: CephMonitors is a collection of Ceph monitors
-	CephMonitors []string `json:"monitors" description:"a collection of Ceph monitors; see http://releases.k8s.io/v1.0.6/examples/rbd/README.md#how-to-use-it"`
+	CephMonitors []string `json:"monitors" description:"a collection of Ceph monitors; see http://releases.k8s.io/v1.0.7/examples/rbd/README.md#how-to-use-it"`
 	// Required: RBDImage is the rados image name
-	RBDImage string `json:"image" description:"rados image name; see http://releases.k8s.io/v1.0.6/examples/rbd/README.md#how-to-use-it"`
+	RBDImage string `json:"image" description:"rados image name; see http://releases.k8s.io/v1.0.7/examples/rbd/README.md#how-to-use-it"`
 	// Required: Filesystem type to mount.
 	// Must be a filesystem type supported by the host operating system.
 	// Ex. "ext4", "xfs", "ntfs"
 	// TODO: how do we prevent errors in the filesystem from compromising the machine
-	FSType string `json:"fsType,omitempty" description:"file system type to mount, such as ext4, xfs, ntfs; see http://releases.k8s.io/v1.0.6/examples/rbd/README.md#how-to-use-it"`
+	FSType string `json:"fsType,omitempty" description:"file system type to mount, such as ext4, xfs, ntfs; see http://releases.k8s.io/v1.0.7/examples/rbd/README.md#how-to-use-it"`
 	// Optional: RadosPool is the rados pool name,default is rbd
-	RBDPool string `json:"pool" description:"rados pool name; default is rbd; optional; see http://releases.k8s.io/v1.0.6/examples/rbd/README.md#how-to-use-it"`
+	RBDPool string `json:"pool" description:"rados pool name; default is rbd; optional; see http://releases.k8s.io/v1.0.7/examples/rbd/README.md#how-to-use-it"`
 	// Optional: RBDUser is the rados user name, default is admin
-	RadosUser string `json:"user" description:"rados user name; default is admin; optional; see http://releases.k8s.io/v1.0.6/examples/rbd/README.md#how-to-use-it"`
+	RadosUser string `json:"user" description:"rados user name; default is admin; optional; see http://releases.k8s.io/v1.0.7/examples/rbd/README.md#how-to-use-it"`
 	// Optional: Keyring is the path to key ring for RBDUser, default is /etc/ceph/keyring
-	Keyring string `json:"keyring" description:"keyring is the path to key ring for rados user; default is /etc/ceph/keyring; optional; see http://releases.k8s.io/v1.0.6/examples/rbd/README.md#how-to-use-it"`
+	Keyring string `json:"keyring" description:"keyring is the path to key ring for rados user; default is /etc/ceph/keyring; optional; see http://releases.k8s.io/v1.0.7/examples/rbd/README.md#how-to-use-it"`
 	// Optional: SecretRef is name of the authentication secret for RBDUser, default is empty.
-	SecretRef *LocalObjectReference `json:"secretRef" description:"name of a secret to authenticate the RBD user; if provided overrides keyring; optional; see http://releases.k8s.io/v1.0.6/examples/rbd/README.md#how-to-use-it"`
+	SecretRef *LocalObjectReference `json:"secretRef" description:"name of a secret to authenticate the RBD user; if provided overrides keyring; optional; see http://releases.k8s.io/v1.0.7/examples/rbd/README.md#how-to-use-it"`
 	// Optional: Defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
-	ReadOnly bool `json:"readOnly,omitempty"  description:"rbd volume to be mounted with read-only permissions; see http://releases.k8s.io/v1.0.6/examples/rbd/README.md#how-to-use-it"`
+	ReadOnly bool `json:"readOnly,omitempty"  description:"rbd volume to be mounted with read-only permissions; see http://releases.k8s.io/v1.0.7/examples/rbd/README.md#how-to-use-it"`
 }
 
 const (
@@ -442,19 +442,19 @@ const (
 // A GCE PD can only be mounted as read/write once.
 type GCEPersistentDiskVolumeSource struct {
 	// Unique name of the PD resource. Used to identify the disk in GCE
-	PDName string `json:"pdName" description:"unique name of the PD resource in GCE; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#gcepersistentdisk"`
+	PDName string `json:"pdName" description:"unique name of the PD resource in GCE; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#gcepersistentdisk"`
 	// Required: Filesystem type to mount.
 	// Must be a filesystem type supported by the host operating system.
 	// Ex. "ext4", "xfs", "ntfs"
 	// TODO: how do we prevent errors in the filesystem from compromising the machine
-	FSType string `json:"fsType" description:"file system type to mount, such as ext4, xfs, ntfs; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#gcepersistentdisk"`
+	FSType string `json:"fsType" description:"file system type to mount, such as ext4, xfs, ntfs; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#gcepersistentdisk"`
 	// Optional: Partition on the disk to mount.
 	// If omitted, kubelet will attempt to mount the device name.
 	// Ex. For /dev/sda1, this field is "1", for /dev/sda, this field is 0 or empty.
-	Partition int `json:"partition,omitempty" description:"partition on the disk to mount (e.g., '1' for /dev/sda1); if omitted the plain device name (e.g., /dev/sda) will be mounted; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#gcepersistentdisk"`
+	Partition int `json:"partition,omitempty" description:"partition on the disk to mount (e.g., '1' for /dev/sda1); if omitted the plain device name (e.g., /dev/sda) will be mounted; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#gcepersistentdisk"`
 	// Optional: Defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
-	ReadOnly bool `json:"readOnly,omitempty" description:"read-only if true, read-write otherwise (false or unspecified); see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#gcepersistentdisk"`
+	ReadOnly bool `json:"readOnly,omitempty" description:"read-only if true, read-write otherwise (false or unspecified); see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#gcepersistentdisk"`
 }
 
 // AWSElasticBlockStoreVolumeSource represents a Persistent Disk resource in AWS.
@@ -464,19 +464,19 @@ type GCEPersistentDiskVolumeSource struct {
 // A AWS PD can only be mounted on a single machine.
 type AWSElasticBlockStoreVolumeSource struct {
 	// Unique id of the PD resource. Used to identify the disk in AWS
-	VolumeID string `json:"volumeID" description:"unique id of the PD resource in AWS; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#awselasticblockstore"`
+	VolumeID string `json:"volumeID" description:"unique id of the PD resource in AWS; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#awselasticblockstore"`
 	// Required: Filesystem type to mount.
 	// Must be a filesystem type supported by the host operating system.
 	// Ex. "ext4", "xfs", "ntfs"
 	// TODO: how do we prevent errors in the filesystem from compromising the machine
-	FSType string `json:"fsType" description:"file system type to mount, such as ext4, xfs, ntfs; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#awselasticblockstore"`
+	FSType string `json:"fsType" description:"file system type to mount, such as ext4, xfs, ntfs; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#awselasticblockstore"`
 	// Optional: Partition on the disk to mount.
 	// If omitted, kubelet will attempt to mount the device name.
 	// Ex. For /dev/sda1, this field is "1", for /dev/sda, this field 0 or empty.
-	Partition int `json:"partition,omitempty" description:"partition on the disk to mount (e.g., '1' for /dev/sda1); if omitted the plain device name (e.g., /dev/sda) will be mounted; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#awselasticblockstore"`
+	Partition int `json:"partition,omitempty" description:"partition on the disk to mount (e.g., '1' for /dev/sda1); if omitted the plain device name (e.g., /dev/sda) will be mounted; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#awselasticblockstore"`
 	// Optional: Defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
-	ReadOnly bool `json:"readOnly,omitempty" description:"read-only if true, read-write otherwise (false or unspecified); see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#awselasticblockstore"`
+	ReadOnly bool `json:"readOnly,omitempty" description:"read-only if true, read-write otherwise (false or unspecified); see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#awselasticblockstore"`
 }
 
 // GitRepoVolumeSource represents a volume that is pulled from git when the pod is created.
@@ -489,23 +489,23 @@ type GitRepoVolumeSource struct {
 
 // SecretVolumeSource adapts a Secret into a VolumeSource
 //
-// http://releases.k8s.io/v1.0.6/docs/design/secrets.md
+// http://releases.k8s.io/v1.0.7/docs/design/secrets.md
 type SecretVolumeSource struct {
 	// Name of the secret in the pod's namespace to use
-	SecretName string `json:"secretName" description:"secretName is the name of a secret in the pod's namespace; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#secrets"`
+	SecretName string `json:"secretName" description:"secretName is the name of a secret in the pod's namespace; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#secrets"`
 }
 
 // NFSVolumeSource represents an NFS mount that lasts the lifetime of a pod
 type NFSVolumeSource struct {
 	// Server is the hostname or IP address of the NFS server
-	Server string `json:"server" description:"the hostname or IP address of the NFS server; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#nfs"`
+	Server string `json:"server" description:"the hostname or IP address of the NFS server; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#nfs"`
 
 	// Path is the exported NFS share
-	Path string `json:"path" description:"the path that is exported by the NFS server; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#nfs"`
+	Path string `json:"path" description:"the path that is exported by the NFS server; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#nfs"`
 
 	// Optional: Defaults to false (read/write). ReadOnly here will force
 	// the NFS export to be mounted with read-only permissions
-	ReadOnly bool `json:"readOnly,omitempty" description:"forces the NFS export to be mounted with read-only permissions; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md#nfs"`
+	ReadOnly bool `json:"readOnly,omitempty" description:"forces the NFS export to be mounted with read-only permissions; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md#nfs"`
 }
 
 // A ISCSI Disk can only be mounted as read/write once.
@@ -626,9 +626,9 @@ type Probe struct {
 	// The action taken to determine the health of a container
 	Handler `json:",inline"`
 	// Length of time before health checking is activated.  In seconds.
-	InitialDelaySeconds int64 `json:"initialDelaySeconds,omitempty" description:"number of seconds after the container has started before liveness probes are initiated; see http://releases.k8s.io/v1.0.6/docs/user-guide/pod-states.md#container-probes"`
+	InitialDelaySeconds int64 `json:"initialDelaySeconds,omitempty" description:"number of seconds after the container has started before liveness probes are initiated; see http://releases.k8s.io/v1.0.7/docs/user-guide/pod-states.md#container-probes"`
 	// Length of time before health checking times out.  In seconds.
-	TimeoutSeconds int64 `json:"timeoutSeconds,omitempty" description:"number of seconds after which liveness probes timeout; defaults to 1 second; see http://releases.k8s.io/v1.0.6/docs/user-guide/pod-states.md#container-probes"`
+	TimeoutSeconds int64 `json:"timeoutSeconds,omitempty" description:"number of seconds after which liveness probes timeout; defaults to 1 second; see http://releases.k8s.io/v1.0.7/docs/user-guide/pod-states.md#container-probes"`
 }
 
 // PullPolicy describes a policy for if/when to pull a container image
@@ -657,12 +657,12 @@ type Capabilities struct {
 // ResourceRequirements describes the compute resource requirements.
 type ResourceRequirements struct {
 	// Limits describes the maximum amount of compute resources required.
-	Limits ResourceList `json:"limits,omitempty" description:"Maximum amount of compute resources allowed; see http://releases.k8s.io/v1.0.6/docs/design/resources.md#resource-specifications"`
+	Limits ResourceList `json:"limits,omitempty" description:"Maximum amount of compute resources allowed; see http://releases.k8s.io/v1.0.7/docs/design/resources.md#resource-specifications"`
 	// Requests describes the minimum amount of compute resources required.
 	// Note: 'Requests' are honored only for Persistent Volumes as of now.
 	// TODO: Update the scheduler to use 'Requests' in addition to 'Limits'. If Request is omitted for a container,
 	// it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value
-	Requests ResourceList `json:"requests,omitempty" description:"Minimum amount of resources requested; requests are honored only for persistent volumes as of now; see http://releases.k8s.io/v1.0.6/docs/design/resources.md#resource-specifications"`
+	Requests ResourceList `json:"requests,omitempty" description:"Minimum amount of resources requested; requests are honored only for persistent volumes as of now; see http://releases.k8s.io/v1.0.7/docs/design/resources.md#resource-specifications"`
 }
 
 const (
@@ -676,34 +676,34 @@ type Container struct {
 	// have a unique name.
 	Name string `json:"name" description:"name of the container; must be a DNS_LABEL and unique within the pod; cannot be updated"`
 	// Optional.
-	Image string `json:"image,omitempty" description:"Docker image name; see http://releases.k8s.io/v1.0.6/docs/user-guide/images.md"`
+	Image string `json:"image,omitempty" description:"Docker image name; see http://releases.k8s.io/v1.0.7/docs/user-guide/images.md"`
 	// Optional: The docker image's entrypoint is used if this is not provided; cannot be updated.
 	// Variable references $(VAR_NAME) are expanded using the container's environment.  If a variable
 	// cannot be resolved, the reference in the input string will be unchanged.  The $(VAR_NAME) syntax
 	// can be escaped with a double $$, ie: $$(VAR_NAME).  Escaped references will never be expanded,
 	// regardless of whether the variable exists or not.
-	Command []string `json:"command,omitempty" description:"entrypoint array; not executed within a shell; the docker image's entrypoint is used if this is not provided; cannot be updated; variable references $(VAR_NAME) are expanded using the container's environment variables; if a variable cannot be resolved, the reference in the input string will be unchanged; the $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME) ; escaped references will never be expanded, regardless of whether the variable exists or not; see http://releases.k8s.io/v1.0.6/docs/user-guide/containers.md#containers-and-commands"`
+	Command []string `json:"command,omitempty" description:"entrypoint array; not executed within a shell; the docker image's entrypoint is used if this is not provided; cannot be updated; variable references $(VAR_NAME) are expanded using the container's environment variables; if a variable cannot be resolved, the reference in the input string will be unchanged; the $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME) ; escaped references will never be expanded, regardless of whether the variable exists or not; see http://releases.k8s.io/v1.0.7/docs/user-guide/containers.md#containers-and-commands"`
 	// Optional: The docker image's cmd is used if this is not provided; cannot be updated.
 	// Variable references $(VAR_NAME) are expanded using the container's environment.  If a variable
 	// cannot be resolved, the reference in the input string will be unchanged.  The $(VAR_NAME) syntax
 	// can be escaped with a double $$, ie: $$(VAR_NAME).  Escaped references will never be expanded,
 	// regardless of whether the variable exists or not.
-	Args []string `json:"args,omitempty" description:"command array; the docker image's cmd is used if this is not provided; arguments to the entrypoint; cannot be updated; variable references $(VAR_NAME) are expanded using the container's environment variables; if a variable cannot be resolved, the reference in the input string will be unchanged; the $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME) ; escaped references will never be expanded, regardless of whether the variable exists or not; see http://releases.k8s.io/v1.0.6/docs/user-guide/containers.md#containers-and-commands"`
+	Args []string `json:"args,omitempty" description:"command array; the docker image's cmd is used if this is not provided; arguments to the entrypoint; cannot be updated; variable references $(VAR_NAME) are expanded using the container's environment variables; if a variable cannot be resolved, the reference in the input string will be unchanged; the $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME) ; escaped references will never be expanded, regardless of whether the variable exists or not; see http://releases.k8s.io/v1.0.7/docs/user-guide/containers.md#containers-and-commands"`
 	// Optional: Defaults to Docker's default.
 	WorkingDir     string               `json:"workingDir,omitempty" description:"container's working directory; defaults to image's default; cannot be updated"`
 	Ports          []ContainerPort      `json:"ports,omitempty" description:"list of ports to expose from the container; cannot be updated" patchStrategy:"merge" patchMergeKey:"containerPort"`
 	Env            []EnvVar             `json:"env,omitempty" description:"list of environment variables to set in the container; cannot be updated" patchStrategy:"merge" patchMergeKey:"name"`
-	Resources      ResourceRequirements `json:"resources,omitempty" description:"Compute Resources required by this container; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/user-guide/compute-resources.md"`
+	Resources      ResourceRequirements `json:"resources,omitempty" description:"Compute Resources required by this container; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/user-guide/compute-resources.md"`
 	VolumeMounts   []VolumeMount        `json:"volumeMounts,omitempty" description:"pod volumes to mount into the container's filesyste; cannot be updated" patchStrategy:"merge" patchMergeKey:"name"`
-	LivenessProbe  *Probe               `json:"livenessProbe,omitempty" description:"periodic probe of container liveness; container will be restarted if the probe fails; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/user-guide/pod-states.md#container-probes"`
-	ReadinessProbe *Probe               `json:"readinessProbe,omitempty" description:"periodic probe of container service readiness; container will be removed from service endpoints if the probe fails; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/user-guide/pod-states.md#container-probes"`
+	LivenessProbe  *Probe               `json:"livenessProbe,omitempty" description:"periodic probe of container liveness; container will be restarted if the probe fails; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/user-guide/pod-states.md#container-probes"`
+	ReadinessProbe *Probe               `json:"readinessProbe,omitempty" description:"periodic probe of container service readiness; container will be removed from service endpoints if the probe fails; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/user-guide/pod-states.md#container-probes"`
 	Lifecycle      *Lifecycle           `json:"lifecycle,omitempty" description:"actions that the management system should take in response to container lifecycle events; cannot be updated"`
 	// Optional: Defaults to /dev/termination-log
 	TerminationMessagePath string `json:"terminationMessagePath,omitempty" description:"path at which the file to which the container's termination message will be written is mounted into the container's filesystem; message written is intended to be brief final status, such as an assertion failure message; defaults to /dev/termination-log; cannot be updated"`
 	// Optional: Policy for pulling images for this container
-	ImagePullPolicy PullPolicy `json:"imagePullPolicy,omitempty" description:"image pull policy; one of Always, Never, IfNotPresent; defaults to Always if :latest tag is specified, or IfNotPresent otherwise; cannot be updated; see http://releases.k8s.io/v1.0.6/docs/user-guide/images.md#updating-images"`
+	ImagePullPolicy PullPolicy `json:"imagePullPolicy,omitempty" description:"image pull policy; one of Always, Never, IfNotPresent; defaults to Always if :latest tag is specified, or IfNotPresent otherwise; cannot be updated; see http://releases.k8s.io/v1.0.7/docs/user-guide/images.md#updating-images"`
 	// Optional: SecurityContext defines the security options the pod should be run with
-	SecurityContext *SecurityContext `json:"securityContext,omitempty" description:"security options the pod should run with; see http://releases.k8s.io/v1.0.6/docs/design/security_context.md"`
+	SecurityContext *SecurityContext `json:"securityContext,omitempty" description:"security options the pod should run with; see http://releases.k8s.io/v1.0.7/docs/design/security_context.md"`
 }
 
 // Handler defines a specific action that should be taken
@@ -725,10 +725,10 @@ type Handler struct {
 type Lifecycle struct {
 	// PostStart is called immediately after a container is created.  If the handler fails, the container
 	// is terminated and restarted.
-	PostStart *Handler `json:"postStart,omitempty" description:"called immediately after a container is started; if the handler fails, the container is terminated and restarted according to its restart policy; other management of the container blocks until the hook completes; see http://releases.k8s.io/v1.0.6/docs/user-guide/container-environment.md#hook-details"`
+	PostStart *Handler `json:"postStart,omitempty" description:"called immediately after a container is started; if the handler fails, the container is terminated and restarted according to its restart policy; other management of the container blocks until the hook completes; see http://releases.k8s.io/v1.0.7/docs/user-guide/container-environment.md#hook-details"`
 	// PreStop is called immediately before a container is terminated.  The reason for termination is
 	// passed to the handler.  Regardless of the outcome of the handler, the container is eventually terminated.
-	PreStop *Handler `json:"preStop,omitempty" description:"called before a container is terminated; the container is terminated after the handler completes; other management of the container blocks until the hook completes; see http://releases.k8s.io/v1.0.6/docs/user-guide/container-environment.md#hook-details"`
+	PreStop *Handler `json:"preStop,omitempty" description:"called before a container is terminated; the container is terminated after the handler completes; other management of the container blocks until the hook completes; see http://releases.k8s.io/v1.0.7/docs/user-guide/container-environment.md#hook-details"`
 }
 
 type ConditionStatus string
@@ -784,9 +784,9 @@ type ContainerStatus struct {
 	RestartCount int `json:"restartCount" description:"the number of times the container has been restarted, currently based on the number of dead containers that have not yet been removed"`
 	// TODO(dchen1107): Which image the container is running with?
 	// The image the container is running
-	Image       string `json:"image" description:"image of the container; see http://releases.k8s.io/v1.0.6/docs/user-guide/images.md"`
+	Image       string `json:"image" description:"image of the container; see http://releases.k8s.io/v1.0.7/docs/user-guide/images.md"`
 	ImageID     string `json:"imageID" description:"ID of the container's image"`
-	ContainerID string `json:"containerID,omitempty" description:"container's ID in the format 'docker://<container_id>'; see http://releases.k8s.io/v1.0.6/docs/user-guide/container-environment.md#container-information"`
+	ContainerID string `json:"containerID,omitempty" description:"container's ID in the format 'docker://<container_id>'; see http://releases.k8s.io/v1.0.7/docs/user-guide/container-environment.md#container-information"`
 }
 
 // PodPhase is a label for the condition of a pod at the current time.
@@ -825,9 +825,9 @@ const (
 // TODO: add LastTransitionTime, Reason, Message to match NodeCondition api.
 type PodCondition struct {
 	// Type is the type of the condition
-	Type PodConditionType `json:"type" description:"kind of the condition, currently only Ready; see http://releases.k8s.io/v1.0.6/docs/user-guide/pod-states.md#pod-conditions"`
+	Type PodConditionType `json:"type" description:"kind of the condition, currently only Ready; see http://releases.k8s.io/v1.0.7/docs/user-guide/pod-states.md#pod-conditions"`
 	// Status is the status of the condition
-	Status ConditionStatus `json:"status" description:"status of the condition, one of True, False, Unknown; see http://releases.k8s.io/v1.0.6/docs/user-guide/pod-states.md#pod-conditions"`
+	Status ConditionStatus `json:"status" description:"status of the condition, one of True, False, Unknown; see http://releases.k8s.io/v1.0.7/docs/user-guide/pod-states.md#pod-conditions"`
 }
 
 // RestartPolicy describes how the container should be restarted.
@@ -858,10 +858,10 @@ const (
 
 // PodSpec is a description of a pod
 type PodSpec struct {
-	Volumes []Volume `json:"volumes,omitempty" description:"list of volumes that can be mounted by containers belonging to the pod; see http://releases.k8s.io/v1.0.6/docs/user-guide/volumes.md" patchStrategy:"merge" patchMergeKey:"name"`
+	Volumes []Volume `json:"volumes,omitempty" description:"list of volumes that can be mounted by containers belonging to the pod; see http://releases.k8s.io/v1.0.7/docs/user-guide/volumes.md" patchStrategy:"merge" patchMergeKey:"name"`
 	// Required: there must be at least one container in a pod.
-	Containers    []Container   `json:"containers" description:"list of containers belonging to the pod; cannot be updated; containers cannot currently be added or removed; there must be at least one container in a Pod; see http://releases.k8s.io/v1.0.6/docs/user-guide/containers.md" patchStrategy:"merge" patchMergeKey:"name"`
-	RestartPolicy RestartPolicy `json:"restartPolicy,omitempty" description:"restart policy for all containers within the pod; one of Always, OnFailure, Never; defaults to Always; see http://releases.k8s.io/v1.0.6/docs/user-guide/pod-states.md#restartpolicy"`
+	Containers    []Container   `json:"containers" description:"list of containers belonging to the pod; cannot be updated; containers cannot currently be added or removed; there must be at least one container in a Pod; see http://releases.k8s.io/v1.0.7/docs/user-guide/containers.md" patchStrategy:"merge" patchMergeKey:"name"`
+	RestartPolicy RestartPolicy `json:"restartPolicy,omitempty" description:"restart policy for all containers within the pod; one of Always, OnFailure, Never; defaults to Always; see http://releases.k8s.io/v1.0.7/docs/user-guide/pod-states.md#restartpolicy"`
 	// Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request.
 	// Value must be non-negative integer. The value zero indicates delete immediately.
 	// If this value is nil, the default grace period will be used instead.
@@ -873,10 +873,10 @@ type PodSpec struct {
 	// Optional: Set DNS policy.  Defaults to "ClusterFirst"
 	DNSPolicy DNSPolicy `json:"dnsPolicy,omitempty" description:"DNS policy for containers within the pod; one of 'ClusterFirst' or 'Default'"`
 	// NodeSelector is a selector which must be true for the pod to fit on a node
-	NodeSelector map[string]string `json:"nodeSelector,omitempty" description:"selector which must match a node's labels for the pod to be scheduled on that node; see http://releases.k8s.io/v1.0.6/docs/user-guide/node-selection/README.md"`
+	NodeSelector map[string]string `json:"nodeSelector,omitempty" description:"selector which must match a node's labels for the pod to be scheduled on that node; see http://releases.k8s.io/v1.0.7/docs/user-guide/node-selection/README.md"`
 
 	// ServiceAccountName is the name of the ServiceAccount to use to run this pod
-	ServiceAccountName string `json:"serviceAccountName,omitempty" description:"name of the ServiceAccount to use to run this pod; see http://releases.k8s.io/v1.0.6/docs/user-guide/service-accounts.md"`
+	ServiceAccountName string `json:"serviceAccountName,omitempty" description:"name of the ServiceAccount to use to run this pod; see http://releases.k8s.io/v1.0.7/docs/user-guide/service-accounts.md"`
 	// DeprecatedServiceAccount is a depreciated alias for ServiceAccountName.
 	DeprecatedServiceAccount string `json:"serviceAccount,omitempty" description:"deprecated; use serviceAccountName instead"`
 
@@ -891,14 +891,14 @@ type PodSpec struct {
 	// ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
 	// If specified, these secrets will be passed to individual puller implementations for them to use.  For example,
 	// in the case of docker, only DockerConfig type secrets are honored.
-	ImagePullSecrets []LocalObjectReference `json:"imagePullSecrets,omitempty" description:"list of references to secrets in the same namespace available for pulling the container images; see http://releases.k8s.io/v1.0.6/docs/user-guide/images.md#specifying-imagepullsecrets-on-a-pod"  patchStrategy:"merge" patchMergeKey:"name"`
+	ImagePullSecrets []LocalObjectReference `json:"imagePullSecrets,omitempty" description:"list of references to secrets in the same namespace available for pulling the container images; see http://releases.k8s.io/v1.0.7/docs/user-guide/images.md#specifying-imagepullsecrets-on-a-pod"  patchStrategy:"merge" patchMergeKey:"name"`
 }
 
 // PodStatus represents information about the status of a pod. Status may trail the actual
 // state of a system.
 type PodStatus struct {
-	Phase      PodPhase       `json:"phase,omitempty" description:"current condition of the pod; see http://releases.k8s.io/v1.0.6/docs/user-guide/pod-states.md#pod-phase"`
-	Conditions []PodCondition `json:"conditions,omitempty" description:"current service state of pod; see http://releases.k8s.io/v1.0.6/docs/user-guide/pod-states.md#pod-conditions" patchStrategy:"merge" patchMergeKey:"type"`
+	Phase      PodPhase       `json:"phase,omitempty" description:"current condition of the pod; see http://releases.k8s.io/v1.0.7/docs/user-guide/pod-states.md#pod-phase"`
+	Conditions []PodCondition `json:"conditions,omitempty" description:"current service state of pod; see http://releases.k8s.io/v1.0.7/docs/user-guide/pod-states.md#pod-conditions" patchStrategy:"merge" patchMergeKey:"type"`
 	// A human readable message indicating details about why the pod is in this state.
 	Message string `json:"message,omitempty" description:"human readable message indicating details about why the pod is in this condition"`
 	// A brief CamelCase message indicating details about why the pod is in this state. e.g. 'OutOfDisk'
@@ -911,62 +911,62 @@ type PodStatus struct {
 
 	// The list has one entry per container in the manifest. Each entry is currently the output
 	// of `docker inspect`.
-	ContainerStatuses []ContainerStatus `json:"containerStatuses,omitempty" description:"list of container statuses; see http://releases.k8s.io/v1.0.6/docs/user-guide/pod-states.md#container-statuses"`
+	ContainerStatuses []ContainerStatus `json:"containerStatuses,omitempty" description:"list of container statuses; see http://releases.k8s.io/v1.0.7/docs/user-guide/pod-states.md#container-statuses"`
 }
 
 // PodStatusResult is a wrapper for PodStatus returned by kubelet that can be encode/decoded
 type PodStatusResult struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"`
 	// Status represents the current information about a pod. This data may not be up
 	// to date.
-	Status PodStatus `json:"status,omitempty" description:"most recently observed status of the pod; populated by the system, read-only; http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#spec-and-status"`
+	Status PodStatus `json:"status,omitempty" description:"most recently observed status of the pod; populated by the system, read-only; http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#spec-and-status"`
 }
 
 // Pod is a collection of containers that can run on a host. This resource is created
 // by clients and scheduled onto hosts.
 type Pod struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"`
 
 	// Spec defines the behavior of a pod.
-	Spec PodSpec `json:"spec,omitempty" description:"specification of the desired behavior of the pod; http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#spec-and-status"`
+	Spec PodSpec `json:"spec,omitempty" description:"specification of the desired behavior of the pod; http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#spec-and-status"`
 
 	// Status represents the current information about a pod. This data may not be up
 	// to date.
-	Status PodStatus `json:"status,omitempty" description:"most recently observed status of the pod; populated by the system, read-only; http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#spec-and-status"`
+	Status PodStatus `json:"status,omitempty" description:"most recently observed status of the pod; populated by the system, read-only; http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#spec-and-status"`
 }
 
 // PodList is a list of Pods.
 type PodList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"`
 
-	Items []Pod `json:"items" description:"list of pods; see http://releases.k8s.io/v1.0.6/docs/user-guide/pods.md"`
+	Items []Pod `json:"items" description:"list of pods; see http://releases.k8s.io/v1.0.7/docs/user-guide/pods.md"`
 }
 
 // PodTemplateSpec describes the data a pod should have when created from a template
 type PodTemplateSpec struct {
 	// Metadata of the pods created from this template.
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"`
 
 	// Spec defines the behavior of a pod.
-	Spec PodSpec `json:"spec,omitempty" description:"specification of the desired behavior of the pod; http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#spec-and-status"`
+	Spec PodSpec `json:"spec,omitempty" description:"specification of the desired behavior of the pod; http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#spec-and-status"`
 }
 
 // PodTemplate describes a template for creating copies of a predefined pod.
 type PodTemplate struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"`
 
 	// Template defines the pods that will be created from this pod template
-	Template PodTemplateSpec `json:"template,omitempty" description:"the template of the desired behavior of the pod; http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#spec-and-status"`
+	Template PodTemplateSpec `json:"template,omitempty" description:"the template of the desired behavior of the pod; http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#spec-and-status"`
 }
 
 // PodTemplateList is a list of PodTemplates.
 type PodTemplateList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"`
 
 	Items []PodTemplate `json:"items" description:"list of pod templates"`
 }
@@ -974,11 +974,11 @@ type PodTemplateList struct {
 // ReplicationControllerSpec is the specification of a replication controller.
 type ReplicationControllerSpec struct {
 	// Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified.
-	Replicas *int `json:"replicas,omitempty" description:"number of replicas desired; defaults to 1; see http://releases.k8s.io/v1.0.6/docs/user-guide/replication-controller.md#what-is-a-replication-controller"`
+	Replicas *int `json:"replicas,omitempty" description:"number of replicas desired; defaults to 1; see http://releases.k8s.io/v1.0.7/docs/user-guide/replication-controller.md#what-is-a-replication-controller"`
 
 	// Selector is a label query over pods that should match the Replicas count.
 	// If Selector is empty, it is defaulted to the labels present on the Pod template.
-	Selector map[string]string `json:"selector,omitempty" description:"label keys and values that must match in order to be controlled by this replication controller, if empty defaulted to labels on Pod template; see http://releases.k8s.io/v1.0.6/docs/user-guide/labels.md#label-selectors"`
+	Selector map[string]string `json:"selector,omitempty" description:"label keys and values that must match in order to be controlled by this replication controller, if empty defaulted to labels on Pod template; see http://releases.k8s.io/v1.0.7/docs/user-guide/labels.md#label-selectors"`
 
 	// TemplateRef is a reference to an object that describes the pod that will be created if
 	// insufficient replicas are detected.
@@ -987,14 +987,14 @@ type ReplicationControllerSpec struct {
 	// Template is the object that describes the pod that will be created if
 	// insufficient replicas are detected. This takes precedence over a
 	// TemplateRef.
-	Template *PodTemplateSpec `json:"template,omitempty" description:"object that describes the pod that will be created if insufficient replicas are detected; takes precendence over templateRef; see http://releases.k8s.io/v1.0.6/docs/user-guide/replication-controller.md#pod-template"`
+	Template *PodTemplateSpec `json:"template,omitempty" description:"object that describes the pod that will be created if insufficient replicas are detected; takes precendence over templateRef; see http://releases.k8s.io/v1.0.7/docs/user-guide/replication-controller.md#pod-template"`
 }
 
 // ReplicationControllerStatus represents the current status of a replication
 // controller.
 type ReplicationControllerStatus struct {
 	// Replicas is the number of actual replicas.
-	Replicas int `json:"replicas" description:"most recently oberved number of replicas; see http://releases.k8s.io/v1.0.6/docs/user-guide/replication-controller.md#what-is-a-replication-controller"`
+	Replicas int `json:"replicas" description:"most recently oberved number of replicas; see http://releases.k8s.io/v1.0.7/docs/user-guide/replication-controller.md#what-is-a-replication-controller"`
 
 	// ObservedGeneration is the most recent generation observed by the controller.
 	ObservedGeneration int64 `json:"observedGeneration,omitempty" description:"reflects the generation of the most recently observed replication controller"`
@@ -1005,22 +1005,22 @@ type ReplicationController struct {
 	TypeMeta `json:",inline"`
 
 	// If the Labels of a ReplicationController are empty, they are defaulted to be the same as the Pod(s) that the replication controller manages.
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"`
 
 	// Spec defines the desired behavior of this replication controller.
-	Spec ReplicationControllerSpec `json:"spec,omitempty" description:"specification of the desired behavior of the replication controller; http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#spec-and-status"`
+	Spec ReplicationControllerSpec `json:"spec,omitempty" description:"specification of the desired behavior of the replication controller; http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#spec-and-status"`
 
 	// Status is the current status of this replication controller. This data may be
 	// out of date by some window of time.
-	Status ReplicationControllerStatus `json:"status,omitempty" description:"most recently observed status of the replication controller; populated by the system, read-only; http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#spec-and-status"`
+	Status ReplicationControllerStatus `json:"status,omitempty" description:"most recently observed status of the replication controller; populated by the system, read-only; http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#spec-and-status"`
 }
 
 // ReplicationControllerList is a collection of replication controllers.
 type ReplicationControllerList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"`
 
-	Items []ReplicationController `json:"items" description:"list of replication controllers; see http://releases.k8s.io/v1.0.6/docs/user-guide/replication-controller.md"`
+	Items []ReplicationController `json:"items" description:"list of replication controllers; see http://releases.k8s.io/v1.0.7/docs/user-guide/replication-controller.md"`
 }
 
 // Session Affinity Type string
@@ -1081,27 +1081,27 @@ type LoadBalancerIngress struct {
 // ServiceSpec describes the attributes that a user creates on a service
 type ServiceSpec struct {
 	// Required: The list of ports that are exposed by this service.
-	Ports []ServicePort `json:"ports" description:"ports exposed by the service; see http://releases.k8s.io/v1.0.6/docs/user-guide/services.md#virtual-ips-and-service-proxies"`
+	Ports []ServicePort `json:"ports" description:"ports exposed by the service; see http://releases.k8s.io/v1.0.7/docs/user-guide/services.md#virtual-ips-and-service-proxies"`
 
 	// This service will route traffic to pods having labels matching this selector. If null, no endpoints will be automatically created. If empty, all pods will be selected.
-	Selector map[string]string `json:"selector,omitempty" description:"label keys and values that must match in order to receive traffic for this service; if empty, all pods are selected, if not specified, endpoints must be manually specified; see http://releases.k8s.io/v1.0.6/docs/user-guide/services.md#overview"`
+	Selector map[string]string `json:"selector,omitempty" description:"label keys and values that must match in order to receive traffic for this service; if empty, all pods are selected, if not specified, endpoints must be manually specified; see http://releases.k8s.io/v1.0.7/docs/user-guide/services.md#overview"`
 
 	// ClusterIP is usually assigned by the master.  If specified by the user
 	// we will try to respect it or else fail the request.  This field can
 	// not be changed by updates.
 	// Valid values are None, empty string (""), or a valid IP address
 	// None can be specified for headless services when proxying is not required
-	ClusterIP string `json:"clusterIP,omitempty" description:"IP address of the service; usually assigned by the system; if specified, it will be allocated to the service if unused or else creation of the service will fail; cannot be updated; 'None' can be specified for a headless service when proxying is not required; see http://releases.k8s.io/v1.0.6/docs/user-guide/services.md#virtual-ips-and-service-proxies"`
+	ClusterIP string `json:"clusterIP,omitempty" description:"IP address of the service; usually assigned by the system; if specified, it will be allocated to the service if unused or else creation of the service will fail; cannot be updated; 'None' can be specified for a headless service when proxying is not required; see http://releases.k8s.io/v1.0.7/docs/user-guide/services.md#virtual-ips-and-service-proxies"`
 
 	// Type determines how the service will be exposed.  Valid options: ClusterIP, NodePort, LoadBalancer
-	Type ServiceType `json:"type,omitempty" description:"type of this service; must be ClusterIP, NodePort, or LoadBalancer; defaults to ClusterIP; see http://releases.k8s.io/v1.0.6/docs/user-guide/services.md#external-services"`
+	Type ServiceType `json:"type,omitempty" description:"type of this service; must be ClusterIP, NodePort, or LoadBalancer; defaults to ClusterIP; see http://releases.k8s.io/v1.0.7/docs/user-guide/services.md#external-services"`
 
 	// Deprecated. PublicIPs are used by external load balancers, or can be set by
 	// users to handle external traffic that arrives at a node.
 	DeprecatedPublicIPs []string `json:"deprecatedPublicIPs,omitempty" description:"deprecated. externally visible IPs (e.g. load balancers) that should be proxied to this service"`
 
 	// Optional: Supports "ClientIP" and "None".  Used to maintain session affinity.
-	SessionAffinity ServiceAffinity `json:"sessionAffinity,omitempty" description:"enable client IP based session affinity; must be ClientIP or None; defaults to None; see http://releases.k8s.io/v1.0.6/docs/user-guide/services.md#virtual-ips-and-service-proxies"`
+	SessionAffinity ServiceAffinity `json:"sessionAffinity,omitempty" description:"enable client IP based session affinity; must be ClientIP or None; defaults to None; see http://releases.k8s.io/v1.0.7/docs/user-guide/services.md#virtual-ips-and-service-proxies"`
 }
 
 type ServicePort struct {
@@ -1122,11 +1122,11 @@ type ServicePort struct {
 	// If this is a string, it will be looked up as a named port in the
 	// target Pod's container ports.  If this is not specified, the value
 	// of Port is used (an identity map).
-	TargetPort util.IntOrString `json:"targetPort,omitempty" description:"number or name of the port to access on the pods targeted by the service; defaults to the service port; number must be in the range 1 to 65535; name must be an IANA_SVC_NAME; see http://releases.k8s.io/v1.0.6/docs/user-guide/services.md#defining-a-service"`
+	TargetPort util.IntOrString `json:"targetPort,omitempty" description:"number or name of the port to access on the pods targeted by the service; defaults to the service port; number must be in the range 1 to 65535; name must be an IANA_SVC_NAME; see http://releases.k8s.io/v1.0.7/docs/user-guide/services.md#defining-a-service"`
 
 	// The port on each node on which this service is exposed.
 	// Default is to auto-allocate a port if the ServiceType of this Service requires one.
-	NodePort int `json:"nodePort" description:"the port on each node on which this service is exposed when type=NodePort or LoadBalancer; usually assigned by the system; if specified, it will be allocated to the service if unused or else creation of the service will fail; see http://releases.k8s.io/v1.0.6/docs/user-guide/services.md#type--nodeport"`
+	NodePort int `json:"nodePort" description:"the port on each node on which this service is exposed when type=NodePort or LoadBalancer; usually assigned by the system; if specified, it will be allocated to the service if unused or else creation of the service will fail; see http://releases.k8s.io/v1.0.7/docs/user-guide/services.md#type--nodeport"`
 }
 
 // Service is a named abstraction of software service (for example, mysql) consisting of local port
@@ -1134,13 +1134,13 @@ type ServicePort struct {
 // will answer requests sent through the proxy.
 type Service struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"`
 
 	// Spec defines the behavior of a service.
-	Spec ServiceSpec `json:"spec,omitempty" description:"specification of the desired behavior of the service; http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#spec-and-status"`
+	Spec ServiceSpec `json:"spec,omitempty" description:"specification of the desired behavior of the service; http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#spec-and-status"`
 
 	// Status represents the current status of a service.
-	Status ServiceStatus `json:"status,omitempty" description:"most recently observed status of the service; populated by the system, read-only; http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#spec-and-status"`
+	Status ServiceStatus `json:"status,omitempty" description:"most recently observed status of the service; populated by the system, read-only; http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#spec-and-status"`
 }
 
 const (
@@ -1152,7 +1152,7 @@ const (
 // ServiceList holds a list of services.
 type ServiceList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"`
 
 	Items []Service `json:"items" description:"list of services"`
 }
@@ -1163,23 +1163,23 @@ type ServiceList struct {
 // * a set of secrets
 type ServiceAccount struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"`
 
 	// Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount
-	Secrets []ObjectReference `json:"secrets,omitempty" description:"list of secrets that can be used by pods running as this service account; see http://releases.k8s.io/v1.0.6/docs/user-guide/secrets.md" patchStrategy:"merge" patchMergeKey:"name"`
+	Secrets []ObjectReference `json:"secrets,omitempty" description:"list of secrets that can be used by pods running as this service account; see http://releases.k8s.io/v1.0.7/docs/user-guide/secrets.md" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images
 	// in pods that reference this ServiceAccount.  ImagePullSecrets are distinct from Secrets because Secrets
 	// can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet.
-	ImagePullSecrets []LocalObjectReference `json:"imagePullSecrets,omitempty" description:"list of references to secrets in the same namespace available for pulling container images; see http://releases.k8s.io/v1.0.6/docs/user-guide/secrets.md#manually-specifying-an-imagepullsecret"`
+	ImagePullSecrets []LocalObjectReference `json:"imagePullSecrets,omitempty" description:"list of references to secrets in the same namespace available for pulling container images; see http://releases.k8s.io/v1.0.7/docs/user-guide/secrets.md#manually-specifying-an-imagepullsecret"`
 }
 
 // ServiceAccountList is a list of ServiceAccount objects
 type ServiceAccountList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"`
 
-	Items []ServiceAccount `json:"items" description:"list of ServiceAccounts; see http://releases.k8s.io/v1.0.6/docs/user-guide/service-accounts.md#service-accounts"`
+	Items []ServiceAccount `json:"items" description:"list of ServiceAccounts; see http://releases.k8s.io/v1.0.7/docs/user-guide/service-accounts.md#service-accounts"`
 }
 
 // Endpoints is a collection of endpoints that implement the actual service.  Example:
@@ -1196,7 +1196,7 @@ type ServiceAccountList struct {
 //  ]
 type Endpoints struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"`
 
 	// The set of all endpoints is the union of all subsets.
 	Subsets []EndpointSubset `json:"subsets" description:"sets of addresses and ports that comprise a service"`
@@ -1243,7 +1243,7 @@ type EndpointPort struct {
 // EndpointsList is a list of endpoints.
 type EndpointsList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"`
 
 	Items []Endpoints `json:"items" description:"list of endpoints"`
 }
@@ -1257,7 +1257,7 @@ type NodeSpec struct {
 	// ID of the node assigned by the cloud provider
 	ProviderID string `json:"providerID,omitempty" description:"ID of the node assigned by the cloud provider in the format: <ProviderName>://<ProviderSpecificNodeID>"`
 	// Unschedulable controls node schedulability of new pods. By default node is schedulable.
-	Unschedulable bool `json:"unschedulable,omitempty" description:"disable pod scheduling on the node; see http://releases.k8s.io/v1.0.6/docs/admin/node.md#manual-node-administration"`
+	Unschedulable bool `json:"unschedulable,omitempty" description:"disable pod scheduling on the node; see http://releases.k8s.io/v1.0.7/docs/admin/node.md#manual-node-administration"`
 }
 
 // NodeSystemInfo is a set of ids/uuids to uniquely identify the node.
@@ -1283,16 +1283,16 @@ type NodeSystemInfo struct {
 // NodeStatus is information about the current status of a node.
 type NodeStatus struct {
 	// Capacity represents the available resources of a node.
-	// see http://releases.k8s.io/v1.0.6/docs/user-guide/compute-resources.md for more details.
-	Capacity ResourceList `json:"capacity,omitempty" description:"compute resource capacity of the node; see http://releases.k8s.io/v1.0.6/docs/user-guide/compute-resources.md"`
+	// see http://releases.k8s.io/v1.0.7/docs/user-guide/compute-resources.md for more details.
+	Capacity ResourceList `json:"capacity,omitempty" description:"compute resource capacity of the node; see http://releases.k8s.io/v1.0.7/docs/user-guide/compute-resources.md"`
 	// NodePhase is the current lifecycle phase of the node.
-	Phase NodePhase `json:"phase,omitempty" description:"most recently observed lifecycle phase of the node; see http://releases.k8s.io/v1.0.6/docs/admin/node.md#node-phase"`
+	Phase NodePhase `json:"phase,omitempty" description:"most recently observed lifecycle phase of the node; see http://releases.k8s.io/v1.0.7/docs/admin/node.md#node-phase"`
 	// Conditions is an array of current node conditions.
-	Conditions []NodeCondition `json:"conditions,omitempty" description:"list of node conditions observed; see http://releases.k8s.io/v1.0.6/docs/admin/node.md#node-condition" patchStrategy:"merge" patchMergeKey:"type"`
+	Conditions []NodeCondition `json:"conditions,omitempty" description:"list of node conditions observed; see http://releases.k8s.io/v1.0.7/docs/admin/node.md#node-condition" patchStrategy:"merge" patchMergeKey:"type"`
 	// Queried from cloud provider, if available.
-	Addresses []NodeAddress `json:"addresses,omitempty" description:"list of addresses reachable to the node; see http://releases.k8s.io/v1.0.6/docs/admin/node.md#node-addresses" patchStrategy:"merge" patchMergeKey:"type"`
+	Addresses []NodeAddress `json:"addresses,omitempty" description:"list of addresses reachable to the node; see http://releases.k8s.io/v1.0.7/docs/admin/node.md#node-addresses" patchStrategy:"merge" patchMergeKey:"type"`
 	// NodeSystemInfo is a set of ids/uuids to uniquely identify the node
-	NodeInfo NodeSystemInfo `json:"nodeInfo,omitempty" description:"set of ids/uuids to uniquely identify the node; see http://releases.k8s.io/v1.0.6/docs/admin/node.md#node-info"`
+	NodeInfo NodeSystemInfo `json:"nodeInfo,omitempty" description:"set of ids/uuids to uniquely identify the node; see http://releases.k8s.io/v1.0.7/docs/admin/node.md#node-info"`
 }
 
 type NodePhase string
@@ -1359,19 +1359,19 @@ type ResourceList map[ResourceName]resource.Quantity
 // The name of the node according to etcd is in ID.
 type Node struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"`
 
 	// Spec defines the behavior of a node.
-	Spec NodeSpec `json:"spec,omitempty" description:"specification of a node; http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#spec-and-status"`
+	Spec NodeSpec `json:"spec,omitempty" description:"specification of a node; http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#spec-and-status"`
 
 	// Status describes the current status of a Node
-	Status NodeStatus `json:"status,omitempty" description:"most recently observed status of the node; populated by the system, read-only; http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#spec-and-status"`
+	Status NodeStatus `json:"status,omitempty" description:"most recently observed status of the node; populated by the system, read-only; http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#spec-and-status"`
 }
 
 // NodeList is a list of minions.
 type NodeList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"`
 
 	Items []Node `json:"items" description:"list of nodes"`
 }
@@ -1386,13 +1386,13 @@ const (
 // NamespaceSpec describes the attributes on a Namespace
 type NamespaceSpec struct {
 	// Finalizers is an opaque list of values that must be empty to permanently remove object from storage
-	Finalizers []FinalizerName `json:"finalizers,omitempty" description:"an opaque list of values that must be empty to permanently remove object from storage; see http://releases.k8s.io/v1.0.6/docs/design/namespaces.md#finalizers"`
+	Finalizers []FinalizerName `json:"finalizers,omitempty" description:"an opaque list of values that must be empty to permanently remove object from storage; see http://releases.k8s.io/v1.0.7/docs/design/namespaces.md#finalizers"`
 }
 
 // NamespaceStatus is information about the current status of a Namespace.
 type NamespaceStatus struct {
 	// Phase is the current lifecycle phase of the namespace.
-	Phase NamespacePhase `json:"phase,omitempty" description:"phase is the current lifecycle phase of the namespace; see http://releases.k8s.io/v1.0.6/docs/design/namespaces.md#phases"`
+	Phase NamespacePhase `json:"phase,omitempty" description:"phase is the current lifecycle phase of the namespace; see http://releases.k8s.io/v1.0.7/docs/design/namespaces.md#phases"`
 }
 
 type NamespacePhase string
@@ -1409,29 +1409,29 @@ const (
 // Use of multiple namespaces is optional
 type Namespace struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"`
 
 	// Spec defines the behavior of the Namespace.
-	Spec NamespaceSpec `json:"spec,omitempty" description:"spec defines the behavior of the Namespace; http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#spec-and-status"`
+	Spec NamespaceSpec `json:"spec,omitempty" description:"spec defines the behavior of the Namespace; http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#spec-and-status"`
 
 	// Status describes the current status of a Namespace
-	Status NamespaceStatus `json:"status,omitempty" description:"status describes the current status of a Namespace; http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#spec-and-status"`
+	Status NamespaceStatus `json:"status,omitempty" description:"status describes the current status of a Namespace; http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#spec-and-status"`
 }
 
 // NamespaceList is a list of Namespaces.
 type NamespaceList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"`
 
 	// Items is the list of Namespace objects in the list
-	Items []Namespace `json:"items"  description:"items is the list of Namespace objects in the list; see http://releases.k8s.io/v1.0.6/docs/user-guide/namespaces.md"`
+	Items []Namespace `json:"items"  description:"items is the list of Namespace objects in the list; see http://releases.k8s.io/v1.0.7/docs/user-guide/namespaces.md"`
 }
 
 // Binding ties one object to another - for example, a pod is bound to a node by a scheduler.
 type Binding struct {
 	TypeMeta `json:",inline"`
 	// ObjectMeta describes the object that is being bound.
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"`
 
 	// Target is the object to bind to.
 	Target ObjectReference `json:"target" description:"an object to bind to"`
@@ -1509,10 +1509,10 @@ type PodProxyOptions struct {
 // Status is a return value for calls that don't return other objects.
 type Status struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"`
 
 	// One of: "Success" or "Failure"
-	Status string `json:"status,omitempty" description:"status of the operation; either Success, or Failure; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#spec-and-status"`
+	Status string `json:"status,omitempty" description:"status of the operation; either Success, or Failure; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#spec-and-status"`
 	// A human-readable description of the status of this operation.
 	Message string `json:"message,omitempty" description:"human-readable description of the status of this operation"`
 	// A machine-readable description of why this operation is in the
@@ -1541,7 +1541,7 @@ type StatusDetails struct {
 	Name string `json:"name,omitempty" description:"the name attribute of the resource associated with the status StatusReason (when there is a single name which can be described)"`
 	// The kind attribute of the resource associated with the status StatusReason.
 	// On some operations may differ from the requested resource Kind.
-	Kind string `json:"kind,omitempty" description:"the kind attribute of the resource associated with the status StatusReason; on some operations may differ from the requested resource Kind; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"`
+	Kind string `json:"kind,omitempty" description:"the kind attribute of the resource associated with the status StatusReason; on some operations may differ from the requested resource Kind; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"`
 	// The Causes array includes more details associated with the StatusReason
 	// failure. Not all StatusReasons may provide detailed causes.
 	Causes []StatusCause `json:"causes,omitempty" description:"the Causes array includes more details associated with the StatusReason failure; not all StatusReasons may provide detailed causes"`
@@ -1662,12 +1662,12 @@ const (
 
 // ObjectReference contains enough information to let you inspect or modify the referred object.
 type ObjectReference struct {
-	Kind            string    `json:"kind,omitempty" description:"kind of the referent; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#types-kinds"`
-	Namespace       string    `json:"namespace,omitempty" description:"namespace of the referent; see http://releases.k8s.io/v1.0.6/docs/user-guide/namespaces.md"`
-	Name            string    `json:"name,omitempty" description:"name of the referent; see http://releases.k8s.io/v1.0.6/docs/user-guide/identifiers.md#names"`
-	UID             types.UID `json:"uid,omitempty" description:"uid of the referent; see http://releases.k8s.io/v1.0.6/docs/user-guide/identifiers.md#uids"`
+	Kind            string    `json:"kind,omitempty" description:"kind of the referent; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#types-kinds"`
+	Namespace       string    `json:"namespace,omitempty" description:"namespace of the referent; see http://releases.k8s.io/v1.0.7/docs/user-guide/namespaces.md"`
+	Name            string    `json:"name,omitempty" description:"name of the referent; see http://releases.k8s.io/v1.0.7/docs/user-guide/identifiers.md#names"`
+	UID             types.UID `json:"uid,omitempty" description:"uid of the referent; see http://releases.k8s.io/v1.0.7/docs/user-guide/identifiers.md#uids"`
 	APIVersion      string    `json:"apiVersion,omitempty" description:"API version of the referent"`
-	ResourceVersion string    `json:"resourceVersion,omitempty" description:"specific resourceVersion to which this reference is made, if any: http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#concurrency-control-and-consistency"`
+	ResourceVersion string    `json:"resourceVersion,omitempty" description:"specific resourceVersion to which this reference is made, if any: http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#concurrency-control-and-consistency"`
 
 	// Optional. If referring to a piece of an object instead of an entire object, this string
 	// should contain information to identify the sub-object. For example, if the object
@@ -1683,7 +1683,7 @@ type ObjectReference struct {
 // LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
 type LocalObjectReference struct {
 	//TODO: Add other useful fields.  apiVersion, kind, uid?
-	Name string `json:"name,omitempty" description:"name of the referent; see http://releases.k8s.io/v1.0.6/docs/user-guide/identifiers.md#names"`
+	Name string `json:"name,omitempty" description:"name of the referent; see http://releases.k8s.io/v1.0.7/docs/user-guide/identifiers.md#names"`
 }
 
 type SerializedReference struct {
@@ -1702,7 +1702,7 @@ type EventSource struct {
 // TODO: Decide whether to store these separately or with the object they apply to.
 type Event struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"`
 
 	// Required. The object that this event is about.
 	InvolvedObject ObjectReference `json:"involvedObject" description:"object this event is about"`
@@ -1732,7 +1732,7 @@ type Event struct {
 // EventList is a list of events.
 type EventList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"`
 
 	Items []Event `json:"items" description:"list of events"`
 }
@@ -1740,7 +1740,7 @@ type EventList struct {
 // List holds a list of objects, which may not be known by the server.
 type List struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"`
 
 	Items []runtime.RawExtension `json:"items" description:"list of objects"`
 }
@@ -1776,19 +1776,19 @@ type LimitRangeSpec struct {
 // LimitRange sets resource usage limits for each kind of resource in a Namespace
 type LimitRange struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"`
 
 	// Spec defines the limits enforced
-	Spec LimitRangeSpec `json:"spec,omitempty" description:"spec defines the limits enforced; http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#spec-and-status"`
+	Spec LimitRangeSpec `json:"spec,omitempty" description:"spec defines the limits enforced; http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#spec-and-status"`
 }
 
 // LimitRangeList is a list of LimitRange items.
 type LimitRangeList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"`
 
 	// Items is a list of LimitRange objects
-	Items []LimitRange `json:"items" description:"items is a list of LimitRange objects; see http://releases.k8s.io/v1.0.6/docs/design/admission_control_limit_range.md"`
+	Items []LimitRange `json:"items" description:"items is a list of LimitRange objects; see http://releases.k8s.io/v1.0.7/docs/design/admission_control_limit_range.md"`
 }
 
 // The following identify resource constants for Kubernetes object types
@@ -1810,13 +1810,13 @@ const (
 // ResourceQuotaSpec defines the desired hard limits to enforce for Quota
 type ResourceQuotaSpec struct {
 	// Hard is the set of desired hard limits for each named resource
-	Hard ResourceList `json:"hard,omitempty" description:"hard is the set of desired hard limits for each named resource; see http://releases.k8s.io/v1.0.6/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota"`
+	Hard ResourceList `json:"hard,omitempty" description:"hard is the set of desired hard limits for each named resource; see http://releases.k8s.io/v1.0.7/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota"`
 }
 
 // ResourceQuotaStatus defines the enforced hard limits and observed use
 type ResourceQuotaStatus struct {
 	// Hard is the set of enforced hard limits for each named resource
-	Hard ResourceList `json:"hard,omitempty" description:"hard is the set of enforced hard limits for each named resource; see http://releases.k8s.io/v1.0.6/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota"`
+	Hard ResourceList `json:"hard,omitempty" description:"hard is the set of enforced hard limits for each named resource; see http://releases.k8s.io/v1.0.7/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota"`
 	// Used is the current observed total usage of the resource in the namespace
 	Used ResourceList `json:"used,omitempty" description:"used is the current observed total usage of the resource in the namespace"`
 }
@@ -1824,29 +1824,29 @@ type ResourceQuotaStatus struct {
 // ResourceQuota sets aggregate quota restrictions enforced per namespace
 type ResourceQuota struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"`
 
 	// Spec defines the desired quota
-	Spec ResourceQuotaSpec `json:"spec,omitempty" description:"spec defines the desired quota; http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#spec-and-status"`
+	Spec ResourceQuotaSpec `json:"spec,omitempty" description:"spec defines the desired quota; http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#spec-and-status"`
 
 	// Status defines the actual enforced quota and its current usage
-	Status ResourceQuotaStatus `json:"status,omitempty" description:"status defines the actual enforced quota and current usage; http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#spec-and-status"`
+	Status ResourceQuotaStatus `json:"status,omitempty" description:"status defines the actual enforced quota and current usage; http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#spec-and-status"`
 }
 
 // ResourceQuotaList is a list of ResourceQuota items
 type ResourceQuotaList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"`
 
 	// Items is a list of ResourceQuota objects
-	Items []ResourceQuota `json:"items" description:"items is a list of ResourceQuota objects; see http://releases.k8s.io/v1.0.6/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota"`
+	Items []ResourceQuota `json:"items" description:"items is a list of ResourceQuota objects; see http://releases.k8s.io/v1.0.7/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota"`
 }
 
 // Secret holds secret data of a certain type.  The total bytes of the values in
 // the Data field must be less than MaxSecretSize bytes.
 type Secret struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"`
 
 	// Data contains the secret data.  Each key must be a valid DNS_SUBDOMAIN
 	// or leading dot followed by valid DNS_SUBDOMAIN.
@@ -1897,9 +1897,9 @@ const (
 
 type SecretList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"`
 
-	Items []Secret `json:"items" description:"items is a list of secret objects; see http://releases.k8s.io/v1.0.6/docs/user-guide/secrets.md"`
+	Items []Secret `json:"items" description:"items is a list of secret objects; see http://releases.k8s.io/v1.0.7/docs/user-guide/secrets.md"`
 }
 
 // Type and constants for component health validation.
@@ -1920,14 +1920,14 @@ type ComponentCondition struct {
 // ComponentStatus (and ComponentStatusList) holds the cluster validation info.
 type ComponentStatus struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"`
 
 	Conditions []ComponentCondition `json:"conditions,omitempty" description:"list of component conditions observed" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
 type ComponentStatusList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"`
 
 	Items []ComponentStatus `json:"items" description:"list of component status objects"`
 }
@@ -1939,39 +1939,39 @@ type ComponentStatusList struct {
 type SecurityContext struct {
 	// Capabilities are the capabilities to add/drop when running the container
 	// Must match Container.Capabilities or be unset.  Will be defaulted to Container.Capabilities if left unset
-	Capabilities *Capabilities `json:"capabilities,omitempty" description:"the linux capabilites that should be added or removed; see http://releases.k8s.io/v1.0.6/docs/design/security_context.md#security-context"`
+	Capabilities *Capabilities `json:"capabilities,omitempty" description:"the linux capabilites that should be added or removed; see http://releases.k8s.io/v1.0.7/docs/design/security_context.md#security-context"`
 
 	// Run the container in privileged mode
 	// Must match Container.Privileged or be unset.  Will be defaulted to Container.Privileged if left unset
-	Privileged *bool `json:"privileged,omitempty" description:"run the container in privileged mode; see http://releases.k8s.io/v1.0.6/docs/design/security_context.md#security-context"`
+	Privileged *bool `json:"privileged,omitempty" description:"run the container in privileged mode; see http://releases.k8s.io/v1.0.7/docs/design/security_context.md#security-context"`
 
 	// SELinuxOptions are the labels to be applied to the container
 	// and volumes
-	SELinuxOptions *SELinuxOptions `json:"seLinuxOptions,omitempty" description:"options that control the SELinux labels applied; see http://releases.k8s.io/v1.0.6/docs/design/security_context.md#security-context"`
+	SELinuxOptions *SELinuxOptions `json:"seLinuxOptions,omitempty" description:"options that control the SELinux labels applied; see http://releases.k8s.io/v1.0.7/docs/design/security_context.md#security-context"`
 
 	// RunAsUser is the UID to run the entrypoint of the container process.
-	RunAsUser *int64 `json:"runAsUser,omitempty" description:"the user id that runs the first process in the container; see http://releases.k8s.io/v1.0.6/docs/design/security_context.md#security-context"`
+	RunAsUser *int64 `json:"runAsUser,omitempty" description:"the user id that runs the first process in the container; see http://releases.k8s.io/v1.0.7/docs/design/security_context.md#security-context"`
 }
 
 // SELinuxOptions are the labels to be applied to the container
 type SELinuxOptions struct {
 	// SELinux user label
-	User string `json:"user,omitempty" description:"the user label to apply to the container; see http://releases.k8s.io/v1.0.6/docs/user-guide/labels.md"`
+	User string `json:"user,omitempty" description:"the user label to apply to the container; see http://releases.k8s.io/v1.0.7/docs/user-guide/labels.md"`
 
 	// SELinux role label
-	Role string `json:"role,omitempty" description:"the role label to apply to the container; see http://releases.k8s.io/v1.0.6/docs/user-guide/labels.md"`
+	Role string `json:"role,omitempty" description:"the role label to apply to the container; see http://releases.k8s.io/v1.0.7/docs/user-guide/labels.md"`
 
 	// SELinux type label
-	Type string `json:"type,omitempty" description:"the type label to apply to the container; see http://releases.k8s.io/v1.0.6/docs/user-guide/labels.md"`
+	Type string `json:"type,omitempty" description:"the type label to apply to the container; see http://releases.k8s.io/v1.0.7/docs/user-guide/labels.md"`
 
 	// SELinux level label.
-	Level string `json:"level,omitempty" description:"the level label to apply to the container; see http://releases.k8s.io/v1.0.6/docs/user-guide/labels.md"`
+	Level string `json:"level,omitempty" description:"the level label to apply to the container; see http://releases.k8s.io/v1.0.7/docs/user-guide/labels.md"`
 }
 
 // RangeAllocation is not a public type
 type RangeAllocation struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/devel/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/devel/api-conventions.md#metadata"`
 
 	Range string `json:"range" description:"a range string that identifies the range represented by 'data'; required"`
 	Data  []byte `json:"data" description:"a bit array containing all allocated addresses in the previous segment"`

--- a/pkg/api/v1beta3/types.go
+++ b/pkg/api/v1beta3/types.go
@@ -76,7 +76,7 @@ type ListMeta struct {
 	// concurrency and change monitoring endpoints.  Clients must treat these values as opaque
 	// and values may only be valid for a particular resource or set of resources. Only servers
 	// will generate resource versions.
-	ResourceVersion string `json:"resourceVersion,omitempty" description:"string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://releases.k8s.io/v1.0.6/docs/api-conventions.md#concurrency-control-and-consistency"`
+	ResourceVersion string `json:"resourceVersion,omitempty" description:"string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://releases.k8s.io/v1.0.7/docs/api-conventions.md#concurrency-control-and-consistency"`
 }
 
 // ObjectMeta is metadata that all persisted resources must have, which includes all objects
@@ -119,7 +119,7 @@ type ObjectMeta struct {
 	// concurrency, change detection, and the watch operation on a resource or set of resources.
 	// Clients must treat these values as opaque and values may only be valid for a particular
 	// resource or set of resources. Only servers will generate resource versions.
-	ResourceVersion string `json:"resourceVersion,omitempty" description:"string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://releases.k8s.io/v1.0.6/docs/api-conventions.md#concurrency-control-and-consistency"`
+	ResourceVersion string `json:"resourceVersion,omitempty" description:"string that identifies the internal version of this object that can be used by clients to determine when objects have changed; populated by the system, read-only; value must be treated as opaque by clients and passed unmodified back to the server: http://releases.k8s.io/v1.0.7/docs/api-conventions.md#concurrency-control-and-consistency"`
 
 	// A sequence number representing a specific generation of the desired state.
 	// Currently only implemented by replication controllers.
@@ -238,7 +238,7 @@ type PersistentVolumeSource struct {
 
 type PersistentVolume struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"`
 
 	//Spec defines a persistent volume owned by the cluster
 	Spec PersistentVolumeSpec `json:"spec,omitempty" description:"specification of a persistent volume as provisioned by an administrator"`
@@ -289,14 +289,14 @@ type PersistentVolumeStatus struct {
 
 type PersistentVolumeList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#types-kinds"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#types-kinds"`
 	Items    []PersistentVolume `json:"items,omitempty" description:"list of persistent volumes"`
 }
 
 // PersistentVolumeClaim is a user's request for and claim to a persistent volume
 type PersistentVolumeClaim struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"`
 
 	// Spec defines the volume requested by a pod author
 	Spec PersistentVolumeClaimSpec `json:"spec,omitempty" description:"the desired characteristics of a volume"`
@@ -307,7 +307,7 @@ type PersistentVolumeClaim struct {
 
 type PersistentVolumeClaimList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#types-kinds"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#types-kinds"`
 	Items    []PersistentVolumeClaim `json:"items,omitempty" description:"a list of persistent volume claims"`
 }
 
@@ -489,7 +489,7 @@ type GitRepoVolumeSource struct {
 
 // SecretVolumeSource adapts a Secret into a VolumeSource
 //
-// http://releases.k8s.io/v1.0.6/docs/design/secrets.md
+// http://releases.k8s.io/v1.0.7/docs/design/secrets.md
 type SecretVolumeSource struct {
 	// Name of the secret in the pod's namespace to use
 	SecretName string `json:"secretName" description:"secretName is the name of a secret in the pod's namespace"`
@@ -919,30 +919,30 @@ type PodStatus struct {
 // PodStatusResult is a wrapper for PodStatus returned by kubelet that can be encode/decoded
 type PodStatusResult struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"`
 	// Status represents the current information about a pod. This data may not be up
 	// to date.
-	Status PodStatus `json:"status,omitempty" description:"most recently observed status of the pod; populated by the system, read-only; http://releases.k8s.io/v1.0.6/docs/api-conventions.md#spec-and-status"`
+	Status PodStatus `json:"status,omitempty" description:"most recently observed status of the pod; populated by the system, read-only; http://releases.k8s.io/v1.0.7/docs/api-conventions.md#spec-and-status"`
 }
 
 // Pod is a collection of containers that can run on a host. This resource is created
 // by clients and scheduled onto hosts.
 type Pod struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"`
 
 	// Spec defines the behavior of a pod.
-	Spec PodSpec `json:"spec,omitempty" description:"specification of the desired behavior of the pod; http://releases.k8s.io/v1.0.6/docs/api-conventions.md#spec-and-status"`
+	Spec PodSpec `json:"spec,omitempty" description:"specification of the desired behavior of the pod; http://releases.k8s.io/v1.0.7/docs/api-conventions.md#spec-and-status"`
 
 	// Status represents the current information about a pod. This data may not be up
 	// to date.
-	Status PodStatus `json:"status,omitempty" description:"most recently observed status of the pod; populated by the system, read-only; http://releases.k8s.io/v1.0.6/docs/api-conventions.md#spec-and-status"`
+	Status PodStatus `json:"status,omitempty" description:"most recently observed status of the pod; populated by the system, read-only; http://releases.k8s.io/v1.0.7/docs/api-conventions.md#spec-and-status"`
 }
 
 // PodList is a list of Pods.
 type PodList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#types-kinds"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#types-kinds"`
 
 	Items []Pod `json:"items" description:"list of pods"`
 }
@@ -950,25 +950,25 @@ type PodList struct {
 // PodTemplateSpec describes the data a pod should have when created from a template
 type PodTemplateSpec struct {
 	// Metadata of the pods created from this template.
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"`
 
 	// Spec defines the behavior of a pod.
-	Spec PodSpec `json:"spec,omitempty" description:"specification of the desired behavior of the pod; http://releases.k8s.io/v1.0.6/docs/api-conventions.md#spec-and-status"`
+	Spec PodSpec `json:"spec,omitempty" description:"specification of the desired behavior of the pod; http://releases.k8s.io/v1.0.7/docs/api-conventions.md#spec-and-status"`
 }
 
 // PodTemplate describes a template for creating copies of a predefined pod.
 type PodTemplate struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"`
 
 	// Template defines the pods that will be created from this pod template
-	Template PodTemplateSpec `json:"template,omitempty" description:"the template of the desired behavior of the pod; http://releases.k8s.io/v1.0.6/docs/api-conventions.md#spec-and-status"`
+	Template PodTemplateSpec `json:"template,omitempty" description:"the template of the desired behavior of the pod; http://releases.k8s.io/v1.0.7/docs/api-conventions.md#spec-and-status"`
 }
 
 // PodTemplateList is a list of PodTemplates.
 type PodTemplateList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"`
 
 	Items []PodTemplate `json:"items" description:"list of pod templates"`
 }
@@ -1006,20 +1006,20 @@ type ReplicationControllerStatus struct {
 type ReplicationController struct {
 	TypeMeta `json:",inline"`
 	// If the Labels of a ReplicationController are empty, they are defaulted to be the same as the Pod(s) that the replication controller manages.
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"`
 
 	// Spec defines the desired behavior of this replication controller.
-	Spec ReplicationControllerSpec `json:"spec,omitempty" description:"specification of the desired behavior of the replication controller; http://releases.k8s.io/v1.0.6/docs/api-conventions.md#spec-and-status"`
+	Spec ReplicationControllerSpec `json:"spec,omitempty" description:"specification of the desired behavior of the replication controller; http://releases.k8s.io/v1.0.7/docs/api-conventions.md#spec-and-status"`
 
 	// Status is the current status of this replication controller. This data may be
 	// out of date by some window of time.
-	Status ReplicationControllerStatus `json:"status,omitempty" description:"most recently observed status of the replication controller; populated by the system, read-only; http://releases.k8s.io/v1.0.6/docs/api-conventions.md#spec-and-status"`
+	Status ReplicationControllerStatus `json:"status,omitempty" description:"most recently observed status of the replication controller; populated by the system, read-only; http://releases.k8s.io/v1.0.7/docs/api-conventions.md#spec-and-status"`
 }
 
 // ReplicationControllerList is a collection of replication controllers.
 type ReplicationControllerList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"`
 
 	Items []ReplicationController `json:"items" description:"list of replication controllers"`
 }
@@ -1138,13 +1138,13 @@ type ServicePort struct {
 // will answer requests sent through the proxy.
 type Service struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"`
 
 	// Spec defines the behavior of a service.
-	Spec ServiceSpec `json:"spec,omitempty" description:"specification of the desired behavior of the service; http://releases.k8s.io/v1.0.6/docs/api-conventions.md#spec-and-status"`
+	Spec ServiceSpec `json:"spec,omitempty" description:"specification of the desired behavior of the service; http://releases.k8s.io/v1.0.7/docs/api-conventions.md#spec-and-status"`
 
 	// Status represents the current status of a service.
-	Status ServiceStatus `json:"status,omitempty" description:"most recently observed status of the service; populated by the system, read-only; http://releases.k8s.io/v1.0.6/docs/api-conventions.md#spec-and-status"`
+	Status ServiceStatus `json:"status,omitempty" description:"most recently observed status of the service; populated by the system, read-only; http://releases.k8s.io/v1.0.7/docs/api-conventions.md#spec-and-status"`
 }
 
 const (
@@ -1156,7 +1156,7 @@ const (
 // ServiceList holds a list of services.
 type ServiceList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"`
 
 	Items []Service `json:"items" description:"list of services"`
 }
@@ -1167,7 +1167,7 @@ type ServiceList struct {
 // * a set of secrets
 type ServiceAccount struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"`
 
 	// Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount
 	Secrets []ObjectReference `json:"secrets,omitempty" description:"list of secrets that can be used by pods running as this service account" patchStrategy:"merge" patchMergeKey:"name"`
@@ -1181,7 +1181,7 @@ type ServiceAccount struct {
 // ServiceAccountList is a list of ServiceAccount objects
 type ServiceAccountList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"`
 
 	Items []ServiceAccount `json:"items" description:"list of ServiceAccounts"`
 }
@@ -1200,7 +1200,7 @@ type ServiceAccountList struct {
 //  ]
 type Endpoints struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"`
 
 	// The set of all endpoints is the union of all subsets.
 	Subsets []EndpointSubset `json:"subsets" description:"sets of addresses and ports that comprise a service"`
@@ -1247,7 +1247,7 @@ type EndpointPort struct {
 // EndpointsList is a list of endpoints.
 type EndpointsList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"`
 
 	Items []Endpoints `json:"items" description:"list of endpoints"`
 }
@@ -1287,8 +1287,8 @@ type NodeSystemInfo struct {
 // NodeStatus is information about the current status of a node.
 type NodeStatus struct {
 	// Capacity represents the available resources of a node.
-	// see http://releases.k8s.io/v1.0.6/docs/resources.md for more details.
-	Capacity ResourceList `json:"capacity,omitempty" description:"compute resource capacity of the node; http://releases.k8s.io/v1.0.6/docs/resources.md"`
+	// see http://releases.k8s.io/v1.0.7/docs/resources.md for more details.
+	Capacity ResourceList `json:"capacity,omitempty" description:"compute resource capacity of the node; http://releases.k8s.io/v1.0.7/docs/resources.md"`
 	// NodePhase is the current lifecycle phase of the node.
 	Phase NodePhase `json:"phase,omitempty" description:"most recently observed lifecycle phase of the node"`
 	// Conditions is an array of current node conditions.
@@ -1363,19 +1363,19 @@ type ResourceList map[ResourceName]resource.Quantity
 // The name of the node according to etcd is in ID.
 type Node struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"`
 
 	// Spec defines the behavior of a node.
-	Spec NodeSpec `json:"spec,omitempty" description:"specification of a node; http://releases.k8s.io/v1.0.6/docs/api-conventions.md#spec-and-status"`
+	Spec NodeSpec `json:"spec,omitempty" description:"specification of a node; http://releases.k8s.io/v1.0.7/docs/api-conventions.md#spec-and-status"`
 
 	// Status describes the current status of a Node
-	Status NodeStatus `json:"status,omitempty" description:"most recently observed status of the node; populated by the system, read-only; http://releases.k8s.io/v1.0.6/docs/api-conventions.md#spec-and-status"`
+	Status NodeStatus `json:"status,omitempty" description:"most recently observed status of the node; populated by the system, read-only; http://releases.k8s.io/v1.0.7/docs/api-conventions.md#spec-and-status"`
 }
 
 // NodeList is a list of minions.
 type NodeList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"`
 
 	Items []Node `json:"items" description:"list of nodes"`
 }
@@ -1413,19 +1413,19 @@ const (
 // Use of multiple namespaces is optional
 type Namespace struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"`
 
 	// Spec defines the behavior of the Namespace.
-	Spec NamespaceSpec `json:"spec,omitempty" description:"spec defines the behavior of the Namespace; http://releases.k8s.io/v1.0.6/docs/api-conventions.md#spec-and-status"`
+	Spec NamespaceSpec `json:"spec,omitempty" description:"spec defines the behavior of the Namespace; http://releases.k8s.io/v1.0.7/docs/api-conventions.md#spec-and-status"`
 
 	// Status describes the current status of a Namespace
-	Status NamespaceStatus `json:"status,omitempty" description:"status describes the current status of a Namespace; http://releases.k8s.io/v1.0.6/docs/api-conventions.md#spec-and-status"`
+	Status NamespaceStatus `json:"status,omitempty" description:"status describes the current status of a Namespace; http://releases.k8s.io/v1.0.7/docs/api-conventions.md#spec-and-status"`
 }
 
 // NamespaceList is a list of Namespaces.
 type NamespaceList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"`
 
 	// Items is the list of Namespace objects in the list
 	Items []Namespace `json:"items"  description:"items is the list of Namespace objects in the list"`
@@ -1435,7 +1435,7 @@ type NamespaceList struct {
 type Binding struct {
 	TypeMeta `json:",inline"`
 	// ObjectMeta describes the object that is being bound.
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"`
 
 	// Target is the object to bind to.
 	Target ObjectReference `json:"target" description:"an object to bind to"`
@@ -1513,7 +1513,7 @@ type PodProxyOptions struct {
 // Status is a return value for calls that don't return other objects.
 type Status struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"`
 
 	// One of: "Success" or "Failure"
 	Status string `json:"status,omitempty" description:"status of the operation; either Success, or Failure"`
@@ -1671,7 +1671,7 @@ type ObjectReference struct {
 	Name            string    `json:"name,omitempty" description:"name of the referent"`
 	UID             types.UID `json:"uid,omitempty" description:"uid of the referent"`
 	APIVersion      string    `json:"apiVersion,omitempty" description:"API version of the referent"`
-	ResourceVersion string    `json:"resourceVersion,omitempty" description:"specific resourceVersion to which this reference is made, if any: http://releases.k8s.io/v1.0.6/docs/api-conventions.md#concurrency-control-and-consistency"`
+	ResourceVersion string    `json:"resourceVersion,omitempty" description:"specific resourceVersion to which this reference is made, if any: http://releases.k8s.io/v1.0.7/docs/api-conventions.md#concurrency-control-and-consistency"`
 
 	// Optional. If referring to a piece of an object instead of an entire object, this string
 	// should contain information to identify the sub-object. For example, if the object
@@ -1706,7 +1706,7 @@ type EventSource struct {
 // TODO: Decide whether to store these separately or with the object they apply to.
 type Event struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"`
 
 	// Required. The object that this event is about.
 	InvolvedObject ObjectReference `json:"involvedObject" description:"object this event is about"`
@@ -1736,7 +1736,7 @@ type Event struct {
 // EventList is a list of events.
 type EventList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"`
 
 	Items []Event `json:"items" description:"list of events"`
 }
@@ -1744,7 +1744,7 @@ type EventList struct {
 // List holds a list of objects, which may not be known by the server.
 type List struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"`
 
 	Items []runtime.RawExtension `json:"items" description:"list of objects"`
 }
@@ -1780,16 +1780,16 @@ type LimitRangeSpec struct {
 // LimitRange sets resource usage limits for each kind of resource in a Namespace
 type LimitRange struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"`
 
 	// Spec defines the limits enforced
-	Spec LimitRangeSpec `json:"spec,omitempty" description:"spec defines the limits enforced; http://releases.k8s.io/v1.0.6/docs/api-conventions.md#spec-and-status"`
+	Spec LimitRangeSpec `json:"spec,omitempty" description:"spec defines the limits enforced; http://releases.k8s.io/v1.0.7/docs/api-conventions.md#spec-and-status"`
 }
 
 // LimitRangeList is a list of LimitRange items.
 type LimitRangeList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"`
 
 	// Items is a list of LimitRange objects
 	Items []LimitRange `json:"items" description:"items is a list of LimitRange objects"`
@@ -1828,19 +1828,19 @@ type ResourceQuotaStatus struct {
 // ResourceQuota sets aggregate quota restrictions enforced per namespace
 type ResourceQuota struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"`
 
 	// Spec defines the desired quota
-	Spec ResourceQuotaSpec `json:"spec,omitempty" description:"spec defines the desired quota; http://releases.k8s.io/v1.0.6/docs/api-conventions.md#spec-and-status"`
+	Spec ResourceQuotaSpec `json:"spec,omitempty" description:"spec defines the desired quota; http://releases.k8s.io/v1.0.7/docs/api-conventions.md#spec-and-status"`
 
 	// Status defines the actual enforced quota and its current usage
-	Status ResourceQuotaStatus `json:"status,omitempty" description:"status defines the actual enforced quota and current usage; http://releases.k8s.io/v1.0.6/docs/api-conventions.md#spec-and-status"`
+	Status ResourceQuotaStatus `json:"status,omitempty" description:"status defines the actual enforced quota and current usage; http://releases.k8s.io/v1.0.7/docs/api-conventions.md#spec-and-status"`
 }
 
 // ResourceQuotaList is a list of ResourceQuota items
 type ResourceQuotaList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"`
 
 	// Items is a list of ResourceQuota objects
 	Items []ResourceQuota `json:"items" description:"items is a list of ResourceQuota objects"`
@@ -1850,7 +1850,7 @@ type ResourceQuotaList struct {
 // the Data field must be less than MaxSecretSize bytes.
 type Secret struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"`
 
 	// Data contains the secret data.  Each key must be a valid DNS_SUBDOMAIN
 	// or leading dot followed by valid DNS_SUBDOMAIN.
@@ -1901,7 +1901,7 @@ const (
 
 type SecretList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"`
 
 	Items []Secret `json:"items" description:"items is a list of secret objects"`
 }
@@ -1924,14 +1924,14 @@ type ComponentCondition struct {
 // ComponentStatus (and ComponentStatusList) holds the cluster validation info.
 type ComponentStatus struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"`
 
 	Conditions []ComponentCondition `json:"conditions,omitempty" description:"list of component conditions observed" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
 type ComponentStatusList struct {
 	TypeMeta `json:",inline"`
-	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"`
+	ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"`
 
 	Items []ComponentStatus `json:"items" description:"list of component status objects"`
 }
@@ -1975,7 +1975,7 @@ type SELinuxOptions struct {
 // RangeAllocation is not a public type
 type RangeAllocation struct {
 	TypeMeta   `json:",inline"`
-	ObjectMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.6/docs/api-conventions.md#metadata"`
+	ObjectMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.0.7/docs/api-conventions.md#metadata"`
 
 	Range string `json:"range" description:"a range string that identifies the range represented by 'data'; required"`
 	Data  []byte `json:"data" description:"a bit array containing all allocated addresses in the previous segment"`

--- a/pkg/version/base.go
+++ b/pkg/version/base.go
@@ -40,7 +40,7 @@ var (
 	// scripts consuming the kubectl version output - but most of
 	// these should be looking at gitVersion already anyways.)
 	gitMajor string = "1"   // major version, always numeric
-	gitMinor string = "0.6" // minor version, numeric possibly followed by "+"
+	gitMinor string = "0.7" // minor version, numeric possibly followed by "+"
 
 	// semantic version, dervied by build scripts (see
 	// https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/design/versioning.md
@@ -51,7 +51,7 @@ var (
 	// semantic version is a git hash, but the version itself is no
 	// longer the direct output of "git describe", but a slight
 	// translation to be semver compliant.
-	gitVersion   string = "v1.0.6-release-1.0+$Format:%h$"
+	gitVersion   string = "v1.0.7-release-1.0+$Format:%h$"
 	gitCommit    string = "$Format:%H$"    // sha1 from git, output of $(git rev-parse HEAD)
 	gitTreeState string = "not a git tree" // state of git tree, either "clean" or "dirty"
 )


### PR DESCRIPTION
This is the PR to get the `release-1.0` branch up to `v1.0.7`.

Included cherry picks:
- Set rlimit for openfile handles to 64k #14191 (ArtfulCoder)
- fixed log format #14882 (ArtfulCoder)
- Added UdpIdleTimeout flag #15797 (ArtfulCoder)
- Add a cloud-provider hook to scrub DNS for pods #16219 (thockin)
- AWS: Create one storage pool for aufs, not two #13803 (justinsb)
- Rename e2e-gce-release job to e2e-gce-release-1.0 #15410 (jlowdermilk)
- Add script to use gcloud to print GCP resources used, and call in Jenkins runs #15189 (ixdy)
- Adding retry logic around service updates #11077 (krousey)
- Use the cluster name instead of the minion tag as the prefix for the firewall rules created in gke e2e tests #14333 (roberthbailey)
- Fix typo that caused an error at end of vagrant up #13154 (derekwaynecarr)
- Stop allowing unnamespaced POST for namespaced objects #11252 (nikhiljindal)
- Move Vagrant provider to Flannel #13986 (derekwaynecarr)
- Don't reuse credentials on cluster create #13068 (jlowdermilk)
- Add config for the main gke jenkins jobs to e2e.sh #13863 (jlowdermilk)
- rate-limit events record in kubelet #13192 (jiangyaoguo)

plus other commits.  Do `git log v1.0.6..v1.0.7` on the `release-1.0` branch for full list of changes.
