### PR TITLE
Changes to expose the v1.1 documentation on kubernetes.io

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -45,8 +45,8 @@ nav:
    slug: gettingstarted
    external: false
  - label: Documentation
-   url: /v1.0
-   slug: v1.0
+   url: /v1.1
+   slug: v1.1
    external: false
  - label: Community
    url: /community

--- a/_includes/404content.html
+++ b/_includes/404content.html
@@ -2,14 +2,14 @@
 	<div><hr></div>
 	<h1 style="text-align:center">404</h1>
 	<p>Oops, we can't find that page.</p>
-	<p>One moment please, I'll redirect to the <a href="http://kubernetes.io/v1.0/">kubernetes.io documentation</a> page.</p>
+	<p>One moment please, I'll redirect to the <a href="http://kubernetes.io/docs">kubernetes.io documentation</a> page.</p>
 	<div><hr></div>
 </div>
 <script>
 	$(document).ready(function () {
 	    // Handler for .ready() called.
 	    window.setTimeout(function () {
-	        location.href = "http://kubernetes.io/v1.0/";
+	        location.href = "http://kubernetes.io/docs";
 	    }, 3000);
 	});
 </script>

--- a/_layouts/docwithnav.html
+++ b/_layouts/docwithnav.html
@@ -16,6 +16,7 @@
 	<div class="row">
 		<!-- Navigation menu -->
 		<div class="col-md-3 hidden-sm hidden-xs" id="wrapper">
+			{% include docversionselector.html %}
 			{% case page.collection %}
 				{% when 'v1.1' %}
 					{% include nav_v1.1.html %}
@@ -25,6 +26,9 @@
 		</div>
 		<!-- Content body -->
 		<div class="col-md-8 col-sm-11 col-xs-11 bodywrapper">
+			{% if page.collection == 'v1.0' %}
+				{% include archivedocnotice.html %}
+			{% endif %}
 			{% include documentation.html %}
 		</div>
 	</div>
@@ -115,7 +119,7 @@
 		}
 		setcurdocver();
 		$(window).load(function() { //temporary fix to close the menu (it stays open for some reason)
-			$('.versionselector .dropdown-menu').slideUp(1200);
+			$('.versionselector .dropdown-menu').slideUp(900);
 		});
 		/* Toggle the version selector menu on button click */
 		$('.versionselector').on("click", function() {

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,5 +3,5 @@ layout: docwithnav
 permalink: /docs/
 show_in_nav: true
 slug: docs
-redirect_to: /v1.0
+redirect_to: /v1.1
 ---

--- a/gettingstarted.md
+++ b/gettingstarted.md
@@ -24,7 +24,7 @@ steps:
     text: Releases of Kubernetes
     slug: releases
   - title: Technical Details
-    text: "Interested in taking a peek inside Kubernetes? You should start by reading the <a href=\"/v1.0/docs/design/README.html\" onclick=\"trackOutboundLink('/v1.0/docs/design/README.html'); return false;\">design overview</a> which introduces core Kubernetes concepts and components. After that, you probably want to take a look at the API documentation and learn about the kubecfg command line tool."
+    text: "Interested in taking a peek inside Kubernetes? You should start by reading the <a href=\"/v1.1/docs/design/README.html\" onclick=\"trackOutboundLink('/v1.1/docs/design/README.html'); return false;\">design overview</a> which introduces core Kubernetes concepts and components. After that, you probably want to take a look at the API documentation and learn about the kubecfg command line tool."
     slug: techdetails
 
 hostedservices:
@@ -33,41 +33,41 @@ hostedservices:
 
 installguides:
   - label: Google Compute Engine
-    url: /v1.0/docs/getting-started-guides/gce.html
+    url: /v1.1/docs/getting-started-guides/gce.html
   - label: Vagrant
-    url: /v1.0/docs/getting-started-guides/vagrant.html
+    url: /v1.1/docs/getting-started-guides/vagrant.html
   - label: Fedora (Ansible)
-    url: /v1.0/docs/getting-started-guides/fedora/fedora_ansible_config.html
+    url: /v1.1/docs/getting-started-guides/fedora/fedora_ansible_config.html
   - label: Fedora (Manual)
-    url: /v1.0/docs/getting-started-guides/fedora/fedora_manual_config.html
+    url: /v1.1/docs/getting-started-guides/fedora/fedora_manual_config.html
   - label: Local
-    url: /v1.0/docs/getting-started-guides/locally.html
+    url: /v1.1/docs/getting-started-guides/locally.html
   - label: Microsoft Azure
-    url: /v1.0/docs/getting-started-guides/azure.html
+    url: /v1.1/docs/getting-started-guides/azure.html
   - label: Rackspace
-    url: /v1.0/docs/getting-started-guides/rackspace.html
+    url: /v1.1/docs/getting-started-guides/rackspace.html
   - label: CoreOS
-    url: /v1.0/docs/getting-started-guides/coreos.html
+    url: /v1.1/docs/getting-started-guides/coreos.html
   - label: vSphere
-    url: /v1.0/docs/getting-started-guides/vsphere.html
+    url: /v1.1/docs/getting-started-guides/vsphere.html
   - label: Amazon Web Services
-    url: /v1.0/docs/getting-started-guides/aws.html
+    url: /v1.1/docs/getting-started-guides/aws.html
   - label: Mesos
-    url: /v1.0/docs/getting-started-guides/mesos.html
+    url: /v1.1/docs/getting-started-guides/mesos.html
 
 firstapp:
     label: Run Now
-    url: /v1.0/examples/guestbook/README.html
+    url: /v1.1/examples/guestbook/README.html
 
 releases:
     label: Releases
-    url: https://github.com/GoogleCloudPlatform/kubernetes/releases
+    url: https://github.com/kubernetes/kubernetes/releases
 
 techdetails:
     api:
         label: API Documentation
-        url: /v1.0/docs/api-reference/operations.html
+        url: /v1.1/docs/api-reference/v1/operations.html
     kubecfg:
         label: Kubectl Command Tool
-        url: /v1.0/docs/user-guide/kubectl/kubectl.html
+        url: /v1.1/docs/user-guide/kubectl-overview.html
 ---


### PR DESCRIPTION
To be merge for v1.1 GA. This contains pieces to expose the changes in #15893.

You can view these changes in my fork: http://richieescarez.github.io/kubernetes/v1.0/

Note: the version menu and links in the getting started page links dont work properly in the fork due to the addition of the intermediate url path "kubernetes" in the fork's url.

@thockin @janetkuo @mansoorj 
