### PR TITLE
Wait for docker termination when creating network bridges

### DIFF
--- a/docs/getting-started-guides/docker-multinode/master.sh
+++ b/docs/getting-started-guides/docker-multinode/master.sh
@@ -33,7 +33,6 @@ else
     echo "k8s version is set to: ${K8S_VERSION}"
 fi
 
-
 # Run as root
 if [ "$(id -u)" != "0" ]; then
     echo >&2 "Please run as root"
@@ -135,7 +134,14 @@ start_k8s(){
             DOCKER_CONF="/etc/default/docker"
             echo "DOCKER_OPTS=\"\$DOCKER_OPTS --mtu=${FLANNEL_MTU} --bip=${FLANNEL_SUBNET}\"" | sudo tee -a ${DOCKER_CONF}
             ifconfig docker0 down
-            apt-get install bridge-utils && brctl delbr docker0 && service docker restart
+            apt-get install bridge-utils
+            brctl delbr docker0
+            service docker stop
+            while [ `ps aux | grep /usr/bin/docker | grep -v grep | wc -l` -gt 0 ]; do
+                echo "Waiting for docker to terminate"
+                sleep 1
+            done
+            service docker start
             ;;
         *)
             echo "Unsupported operations system ${lsb_dist}"

--- a/docs/getting-started-guides/docker-multinode/worker.sh
+++ b/docs/getting-started-guides/docker-multinode/worker.sh
@@ -33,8 +33,6 @@ else
     echo "k8s version is set to: ${K8S_VERSION}"
 fi
 
-
-
 # Run as root
 if [ "$(id -u)" != "0" ]; then
     echo >&2 "Please run as root"
@@ -137,7 +135,14 @@ start_k8s() {
             DOCKER_CONF="/etc/default/docker"
             echo "DOCKER_OPTS=\"\$DOCKER_OPTS --mtu=${FLANNEL_MTU} --bip=${FLANNEL_SUBNET}\"" | sudo tee -a ${DOCKER_CONF}
             ifconfig docker0 down
-            apt-get install bridge-utils && brctl delbr docker0 && service docker restart
+            apt-get install bridge-utils
+            brctl delbr docker0
+            service docker stop
+            while [ `ps aux | grep /usr/bin/docker | grep -v grep | wc -l` -gt 0 ]; do
+                echo "Waiting for docker to terminate"
+                sleep 1
+            done
+            service docker start
             ;;
         *)
             echo "Unsupported operations system ${lsb_dist}"


### PR DESCRIPTION
Wait for docker termination when creating network bridges. Currently we might have data races.
