### PR TITLE
Kubelet ipnet

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2461,7 +2461,7 @@ func (kl *Kubelet) setNodeStatus(node *api.Node) error {
 		}
 		addresses, err := kl.getNodeAddress(addr)
 		if err != nil || len(addresses) == 0 {
-			return err
+			return fmt.Errorf("can't get ip network of node %s", node.Name)
 		}
 		node.Status.Addresses = addresses
 	}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2387,6 +2387,32 @@ func (kl *Kubelet) syncNetworkStatus() {
 	kl.networkConfigured = networkConfigured
 }
 
+func (kl *kubelet) getNodeAddress(addr net.IP) ([]api.NodeAddress, error) {
+	var addresses []api.NodeAddress
+	ifaces, err := net.Interface()
+	if err != nil {
+		return []api.NodeAddress{}, err
+	}
+	for _, i := range ifaces {
+		addrs, err := i.Addrs()
+		if err == nil {
+			for _, addr := range addrs {
+				if addrOrigin, ok := addr.(*net.IPNet); ok {
+					if addrOrigin.IP.Equal(addr) {
+						addresses = []api.NodeAddress{
+							api.NodeAddress{api.NodeLegacyHostIP, addrOrigin.String()},
+							api.NodeAddress{api.NodeInternalIP, addrOrigin.String()},
+						}
+						break FIND
+					}
+				}
+			}
+		}
+	}
+FIND:
+	return addresses, nil
+}
+
 // setNodeStatus fills in the Status fields of the given Node, overwriting
 // any fields that are currently set.
 func (kl *Kubelet) setNodeStatus(node *api.Node) error {
@@ -2406,47 +2432,38 @@ func (kl *Kubelet) setNodeStatus(node *api.Node) error {
 		node.Status.Addresses = nodeAddresses
 	} else {
 		addr := net.ParseIP(kl.hostname)
-		if addr != nil {
-			node.Status.Addresses = []api.NodeAddress{
-				{Type: api.NodeLegacyHostIP, Address: addr.String()},
-				{Type: api.NodeInternalIP, Address: addr.String()},
-			}
-		} else {
+		if addr == nil {
 			addrs, err := net.LookupIP(node.Name)
 			if err != nil {
 				return fmt.Errorf("can't get ip address of node %s: %v", node.Name, err)
 			} else if len(addrs) == 0 {
 				return fmt.Errorf("no ip address for node %v", node.Name)
-			} else {
-				// check all ip addresses for this node.Name and try to find the first non-loopback IPv4 address.
-				// If no match is found, it uses the IP of the interface with gateway on it.
-				for _, ip := range addrs {
-					if ip.IsLoopback() {
-						continue
-					}
-
-					if ip.To4() != nil {
-						node.Status.Addresses = []api.NodeAddress{
-							{Type: api.NodeLegacyHostIP, Address: ip.String()},
-							{Type: api.NodeInternalIP, Address: ip.String()},
-						}
-						break
-					}
+			}
+			// check all ip addresses for this node.Name and try to find the first non-loopback IPv4 address.
+			// If no match is found, it uses the IP of the interface with gateway on it.
+			for _, ip := range addrs {
+				if ip.IsLoopback() {
+					continue
 				}
 
-				if len(node.Status.Addresses) == 0 {
-					ip, err := util.ChooseHostInterface()
-					if err != nil {
-						return err
-					}
-
-					node.Status.Addresses = []api.NodeAddress{
-						{Type: api.NodeLegacyHostIP, Address: ip.String()},
-						{Type: api.NodeInternalIP, Address: ip.String()},
-					}
+				if ip.To4() != nil {
+					addr = ip
+					break
 				}
 			}
+			if addr == nil {
+				ip, err := util.ChooseHostInterface()
+				if err != nil {
+					return err
+				}
+				addr = ip
+			}
 		}
+		addresses, err := kl.getNodeAddress(addr)
+		if err != nil || len(addresses) == 0 {
+			return err
+		}
+		node.Status.Addresses = addresses
 	}
 
 	// TODO: Post NotReady if we cannot get MachineInfo from cAdvisor. This needs to start


### PR DESCRIPTION
kubelet report node's ipnetwork instead of ip address. This can help scheduler to deploy pods among different subnets, because of most IDC production env get each switch has a individual subnet, Shceduler can add a priority for making less pods down when a switch down.
