### PR TITLE
Put pod full name, namespace and uid into docker label

### DIFF
--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -211,6 +211,7 @@ func (p throttledDockerPuller) IsImagePresent(name string) (bool, error) {
 	return p.puller.IsImagePresent(name)
 }
 
+// TODO (random-liu) Almost never used, should we remove this?
 // DockerContainers is a map of containers
 type DockerContainers map[kubetypes.DockerID]*docker.APIContainers
 

--- a/pkg/kubelet/dockertools/fake_docker_client.go
+++ b/pkg/kubelet/dockertools/fake_docker_client.go
@@ -146,13 +146,14 @@ func (f *FakeDockerClient) ListContainers(options docker.ListContainersOptions) 
 	defer f.Unlock()
 	f.called = append(f.called, "list")
 	err := f.popError("list")
+	containerList := append([]docker.APIContainers{}, f.ContainerList...)
 	if options.All {
 		// Althought the container is not sorted, but the container with the same name should be in order,
 		// that is enough for us now.
 		// TODO (random-liu) Is a fully sorted array needed?
-		return append(f.ContainerList, f.ExitedContainerList...), err
+		containerList = append(containerList, f.ExitedContainerList...)
 	}
-	return append([]docker.APIContainers{}, f.ContainerList...), err
+	return containerList, err
 }
 
 // InspectContainer is a test-spy implementation of DockerInterface.InspectContainer.

--- a/pkg/kubelet/dockertools/labels.go
+++ b/pkg/kubelet/dockertools/labels.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockertools
+
+import (
+	"strconv"
+
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/api"
+)
+
+// This file contains all docker label related constants and functions, including:
+//  * label setters and getters
+//  * label filters (maybe in the future)
+
+const (
+	kubernetesPodNameLabel      = "io.kubernetes.pod.name"
+	kubernetesPodNamespaceLabel = "io.kubernetes.pod.namespace"
+	kubernetesPodUID            = "io.kubernetes.pod.uid"
+
+	kubernetesPodLabel                    = "io.kubernetes.pod.data"
+	kubernetesTerminationGracePeriodLabel = "io.kubernetes.pod.terminationGracePeriod"
+	kubernetesContainerLabel              = "io.kubernetes.container.name"
+	kubernetesContainerRestartCountLabel  = "io.kubernetes.container.restartCount"
+)
+
+func newLabels(container *api.Container, pod *api.Pod, restartCount int) map[string]string {
+	// TODO (random-liu) Move more label initialization here
+	labels := map[string]string{}
+	labels[kubernetesPodNameLabel] = pod.Name
+	labels[kubernetesPodNamespaceLabel] = pod.Namespace
+	labels[kubernetesPodUID] = string(pod.UID)
+
+	labels[kubernetesContainerRestartCountLabel] = strconv.Itoa(restartCount)
+
+	return labels
+}
+
+func getRestartCountFromLabel(labels map[string]string) (restartCount int, err error) {
+	if restartCountString, found := labels[kubernetesContainerRestartCountLabel]; found {
+		restartCount, err = strconv.Atoi(restartCountString)
+		if err != nil {
+			// This really should not happen. Just set restartCount to 0 to handle this abnormal case
+			restartCount = 0
+		}
+	} else {
+		// Get restartCount from docker label. If there is no restart count label in a container,
+		// it should be an old container or an invalid container, we just set restart count to 0.
+		// Do not report error, because there should be many old containers without this label now
+		glog.V(3).Infof("Container doesn't have label %s, it may be an old or invalid container", kubernetesContainerRestartCountLabel)
+	}
+	return restartCount, err
+}

--- a/pkg/kubelet/dockertools/manager_test.go
+++ b/pkg/kubelet/dockertools/manager_test.go
@@ -1169,6 +1169,17 @@ func TestGetPodStatusWithLastTermination(t *testing.T) {
 		{Name: "failed"},
 	}
 
+	pod := &api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			UID:       "12345678",
+			Name:      "foo",
+			Namespace: "new",
+		},
+		Spec: api.PodSpec{
+			Containers: containers,
+		},
+	}
+
 	exitedAPIContainers := []docker.APIContainers{
 		{
 			// format is // k8s_<container-id>_<pod-fullname>_<pod-uid>
@@ -1248,17 +1259,7 @@ func TestGetPodStatusWithLastTermination(t *testing.T) {
 		fakeDocker.ExitedContainerList = exitedAPIContainers
 		fakeDocker.ContainerMap = containerMap
 		fakeDocker.ClearCalls()
-		pod := &api.Pod{
-			ObjectMeta: api.ObjectMeta{
-				UID:       "12345678",
-				Name:      "foo",
-				Namespace: "new",
-			},
-			Spec: api.PodSpec{
-				Containers:    containers,
-				RestartPolicy: tt.policy,
-			},
-		}
+		pod.Spec.RestartPolicy = tt.policy
 		fakeDocker.ContainerList = []docker.APIContainers{
 			{
 				// pod infra container


### PR DESCRIPTION
This PR mainly did 3 things:
1. Add file container_labels.go, and move label and filter functions into it, so as to simplify  the label related code and prepare for adding more labels in the future.
2. Add pod full name filter in GetPodStatus() so that ListContainers() will only list containers belong to the target pod.
3. Add related test case and make fakeDockerContainer support label filter.

Some questions or TODOs:
1. A lot of manually initialized containers in old test cases of dockertools don't have docker labels, if they use functions using label filter (current now only GetPodStatus() uses label filter), the test case may get unexpected result. I added a simple function to set default labels, but it is still inconvenient to add label for each test case. In this PR I just modified test cases which went wrong. Should I add label for each test case? Or should I think a better way?
2. In fact, pod full name label was added before https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/dockertools/manager.go#L701. Can I assume that even old containers have pod name label? If not, I should comment my filter code and uncomment it in the future.

(For issue #15089)
