### PR TITLE
Revert "Merge pull request #16358 from kubernetes/revert-16084-improve_e2e"

### DIFF
--- a/test/e2e/container_probe.go
+++ b/test/e2e/container_probe.go
@@ -29,16 +29,13 @@ import (
 )
 
 var _ = Describe("Probing container", func() {
-	framework := Framework{BaseName: "container-probe"}
+	framework := NewFramework("container-probe")
 	var podClient client.PodInterface
 	probe := webserverProbeBuilder{}
 
 	BeforeEach(func() {
-		framework.beforeEach()
 		podClient = framework.Client.Pods(framework.Namespace.Name)
 	})
-
-	AfterEach(framework.afterEach)
 
 	It("with readiness probe should not be ready before initial delay and never restart [Conformance]", func() {
 		p, err := podClient.Create(makePodSpec(probe.withInitialDelay().build(), nil))

--- a/test/e2e/daemon_restart.go
+++ b/test/e2e/daemon_restart.go
@@ -185,7 +185,7 @@ func getContainerRestarts(c *client.Client, ns string, labelSelector labels.Sele
 
 var _ = Describe("DaemonRestart", func() {
 
-	framework := Framework{BaseName: "daemonrestart"}
+	framework := NewFramework("daemonrestart")
 	rcName := "daemonrestart" + strconv.Itoa(numPods) + "-" + string(util.NewUUID())
 	labelSelector := labels.Set(map[string]string{"name": rcName}).AsSelector()
 	existingPods := cache.NewStore(cache.MetaNamespaceKeyFunc)
@@ -197,11 +197,9 @@ var _ = Describe("DaemonRestart", func() {
 	var tracker *podTracker
 
 	BeforeEach(func() {
-
 		// These tests require SSH
 		// TODO(11834): Enable this test in GKE once experimental API there is switched on
 		SkipUnlessProviderIs("gce", "aws")
-		framework.beforeEach()
 		ns = framework.Namespace.Name
 
 		// All the restart tests need an rc and a watch on pods of the rc.
@@ -246,9 +244,7 @@ var _ = Describe("DaemonRestart", func() {
 	})
 
 	AfterEach(func() {
-		defer framework.afterEach()
 		close(stopCh)
-		expectNoError(DeleteRC(framework.Client, ns, rcName))
 	})
 
 	It("Controller Manager should not create/delete replicas across restart", func() {

--- a/test/e2e/daemon_set.go
+++ b/test/e2e/daemon_set.go
@@ -48,7 +48,14 @@ const (
 )
 
 var _ = Describe("Daemon set", func() {
-	f := &Framework{BaseName: "daemonsets"}
+	var f *Framework
+
+	AfterEach(func() {
+		err := clearDaemonSetNodeLabels(f.Client)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	f = NewFramework("daemonsets")
 
 	image := "gcr.io/google_containers/serve_hostname:1.1"
 	dsName := "daemon-set"
@@ -57,16 +64,9 @@ var _ = Describe("Daemon set", func() {
 	var c *client.Client
 
 	BeforeEach(func() {
-		f.beforeEach()
 		ns = f.Namespace.Name
 		c = f.Client
 		err := clearDaemonSetNodeLabels(c)
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	AfterEach(func() {
-		defer f.afterEach()
-		err := clearDaemonSetNodeLabels(f.Client)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/test/e2e/density.go
+++ b/test/e2e/density.go
@@ -80,10 +80,39 @@ var _ = Describe("Density", func() {
 	var additionalPodsPrefix string
 	var ns string
 	var uuid string
-	framework := Framework{BaseName: "density", NamespaceDeletionTimeout: time.Hour}
+
+	// Gathers data prior to framework namespace teardown
+	AfterEach(func() {
+		// Remove any remaining pods from this test if the
+		// replication controller still exists and the replica count
+		// isn't 0.  This means the controller wasn't cleaned up
+		// during the test so clean it up here. We want to do it separately
+		// to not cause a timeout on Namespace removal.
+		rc, err := c.ReplicationControllers(ns).Get(RCName)
+		if err == nil && rc.Spec.Replicas != 0 {
+			By("Cleaning up the replication controller")
+			err := DeleteRC(c, ns, RCName)
+			expectNoError(err)
+		}
+
+		By("Removing additional pods if any")
+		for i := 1; i <= nodeCount; i++ {
+			name := additionalPodsPrefix + "-" + strconv.Itoa(i)
+			c.Pods(ns).Delete(name, nil)
+		}
+
+		expectNoError(writePerfData(c, fmt.Sprintf(testContext.OutputDir+"/%s", uuid), "after"))
+
+		// Verify latency metrics
+		highLatencyRequests, err := HighLatencyRequests(c)
+		expectNoError(err)
+		Expect(highLatencyRequests).NotTo(BeNumerically(">", 0), "There should be no high-latency requests")
+	})
+
+	framework := NewFramework("density")
+	framework.NamespaceDeletionTimeout = time.Hour
 
 	BeforeEach(func() {
-		framework.beforeEach()
 		c = framework.Client
 		ns = framework.Namespace.Name
 		var err error
@@ -113,37 +142,6 @@ var _ = Describe("Density", func() {
 				}
 			}
 		}
-	})
-
-	AfterEach(func() {
-		// We can't call it explicitly at the end, because it will not be called
-		// if Expect() fails.
-		defer framework.afterEach()
-
-		// Remove any remaining pods from this test if the
-		// replication controller still exists and the replica count
-		// isn't 0.  This means the controller wasn't cleaned up
-		// during the test so clean it up here. We want to do it separately
-		// to not cause a timeout on Namespace removal.
-		rc, err := c.ReplicationControllers(ns).Get(RCName)
-		if err == nil && rc.Spec.Replicas != 0 {
-			By("Cleaning up the replication controller")
-			err := DeleteRC(c, ns, RCName)
-			expectNoError(err)
-		}
-
-		By("Removing additional pods if any")
-		for i := 1; i <= nodeCount; i++ {
-			name := additionalPodsPrefix + "-" + strconv.Itoa(i)
-			c.Pods(ns).Delete(name, nil)
-		}
-
-		expectNoError(writePerfData(c, fmt.Sprintf(testContext.OutputDir+"/%s", uuid), "after"))
-
-		// Verify latency metrics
-		highLatencyRequests, err := HighLatencyRequests(c)
-		expectNoError(err)
-		Expect(highLatencyRequests).NotTo(BeNumerically(">", 0), "There should be no high-latency requests")
 	})
 
 	// Tests with "Skipped" substring in their name will be skipped when running

--- a/test/e2e/etcd_failure.go
+++ b/test/e2e/etcd_failure.go
@@ -31,7 +31,7 @@ import (
 var _ = Describe("Etcd failure", func() {
 
 	var skipped bool
-	framework := Framework{BaseName: "etcd-failure"}
+	framework := NewFramework("etcd-failure")
 
 	BeforeEach(func() {
 		// This test requires:
@@ -43,8 +43,6 @@ var _ = Describe("Etcd failure", func() {
 		SkipUnlessProviderIs("gce")
 		skipped = false
 
-		framework.beforeEach()
-
 		Expect(RunRC(RCConfig{
 			Client:    framework.Client,
 			Name:      "baz",
@@ -52,14 +50,6 @@ var _ = Describe("Etcd failure", func() {
 			Image:     "beta.gcr.io/google_containers/pause:2.0",
 			Replicas:  1,
 		})).NotTo(HaveOccurred())
-	})
-
-	AfterEach(func() {
-		if skipped {
-			return
-		}
-
-		framework.afterEach()
 	})
 
 	It("should recover from network partition with master", func() {
@@ -79,12 +69,12 @@ var _ = Describe("Etcd failure", func() {
 	})
 })
 
-func etcdFailTest(framework Framework, failCommand, fixCommand string) {
+func etcdFailTest(framework *Framework, failCommand, fixCommand string) {
 	doEtcdFailure(failCommand, fixCommand)
 
 	checkExistingRCRecovers(framework)
 
-	ServeImageOrFail(&framework, "basic", "gcr.io/google_containers/serve_hostname:1.1")
+	ServeImageOrFail(framework, "basic", "gcr.io/google_containers/serve_hostname:1.1")
 }
 
 // For this duration, etcd will be failed by executing a failCommand on the master.
@@ -110,7 +100,7 @@ func masterExec(cmd string) {
 	}
 }
 
-func checkExistingRCRecovers(f Framework) {
+func checkExistingRCRecovers(f *Framework) {
 	By("assert that the pre-existing replication controller recovers")
 	podClient := f.Client.Pods(f.Namespace.Name)
 	rcSelector := labels.Set{"name": "baz"}.AsSelector()

--- a/test/e2e/latency.go
+++ b/test/e2e/latency.go
@@ -45,10 +45,31 @@ var _ = Describe("[Performance Suite] Latency", func() {
 	var additionalPodsPrefix string
 	var ns string
 	var uuid string
-	framework := Framework{BaseName: "latency", NamespaceDeletionTimeout: time.Hour}
+
+	AfterEach(func() {
+		By("Removing additional pods if any")
+		for i := 1; i <= nodeCount; i++ {
+			name := additionalPodsPrefix + "-" + strconv.Itoa(i)
+			c.Pods(ns).Delete(name, nil)
+		}
+
+		By(fmt.Sprintf("Destroying namespace for this suite %v", ns))
+		if err := c.Namespaces().Delete(ns); err != nil {
+			Failf("Couldn't delete ns %s", err)
+		}
+
+		expectNoError(writePerfData(c, fmt.Sprintf(testContext.OutputDir+"/%s", uuid), "after"))
+
+		// Verify latency metrics
+		highLatencyRequests, err := HighLatencyRequests(c)
+		expectNoError(err)
+		Expect(highLatencyRequests).NotTo(BeNumerically(">", 0), "There should be no high-latency requests")
+	})
+
+	framework := NewFramework("latency")
+	framework.NamespaceDeletionTimeout = time.Hour
 
 	BeforeEach(func() {
-		framework.beforeEach()
 		c = framework.Client
 		ns = framework.Namespace.Name
 		var err error
@@ -77,27 +98,6 @@ var _ = Describe("[Performance Suite] Latency", func() {
 				}
 			}
 		}
-	})
-
-	AfterEach(func() {
-		defer framework.afterEach()
-		By("Removing additional pods if any")
-		for i := 1; i <= nodeCount; i++ {
-			name := additionalPodsPrefix + "-" + strconv.Itoa(i)
-			c.Pods(ns).Delete(name, nil)
-		}
-
-		By(fmt.Sprintf("Destroying namespace for this suite %v", ns))
-		if err := c.Namespaces().Delete(ns); err != nil {
-			Failf("Couldn't delete ns %s", err)
-		}
-
-		expectNoError(writePerfData(c, fmt.Sprintf(testContext.OutputDir+"/%s", uuid), "after"))
-
-		// Verify latency metrics
-		highLatencyRequests, err := HighLatencyRequests(c)
-		expectNoError(err)
-		Expect(highLatencyRequests).NotTo(BeNumerically(">", 0), "There should be no high-latency requests")
 	})
 
 	// Skipped to avoid running in e2e

--- a/test/e2e/resize_nodes.go
+++ b/test/e2e/resize_nodes.go
@@ -384,17 +384,14 @@ func performTemporaryNetworkFailure(c *client.Client, ns, rcName string, replica
 }
 
 var _ = Describe("Nodes", func() {
-	framework := Framework{BaseName: "resize-nodes"}
+	framework := NewFramework("resize-nodes")
 	var c *client.Client
 	var ns string
 
 	BeforeEach(func() {
-		framework.beforeEach()
 		c = framework.Client
 		ns = framework.Namespace.Name
 	})
-
-	AfterEach(framework.afterEach)
 
 	Describe("Resize", func() {
 		var skipped bool

--- a/test/e2e/scheduler_predicates.go
+++ b/test/e2e/scheduler_predicates.go
@@ -175,30 +175,29 @@ func waitForStableCluster(c *client.Client) int {
 }
 
 var _ = Describe("SchedulerPredicates", func() {
-	framework := Framework{BaseName: "sched-pred"}
 	var c *client.Client
 	var nodeList *api.NodeList
 	var totalPodCapacity int64
 	var RCName string
 	var ns string
 
-	BeforeEach(func() {
-		framework.beforeEach()
-		c = framework.Client
-		ns = framework.Namespace.Name
-		var err error
-		nodeList, err = c.Nodes().List(labels.Everything(), fields.Everything())
-		expectNoError(err)
-	})
-
 	AfterEach(func() {
-		defer framework.afterEach()
 		rc, err := c.ReplicationControllers(ns).Get(RCName)
 		if err == nil && rc.Spec.Replicas != 0 {
 			By("Cleaning up the replication controller")
 			err := DeleteRC(c, ns, RCName)
 			expectNoError(err)
 		}
+	})
+
+	framework := NewFramework("sched-pred")
+
+	BeforeEach(func() {
+		c = framework.Client
+		ns = framework.Namespace.Name
+		var err error
+		nodeList, err = c.Nodes().List(labels.Everything(), fields.Everything())
+		expectNoError(err)
 	})
 
 	// This test verifies that max-pods flag works as advertised. It assumes that cluster add-on pods stay stable

--- a/test/e2e/serviceloadbalancers.go
+++ b/test/e2e/serviceloadbalancers.go
@@ -210,17 +210,12 @@ var _ = Describe("ServiceLoadBalancer", func() {
 	var repoRoot string
 	var client *client.Client
 
-	framework := Framework{BaseName: "servicelb"}
+	framework := NewFramework("servicelb")
 
 	BeforeEach(func() {
-		framework.beforeEach()
 		client = framework.Client
 		ns = framework.Namespace.Name
 		repoRoot = testContext.RepoRoot
-	})
-
-	AfterEach(func() {
-		framework.afterEach()
 	})
 
 	It("should support simple GET on Ingress ips", func() {


### PR DESCRIPTION
Deleted unneeded removal of ReplicationController in `test/e2e/daemon_restart.go`, which tried to use already destroyed framework. L251

This reverts commit 465c5b0791f997a1a0e64ca42b7a7e16ff5bc672, reversing
changes made to 154923221f31e24c1594edc8e3a91dd53cf5abab.

cc @jszczepkowski @smarterclayton @lavalamp 
