### PR TITLE
Add TypeMeta to discovery response objects

### DIFF
--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -71,6 +71,10 @@ func init() {
 
 	// Register Unversioned types
 	Scheme.AddKnownTypes("", &unversioned.Status{})
+	Scheme.AddKnownTypes("", &unversioned.APIVersions{})
+	Scheme.AddKnownTypes("", &unversioned.APIGroupList{})
+	Scheme.AddKnownTypes("", &unversioned.APIGroup{})
+	Scheme.AddKnownTypes("", &unversioned.APIResourceList{})
 }
 
 func (*Pod) IsAnAPIObject()                       {}

--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/sets"
@@ -94,6 +95,7 @@ func roundTripSame(t *testing.T, item runtime.Object, except ...string) {
 	codec, err := testapi.GetCodecForObject(item)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
+		return
 	}
 
 	version := testapi.Default.Version()
@@ -201,6 +203,37 @@ func TestBadJSONRejection(t *testing.T) {
 	if err2 := DecodeInto(badJSONKindMismatch, &Minion{}); err2 == nil {
 		t.Errorf("Kind is set but doesn't match the object type: %s", badJSONKindMismatch)
 	}*/
+}
+
+func TestUnversionedTypes(t *testing.T) {
+	testcases := []runtime.Object{
+		&unversioned.Status{Status: "Failure", Message: "something went wrong"},
+		&unversioned.APIVersions{Versions: []string{"A", "B", "C"}},
+		&unversioned.APIGroupList{Groups: []unversioned.APIGroup{{Name: "mygroup"}}},
+		&unversioned.APIGroup{Name: "mygroup"},
+		&unversioned.APIResourceList{GroupVersion: "mygroup/myversion"},
+	}
+
+	for _, obj := range testcases {
+		// Make sure the unversioned codec can encode
+		unversionedJSON, err := api.Codec.Encode(obj)
+		if err != nil {
+			t.Errorf("%v: unexpected error: %v", obj, err)
+			continue
+		}
+
+		// Make sure the versioned codec under test can decode
+		versionDecodedObject, err := testapi.Default.Codec().Decode(unversionedJSON)
+		if err != nil {
+			t.Errorf("%v: unexpected error: %v", obj, err)
+			continue
+		}
+		// Make sure it decodes correctly
+		if !reflect.DeepEqual(obj, versionDecodedObject) {
+			t.Errorf("%v: expected %#v, got %#v", obj, obj, versionDecodedObject)
+			continue
+		}
+	}
 }
 
 const benchmarkSeed = 100

--- a/pkg/api/testapi/testapi.go
+++ b/pkg/api/testapi/testapi.go
@@ -225,5 +225,9 @@ func GetCodecForObject(obj runtime.Object) (runtime.Codec, error) {
 			return group.Codec(), nil
 		}
 	}
+	// Codec used for unversioned types
+	if api.Scheme.Recognizes("", kind) {
+		return api.Codec, nil
+	}
 	return nil, fmt.Errorf("unexpected kind: %v", kind)
 }

--- a/pkg/api/unversioned/types.go
+++ b/pkg/api/unversioned/types.go
@@ -270,11 +270,16 @@ const (
 	CauseTypeUnexpectedServerResponse CauseType = "UnexpectedServerResponse"
 )
 
-func (*Status) IsAnAPIObject() {}
+func (*Status) IsAnAPIObject()          {}
+func (*APIVersions) IsAnAPIObject()     {}
+func (*APIGroupList) IsAnAPIObject()    {}
+func (*APIGroup) IsAnAPIObject()        {}
+func (*APIResourceList) IsAnAPIObject() {}
 
 // APIVersions lists the versions that are available, to allow clients to
 // discover the API at /api, which is the root path of the legacy v1 API.
 type APIVersions struct {
+	TypeMeta `json:",inline"`
 	// versions are the api versions that are available.
 	Versions []string `json:"versions"`
 }
