### PR TITLE
Fix flags for kubelet in docker-multinode setup

### DIFF
--- a/docs/getting-started-guides/docker-multinode/master.sh
+++ b/docs/getting-started-guides/docker-multinode/master.sh
@@ -161,13 +161,12 @@ start_k8s(){
         -v /var/lib/kubelet/:/var/lib/kubelet:rw \
         gcr.io/google_containers/hyperkube:v${K8S_VERSION} \
         /hyperkube kubelet \
-        --api-servers=http://localhost:8080 \
         --v=2 --address=0.0.0.0 --enable-server \
-        --hostname-override=127.0.0.1 \
         --config=/etc/kubernetes/manifests-multi \
         --cluster-dns=10.0.0.10 \
-        --cluster-domain=cluster.local
-    
+        --cluster-domain=cluster.local \
+        --containerized
+
     docker run \
         -d \
         --net=host \

--- a/docs/getting-started-guides/docker-multinode/worker.sh
+++ b/docs/getting-started-guides/docker-multinode/worker.sh
@@ -149,6 +149,7 @@ start_k8s() {
     sleep 5
     
     # Start kubelet & proxy in container
+    # TODO: Use secure port for communication
     docker run \
         --net=host \
         --pid=host \
@@ -157,15 +158,16 @@ start_k8s() {
         -d \
         -v /sys:/sys:ro \
         -v /var/run:/var/run:rw  \
+        -v /:/rootfs:ro \
         -v /dev:/dev \
         -v /var/lib/docker/:/var/lib/docker:rw \
         -v /var/lib/kubelet/:/var/lib/kubelet:rw \
         gcr.io/google_containers/hyperkube:v${K8S_VERSION} \
         /hyperkube kubelet --api-servers=http://${MASTER_IP}:8080 \
         --v=2 --address=0.0.0.0 --enable-server \
-        --hostname-override=$(hostname -i) \
         --cluster-dns=10.0.0.10 \
-        --cluster-domain=cluster.local
+        --cluster-domain=cluster.local \
+        --containerized
     
     docker run \
         -d \


### PR DESCRIPTION
Fix flags for kubelet in docker-multinode setup:
- master node should not register (it doesn't work)
- no reason for hostname override
- add required flag `--containerized`
- add missing kubelet volume on worker node
