### PR TITLE
Fix timeoutSeconds parameter

### DIFF
--- a/pkg/client/unversioned/request.go
+++ b/pkg/client/unversioned/request.go
@@ -466,7 +466,8 @@ func (r *Request) TimeoutSeconds(d time.Duration) *Request {
 		return r
 	}
 	if d != 0 {
-		r.Param("timeoutSeconds", d.String())
+		timeout := int64(d.Seconds())
+		r.Param("timeoutSeconds", strconv.FormatInt(timeout, 10))
 	}
 	return r
 }


### PR DESCRIPTION
This is fixing a problem introduced by #16266 (which caused generating thousands of bad (unparsable) requests).

This should fix (hopefully) #15382