@@ -282,6 +287,7 @@ type APIVersions struct {
 // APIGroupList is a list of APIGroup, to allow clients to discover the API at
 // /apis.
 type APIGroupList struct {
+	TypeMeta `json:",inline"`
 	// groups is a list of APIGroup.
 	Groups []APIGroup `json:"groups"`
 }
@@ -289,6 +295,7 @@ type APIGroupList struct {
 // APIGroup contains the name, the supported versions, and the preferred version
 // of a group.
 type APIGroup struct {
+	TypeMeta `json:",inline"`
 	// name is the name of the group.
 	Name string `json:"name"`
 	// versions are the versions supported in this group.
@@ -320,6 +327,7 @@ type APIResource struct {
 // resources supported in a specific group and version, and if the resource
 // is namespaced.
 type APIResourceList struct {
+	TypeMeta `json:",inline"`
 	// groupVersion is the group and version this APIResourceList is for.
 	GroupVersion string `json:"groupVersion"`
 	// resources contains the name of the resources and if they are namespaced.

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -306,7 +306,7 @@ func handleVersion(req *restful.Request, resp *restful.Response) {
 func APIVersionHandler(versions ...string) restful.RouteFunction {
 	return func(req *restful.Request, resp *restful.Response) {
 		// TODO: use restful's Response methods
-		writeRawJSON(http.StatusOK, unversioned.APIVersions{Versions: versions}, resp.ResponseWriter)
+		writeJSON(http.StatusOK, api.Codec, &unversioned.APIVersions{Versions: versions}, resp.ResponseWriter, true)
 	}
 }
 
@@ -314,7 +314,7 @@ func APIVersionHandler(versions ...string) restful.RouteFunction {
 func RootAPIHandler(groups []unversioned.APIGroup) restful.RouteFunction {
 	return func(req *restful.Request, resp *restful.Response) {
 		// TODO: use restful's Response methods
-		writeRawJSON(http.StatusOK, unversioned.APIGroupList{Groups: groups}, resp.ResponseWriter)
+		writeJSON(http.StatusOK, api.Codec, &unversioned.APIGroupList{Groups: groups}, resp.ResponseWriter, true)
 	}
 }
 
@@ -323,7 +323,7 @@ func RootAPIHandler(groups []unversioned.APIGroup) restful.RouteFunction {
 func GroupHandler(group unversioned.APIGroup) restful.RouteFunction {
 	return func(req *restful.Request, resp *restful.Response) {
 		// TODO: use restful's Response methods
-		writeRawJSON(http.StatusOK, group, resp.ResponseWriter)
+		writeJSON(http.StatusOK, api.Codec, &group, resp.ResponseWriter, true)
 	}
 }
 
@@ -331,7 +331,7 @@ func GroupHandler(group unversioned.APIGroup) restful.RouteFunction {
 func SupportedResourcesHandler(groupVersion string, apiResources []unversioned.APIResource) restful.RouteFunction {
 	return func(req *restful.Request, resp *restful.Response) {
 		// TODO: use restful's Response methods
-		writeRawJSON(http.StatusOK, unversioned.APIResourceList{GroupVersion: groupVersion, APIResources: apiResources}, resp.ResponseWriter)
+		writeJSON(http.StatusOK, api.Codec, &unversioned.APIResourceList{GroupVersion: groupVersion, APIResources: apiResources}, resp.ResponseWriter, true)
 	}
 }
 


### PR DESCRIPTION
Fixes #16321

This will let us use a standard codec to read discovery documents under `/apis`
It also adds tests to make sure versioned codecs can read unversioned responses

For reference, this is what a 1.0 server returns:

```
http://localhost:8080/api/
{
  "versions": [
    "v1"
  ]
}

http://localhost:8080/api/v1/
{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {},
  "status": "Failure",
  "message": "the server could not find the requested resource",
  "reason": "NotFound",
  "details": {},
  "code": 404
}
```

With this PR:

```
http://localhost:8080/api/
{
  "kind": "APIVersions",
  "versions": [
    "v1"
  ]
}

http://localhost:8080/api/v1/
{
  "kind": "APIResourceList",
  "groupVersion": "v1",
  "resources": [
    {
      "name": "bindings",
      "namespaced": true
    },
    ...
}

http://localhost:8080/apis/
{
  "kind": "APIGroupList",
  "groups": [
    {
      "name": "extensions",
      "versions": [
        {
          "groupVersion": "extensions/v1beta1",
          "version": "v1beta1"
        }
      ],
      "preferredVersion": {
        "groupVersion": "extensions/v1beta1",
        "version": "v1beta1"
      }
    }
  ]
}

http://localhost:8080/apis/extensions/
{
  "kind": "APIGroup",
  "name": "extensions",
  "versions": [
    {
      "groupVersion": "extensions/v1beta1",
      "version": "v1beta1"
    }
  ],
  "preferredVersion": {
    "groupVersion": "extensions/v1beta1",
    "version": "v1beta1"
  }
}

http://localhost:8080/apis/extensions/v1beta1/
{
  "kind": "APIResourceList",
  "groupVersion": "extensions/v1beta1",
  "resources": [
    {
      "name": "horizontalpodautoscalers",
      "namespaced": true
    },
    ...
}
```
