### PR TITLE
Remove create.go call to UpdateAnnotation.

### DIFF
--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -107,12 +107,6 @@ func RunCreate(f *cmdutil.Factory, cmd *cobra.Command, out io.Writer, options *C
 			return err
 		}
 
-		// Update the annotation used by kubectl apply
-		if err := kubectl.UpdateApplyAnnotation(info); err != nil {
-			return cmdutil.AddSourceToErr("creating", info.Source, err)
-		}
-
-		// Serialize the object with the annotation applied.
 		data, err := info.Mapping.Codec.Encode(info.Object)
 		if err != nil {
 			return cmdutil.AddSourceToErr("creating", info.Source, err)


### PR DESCRIPTION
Remove the call to UpdateAnnotation in pkg/kubectl/cmd/create.go, since it will always be a noop per https://github.com/kubernetes/kubernetes/pull/16086#issuecomment-150704518 from @janetkuo.

cc @bgrant0607, @jlowdermilk, @janetkuo, @kubernetes/kubectl
