### PR TITLE
Large amount of memory churn in etcd helper prefixing keys

### DIFF
--- a/pkg/storage/etcd/etcd_helper.go
+++ b/pkg/storage/etcd/etcd_helper.go
@@ -44,7 +44,7 @@ func NewEtcdStorage(client tools.EtcdClient, codec runtime.Codec, prefix string)
 		codec:      codec,
 		versioner:  APIObjectVersioner{},
 		copier:     api.Scheme,
-		pathPrefix: prefix,
+		pathPrefix: path.Join("/", prefix),
 		cache:      util.NewCache(maxEtcdCacheEntries),
 	}
 }
@@ -489,10 +489,10 @@ func (h *etcdHelper) GuaranteedUpdate(ctx context.Context, key string, ptrToType
 }
 
 func (h *etcdHelper) prefixEtcdKey(key string) string {
-	if strings.HasPrefix(key, path.Join("/", h.pathPrefix)) {
+	if strings.HasPrefix(key, h.pathPrefix) {
 		return key
 	}
-	return path.Join("/", h.pathPrefix, key)
+	return path.Join(h.pathPrefix, key)
 }
 
 // etcdCache defines interface used for caching objects stored in etcd. Objects are keyed by


### PR DESCRIPTION
``` shell
$ go tool pprof --alloc_space ./_output/local/go/bin/openshift /home/decarr/Downloads/meminfo/mem.pprof 
Entering interactive mode (type "help" for commands)
(pprof) top
189.15GB of 360.87GB total (52.41%)
Dropped 2118 nodes (cum <= 1.80GB)
Showing top 10 nodes out of 280 (cum >= 6.68GB)
      flat  flat%   sum%        cum   cum%
   54.21GB 15.02% 15.02%    54.21GB 15.02%  bytes.(*Buffer).ReadRune
   33.39GB  9.25% 24.27%    33.39GB  9.25%  github.com/ugorji/go/codec.(*encFnInfo).kInt
   23.55GB  6.52% 30.80%    23.55GB  6.52%  reflect.methodReceiver
   19.33GB  5.36% 36.15%    25.40GB  7.04%  math/big.divisors
   11.77GB  3.26% 39.42%    11.77GB  3.26%  math/big.nat.mul
   11.21GB  3.11% 42.52%    11.21GB  3.11%  reflect.(*structType).FieldByNameFunc
   11.04GB  3.06% 45.58%    21.03GB  5.83%  encoding/json.(*decodeState).literalStore
    9.73GB  2.70% 48.28%    44.67GB 12.38%  type..hash.github.com/ugorji/go/codec.encFnInfo
    8.25GB  2.29% 50.56%    42.76GB 11.85%  k8s.io/kubernetes/pkg/storage/etcd.(*etcdHelper).prefixEtcdKey
    6.68GB  1.85% 52.41%     6.68GB  1.85%  github.com/openshift/origin/pkg/authorization/cache.(*readOnlyAuthorizationCache).ListClusterPolicyBindings
(pprof) list prefixEtcdKey
Total: 360.87GB
ROUTINE ======================== k8s.io/kubernetes/pkg/storage/etcd.(*etcdHelper).prefixEtcdKey in /home/decarr/go/src/github.com/openshift/ose/Godeps/_workspace/src/k8s.io/kubernetes/pkg/storage/etcd/etcd_helper.go
    8.25GB       51GB (flat, cum) 14.13% of Total
         .          .    446:       _, _, err = h.extractObj(response, err, ptrToType, false, false)
         .          .    447:       return err
         .          .    448:   }
         .          .    449:}
         .          .    450:
         .     1.41MB    451:func (h *etcdHelper) prefixEtcdKey(key string) string {
         .    42.75GB    452:   if strings.HasPrefix(key, path.Join("/", h.pathPrefix)) {
         .          .    453:       return key
         .          .    454:   }
    8.25GB     8.25GB    455:   return path.Join("/", h.pathPrefix, key)
         .          .    456:}
         .          .    457:
         .          .    458:// etcdCache defines interface used for caching objects stored in etcd. Objects are keyed by
         .          .    459:// their Node.ModifiedIndex, which is unique across all types.
         .          .    460:// All implementations must be thread-safe.
```

Fix is to only join with / with pathPrefix one time.
