### PR TITLE
flake: Disable flaky service e2e per #16285

### DIFF
--- a/hack/jenkins/e2e.sh
+++ b/hack/jenkins/e2e.sh
@@ -177,6 +177,7 @@ GCE_PARALLEL_FLAKY_TESTS=(
     "PD"
     "ServiceAccounts"
     "Networking\sshould\sfunction\sfor\sintra-pod\scommunication"  # possibly causing Ginkgo to get stuck, issue: #13485
+    "Services.*identically\snamed" # error waiting for reachability, issue: #16285
     )
 
 # Tests that should not run on soak cluster.


### PR DESCRIPTION
Disables "Services should serve identically named services in different namespaces on different load-balancers" via `GCE_PARALLEL_FLAKY_TESTS`.
