### PR TITLE
New version selector button with drop down menu

### DIFF
--- a/_includes/docversionselector.html
+++ b/_includes/docversionselector.html
@@ -1,0 +1,10 @@
+<!-- button selector for specifying version of documentation -->
+<div class="versionselector">
+  <button>Version:</button>
+  <ul class="dropdown-menu">
+    <li class="text-only">Latest:</li>
+    <li><a href="{{ site.url }}/v1.1/index.html" id="v11">v1.1</a></li>
+    <li class="text-only">Archived:</li>
+    <li><a href="{{ site.url }}/v1.0/index.html" id="v10">v1.0</a></li>
+  </ul>
+</div>

--- a/_layouts/docwithnav.html
+++ b/_layouts/docwithnav.html
@@ -85,13 +85,43 @@
 		    });
 		}
 		loadonstatechange();
-		/* Watch for any click in the content area and close the nav menu if its open (for small res. desiplays) */
-		$('.bodywrapper').on("click", function(e) {
+		/* Watch for any click in the content area and if they are open, close the version selector menu and the nav menu (for small res. desiplays). */
+		$('.bodywrapper').on("click", function() {
 			if($('#wrapper').hasClass('col-sm-5')) {
 				togglenavmenu();
 			}
+			//$('.versionselector .dropdown-menu').hide();
 		});
-		/* Handle clicks in nav menu, content body, and header. Also track history by pushing state (so back/forward browser buttons work)*/
+		/* Get and display the current doc version in the version selector button */
+		function setcurdocver(){
+			var urlsplit = window.location.pathname.split('/'),
+			    curversion = urlsplit[1],
+				curdocver = "Click Here";
+			switch (curversion) {
+				case 'v1.0':
+					curdocver = curversion;
+					$('.versionselector a#v10').addClass('active');
+					$('.versionselector a#v11').removeClass('active');
+					break;
+				case 'v1.1':
+					curdocver = curversion;
+					$('.versionselector a#v11').addClass('active');
+					$('.versionselector a#v10').removeClass('active');
+					break;
+				default:
+					curdocver = curversion;
+			}
+			$('.versionselector button').text("Version: " + curdocver);
+		}
+		setcurdocver();
+		$(window).load(function() { //temporary fix to close the menu (it stays open for some reason)
+			$('.versionselector .dropdown-menu').slideUp(1200);
+		});
+		/* Toggle the version selector menu on button click */
+		$('.versionselector').on("click", function() {
+			$('.versionselector .dropdown-menu').toggle('display');
+			});
+		/* Handle clicks on 'a' elements in nav menu, content body, and header. Also track history by pushing state (so back/forward browser buttons work)*/
 	    $(document).on("click", 'a', function(e) {
 	        e.preventDefault();
 			var clickedon = $(this),
@@ -117,8 +147,11 @@
 				if($('#wrapper').hasClass('col-sm-5') && !(clickedon.parent().hasClass('haschild'))) {
 					togglenavmenu();
 				}
+				//perform an action base on the type of 'a' element clicked
 				if(this.host != location.host) {//open external links in new tab/window
 					window.open(href, '_blank');
+				} else if(clickedon.is('.versionselector .dropdown-menu a')) {//perform a full page load when clicking on a doc version from the drop-down menu
+					window.location=href;
 				} else if(href != "#" && !clickedon.parents('header').is('#nav') && !clickedon.parents('div').is('#mobile-nav-container')) {//skip empty nav menu containers and any clicks in the banner and banner menu
 					//track all history but exclude clicks that only toggle open/closed container menus
 					if (!(clickedon.hasClass('active') && clickedon.parent('li').hasClass('haschild'))) {

--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -21,6 +21,66 @@ ul, ul ul {
         margin-left: $searchboxpadding - 1px;
     }
 }
+.versionselector {
+	position: relative;
+	left: 0;
+	display: inline-block;
+	padding: 5px 5px 0 10px;
+	button {
+		border-style: solid;
+		border-width: 1px;
+		border-radius: 2px;
+		box-shadow: inset 0 1px 0 rgba(255,255,255,0.2),0 1px 2px rgba(0,0,0,0.25);
+		background-color: #ffffff;
+		margin: 0;
+		padding: 0.4em 0.8em;
+		font-size: 1em;
+		text-align: center;
+		white-space: nowrap;
+		vertical-align: middle;
+	}
+	button:hover {
+		font-weight: bold;
+		box-shadow: inset 0 2px 0 rgba(255,255,255,0.2),0 2px 3px rgba(0,0,0,0.25);
+	}
+}.versionselector .dropdown-menu {
+	position: absolute;
+	list-style: none;
+	display: none;
+	top: 100%;
+	left: 5px;
+	width: 150%;
+	margin: 0;
+	padding: 5px;
+	border-color: #f6f6f6;
+	border-style: ridge;
+	border-width: .25px;
+	border-radius: 1px;
+	background: white;
+	box-shadow: 3px 3px 6px #888888;
+	li {
+		left: 10px;
+	}
+	li.text-only {
+		left: 5px;
+		color: #000000;
+		font-style: italic;
+		text-decoration: none;
+		border-bottom: 1px solid #000000;
+		padding-top: 5px;
+	}
+	a {
+		left: 25%;
+		display: block;
+		padding: 0.5em 0.5em;
+	}
+	a.active {
+		color: #428BCB;
+	}
+	a:hover {
+		font-weight: bold;
+	}
+}
 #wrapper {
 	position: fixed;
 	left: 3px;
@@ -58,7 +118,7 @@ ul, ul ul {
 	text-indent: .75em;
 	position: center;
 }
-.menu > li > a:hover, .menu > li > a.active {
+.menu > li > a:hover, .menu > li > a.active, .menu > li > ul > li > a.active {
 	color: #428BCB;
 }
 /* add caret to container topics (that have sub-menus) */


### PR DESCRIPTION
This is not exposed yet but looks like this:
![image](https://cloud.githubusercontent.com/assets/11762685/10774388/1bbeb936-7cbe-11e5-9fdd-af917801754c.png)

Note: 
You can partially test this in my fork at (i have exposed it here (ive added the one line as explained below)): http://richieescarez.github.io/kubernetes/v1.0/index.html
- Because our forks insert an intermediate folder name "kubernetes" the 'v1.0' and 'v1.1' url paths the javascript uses have been shifted (which is why the button says Version: kubernetes). This is also why the menu width spans outside the menu width. These both go away when pushed to k8s.io (where the intermediate folder name is nonexistant). 

This works well in my local build (you can also cherry-pick this and test it fully that way).

**Known issue**: As it is now, something holds open the menu after clicking on a version in the menu. My temporary workaround is to just slowly close it. This only happens when you click on a version in the menu and this behavior is not seen otherwise.

```
        $(window).load(function() { //temporary fix to close the menu (it stays open for some reason)
            $('.versionselector .dropdown-menu').slideUp(1200);
        });
```

FYI (i will open a separate PR to expose this see #15893):

For GA we need to add this line to the _layouts/docwithnav.html file:

```
{% include docversionselector.html %}
```

At this location:

```
        <!-- Navigation menu -->
        <div class="col-md-3 hidden-sm hidden-xs" id="wrapper">
        {% include docversionselector.html %}
            {% case page.collection %}
```

cc @janetkuo @thockin 
#15893
