### PR TITLE
kubelet report node's ipnetwork instead of ip

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2385,6 +2385,33 @@ func (kl *Kubelet) syncNetworkStatus() {
 	kl.networkConfigured = networkConfigured
 }
 
+func (kl *Kubelet) getNodeAddress(ip net.IP) ([]api.NodeAddress, error) {
+	var addresses []api.NodeAddress
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return []api.NodeAddress{}, err
+	}
+FIND:
+	for _, i := range ifaces {
+		addrs, err := i.Addrs()
+		if err == nil {
+			for _, addr := range addrs {
+				if addrOri, ok := addr.(*net.IPNet); ok {
+					if addrOri.IP.Equal(ip) {
+						addresses = []api.NodeAddress{
+							api.NodeAddress{api.NodeLegacyHostIP, addrOri.String()},
+							api.NodeAddress{api.NodeInternalIP, addrOri.String()},
+						}
+						break FIND
+					}
+				}
+			}
+		}
+	}
+
+	return addresses, nil
+}
+
 // setNodeStatus fills in the Status fields of the given Node, overwriting
 // any fields that are currently set.
 func (kl *Kubelet) setNodeStatus(node *api.Node) error {
@@ -2404,47 +2431,38 @@ func (kl *Kubelet) setNodeStatus(node *api.Node) error {
 		node.Status.Addresses = nodeAddresses
 	} else {
 		addr := net.ParseIP(kl.hostname)
-		if addr != nil {
-			node.Status.Addresses = []api.NodeAddress{
-				{Type: api.NodeLegacyHostIP, Address: addr.String()},
-				{Type: api.NodeInternalIP, Address: addr.String()},
-			}
-		} else {
+		if addr == nil {
 			addrs, err := net.LookupIP(node.Name)
 			if err != nil {
 				return fmt.Errorf("can't get ip address of node %s: %v", node.Name, err)
 			} else if len(addrs) == 0 {
 				return fmt.Errorf("no ip address for node %v", node.Name)
-			} else {
-				// check all ip addresses for this node.Name and try to find the first non-loopback IPv4 address.
-				// If no match is found, it uses the IP of the interface with gateway on it.
-				for _, ip := range addrs {
-					if ip.IsLoopback() {
-						continue
-					}
-
-					if ip.To4() != nil {
-						node.Status.Addresses = []api.NodeAddress{
-							{Type: api.NodeLegacyHostIP, Address: ip.String()},
-							{Type: api.NodeInternalIP, Address: ip.String()},
-						}
-						break
-					}
+			}
+			// check all ip addresses for this node.Name and try to find the first non-loopback IPv4 address.
+			// If no match is found, it uses the IP of the interface with gateway on it.
+			for _, ip := range addrs {
+				if ip.IsLoopback() {
+					continue
 				}
 
-				if len(node.Status.Addresses) == 0 {
-					ip, err := util.ChooseHostInterface()
-					if err != nil {
-						return err
-					}
-
-					node.Status.Addresses = []api.NodeAddress{
-						{Type: api.NodeLegacyHostIP, Address: ip.String()},
-						{Type: api.NodeInternalIP, Address: ip.String()},
-					}
+				if ip.To4() != nil {
+					addr = ip
+					break
 				}
 			}
+			if addr == nil {
+				ip, err := util.ChooseHostInterface()
+				if err != nil {
+					return err
+				}
+				addr = ip
+			}
 		}
+		addresses, err := kl.getNodeAddress(addr)
+		if err != nil || len(addresses) == 0 {
+			return fmt.Errorf("can't get ip network of node %s", node.Name)
+		}
+		node.Status.Addresses = addresses
 	}
 
 	// TODO: Post NotReady if we cannot get MachineInfo from cAdvisor. This needs to start

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2399,8 +2399,8 @@ FIND:
 				if addrOri, ok := addr.(*net.IPNet); ok {
 					if addrOri.IP.Equal(ip) {
 						addresses = []api.NodeAddress{
-							api.NodeAddress{api.NodeLegacyHostIP, addrOri.String()},
-							api.NodeAddress{api.NodeInternalIP, addrOri.String()},
+							{api.NodeLegacyHostIP, addrOri.String()},
+							{api.NodeInternalIP, addrOri.String()},
 						}
 						break FIND
 					}


### PR DESCRIPTION
kubelet report node's ipnetwork instead of ip. This can help scheduler to deploy pods among different subnets, because of most IDC production env get each switch has a individual subnet, This priority can make less pods down when a switch down
