### PR TITLE
add key subnet in struct NodeAddress to help scheduler create a priority about deploying pods to different switches. 

### DIFF
--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -12382,7 +12382,8 @@
     "description": "NodeAddress contains information for the node's address.",
     "required": [
      "type",
-     "address"
+     "address",
+     "subnet"
     ],
     "properties": {
      "type": {
@@ -12392,6 +12393,10 @@
      "address": {
       "type": "string",
       "description": "The node address."
+     },
+     "subnet": {
+      "type": "string",
+      "description": "The node subnet."
      }
     }
    },

--- a/pkg/api/deep_copy_generated.go
+++ b/pkg/api/deep_copy_generated.go
@@ -939,6 +939,7 @@ func deepCopy_api_Node(in Node, out *Node, c *conversion.Cloner) error {
 func deepCopy_api_NodeAddress(in NodeAddress, out *NodeAddress, c *conversion.Cloner) error {
 	out.Type = in.Type
 	out.Address = in.Address
+	out.Subnet = in.Subnet
 	return nil
 }
 

--- a/pkg/api/types.generated.go
+++ b/pkg/api/types.generated.go
@@ -27997,13 +27997,13 @@ func (x *NodeAddress) CodecEncodeSelf(e *codec1978.Encoder) {
 		} else {
 			yysep2361 := !z.EncBinary()
 			yy2arr2361 := z.EncBasicHandle().StructToArray
-			var yyq2361 [2]bool
+			var yyq2361 [3]bool
 			_, _, _ = yysep2361, yyq2361, yy2arr2361
 			const yyr2361 bool = false
 			if yyr2361 || yy2arr2361 {
-				r.EncodeArrayStart(2)
+				r.EncodeArrayStart(3)
 			} else {
-				var yynn2361 int = 2
+				var yynn2361 int = 3
 				for _, b := range yyq2361 {
 					if b {
 						yynn2361++
@@ -28033,6 +28033,22 @@ func (x *NodeAddress) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Address))
 				}
 			}
+			if yyr2361 || yy2arr2361 {
+				yym2367 := z.EncBinary()
+				_ = yym2367
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Subnet))
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("subnet"))
+				yym2368 := z.EncBinary()
+				_ = yym2368
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Subnet))
+				}
+			}
 			if yysep2361 {
 				r.EncodeEnd()
 			}
@@ -28044,24 +28060,24 @@ func (x *NodeAddress) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2366 := z.DecBinary()
-	_ = yym2366
+	yym2369 := z.DecBinary()
+	_ = yym2369
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2367 := r.ReadMapStart()
-			if yyl2367 == 0 {
+			yyl2370 := r.ReadMapStart()
+			if yyl2370 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2367, d)
+				x.codecDecodeSelfFromMap(yyl2370, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2367 := r.ReadArrayStart()
-			if yyl2367 == 0 {
+			yyl2370 := r.ReadArrayStart()
+			if yyl2370 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2367, d)
+				x.codecDecodeSelfFromArray(yyl2370, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -28073,12 +28089,12 @@ func (x *NodeAddress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2368Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2368Slc
-	var yyhl2368 bool = l >= 0
-	for yyj2368 := 0; ; yyj2368++ {
-		if yyhl2368 {
-			if yyj2368 >= l {
+	var yys2371Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2371Slc
+	var yyhl2371 bool = l >= 0
+	for yyj2371 := 0; ; yyj2371++ {
+		if yyhl2371 {
+			if yyj2371 >= l {
 				break
 			}
 		} else {
@@ -28086,9 +28102,9 @@ func (x *NodeAddress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2368Slc = r.DecodeBytes(yys2368Slc, true, true)
-		yys2368 := string(yys2368Slc)
-		switch yys2368 {
+		yys2371Slc = r.DecodeBytes(yys2371Slc, true, true)
+		yys2371 := string(yys2371Slc)
+		switch yys2371 {
 		case "type":
 			if r.TryDecodeAsNil() {
 				x.Type = ""
@@ -28101,11 +28117,17 @@ func (x *NodeAddress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			} else {
 				x.Address = string(r.DecodeString())
 			}
+		case "subnet":
+			if r.TryDecodeAsNil() {
+				x.Subnet = ""
+			} else {
+				x.Subnet = string(r.DecodeString())
+			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2368)
-		} // end switch yys2368
-	} // end for yyj2368
-	if !yyhl2368 {
+			z.DecStructFieldNotFound(-1, yys2371)
+		} // end switch yys2371
+	} // end for yyj2371
+	if !yyhl2371 {
 		r.ReadEnd()
 	}
 }
@@ -28114,16 +28136,16 @@ func (x *NodeAddress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2371 int
-	var yyb2371 bool
-	var yyhl2371 bool = l >= 0
-	yyj2371++
-	if yyhl2371 {
-		yyb2371 = yyj2371 > l
+	var yyj2375 int
+	var yyb2375 bool
+	var yyhl2375 bool = l >= 0
+	yyj2375++
+	if yyhl2375 {
+		yyb2375 = yyj2375 > l
 	} else {
-		yyb2371 = r.CheckBreak()
+		yyb2375 = r.CheckBreak()
 	}
-	if yyb2371 {
+	if yyb2375 {
 		r.ReadEnd()
 		return
 	}
@@ -28132,13 +28154,13 @@ func (x *NodeAddress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Type = NodeAddressType(r.DecodeString())
 	}
-	yyj2371++
-	if yyhl2371 {
-		yyb2371 = yyj2371 > l
+	yyj2375++
+	if yyhl2375 {
+		yyb2375 = yyj2375 > l
 	} else {
-		yyb2371 = r.CheckBreak()
+		yyb2375 = r.CheckBreak()
 	}
-	if yyb2371 {
+	if yyb2375 {
 		r.ReadEnd()
 		return
 	}
@@ -28147,17 +28169,32 @@ func (x *NodeAddress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Address = string(r.DecodeString())
 	}
+	yyj2375++
+	if yyhl2375 {
+		yyb2375 = yyj2375 > l
+	} else {
+		yyb2375 = r.CheckBreak()
+	}
+	if yyb2375 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Subnet = ""
+	} else {
+		x.Subnet = string(r.DecodeString())
+	}
 	for {
-		yyj2371++
-		if yyhl2371 {
-			yyb2371 = yyj2371 > l
+		yyj2375++
+		if yyhl2375 {
+			yyb2375 = yyj2375 > l
 		} else {
-			yyb2371 = r.CheckBreak()
+			yyb2375 = r.CheckBreak()
 		}
-		if yyb2371 {
+		if yyb2375 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2371-1, "")
+		z.DecStructFieldNotFound(yyj2375-1, "")
 	}
 	r.ReadEnd()
 }
@@ -28169,30 +28206,30 @@ func (x *NodeResources) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2374 := z.EncBinary()
-		_ = yym2374
+		yym2379 := z.EncBinary()
+		_ = yym2379
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2375 := !z.EncBinary()
-			yy2arr2375 := z.EncBasicHandle().StructToArray
-			var yyq2375 [1]bool
-			_, _, _ = yysep2375, yyq2375, yy2arr2375
-			const yyr2375 bool = false
-			yyq2375[0] = len(x.Capacity) != 0
-			if yyr2375 || yy2arr2375 {
+			yysep2380 := !z.EncBinary()
+			yy2arr2380 := z.EncBasicHandle().StructToArray
+			var yyq2380 [1]bool
+			_, _, _ = yysep2380, yyq2380, yy2arr2380
+			const yyr2380 bool = false
+			yyq2380[0] = len(x.Capacity) != 0
+			if yyr2380 || yy2arr2380 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn2375 int = 0
-				for _, b := range yyq2375 {
+				var yynn2380 int = 0
+				for _, b := range yyq2380 {
 					if b {
-						yynn2375++
+						yynn2380++
 					}
 				}
-				r.EncodeMapStart(yynn2375)
+				r.EncodeMapStart(yynn2380)
 			}
-			if yyr2375 || yy2arr2375 {
-				if yyq2375[0] {
+			if yyr2380 || yy2arr2380 {
+				if yyq2380[0] {
 					if x.Capacity == nil {
 						r.EncodeNil()
 					} else {
@@ -28202,7 +28239,7 @@ func (x *NodeResources) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2375[0] {
+				if yyq2380[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("capacity"))
 					if x.Capacity == nil {
 						r.EncodeNil()
@@ -28211,7 +28248,7 @@ func (x *NodeResources) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2375 {
+			if yysep2380 {
 				r.EncodeEnd()
 			}
 		}
@@ -28222,24 +28259,24 @@ func (x *NodeResources) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2377 := z.DecBinary()
-	_ = yym2377
+	yym2382 := z.DecBinary()
+	_ = yym2382
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2378 := r.ReadMapStart()
-			if yyl2378 == 0 {
+			yyl2383 := r.ReadMapStart()
+			if yyl2383 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2378, d)
+				x.codecDecodeSelfFromMap(yyl2383, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2378 := r.ReadArrayStart()
-			if yyl2378 == 0 {
+			yyl2383 := r.ReadArrayStart()
+			if yyl2383 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2378, d)
+				x.codecDecodeSelfFromArray(yyl2383, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -28251,12 +28288,12 @@ func (x *NodeResources) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2379Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2379Slc
-	var yyhl2379 bool = l >= 0
-	for yyj2379 := 0; ; yyj2379++ {
-		if yyhl2379 {
-			if yyj2379 >= l {
+	var yys2384Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2384Slc
+	var yyhl2384 bool = l >= 0
+	for yyj2384 := 0; ; yyj2384++ {
+		if yyhl2384 {
+			if yyj2384 >= l {
 				break
 			}
 		} else {
@@ -28264,21 +28301,21 @@ func (x *NodeResources) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2379Slc = r.DecodeBytes(yys2379Slc, true, true)
-		yys2379 := string(yys2379Slc)
-		switch yys2379 {
+		yys2384Slc = r.DecodeBytes(yys2384Slc, true, true)
+		yys2384 := string(yys2384Slc)
+		switch yys2384 {
 		case "capacity":
 			if r.TryDecodeAsNil() {
 				x.Capacity = nil
 			} else {
-				yyv2380 := &x.Capacity
-				yyv2380.CodecDecodeSelf(d)
+				yyv2385 := &x.Capacity
+				yyv2385.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2379)
-		} // end switch yys2379
-	} // end for yyj2379
-	if !yyhl2379 {
+			z.DecStructFieldNotFound(-1, yys2384)
+		} // end switch yys2384
+	} // end for yyj2384
+	if !yyhl2384 {
 		r.ReadEnd()
 	}
 }
@@ -28287,36 +28324,36 @@ func (x *NodeResources) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2381 int
-	var yyb2381 bool
-	var yyhl2381 bool = l >= 0
-	yyj2381++
-	if yyhl2381 {
-		yyb2381 = yyj2381 > l
+	var yyj2386 int
+	var yyb2386 bool
+	var yyhl2386 bool = l >= 0
+	yyj2386++
+	if yyhl2386 {
+		yyb2386 = yyj2386 > l
 	} else {
-		yyb2381 = r.CheckBreak()
+		yyb2386 = r.CheckBreak()
 	}
-	if yyb2381 {
+	if yyb2386 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Capacity = nil
 	} else {
-		yyv2382 := &x.Capacity
-		yyv2382.CodecDecodeSelf(d)
+		yyv2387 := &x.Capacity
+		yyv2387.CodecDecodeSelf(d)
 	}
 	for {
-		yyj2381++
-		if yyhl2381 {
-			yyb2381 = yyj2381 > l
+		yyj2386++
+		if yyhl2386 {
+			yyb2386 = yyj2386 > l
 		} else {
-			yyb2381 = r.CheckBreak()
+			yyb2386 = r.CheckBreak()
 		}
-		if yyb2381 {
+		if yyb2386 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2381-1, "")
+		z.DecStructFieldNotFound(yyj2386-1, "")
 	}
 	r.ReadEnd()
 }
@@ -28325,8 +28362,8 @@ func (x ResourceName) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym2383 := z.EncBinary()
-	_ = yym2383
+	yym2388 := z.EncBinary()
+	_ = yym2388
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -28338,8 +28375,8 @@ func (x *ResourceName) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2384 := z.DecBinary()
-	_ = yym2384
+	yym2389 := z.DecBinary()
+	_ = yym2389
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -28354,8 +28391,8 @@ func (x ResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2385 := z.EncBinary()
-		_ = yym2385
+		yym2390 := z.EncBinary()
+		_ = yym2390
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
@@ -28368,8 +28405,8 @@ func (x *ResourceList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2386 := z.DecBinary()
-	_ = yym2386
+	yym2391 := z.DecBinary()
+	_ = yym2391
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -28384,36 +28421,36 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2387 := z.EncBinary()
-		_ = yym2387
+		yym2392 := z.EncBinary()
+		_ = yym2392
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2388 := !z.EncBinary()
-			yy2arr2388 := z.EncBasicHandle().StructToArray
-			var yyq2388 [5]bool
-			_, _, _ = yysep2388, yyq2388, yy2arr2388
-			const yyr2388 bool = false
-			yyq2388[0] = x.Kind != ""
-			yyq2388[1] = x.APIVersion != ""
-			yyq2388[2] = true
-			yyq2388[3] = true
-			yyq2388[4] = true
-			if yyr2388 || yy2arr2388 {
+			yysep2393 := !z.EncBinary()
+			yy2arr2393 := z.EncBasicHandle().StructToArray
+			var yyq2393 [5]bool
+			_, _, _ = yysep2393, yyq2393, yy2arr2393
+			const yyr2393 bool = false
+			yyq2393[0] = x.Kind != ""
+			yyq2393[1] = x.APIVersion != ""
+			yyq2393[2] = true
+			yyq2393[3] = true
+			yyq2393[4] = true
+			if yyr2393 || yy2arr2393 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn2388 int = 0
-				for _, b := range yyq2388 {
+				var yynn2393 int = 0
+				for _, b := range yyq2393 {
 					if b {
-						yynn2388++
+						yynn2393++
 					}
 				}
-				r.EncodeMapStart(yynn2388)
+				r.EncodeMapStart(yynn2393)
 			}
-			if yyr2388 || yy2arr2388 {
-				if yyq2388[0] {
-					yym2390 := z.EncBinary()
-					_ = yym2390
+			if yyr2393 || yy2arr2393 {
+				if yyq2393[0] {
+					yym2395 := z.EncBinary()
+					_ = yym2395
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -28422,20 +28459,20 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2388[0] {
+				if yyq2393[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2391 := z.EncBinary()
-					_ = yym2391
+					yym2396 := z.EncBinary()
+					_ = yym2396
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2388 || yy2arr2388 {
-				if yyq2388[1] {
-					yym2393 := z.EncBinary()
-					_ = yym2393
+			if yyr2393 || yy2arr2393 {
+				if yyq2393[1] {
+					yym2398 := z.EncBinary()
+					_ = yym2398
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -28444,59 +28481,59 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2388[1] {
+				if yyq2393[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2394 := z.EncBinary()
-					_ = yym2394
+					yym2399 := z.EncBinary()
+					_ = yym2399
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2388 || yy2arr2388 {
-				if yyq2388[2] {
-					yy2396 := &x.ObjectMeta
-					yy2396.CodecEncodeSelf(e)
+			if yyr2393 || yy2arr2393 {
+				if yyq2393[2] {
+					yy2401 := &x.ObjectMeta
+					yy2401.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2388[2] {
+				if yyq2393[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy2397 := &x.ObjectMeta
-					yy2397.CodecEncodeSelf(e)
-				}
-			}
-			if yyr2388 || yy2arr2388 {
-				if yyq2388[3] {
-					yy2399 := &x.Spec
-					yy2399.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2388[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy2400 := &x.Spec
-					yy2400.CodecEncodeSelf(e)
-				}
-			}
-			if yyr2388 || yy2arr2388 {
-				if yyq2388[4] {
-					yy2402 := &x.Status
+					yy2402 := &x.ObjectMeta
 					yy2402.CodecEncodeSelf(e)
+				}
+			}
+			if yyr2393 || yy2arr2393 {
+				if yyq2393[3] {
+					yy2404 := &x.Spec
+					yy2404.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2388[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy2403 := &x.Status
-					yy2403.CodecEncodeSelf(e)
+				if yyq2393[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					yy2405 := &x.Spec
+					yy2405.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2388 {
+			if yyr2393 || yy2arr2393 {
+				if yyq2393[4] {
+					yy2407 := &x.Status
+					yy2407.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq2393[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					yy2408 := &x.Status
+					yy2408.CodecEncodeSelf(e)
+				}
+			}
+			if yysep2393 {
 				r.EncodeEnd()
 			}
 		}
@@ -28507,24 +28544,24 @@ func (x *Node) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2404 := z.DecBinary()
-	_ = yym2404
+	yym2409 := z.DecBinary()
+	_ = yym2409
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2405 := r.ReadMapStart()
-			if yyl2405 == 0 {
+			yyl2410 := r.ReadMapStart()
+			if yyl2410 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2405, d)
+				x.codecDecodeSelfFromMap(yyl2410, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2405 := r.ReadArrayStart()
-			if yyl2405 == 0 {
+			yyl2410 := r.ReadArrayStart()
+			if yyl2410 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2405, d)
+				x.codecDecodeSelfFromArray(yyl2410, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -28536,12 +28573,12 @@ func (x *Node) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2406Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2406Slc
-	var yyhl2406 bool = l >= 0
-	for yyj2406 := 0; ; yyj2406++ {
-		if yyhl2406 {
-			if yyj2406 >= l {
+	var yys2411Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2411Slc
+	var yyhl2411 bool = l >= 0
+	for yyj2411 := 0; ; yyj2411++ {
+		if yyhl2411 {
+			if yyj2411 >= l {
 				break
 			}
 		} else {
@@ -28549,9 +28586,9 @@ func (x *Node) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2406Slc = r.DecodeBytes(yys2406Slc, true, true)
-		yys2406 := string(yys2406Slc)
-		switch yys2406 {
+		yys2411Slc = r.DecodeBytes(yys2411Slc, true, true)
+		yys2411 := string(yys2411Slc)
+		switch yys2411 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -28568,28 +28605,28 @@ func (x *Node) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv2409 := &x.ObjectMeta
-				yyv2409.CodecDecodeSelf(d)
+				yyv2414 := &x.ObjectMeta
+				yyv2414.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = NodeSpec{}
 			} else {
-				yyv2410 := &x.Spec
-				yyv2410.CodecDecodeSelf(d)
+				yyv2415 := &x.Spec
+				yyv2415.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = NodeStatus{}
 			} else {
-				yyv2411 := &x.Status
-				yyv2411.CodecDecodeSelf(d)
+				yyv2416 := &x.Status
+				yyv2416.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2406)
-		} // end switch yys2406
-	} // end for yyj2406
-	if !yyhl2406 {
+			z.DecStructFieldNotFound(-1, yys2411)
+		} // end switch yys2411
+	} // end for yyj2411
+	if !yyhl2411 {
 		r.ReadEnd()
 	}
 }
@@ -28598,16 +28635,16 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2412 int
-	var yyb2412 bool
-	var yyhl2412 bool = l >= 0
-	yyj2412++
-	if yyhl2412 {
-		yyb2412 = yyj2412 > l
+	var yyj2417 int
+	var yyb2417 bool
+	var yyhl2417 bool = l >= 0
+	yyj2417++
+	if yyhl2417 {
+		yyb2417 = yyj2417 > l
 	} else {
-		yyb2412 = r.CheckBreak()
+		yyb2417 = r.CheckBreak()
 	}
-	if yyb2412 {
+	if yyb2417 {
 		r.ReadEnd()
 		return
 	}
@@ -28616,13 +28653,13 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2412++
-	if yyhl2412 {
-		yyb2412 = yyj2412 > l
+	yyj2417++
+	if yyhl2417 {
+		yyb2417 = yyj2417 > l
 	} else {
-		yyb2412 = r.CheckBreak()
+		yyb2417 = r.CheckBreak()
 	}
-	if yyb2412 {
+	if yyb2417 {
 		r.ReadEnd()
 		return
 	}
@@ -28631,65 +28668,65 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2412++
-	if yyhl2412 {
-		yyb2412 = yyj2412 > l
+	yyj2417++
+	if yyhl2417 {
+		yyb2417 = yyj2417 > l
 	} else {
-		yyb2412 = r.CheckBreak()
+		yyb2417 = r.CheckBreak()
 	}
-	if yyb2412 {
+	if yyb2417 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv2415 := &x.ObjectMeta
-		yyv2415.CodecDecodeSelf(d)
+		yyv2420 := &x.ObjectMeta
+		yyv2420.CodecDecodeSelf(d)
 	}
-	yyj2412++
-	if yyhl2412 {
-		yyb2412 = yyj2412 > l
+	yyj2417++
+	if yyhl2417 {
+		yyb2417 = yyj2417 > l
 	} else {
-		yyb2412 = r.CheckBreak()
+		yyb2417 = r.CheckBreak()
 	}
-	if yyb2412 {
+	if yyb2417 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = NodeSpec{}
 	} else {
-		yyv2416 := &x.Spec
-		yyv2416.CodecDecodeSelf(d)
+		yyv2421 := &x.Spec
+		yyv2421.CodecDecodeSelf(d)
 	}
-	yyj2412++
-	if yyhl2412 {
-		yyb2412 = yyj2412 > l
+	yyj2417++
+	if yyhl2417 {
+		yyb2417 = yyj2417 > l
 	} else {
-		yyb2412 = r.CheckBreak()
+		yyb2417 = r.CheckBreak()
 	}
-	if yyb2412 {
+	if yyb2417 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = NodeStatus{}
 	} else {
-		yyv2417 := &x.Status
-		yyv2417.CodecDecodeSelf(d)
+		yyv2422 := &x.Status
+		yyv2422.CodecDecodeSelf(d)
 	}
 	for {
-		yyj2412++
-		if yyhl2412 {
-			yyb2412 = yyj2412 > l
+		yyj2417++
+		if yyhl2417 {
+			yyb2417 = yyj2417 > l
 		} else {
-			yyb2412 = r.CheckBreak()
+			yyb2417 = r.CheckBreak()
 		}
-		if yyb2412 {
+		if yyb2417 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2412-1, "")
+		z.DecStructFieldNotFound(yyj2417-1, "")
 	}
 	r.ReadEnd()
 }
@@ -28701,34 +28738,34 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2418 := z.EncBinary()
-		_ = yym2418
+		yym2423 := z.EncBinary()
+		_ = yym2423
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2419 := !z.EncBinary()
-			yy2arr2419 := z.EncBasicHandle().StructToArray
-			var yyq2419 [4]bool
-			_, _, _ = yysep2419, yyq2419, yy2arr2419
-			const yyr2419 bool = false
-			yyq2419[0] = x.Kind != ""
-			yyq2419[1] = x.APIVersion != ""
-			yyq2419[2] = true
-			if yyr2419 || yy2arr2419 {
+			yysep2424 := !z.EncBinary()
+			yy2arr2424 := z.EncBasicHandle().StructToArray
+			var yyq2424 [4]bool
+			_, _, _ = yysep2424, yyq2424, yy2arr2424
+			const yyr2424 bool = false
+			yyq2424[0] = x.Kind != ""
+			yyq2424[1] = x.APIVersion != ""
+			yyq2424[2] = true
+			if yyr2424 || yy2arr2424 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2419 int = 1
-				for _, b := range yyq2419 {
+				var yynn2424 int = 1
+				for _, b := range yyq2424 {
 					if b {
-						yynn2419++
+						yynn2424++
 					}
 				}
-				r.EncodeMapStart(yynn2419)
+				r.EncodeMapStart(yynn2424)
 			}
-			if yyr2419 || yy2arr2419 {
-				if yyq2419[0] {
-					yym2421 := z.EncBinary()
-					_ = yym2421
+			if yyr2424 || yy2arr2424 {
+				if yyq2424[0] {
+					yym2426 := z.EncBinary()
+					_ = yym2426
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -28737,20 +28774,20 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2419[0] {
+				if yyq2424[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2422 := z.EncBinary()
-					_ = yym2422
+					yym2427 := z.EncBinary()
+					_ = yym2427
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2419 || yy2arr2419 {
-				if yyq2419[1] {
-					yym2424 := z.EncBinary()
-					_ = yym2424
+			if yyr2424 || yy2arr2424 {
+				if yyq2424[1] {
+					yym2429 := z.EncBinary()
+					_ = yym2429
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -28759,48 +28796,48 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2419[1] {
+				if yyq2424[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2425 := z.EncBinary()
-					_ = yym2425
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2419 || yy2arr2419 {
-				if yyq2419[2] {
-					yy2427 := &x.ListMeta
-					yym2428 := z.EncBinary()
-					_ = yym2428
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2427) {
-					} else {
-						z.EncFallback(yy2427)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2419[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy2429 := &x.ListMeta
 					yym2430 := z.EncBinary()
 					_ = yym2430
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2429) {
 					} else {
-						z.EncFallback(yy2429)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2419 || yy2arr2419 {
+			if yyr2424 || yy2arr2424 {
+				if yyq2424[2] {
+					yy2432 := &x.ListMeta
+					yym2433 := z.EncBinary()
+					_ = yym2433
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2432) {
+					} else {
+						z.EncFallback(yy2432)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq2424[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy2434 := &x.ListMeta
+					yym2435 := z.EncBinary()
+					_ = yym2435
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2434) {
+					} else {
+						z.EncFallback(yy2434)
+					}
+				}
+			}
+			if yyr2424 || yy2arr2424 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2432 := z.EncBinary()
-					_ = yym2432
+					yym2437 := z.EncBinary()
+					_ = yym2437
 					if false {
 					} else {
 						h.encSliceNode(([]Node)(x.Items), e)
@@ -28811,15 +28848,15 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2433 := z.EncBinary()
-					_ = yym2433
+					yym2438 := z.EncBinary()
+					_ = yym2438
 					if false {
 					} else {
 						h.encSliceNode(([]Node)(x.Items), e)
 					}
 				}
 			}
-			if yysep2419 {
+			if yysep2424 {
 				r.EncodeEnd()
 			}
 		}
@@ -28830,24 +28867,24 @@ func (x *NodeList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2434 := z.DecBinary()
-	_ = yym2434
+	yym2439 := z.DecBinary()
+	_ = yym2439
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2435 := r.ReadMapStart()
-			if yyl2435 == 0 {
+			yyl2440 := r.ReadMapStart()
+			if yyl2440 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2435, d)
+				x.codecDecodeSelfFromMap(yyl2440, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2435 := r.ReadArrayStart()
-			if yyl2435 == 0 {
+			yyl2440 := r.ReadArrayStart()
+			if yyl2440 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2435, d)
+				x.codecDecodeSelfFromArray(yyl2440, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -28859,12 +28896,12 @@ func (x *NodeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2436Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2436Slc
-	var yyhl2436 bool = l >= 0
-	for yyj2436 := 0; ; yyj2436++ {
-		if yyhl2436 {
-			if yyj2436 >= l {
+	var yys2441Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2441Slc
+	var yyhl2441 bool = l >= 0
+	for yyj2441 := 0; ; yyj2441++ {
+		if yyhl2441 {
+			if yyj2441 >= l {
 				break
 			}
 		} else {
@@ -28872,9 +28909,9 @@ func (x *NodeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2436Slc = r.DecodeBytes(yys2436Slc, true, true)
-		yys2436 := string(yys2436Slc)
-		switch yys2436 {
+		yys2441Slc = r.DecodeBytes(yys2441Slc, true, true)
+		yys2441 := string(yys2441Slc)
+		switch yys2441 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -28891,32 +28928,32 @@ func (x *NodeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv2439 := &x.ListMeta
-				yym2440 := z.DecBinary()
-				_ = yym2440
+				yyv2444 := &x.ListMeta
+				yym2445 := z.DecBinary()
+				_ = yym2445
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2439) {
+				} else if z.HasExtensions() && z.DecExt(yyv2444) {
 				} else {
-					z.DecFallback(yyv2439, false)
+					z.DecFallback(yyv2444, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv2441 := &x.Items
-				yym2442 := z.DecBinary()
-				_ = yym2442
+				yyv2446 := &x.Items
+				yym2447 := z.DecBinary()
+				_ = yym2447
 				if false {
 				} else {
-					h.decSliceNode((*[]Node)(yyv2441), d)
+					h.decSliceNode((*[]Node)(yyv2446), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2436)
-		} // end switch yys2436
-	} // end for yyj2436
-	if !yyhl2436 {
+			z.DecStructFieldNotFound(-1, yys2441)
+		} // end switch yys2441
+	} // end for yyj2441
+	if !yyhl2441 {
 		r.ReadEnd()
 	}
 }
@@ -28925,16 +28962,16 @@ func (x *NodeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2443 int
-	var yyb2443 bool
-	var yyhl2443 bool = l >= 0
-	yyj2443++
-	if yyhl2443 {
-		yyb2443 = yyj2443 > l
+	var yyj2448 int
+	var yyb2448 bool
+	var yyhl2448 bool = l >= 0
+	yyj2448++
+	if yyhl2448 {
+		yyb2448 = yyj2448 > l
 	} else {
-		yyb2443 = r.CheckBreak()
+		yyb2448 = r.CheckBreak()
 	}
-	if yyb2443 {
+	if yyb2448 {
 		r.ReadEnd()
 		return
 	}
@@ -28943,13 +28980,13 @@ func (x *NodeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2443++
-	if yyhl2443 {
-		yyb2443 = yyj2443 > l
+	yyj2448++
+	if yyhl2448 {
+		yyb2448 = yyj2448 > l
 	} else {
-		yyb2443 = r.CheckBreak()
+		yyb2448 = r.CheckBreak()
 	}
-	if yyb2443 {
+	if yyb2448 {
 		r.ReadEnd()
 		return
 	}
@@ -28958,60 +28995,60 @@ func (x *NodeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2443++
-	if yyhl2443 {
-		yyb2443 = yyj2443 > l
+	yyj2448++
+	if yyhl2448 {
+		yyb2448 = yyj2448 > l
 	} else {
-		yyb2443 = r.CheckBreak()
+		yyb2448 = r.CheckBreak()
 	}
-	if yyb2443 {
+	if yyb2448 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv2446 := &x.ListMeta
-		yym2447 := z.DecBinary()
-		_ = yym2447
+		yyv2451 := &x.ListMeta
+		yym2452 := z.DecBinary()
+		_ = yym2452
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2446) {
+		} else if z.HasExtensions() && z.DecExt(yyv2451) {
 		} else {
-			z.DecFallback(yyv2446, false)
+			z.DecFallback(yyv2451, false)
 		}
 	}
-	yyj2443++
-	if yyhl2443 {
-		yyb2443 = yyj2443 > l
+	yyj2448++
+	if yyhl2448 {
+		yyb2448 = yyj2448 > l
 	} else {
-		yyb2443 = r.CheckBreak()
+		yyb2448 = r.CheckBreak()
 	}
-	if yyb2443 {
+	if yyb2448 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv2448 := &x.Items
-		yym2449 := z.DecBinary()
-		_ = yym2449
+		yyv2453 := &x.Items
+		yym2454 := z.DecBinary()
+		_ = yym2454
 		if false {
 		} else {
-			h.decSliceNode((*[]Node)(yyv2448), d)
+			h.decSliceNode((*[]Node)(yyv2453), d)
 		}
 	}
 	for {
-		yyj2443++
-		if yyhl2443 {
-			yyb2443 = yyj2443 > l
+		yyj2448++
+		if yyhl2448 {
+			yyb2448 = yyj2448 > l
 		} else {
-			yyb2443 = r.CheckBreak()
+			yyb2448 = r.CheckBreak()
 		}
-		if yyb2443 {
+		if yyb2448 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2443-1, "")
+		z.DecStructFieldNotFound(yyj2448-1, "")
 	}
 	r.ReadEnd()
 }
@@ -29023,33 +29060,33 @@ func (x *NamespaceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2450 := z.EncBinary()
-		_ = yym2450
+		yym2455 := z.EncBinary()
+		_ = yym2455
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2451 := !z.EncBinary()
-			yy2arr2451 := z.EncBasicHandle().StructToArray
-			var yyq2451 [1]bool
-			_, _, _ = yysep2451, yyq2451, yy2arr2451
-			const yyr2451 bool = false
-			if yyr2451 || yy2arr2451 {
+			yysep2456 := !z.EncBinary()
+			yy2arr2456 := z.EncBasicHandle().StructToArray
+			var yyq2456 [1]bool
+			_, _, _ = yysep2456, yyq2456, yy2arr2456
+			const yyr2456 bool = false
+			if yyr2456 || yy2arr2456 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn2451 int = 1
-				for _, b := range yyq2451 {
+				var yynn2456 int = 1
+				for _, b := range yyq2456 {
 					if b {
-						yynn2451++
+						yynn2456++
 					}
 				}
-				r.EncodeMapStart(yynn2451)
+				r.EncodeMapStart(yynn2456)
 			}
-			if yyr2451 || yy2arr2451 {
+			if yyr2456 || yy2arr2456 {
 				if x.Finalizers == nil {
 					r.EncodeNil()
 				} else {
-					yym2453 := z.EncBinary()
-					_ = yym2453
+					yym2458 := z.EncBinary()
+					_ = yym2458
 					if false {
 					} else {
 						h.encSliceFinalizerName(([]FinalizerName)(x.Finalizers), e)
@@ -29060,15 +29097,15 @@ func (x *NamespaceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Finalizers == nil {
 					r.EncodeNil()
 				} else {
-					yym2454 := z.EncBinary()
-					_ = yym2454
+					yym2459 := z.EncBinary()
+					_ = yym2459
 					if false {
 					} else {
 						h.encSliceFinalizerName(([]FinalizerName)(x.Finalizers), e)
 					}
 				}
 			}
-			if yysep2451 {
+			if yysep2456 {
 				r.EncodeEnd()
 			}
 		}
@@ -29079,24 +29116,24 @@ func (x *NamespaceSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2455 := z.DecBinary()
-	_ = yym2455
+	yym2460 := z.DecBinary()
+	_ = yym2460
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2456 := r.ReadMapStart()
-			if yyl2456 == 0 {
+			yyl2461 := r.ReadMapStart()
+			if yyl2461 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2456, d)
+				x.codecDecodeSelfFromMap(yyl2461, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2456 := r.ReadArrayStart()
-			if yyl2456 == 0 {
+			yyl2461 := r.ReadArrayStart()
+			if yyl2461 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2456, d)
+				x.codecDecodeSelfFromArray(yyl2461, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -29108,12 +29145,12 @@ func (x *NamespaceSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2457Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2457Slc
-	var yyhl2457 bool = l >= 0
-	for yyj2457 := 0; ; yyj2457++ {
-		if yyhl2457 {
-			if yyj2457 >= l {
+	var yys2462Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2462Slc
+	var yyhl2462 bool = l >= 0
+	for yyj2462 := 0; ; yyj2462++ {
+		if yyhl2462 {
+			if yyj2462 >= l {
 				break
 			}
 		} else {
@@ -29121,26 +29158,26 @@ func (x *NamespaceSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2457Slc = r.DecodeBytes(yys2457Slc, true, true)
-		yys2457 := string(yys2457Slc)
-		switch yys2457 {
+		yys2462Slc = r.DecodeBytes(yys2462Slc, true, true)
+		yys2462 := string(yys2462Slc)
+		switch yys2462 {
 		case "Finalizers":
 			if r.TryDecodeAsNil() {
 				x.Finalizers = nil
 			} else {
-				yyv2458 := &x.Finalizers
-				yym2459 := z.DecBinary()
-				_ = yym2459
+				yyv2463 := &x.Finalizers
+				yym2464 := z.DecBinary()
+				_ = yym2464
 				if false {
 				} else {
-					h.decSliceFinalizerName((*[]FinalizerName)(yyv2458), d)
+					h.decSliceFinalizerName((*[]FinalizerName)(yyv2463), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2457)
-		} // end switch yys2457
-	} // end for yyj2457
-	if !yyhl2457 {
+			z.DecStructFieldNotFound(-1, yys2462)
+		} // end switch yys2462
+	} // end for yyj2462
+	if !yyhl2462 {
 		r.ReadEnd()
 	}
 }
@@ -29149,41 +29186,41 @@ func (x *NamespaceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2460 int
-	var yyb2460 bool
-	var yyhl2460 bool = l >= 0
-	yyj2460++
-	if yyhl2460 {
-		yyb2460 = yyj2460 > l
+	var yyj2465 int
+	var yyb2465 bool
+	var yyhl2465 bool = l >= 0
+	yyj2465++
+	if yyhl2465 {
+		yyb2465 = yyj2465 > l
 	} else {
-		yyb2460 = r.CheckBreak()
+		yyb2465 = r.CheckBreak()
 	}
-	if yyb2460 {
+	if yyb2465 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Finalizers = nil
 	} else {
-		yyv2461 := &x.Finalizers
-		yym2462 := z.DecBinary()
-		_ = yym2462
+		yyv2466 := &x.Finalizers
+		yym2467 := z.DecBinary()
+		_ = yym2467
 		if false {
 		} else {
-			h.decSliceFinalizerName((*[]FinalizerName)(yyv2461), d)
+			h.decSliceFinalizerName((*[]FinalizerName)(yyv2466), d)
 		}
 	}
 	for {
-		yyj2460++
-		if yyhl2460 {
-			yyb2460 = yyj2460 > l
+		yyj2465++
+		if yyhl2465 {
+			yyb2465 = yyj2465 > l
 		} else {
-			yyb2460 = r.CheckBreak()
+			yyb2465 = r.CheckBreak()
 		}
-		if yyb2460 {
+		if yyb2465 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2460-1, "")
+		z.DecStructFieldNotFound(yyj2465-1, "")
 	}
 	r.ReadEnd()
 }
@@ -29192,8 +29229,8 @@ func (x FinalizerName) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym2463 := z.EncBinary()
-	_ = yym2463
+	yym2468 := z.EncBinary()
+	_ = yym2468
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -29205,8 +29242,8 @@ func (x *FinalizerName) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2464 := z.DecBinary()
-	_ = yym2464
+	yym2469 := z.DecBinary()
+	_ = yym2469
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -29221,41 +29258,41 @@ func (x *NamespaceStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2465 := z.EncBinary()
-		_ = yym2465
+		yym2470 := z.EncBinary()
+		_ = yym2470
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2466 := !z.EncBinary()
-			yy2arr2466 := z.EncBasicHandle().StructToArray
-			var yyq2466 [1]bool
-			_, _, _ = yysep2466, yyq2466, yy2arr2466
-			const yyr2466 bool = false
-			yyq2466[0] = x.Phase != ""
-			if yyr2466 || yy2arr2466 {
+			yysep2471 := !z.EncBinary()
+			yy2arr2471 := z.EncBasicHandle().StructToArray
+			var yyq2471 [1]bool
+			_, _, _ = yysep2471, yyq2471, yy2arr2471
+			const yyr2471 bool = false
+			yyq2471[0] = x.Phase != ""
+			if yyr2471 || yy2arr2471 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn2466 int = 0
-				for _, b := range yyq2466 {
+				var yynn2471 int = 0
+				for _, b := range yyq2471 {
 					if b {
-						yynn2466++
+						yynn2471++
 					}
 				}
-				r.EncodeMapStart(yynn2466)
+				r.EncodeMapStart(yynn2471)
 			}
-			if yyr2466 || yy2arr2466 {
-				if yyq2466[0] {
+			if yyr2471 || yy2arr2471 {
+				if yyq2471[0] {
 					x.Phase.CodecEncodeSelf(e)
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2466[0] {
+				if yyq2471[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("phase"))
 					x.Phase.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2466 {
+			if yysep2471 {
 				r.EncodeEnd()
 			}
 		}
@@ -29266,24 +29303,24 @@ func (x *NamespaceStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2468 := z.DecBinary()
-	_ = yym2468
+	yym2473 := z.DecBinary()
+	_ = yym2473
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2469 := r.ReadMapStart()
-			if yyl2469 == 0 {
+			yyl2474 := r.ReadMapStart()
+			if yyl2474 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2469, d)
+				x.codecDecodeSelfFromMap(yyl2474, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2469 := r.ReadArrayStart()
-			if yyl2469 == 0 {
+			yyl2474 := r.ReadArrayStart()
+			if yyl2474 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2469, d)
+				x.codecDecodeSelfFromArray(yyl2474, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -29295,12 +29332,12 @@ func (x *NamespaceStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2470Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2470Slc
-	var yyhl2470 bool = l >= 0
-	for yyj2470 := 0; ; yyj2470++ {
-		if yyhl2470 {
-			if yyj2470 >= l {
+	var yys2475Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2475Slc
+	var yyhl2475 bool = l >= 0
+	for yyj2475 := 0; ; yyj2475++ {
+		if yyhl2475 {
+			if yyj2475 >= l {
 				break
 			}
 		} else {
@@ -29308,9 +29345,9 @@ func (x *NamespaceStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2470Slc = r.DecodeBytes(yys2470Slc, true, true)
-		yys2470 := string(yys2470Slc)
-		switch yys2470 {
+		yys2475Slc = r.DecodeBytes(yys2475Slc, true, true)
+		yys2475 := string(yys2475Slc)
+		switch yys2475 {
 		case "phase":
 			if r.TryDecodeAsNil() {
 				x.Phase = ""
@@ -29318,10 +29355,10 @@ func (x *NamespaceStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Phase = NamespacePhase(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2470)
-		} // end switch yys2470
-	} // end for yyj2470
-	if !yyhl2470 {
+			z.DecStructFieldNotFound(-1, yys2475)
+		} // end switch yys2475
+	} // end for yyj2475
+	if !yyhl2475 {
 		r.ReadEnd()
 	}
 }
@@ -29330,16 +29367,16 @@ func (x *NamespaceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2472 int
-	var yyb2472 bool
-	var yyhl2472 bool = l >= 0
-	yyj2472++
-	if yyhl2472 {
-		yyb2472 = yyj2472 > l
+	var yyj2477 int
+	var yyb2477 bool
+	var yyhl2477 bool = l >= 0
+	yyj2477++
+	if yyhl2477 {
+		yyb2477 = yyj2477 > l
 	} else {
-		yyb2472 = r.CheckBreak()
+		yyb2477 = r.CheckBreak()
 	}
-	if yyb2472 {
+	if yyb2477 {
 		r.ReadEnd()
 		return
 	}
@@ -29349,16 +29386,16 @@ func (x *NamespaceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.Phase = NamespacePhase(r.DecodeString())
 	}
 	for {
-		yyj2472++
-		if yyhl2472 {
-			yyb2472 = yyj2472 > l
+		yyj2477++
+		if yyhl2477 {
+			yyb2477 = yyj2477 > l
 		} else {
-			yyb2472 = r.CheckBreak()
+			yyb2477 = r.CheckBreak()
 		}
-		if yyb2472 {
+		if yyb2477 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2472-1, "")
+		z.DecStructFieldNotFound(yyj2477-1, "")
 	}
 	r.ReadEnd()
 }
@@ -29367,8 +29404,8 @@ func (x NamespacePhase) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym2474 := z.EncBinary()
-	_ = yym2474
+	yym2479 := z.EncBinary()
+	_ = yym2479
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -29380,8 +29417,8 @@ func (x *NamespacePhase) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2475 := z.DecBinary()
-	_ = yym2475
+	yym2480 := z.DecBinary()
+	_ = yym2480
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -29396,36 +29433,36 @@ func (x *Namespace) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2476 := z.EncBinary()
-		_ = yym2476
+		yym2481 := z.EncBinary()
+		_ = yym2481
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2477 := !z.EncBinary()
-			yy2arr2477 := z.EncBasicHandle().StructToArray
-			var yyq2477 [5]bool
-			_, _, _ = yysep2477, yyq2477, yy2arr2477
-			const yyr2477 bool = false
-			yyq2477[0] = x.Kind != ""
-			yyq2477[1] = x.APIVersion != ""
-			yyq2477[2] = true
-			yyq2477[3] = true
-			yyq2477[4] = true
-			if yyr2477 || yy2arr2477 {
+			yysep2482 := !z.EncBinary()
+			yy2arr2482 := z.EncBasicHandle().StructToArray
+			var yyq2482 [5]bool
+			_, _, _ = yysep2482, yyq2482, yy2arr2482
+			const yyr2482 bool = false
+			yyq2482[0] = x.Kind != ""
+			yyq2482[1] = x.APIVersion != ""
+			yyq2482[2] = true
+			yyq2482[3] = true
+			yyq2482[4] = true
+			if yyr2482 || yy2arr2482 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn2477 int = 0
-				for _, b := range yyq2477 {
+				var yynn2482 int = 0
+				for _, b := range yyq2482 {
 					if b {
-						yynn2477++
+						yynn2482++
 					}
 				}
-				r.EncodeMapStart(yynn2477)
+				r.EncodeMapStart(yynn2482)
 			}
-			if yyr2477 || yy2arr2477 {
-				if yyq2477[0] {
-					yym2479 := z.EncBinary()
-					_ = yym2479
+			if yyr2482 || yy2arr2482 {
+				if yyq2482[0] {
+					yym2484 := z.EncBinary()
+					_ = yym2484
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -29434,20 +29471,20 @@ func (x *Namespace) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2477[0] {
+				if yyq2482[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2480 := z.EncBinary()
-					_ = yym2480
+					yym2485 := z.EncBinary()
+					_ = yym2485
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2477 || yy2arr2477 {
-				if yyq2477[1] {
-					yym2482 := z.EncBinary()
-					_ = yym2482
+			if yyr2482 || yy2arr2482 {
+				if yyq2482[1] {
+					yym2487 := z.EncBinary()
+					_ = yym2487
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -29456,59 +29493,59 @@ func (x *Namespace) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2477[1] {
+				if yyq2482[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2483 := z.EncBinary()
-					_ = yym2483
+					yym2488 := z.EncBinary()
+					_ = yym2488
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2477 || yy2arr2477 {
-				if yyq2477[2] {
-					yy2485 := &x.ObjectMeta
-					yy2485.CodecEncodeSelf(e)
+			if yyr2482 || yy2arr2482 {
+				if yyq2482[2] {
+					yy2490 := &x.ObjectMeta
+					yy2490.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2477[2] {
+				if yyq2482[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy2486 := &x.ObjectMeta
-					yy2486.CodecEncodeSelf(e)
-				}
-			}
-			if yyr2477 || yy2arr2477 {
-				if yyq2477[3] {
-					yy2488 := &x.Spec
-					yy2488.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2477[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy2489 := &x.Spec
-					yy2489.CodecEncodeSelf(e)
-				}
-			}
-			if yyr2477 || yy2arr2477 {
-				if yyq2477[4] {
-					yy2491 := &x.Status
+					yy2491 := &x.ObjectMeta
 					yy2491.CodecEncodeSelf(e)
+				}
+			}
+			if yyr2482 || yy2arr2482 {
+				if yyq2482[3] {
+					yy2493 := &x.Spec
+					yy2493.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2477[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy2492 := &x.Status
-					yy2492.CodecEncodeSelf(e)
+				if yyq2482[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					yy2494 := &x.Spec
+					yy2494.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2477 {
+			if yyr2482 || yy2arr2482 {
+				if yyq2482[4] {
+					yy2496 := &x.Status
+					yy2496.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq2482[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					yy2497 := &x.Status
+					yy2497.CodecEncodeSelf(e)
+				}
+			}
+			if yysep2482 {
 				r.EncodeEnd()
 			}
 		}
@@ -29519,24 +29556,24 @@ func (x *Namespace) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2493 := z.DecBinary()
-	_ = yym2493
+	yym2498 := z.DecBinary()
+	_ = yym2498
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2494 := r.ReadMapStart()
-			if yyl2494 == 0 {
+			yyl2499 := r.ReadMapStart()
+			if yyl2499 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2494, d)
+				x.codecDecodeSelfFromMap(yyl2499, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2494 := r.ReadArrayStart()
-			if yyl2494 == 0 {
+			yyl2499 := r.ReadArrayStart()
+			if yyl2499 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2494, d)
+				x.codecDecodeSelfFromArray(yyl2499, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -29548,12 +29585,12 @@ func (x *Namespace) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2495Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2495Slc
-	var yyhl2495 bool = l >= 0
-	for yyj2495 := 0; ; yyj2495++ {
-		if yyhl2495 {
-			if yyj2495 >= l {
+	var yys2500Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2500Slc
+	var yyhl2500 bool = l >= 0
+	for yyj2500 := 0; ; yyj2500++ {
+		if yyhl2500 {
+			if yyj2500 >= l {
 				break
 			}
 		} else {
@@ -29561,9 +29598,9 @@ func (x *Namespace) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2495Slc = r.DecodeBytes(yys2495Slc, true, true)
-		yys2495 := string(yys2495Slc)
-		switch yys2495 {
+		yys2500Slc = r.DecodeBytes(yys2500Slc, true, true)
+		yys2500 := string(yys2500Slc)
+		switch yys2500 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -29580,28 +29617,28 @@ func (x *Namespace) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv2498 := &x.ObjectMeta
-				yyv2498.CodecDecodeSelf(d)
+				yyv2503 := &x.ObjectMeta
+				yyv2503.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = NamespaceSpec{}
 			} else {
-				yyv2499 := &x.Spec
-				yyv2499.CodecDecodeSelf(d)
+				yyv2504 := &x.Spec
+				yyv2504.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = NamespaceStatus{}
 			} else {
-				yyv2500 := &x.Status
-				yyv2500.CodecDecodeSelf(d)
+				yyv2505 := &x.Status
+				yyv2505.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2495)
-		} // end switch yys2495
-	} // end for yyj2495
-	if !yyhl2495 {
+			z.DecStructFieldNotFound(-1, yys2500)
+		} // end switch yys2500
+	} // end for yyj2500
+	if !yyhl2500 {
 		r.ReadEnd()
 	}
 }
@@ -29610,16 +29647,16 @@ func (x *Namespace) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2501 int
-	var yyb2501 bool
-	var yyhl2501 bool = l >= 0
-	yyj2501++
-	if yyhl2501 {
-		yyb2501 = yyj2501 > l
+	var yyj2506 int
+	var yyb2506 bool
+	var yyhl2506 bool = l >= 0
+	yyj2506++
+	if yyhl2506 {
+		yyb2506 = yyj2506 > l
 	} else {
-		yyb2501 = r.CheckBreak()
+		yyb2506 = r.CheckBreak()
 	}
-	if yyb2501 {
+	if yyb2506 {
 		r.ReadEnd()
 		return
 	}
@@ -29628,13 +29665,13 @@ func (x *Namespace) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2501++
-	if yyhl2501 {
-		yyb2501 = yyj2501 > l
+	yyj2506++
+	if yyhl2506 {
+		yyb2506 = yyj2506 > l
 	} else {
-		yyb2501 = r.CheckBreak()
+		yyb2506 = r.CheckBreak()
 	}
-	if yyb2501 {
+	if yyb2506 {
 		r.ReadEnd()
 		return
 	}
@@ -29643,65 +29680,65 @@ func (x *Namespace) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2501++
-	if yyhl2501 {
-		yyb2501 = yyj2501 > l
+	yyj2506++
+	if yyhl2506 {
+		yyb2506 = yyj2506 > l
 	} else {
-		yyb2501 = r.CheckBreak()
+		yyb2506 = r.CheckBreak()
 	}
-	if yyb2501 {
+	if yyb2506 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv2504 := &x.ObjectMeta
-		yyv2504.CodecDecodeSelf(d)
+		yyv2509 := &x.ObjectMeta
+		yyv2509.CodecDecodeSelf(d)
 	}
-	yyj2501++
-	if yyhl2501 {
-		yyb2501 = yyj2501 > l
+	yyj2506++
+	if yyhl2506 {
+		yyb2506 = yyj2506 > l
 	} else {
-		yyb2501 = r.CheckBreak()
+		yyb2506 = r.CheckBreak()
 	}
-	if yyb2501 {
+	if yyb2506 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = NamespaceSpec{}
 	} else {
-		yyv2505 := &x.Spec
-		yyv2505.CodecDecodeSelf(d)
+		yyv2510 := &x.Spec
+		yyv2510.CodecDecodeSelf(d)
 	}
-	yyj2501++
-	if yyhl2501 {
-		yyb2501 = yyj2501 > l
+	yyj2506++
+	if yyhl2506 {
+		yyb2506 = yyj2506 > l
 	} else {
-		yyb2501 = r.CheckBreak()
+		yyb2506 = r.CheckBreak()
 	}
-	if yyb2501 {
+	if yyb2506 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = NamespaceStatus{}
 	} else {
-		yyv2506 := &x.Status
-		yyv2506.CodecDecodeSelf(d)
+		yyv2511 := &x.Status
+		yyv2511.CodecDecodeSelf(d)
 	}
 	for {
-		yyj2501++
-		if yyhl2501 {
-			yyb2501 = yyj2501 > l
+		yyj2506++
+		if yyhl2506 {
+			yyb2506 = yyj2506 > l
 		} else {
-			yyb2501 = r.CheckBreak()
+			yyb2506 = r.CheckBreak()
 		}
-		if yyb2501 {
+		if yyb2506 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2501-1, "")
+		z.DecStructFieldNotFound(yyj2506-1, "")
 	}
 	r.ReadEnd()
 }
@@ -29713,34 +29750,34 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2507 := z.EncBinary()
-		_ = yym2507
+		yym2512 := z.EncBinary()
+		_ = yym2512
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2508 := !z.EncBinary()
-			yy2arr2508 := z.EncBasicHandle().StructToArray
-			var yyq2508 [4]bool
-			_, _, _ = yysep2508, yyq2508, yy2arr2508
-			const yyr2508 bool = false
-			yyq2508[0] = x.Kind != ""
-			yyq2508[1] = x.APIVersion != ""
-			yyq2508[2] = true
-			if yyr2508 || yy2arr2508 {
+			yysep2513 := !z.EncBinary()
+			yy2arr2513 := z.EncBasicHandle().StructToArray
+			var yyq2513 [4]bool
+			_, _, _ = yysep2513, yyq2513, yy2arr2513
+			const yyr2513 bool = false
+			yyq2513[0] = x.Kind != ""
+			yyq2513[1] = x.APIVersion != ""
+			yyq2513[2] = true
+			if yyr2513 || yy2arr2513 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2508 int = 1
-				for _, b := range yyq2508 {
+				var yynn2513 int = 1
+				for _, b := range yyq2513 {
 					if b {
-						yynn2508++
+						yynn2513++
 					}
 				}
-				r.EncodeMapStart(yynn2508)
+				r.EncodeMapStart(yynn2513)
 			}
-			if yyr2508 || yy2arr2508 {
-				if yyq2508[0] {
-					yym2510 := z.EncBinary()
-					_ = yym2510
+			if yyr2513 || yy2arr2513 {
+				if yyq2513[0] {
+					yym2515 := z.EncBinary()
+					_ = yym2515
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -29749,20 +29786,20 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2508[0] {
+				if yyq2513[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2511 := z.EncBinary()
-					_ = yym2511
+					yym2516 := z.EncBinary()
+					_ = yym2516
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2508 || yy2arr2508 {
-				if yyq2508[1] {
-					yym2513 := z.EncBinary()
-					_ = yym2513
+			if yyr2513 || yy2arr2513 {
+				if yyq2513[1] {
+					yym2518 := z.EncBinary()
+					_ = yym2518
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -29771,48 +29808,48 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2508[1] {
+				if yyq2513[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2514 := z.EncBinary()
-					_ = yym2514
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2508 || yy2arr2508 {
-				if yyq2508[2] {
-					yy2516 := &x.ListMeta
-					yym2517 := z.EncBinary()
-					_ = yym2517
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2516) {
-					} else {
-						z.EncFallback(yy2516)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2508[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy2518 := &x.ListMeta
 					yym2519 := z.EncBinary()
 					_ = yym2519
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2518) {
 					} else {
-						z.EncFallback(yy2518)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2508 || yy2arr2508 {
+			if yyr2513 || yy2arr2513 {
+				if yyq2513[2] {
+					yy2521 := &x.ListMeta
+					yym2522 := z.EncBinary()
+					_ = yym2522
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2521) {
+					} else {
+						z.EncFallback(yy2521)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq2513[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy2523 := &x.ListMeta
+					yym2524 := z.EncBinary()
+					_ = yym2524
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2523) {
+					} else {
+						z.EncFallback(yy2523)
+					}
+				}
+			}
+			if yyr2513 || yy2arr2513 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2521 := z.EncBinary()
-					_ = yym2521
+					yym2526 := z.EncBinary()
+					_ = yym2526
 					if false {
 					} else {
 						h.encSliceNamespace(([]Namespace)(x.Items), e)
@@ -29823,15 +29860,15 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2522 := z.EncBinary()
-					_ = yym2522
+					yym2527 := z.EncBinary()
+					_ = yym2527
 					if false {
 					} else {
 						h.encSliceNamespace(([]Namespace)(x.Items), e)
 					}
 				}
 			}
-			if yysep2508 {
+			if yysep2513 {
 				r.EncodeEnd()
 			}
 		}
@@ -29842,24 +29879,24 @@ func (x *NamespaceList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2523 := z.DecBinary()
-	_ = yym2523
+	yym2528 := z.DecBinary()
+	_ = yym2528
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2524 := r.ReadMapStart()
-			if yyl2524 == 0 {
+			yyl2529 := r.ReadMapStart()
+			if yyl2529 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2524, d)
+				x.codecDecodeSelfFromMap(yyl2529, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2524 := r.ReadArrayStart()
-			if yyl2524 == 0 {
+			yyl2529 := r.ReadArrayStart()
+			if yyl2529 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2524, d)
+				x.codecDecodeSelfFromArray(yyl2529, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -29871,12 +29908,12 @@ func (x *NamespaceList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2525Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2525Slc
-	var yyhl2525 bool = l >= 0
-	for yyj2525 := 0; ; yyj2525++ {
-		if yyhl2525 {
-			if yyj2525 >= l {
+	var yys2530Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2530Slc
+	var yyhl2530 bool = l >= 0
+	for yyj2530 := 0; ; yyj2530++ {
+		if yyhl2530 {
+			if yyj2530 >= l {
 				break
 			}
 		} else {
@@ -29884,9 +29921,9 @@ func (x *NamespaceList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2525Slc = r.DecodeBytes(yys2525Slc, true, true)
-		yys2525 := string(yys2525Slc)
-		switch yys2525 {
+		yys2530Slc = r.DecodeBytes(yys2530Slc, true, true)
+		yys2530 := string(yys2530Slc)
+		switch yys2530 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -29903,32 +29940,32 @@ func (x *NamespaceList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv2528 := &x.ListMeta
-				yym2529 := z.DecBinary()
-				_ = yym2529
+				yyv2533 := &x.ListMeta
+				yym2534 := z.DecBinary()
+				_ = yym2534
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2528) {
+				} else if z.HasExtensions() && z.DecExt(yyv2533) {
 				} else {
-					z.DecFallback(yyv2528, false)
+					z.DecFallback(yyv2533, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv2530 := &x.Items
-				yym2531 := z.DecBinary()
-				_ = yym2531
+				yyv2535 := &x.Items
+				yym2536 := z.DecBinary()
+				_ = yym2536
 				if false {
 				} else {
-					h.decSliceNamespace((*[]Namespace)(yyv2530), d)
+					h.decSliceNamespace((*[]Namespace)(yyv2535), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2525)
-		} // end switch yys2525
-	} // end for yyj2525
-	if !yyhl2525 {
+			z.DecStructFieldNotFound(-1, yys2530)
+		} // end switch yys2530
+	} // end for yyj2530
+	if !yyhl2530 {
 		r.ReadEnd()
 	}
 }
@@ -29937,16 +29974,16 @@ func (x *NamespaceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2532 int
-	var yyb2532 bool
-	var yyhl2532 bool = l >= 0
-	yyj2532++
-	if yyhl2532 {
-		yyb2532 = yyj2532 > l
+	var yyj2537 int
+	var yyb2537 bool
+	var yyhl2537 bool = l >= 0
+	yyj2537++
+	if yyhl2537 {
+		yyb2537 = yyj2537 > l
 	} else {
-		yyb2532 = r.CheckBreak()
+		yyb2537 = r.CheckBreak()
 	}
-	if yyb2532 {
+	if yyb2537 {
 		r.ReadEnd()
 		return
 	}
@@ -29955,13 +29992,13 @@ func (x *NamespaceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2532++
-	if yyhl2532 {
-		yyb2532 = yyj2532 > l
+	yyj2537++
+	if yyhl2537 {
+		yyb2537 = yyj2537 > l
 	} else {
-		yyb2532 = r.CheckBreak()
+		yyb2537 = r.CheckBreak()
 	}
-	if yyb2532 {
+	if yyb2537 {
 		r.ReadEnd()
 		return
 	}
@@ -29970,60 +30007,60 @@ func (x *NamespaceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2532++
-	if yyhl2532 {
-		yyb2532 = yyj2532 > l
+	yyj2537++
+	if yyhl2537 {
+		yyb2537 = yyj2537 > l
 	} else {
-		yyb2532 = r.CheckBreak()
+		yyb2537 = r.CheckBreak()
 	}
-	if yyb2532 {
+	if yyb2537 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv2535 := &x.ListMeta
-		yym2536 := z.DecBinary()
-		_ = yym2536
+		yyv2540 := &x.ListMeta
+		yym2541 := z.DecBinary()
+		_ = yym2541
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2535) {
+		} else if z.HasExtensions() && z.DecExt(yyv2540) {
 		} else {
-			z.DecFallback(yyv2535, false)
+			z.DecFallback(yyv2540, false)
 		}
 	}
-	yyj2532++
-	if yyhl2532 {
-		yyb2532 = yyj2532 > l
+	yyj2537++
+	if yyhl2537 {
+		yyb2537 = yyj2537 > l
 	} else {
-		yyb2532 = r.CheckBreak()
+		yyb2537 = r.CheckBreak()
 	}
-	if yyb2532 {
+	if yyb2537 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv2537 := &x.Items
-		yym2538 := z.DecBinary()
-		_ = yym2538
+		yyv2542 := &x.Items
+		yym2543 := z.DecBinary()
+		_ = yym2543
 		if false {
 		} else {
-			h.decSliceNamespace((*[]Namespace)(yyv2537), d)
+			h.decSliceNamespace((*[]Namespace)(yyv2542), d)
 		}
 	}
 	for {
-		yyj2532++
-		if yyhl2532 {
-			yyb2532 = yyj2532 > l
+		yyj2537++
+		if yyhl2537 {
+			yyb2537 = yyj2537 > l
 		} else {
-			yyb2532 = r.CheckBreak()
+			yyb2537 = r.CheckBreak()
 		}
-		if yyb2532 {
+		if yyb2537 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2532-1, "")
+		z.DecStructFieldNotFound(yyj2537-1, "")
 	}
 	r.ReadEnd()
 }
@@ -30035,34 +30072,34 @@ func (x *Binding) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2539 := z.EncBinary()
-		_ = yym2539
+		yym2544 := z.EncBinary()
+		_ = yym2544
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2540 := !z.EncBinary()
-			yy2arr2540 := z.EncBasicHandle().StructToArray
-			var yyq2540 [4]bool
-			_, _, _ = yysep2540, yyq2540, yy2arr2540
-			const yyr2540 bool = false
-			yyq2540[0] = x.Kind != ""
-			yyq2540[1] = x.APIVersion != ""
-			yyq2540[2] = true
-			if yyr2540 || yy2arr2540 {
+			yysep2545 := !z.EncBinary()
+			yy2arr2545 := z.EncBasicHandle().StructToArray
+			var yyq2545 [4]bool
+			_, _, _ = yysep2545, yyq2545, yy2arr2545
+			const yyr2545 bool = false
+			yyq2545[0] = x.Kind != ""
+			yyq2545[1] = x.APIVersion != ""
+			yyq2545[2] = true
+			if yyr2545 || yy2arr2545 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2540 int = 1
-				for _, b := range yyq2540 {
+				var yynn2545 int = 1
+				for _, b := range yyq2545 {
 					if b {
-						yynn2540++
+						yynn2545++
 					}
 				}
-				r.EncodeMapStart(yynn2540)
+				r.EncodeMapStart(yynn2545)
 			}
-			if yyr2540 || yy2arr2540 {
-				if yyq2540[0] {
-					yym2542 := z.EncBinary()
-					_ = yym2542
+			if yyr2545 || yy2arr2545 {
+				if yyq2545[0] {
+					yym2547 := z.EncBinary()
+					_ = yym2547
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -30071,20 +30108,20 @@ func (x *Binding) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2540[0] {
+				if yyq2545[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2543 := z.EncBinary()
-					_ = yym2543
+					yym2548 := z.EncBinary()
+					_ = yym2548
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2540 || yy2arr2540 {
-				if yyq2540[1] {
-					yym2545 := z.EncBinary()
-					_ = yym2545
+			if yyr2545 || yy2arr2545 {
+				if yyq2545[1] {
+					yym2550 := z.EncBinary()
+					_ = yym2550
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -30093,39 +30130,39 @@ func (x *Binding) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2540[1] {
+				if yyq2545[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2546 := z.EncBinary()
-					_ = yym2546
+					yym2551 := z.EncBinary()
+					_ = yym2551
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2540 || yy2arr2540 {
-				if yyq2540[2] {
-					yy2548 := &x.ObjectMeta
-					yy2548.CodecEncodeSelf(e)
+			if yyr2545 || yy2arr2545 {
+				if yyq2545[2] {
+					yy2553 := &x.ObjectMeta
+					yy2553.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2540[2] {
+				if yyq2545[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy2549 := &x.ObjectMeta
-					yy2549.CodecEncodeSelf(e)
+					yy2554 := &x.ObjectMeta
+					yy2554.CodecEncodeSelf(e)
 				}
 			}
-			if yyr2540 || yy2arr2540 {
-				yy2551 := &x.Target
-				yy2551.CodecEncodeSelf(e)
+			if yyr2545 || yy2arr2545 {
+				yy2556 := &x.Target
+				yy2556.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("target"))
-				yy2552 := &x.Target
-				yy2552.CodecEncodeSelf(e)
+				yy2557 := &x.Target
+				yy2557.CodecEncodeSelf(e)
 			}
-			if yysep2540 {
+			if yysep2545 {
 				r.EncodeEnd()
 			}
 		}
@@ -30136,24 +30173,24 @@ func (x *Binding) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2553 := z.DecBinary()
-	_ = yym2553
+	yym2558 := z.DecBinary()
+	_ = yym2558
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2554 := r.ReadMapStart()
-			if yyl2554 == 0 {
+			yyl2559 := r.ReadMapStart()
+			if yyl2559 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2554, d)
+				x.codecDecodeSelfFromMap(yyl2559, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2554 := r.ReadArrayStart()
-			if yyl2554 == 0 {
+			yyl2559 := r.ReadArrayStart()
+			if yyl2559 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2554, d)
+				x.codecDecodeSelfFromArray(yyl2559, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -30165,12 +30202,12 @@ func (x *Binding) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2555Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2555Slc
-	var yyhl2555 bool = l >= 0
-	for yyj2555 := 0; ; yyj2555++ {
-		if yyhl2555 {
-			if yyj2555 >= l {
+	var yys2560Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2560Slc
+	var yyhl2560 bool = l >= 0
+	for yyj2560 := 0; ; yyj2560++ {
+		if yyhl2560 {
+			if yyj2560 >= l {
 				break
 			}
 		} else {
@@ -30178,9 +30215,9 @@ func (x *Binding) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2555Slc = r.DecodeBytes(yys2555Slc, true, true)
-		yys2555 := string(yys2555Slc)
-		switch yys2555 {
+		yys2560Slc = r.DecodeBytes(yys2560Slc, true, true)
+		yys2560 := string(yys2560Slc)
+		switch yys2560 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -30197,21 +30234,21 @@ func (x *Binding) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv2558 := &x.ObjectMeta
-				yyv2558.CodecDecodeSelf(d)
+				yyv2563 := &x.ObjectMeta
+				yyv2563.CodecDecodeSelf(d)
 			}
 		case "target":
 			if r.TryDecodeAsNil() {
 				x.Target = ObjectReference{}
 			} else {
-				yyv2559 := &x.Target
-				yyv2559.CodecDecodeSelf(d)
+				yyv2564 := &x.Target
+				yyv2564.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2555)
-		} // end switch yys2555
-	} // end for yyj2555
-	if !yyhl2555 {
+			z.DecStructFieldNotFound(-1, yys2560)
+		} // end switch yys2560
+	} // end for yyj2560
+	if !yyhl2560 {
 		r.ReadEnd()
 	}
 }
@@ -30220,16 +30257,16 @@ func (x *Binding) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2560 int
-	var yyb2560 bool
-	var yyhl2560 bool = l >= 0
-	yyj2560++
-	if yyhl2560 {
-		yyb2560 = yyj2560 > l
+	var yyj2565 int
+	var yyb2565 bool
+	var yyhl2565 bool = l >= 0
+	yyj2565++
+	if yyhl2565 {
+		yyb2565 = yyj2565 > l
 	} else {
-		yyb2560 = r.CheckBreak()
+		yyb2565 = r.CheckBreak()
 	}
-	if yyb2560 {
+	if yyb2565 {
 		r.ReadEnd()
 		return
 	}
@@ -30238,13 +30275,13 @@ func (x *Binding) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2560++
-	if yyhl2560 {
-		yyb2560 = yyj2560 > l
+	yyj2565++
+	if yyhl2565 {
+		yyb2565 = yyj2565 > l
 	} else {
-		yyb2560 = r.CheckBreak()
+		yyb2565 = r.CheckBreak()
 	}
-	if yyb2560 {
+	if yyb2565 {
 		r.ReadEnd()
 		return
 	}
@@ -30253,49 +30290,49 @@ func (x *Binding) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2560++
-	if yyhl2560 {
-		yyb2560 = yyj2560 > l
+	yyj2565++
+	if yyhl2565 {
+		yyb2565 = yyj2565 > l
 	} else {
-		yyb2560 = r.CheckBreak()
+		yyb2565 = r.CheckBreak()
 	}
-	if yyb2560 {
+	if yyb2565 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv2563 := &x.ObjectMeta
-		yyv2563.CodecDecodeSelf(d)
+		yyv2568 := &x.ObjectMeta
+		yyv2568.CodecDecodeSelf(d)
 	}
-	yyj2560++
-	if yyhl2560 {
-		yyb2560 = yyj2560 > l
+	yyj2565++
+	if yyhl2565 {
+		yyb2565 = yyj2565 > l
 	} else {
-		yyb2560 = r.CheckBreak()
+		yyb2565 = r.CheckBreak()
 	}
-	if yyb2560 {
+	if yyb2565 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Target = ObjectReference{}
 	} else {
-		yyv2564 := &x.Target
-		yyv2564.CodecDecodeSelf(d)
+		yyv2569 := &x.Target
+		yyv2569.CodecDecodeSelf(d)
 	}
 	for {
-		yyj2560++
-		if yyhl2560 {
-			yyb2560 = yyj2560 > l
+		yyj2565++
+		if yyhl2565 {
+			yyb2565 = yyj2565 > l
 		} else {
-			yyb2560 = r.CheckBreak()
+			yyb2565 = r.CheckBreak()
 		}
-		if yyb2560 {
+		if yyb2565 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2560-1, "")
+		z.DecStructFieldNotFound(yyj2565-1, "")
 	}
 	r.ReadEnd()
 }
@@ -30307,33 +30344,33 @@ func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2565 := z.EncBinary()
-		_ = yym2565
+		yym2570 := z.EncBinary()
+		_ = yym2570
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2566 := !z.EncBinary()
-			yy2arr2566 := z.EncBasicHandle().StructToArray
-			var yyq2566 [3]bool
-			_, _, _ = yysep2566, yyq2566, yy2arr2566
-			const yyr2566 bool = false
-			yyq2566[0] = x.Kind != ""
-			yyq2566[1] = x.APIVersion != ""
-			if yyr2566 || yy2arr2566 {
+			yysep2571 := !z.EncBinary()
+			yy2arr2571 := z.EncBasicHandle().StructToArray
+			var yyq2571 [3]bool
+			_, _, _ = yysep2571, yyq2571, yy2arr2571
+			const yyr2571 bool = false
+			yyq2571[0] = x.Kind != ""
+			yyq2571[1] = x.APIVersion != ""
+			if yyr2571 || yy2arr2571 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn2566 int = 1
-				for _, b := range yyq2566 {
+				var yynn2571 int = 1
+				for _, b := range yyq2571 {
 					if b {
-						yynn2566++
+						yynn2571++
 					}
 				}
-				r.EncodeMapStart(yynn2566)
+				r.EncodeMapStart(yynn2571)
 			}
-			if yyr2566 || yy2arr2566 {
-				if yyq2566[0] {
-					yym2568 := z.EncBinary()
-					_ = yym2568
+			if yyr2571 || yy2arr2571 {
+				if yyq2571[0] {
+					yym2573 := z.EncBinary()
+					_ = yym2573
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -30342,20 +30379,20 @@ func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2566[0] {
+				if yyq2571[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2569 := z.EncBinary()
-					_ = yym2569
+					yym2574 := z.EncBinary()
+					_ = yym2574
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2566 || yy2arr2566 {
-				if yyq2566[1] {
-					yym2571 := z.EncBinary()
-					_ = yym2571
+			if yyr2571 || yy2arr2571 {
+				if yyq2571[1] {
+					yym2576 := z.EncBinary()
+					_ = yym2576
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -30364,26 +30401,26 @@ func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2566[1] {
+				if yyq2571[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2572 := z.EncBinary()
-					_ = yym2572
+					yym2577 := z.EncBinary()
+					_ = yym2577
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2566 || yy2arr2566 {
+			if yyr2571 || yy2arr2571 {
 				if x.GracePeriodSeconds == nil {
 					r.EncodeNil()
 				} else {
-					yy2574 := *x.GracePeriodSeconds
-					yym2575 := z.EncBinary()
-					_ = yym2575
+					yy2579 := *x.GracePeriodSeconds
+					yym2580 := z.EncBinary()
+					_ = yym2580
 					if false {
 					} else {
-						r.EncodeInt(int64(yy2574))
+						r.EncodeInt(int64(yy2579))
 					}
 				}
 			} else {
@@ -30391,16 +30428,16 @@ func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.GracePeriodSeconds == nil {
 					r.EncodeNil()
 				} else {
-					yy2576 := *x.GracePeriodSeconds
-					yym2577 := z.EncBinary()
-					_ = yym2577
+					yy2581 := *x.GracePeriodSeconds
+					yym2582 := z.EncBinary()
+					_ = yym2582
 					if false {
 					} else {
-						r.EncodeInt(int64(yy2576))
+						r.EncodeInt(int64(yy2581))
 					}
 				}
 			}
-			if yysep2566 {
+			if yysep2571 {
 				r.EncodeEnd()
 			}
 		}
@@ -30411,24 +30448,24 @@ func (x *DeleteOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2578 := z.DecBinary()
-	_ = yym2578
+	yym2583 := z.DecBinary()
+	_ = yym2583
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2579 := r.ReadMapStart()
-			if yyl2579 == 0 {
+			yyl2584 := r.ReadMapStart()
+			if yyl2584 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2579, d)
+				x.codecDecodeSelfFromMap(yyl2584, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2579 := r.ReadArrayStart()
-			if yyl2579 == 0 {
+			yyl2584 := r.ReadArrayStart()
+			if yyl2584 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2579, d)
+				x.codecDecodeSelfFromArray(yyl2584, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -30440,12 +30477,12 @@ func (x *DeleteOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2580Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2580Slc
-	var yyhl2580 bool = l >= 0
-	for yyj2580 := 0; ; yyj2580++ {
-		if yyhl2580 {
-			if yyj2580 >= l {
+	var yys2585Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2585Slc
+	var yyhl2585 bool = l >= 0
+	for yyj2585 := 0; ; yyj2585++ {
+		if yyhl2585 {
+			if yyj2585 >= l {
 				break
 			}
 		} else {
@@ -30453,9 +30490,9 @@ func (x *DeleteOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2580Slc = r.DecodeBytes(yys2580Slc, true, true)
-		yys2580 := string(yys2580Slc)
-		switch yys2580 {
+		yys2585Slc = r.DecodeBytes(yys2585Slc, true, true)
+		yys2585 := string(yys2585Slc)
+		switch yys2585 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -30477,18 +30514,18 @@ func (x *DeleteOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.GracePeriodSeconds == nil {
 					x.GracePeriodSeconds = new(int64)
 				}
-				yym2584 := z.DecBinary()
-				_ = yym2584
+				yym2589 := z.DecBinary()
+				_ = yym2589
 				if false {
 				} else {
 					*((*int64)(x.GracePeriodSeconds)) = int64(r.DecodeInt(64))
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2580)
-		} // end switch yys2580
-	} // end for yyj2580
-	if !yyhl2580 {
+			z.DecStructFieldNotFound(-1, yys2585)
+		} // end switch yys2585
+	} // end for yyj2585
+	if !yyhl2585 {
 		r.ReadEnd()
 	}
 }
@@ -30497,16 +30534,16 @@ func (x *DeleteOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2585 int
-	var yyb2585 bool
-	var yyhl2585 bool = l >= 0
-	yyj2585++
-	if yyhl2585 {
-		yyb2585 = yyj2585 > l
+	var yyj2590 int
+	var yyb2590 bool
+	var yyhl2590 bool = l >= 0
+	yyj2590++
+	if yyhl2590 {
+		yyb2590 = yyj2590 > l
 	} else {
-		yyb2585 = r.CheckBreak()
+		yyb2590 = r.CheckBreak()
 	}
-	if yyb2585 {
+	if yyb2590 {
 		r.ReadEnd()
 		return
 	}
@@ -30515,13 +30552,13 @@ func (x *DeleteOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2585++
-	if yyhl2585 {
-		yyb2585 = yyj2585 > l
+	yyj2590++
+	if yyhl2590 {
+		yyb2590 = yyj2590 > l
 	} else {
-		yyb2585 = r.CheckBreak()
+		yyb2590 = r.CheckBreak()
 	}
-	if yyb2585 {
+	if yyb2590 {
 		r.ReadEnd()
 		return
 	}
@@ -30530,13 +30567,13 @@ func (x *DeleteOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2585++
-	if yyhl2585 {
-		yyb2585 = yyj2585 > l
+	yyj2590++
+	if yyhl2590 {
+		yyb2590 = yyj2590 > l
 	} else {
-		yyb2585 = r.CheckBreak()
+		yyb2590 = r.CheckBreak()
 	}
-	if yyb2585 {
+	if yyb2590 {
 		r.ReadEnd()
 		return
 	}
@@ -30548,24 +30585,24 @@ func (x *DeleteOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.GracePeriodSeconds == nil {
 			x.GracePeriodSeconds = new(int64)
 		}
-		yym2589 := z.DecBinary()
-		_ = yym2589
+		yym2594 := z.DecBinary()
+		_ = yym2594
 		if false {
 		} else {
 			*((*int64)(x.GracePeriodSeconds)) = int64(r.DecodeInt(64))
 		}
 	}
 	for {
-		yyj2585++
-		if yyhl2585 {
-			yyb2585 = yyj2585 > l
+		yyj2590++
+		if yyhl2590 {
+			yyb2590 = yyj2590 > l
 		} else {
-			yyb2585 = r.CheckBreak()
+			yyb2590 = r.CheckBreak()
 		}
-		if yyb2585 {
+		if yyb2590 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2585-1, "")
+		z.DecStructFieldNotFound(yyj2590-1, "")
 	}
 	r.ReadEnd()
 }
@@ -30577,33 +30614,33 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2590 := z.EncBinary()
-		_ = yym2590
+		yym2595 := z.EncBinary()
+		_ = yym2595
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2591 := !z.EncBinary()
-			yy2arr2591 := z.EncBasicHandle().StructToArray
-			var yyq2591 [7]bool
-			_, _, _ = yysep2591, yyq2591, yy2arr2591
-			const yyr2591 bool = false
-			yyq2591[0] = x.Kind != ""
-			yyq2591[1] = x.APIVersion != ""
-			if yyr2591 || yy2arr2591 {
+			yysep2596 := !z.EncBinary()
+			yy2arr2596 := z.EncBasicHandle().StructToArray
+			var yyq2596 [7]bool
+			_, _, _ = yysep2596, yyq2596, yy2arr2596
+			const yyr2596 bool = false
+			yyq2596[0] = x.Kind != ""
+			yyq2596[1] = x.APIVersion != ""
+			if yyr2596 || yy2arr2596 {
 				r.EncodeArrayStart(7)
 			} else {
-				var yynn2591 int = 5
-				for _, b := range yyq2591 {
+				var yynn2596 int = 5
+				for _, b := range yyq2596 {
 					if b {
-						yynn2591++
+						yynn2596++
 					}
 				}
-				r.EncodeMapStart(yynn2591)
+				r.EncodeMapStart(yynn2596)
 			}
-			if yyr2591 || yy2arr2591 {
-				if yyq2591[0] {
-					yym2593 := z.EncBinary()
-					_ = yym2593
+			if yyr2596 || yy2arr2596 {
+				if yyq2596[0] {
+					yym2598 := z.EncBinary()
+					_ = yym2598
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -30612,20 +30649,20 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2591[0] {
+				if yyq2596[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2594 := z.EncBinary()
-					_ = yym2594
+					yym2599 := z.EncBinary()
+					_ = yym2599
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2591 || yy2arr2591 {
-				if yyq2591[1] {
-					yym2596 := z.EncBinary()
-					_ = yym2596
+			if yyr2596 || yy2arr2596 {
+				if yyq2596[1] {
+					yym2601 := z.EncBinary()
+					_ = yym2601
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -30634,22 +30671,22 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2591[1] {
+				if yyq2596[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2597 := z.EncBinary()
-					_ = yym2597
+					yym2602 := z.EncBinary()
+					_ = yym2602
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2591 || yy2arr2591 {
+			if yyr2596 || yy2arr2596 {
 				if x.LabelSelector == nil {
 					r.EncodeNil()
 				} else {
-					yym2599 := z.EncBinary()
-					_ = yym2599
+					yym2604 := z.EncBinary()
+					_ = yym2604
 					if false {
 					} else if z.HasExtensions() && z.EncExt(x.LabelSelector) {
 					} else {
@@ -30661,8 +30698,8 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.LabelSelector == nil {
 					r.EncodeNil()
 				} else {
-					yym2600 := z.EncBinary()
-					_ = yym2600
+					yym2605 := z.EncBinary()
+					_ = yym2605
 					if false {
 					} else if z.HasExtensions() && z.EncExt(x.LabelSelector) {
 					} else {
@@ -30670,12 +30707,12 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr2591 || yy2arr2591 {
+			if yyr2596 || yy2arr2596 {
 				if x.FieldSelector == nil {
 					r.EncodeNil()
 				} else {
-					yym2602 := z.EncBinary()
-					_ = yym2602
+					yym2607 := z.EncBinary()
+					_ = yym2607
 					if false {
 					} else if z.HasExtensions() && z.EncExt(x.FieldSelector) {
 					} else {
@@ -30687,8 +30724,8 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.FieldSelector == nil {
 					r.EncodeNil()
 				} else {
-					yym2603 := z.EncBinary()
-					_ = yym2603
+					yym2608 := z.EncBinary()
+					_ = yym2608
 					if false {
 					} else if z.HasExtensions() && z.EncExt(x.FieldSelector) {
 					} else {
@@ -30696,48 +30733,48 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr2591 || yy2arr2591 {
-				yym2605 := z.EncBinary()
-				_ = yym2605
+			if yyr2596 || yy2arr2596 {
+				yym2610 := z.EncBinary()
+				_ = yym2610
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Watch))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("Watch"))
-				yym2606 := z.EncBinary()
-				_ = yym2606
+				yym2611 := z.EncBinary()
+				_ = yym2611
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Watch))
 				}
 			}
-			if yyr2591 || yy2arr2591 {
-				yym2608 := z.EncBinary()
-				_ = yym2608
+			if yyr2596 || yy2arr2596 {
+				yym2613 := z.EncBinary()
+				_ = yym2613
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("ResourceVersion"))
-				yym2609 := z.EncBinary()
-				_ = yym2609
+				yym2614 := z.EncBinary()
+				_ = yym2614
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
 				}
 			}
-			if yyr2591 || yy2arr2591 {
+			if yyr2596 || yy2arr2596 {
 				if x.TimeoutSeconds == nil {
 					r.EncodeNil()
 				} else {
-					yy2611 := *x.TimeoutSeconds
-					yym2612 := z.EncBinary()
-					_ = yym2612
+					yy2616 := *x.TimeoutSeconds
+					yym2617 := z.EncBinary()
+					_ = yym2617
 					if false {
 					} else {
-						r.EncodeInt(int64(yy2611))
+						r.EncodeInt(int64(yy2616))
 					}
 				}
 			} else {
@@ -30745,16 +30782,16 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.TimeoutSeconds == nil {
 					r.EncodeNil()
 				} else {
-					yy2613 := *x.TimeoutSeconds
-					yym2614 := z.EncBinary()
-					_ = yym2614
+					yy2618 := *x.TimeoutSeconds
+					yym2619 := z.EncBinary()
+					_ = yym2619
 					if false {
 					} else {
-						r.EncodeInt(int64(yy2613))
+						r.EncodeInt(int64(yy2618))
 					}
 				}
 			}
-			if yysep2591 {
+			if yysep2596 {
 				r.EncodeEnd()
 			}
 		}
@@ -30765,24 +30802,24 @@ func (x *ListOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2615 := z.DecBinary()
-	_ = yym2615
+	yym2620 := z.DecBinary()
+	_ = yym2620
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2616 := r.ReadMapStart()
-			if yyl2616 == 0 {
+			yyl2621 := r.ReadMapStart()
+			if yyl2621 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2616, d)
+				x.codecDecodeSelfFromMap(yyl2621, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2616 := r.ReadArrayStart()
-			if yyl2616 == 0 {
+			yyl2621 := r.ReadArrayStart()
+			if yyl2621 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2616, d)
+				x.codecDecodeSelfFromArray(yyl2621, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -30794,12 +30831,12 @@ func (x *ListOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2617Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2617Slc
-	var yyhl2617 bool = l >= 0
-	for yyj2617 := 0; ; yyj2617++ {
-		if yyhl2617 {
-			if yyj2617 >= l {
+	var yys2622Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2622Slc
+	var yyhl2622 bool = l >= 0
+	for yyj2622 := 0; ; yyj2622++ {
+		if yyhl2622 {
+			if yyj2622 >= l {
 				break
 			}
 		} else {
@@ -30807,9 +30844,9 @@ func (x *ListOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2617Slc = r.DecodeBytes(yys2617Slc, true, true)
-		yys2617 := string(yys2617Slc)
-		switch yys2617 {
+		yys2622Slc = r.DecodeBytes(yys2622Slc, true, true)
+		yys2622 := string(yys2622Slc)
+		switch yys2622 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -30826,26 +30863,26 @@ func (x *ListOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.LabelSelector = nil
 			} else {
-				yyv2620 := &x.LabelSelector
-				yym2621 := z.DecBinary()
-				_ = yym2621
+				yyv2625 := &x.LabelSelector
+				yym2626 := z.DecBinary()
+				_ = yym2626
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2620) {
+				} else if z.HasExtensions() && z.DecExt(yyv2625) {
 				} else {
-					z.DecFallback(yyv2620, true)
+					z.DecFallback(yyv2625, true)
 				}
 			}
 		case "FieldSelector":
 			if r.TryDecodeAsNil() {
 				x.FieldSelector = nil
 			} else {
-				yyv2622 := &x.FieldSelector
-				yym2623 := z.DecBinary()
-				_ = yym2623
+				yyv2627 := &x.FieldSelector
+				yym2628 := z.DecBinary()
+				_ = yym2628
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2622) {
+				} else if z.HasExtensions() && z.DecExt(yyv2627) {
 				} else {
-					z.DecFallback(yyv2622, true)
+					z.DecFallback(yyv2627, true)
 				}
 			}
 		case "Watch":
@@ -30869,18 +30906,18 @@ func (x *ListOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TimeoutSeconds == nil {
 					x.TimeoutSeconds = new(int64)
 				}
-				yym2627 := z.DecBinary()
-				_ = yym2627
+				yym2632 := z.DecBinary()
+				_ = yym2632
 				if false {
 				} else {
 					*((*int64)(x.TimeoutSeconds)) = int64(r.DecodeInt(64))
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2617)
-		} // end switch yys2617
-	} // end for yyj2617
-	if !yyhl2617 {
+			z.DecStructFieldNotFound(-1, yys2622)
+		} // end switch yys2622
+	} // end for yyj2622
+	if !yyhl2622 {
 		r.ReadEnd()
 	}
 }
@@ -30889,16 +30926,16 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2628 int
-	var yyb2628 bool
-	var yyhl2628 bool = l >= 0
-	yyj2628++
-	if yyhl2628 {
-		yyb2628 = yyj2628 > l
+	var yyj2633 int
+	var yyb2633 bool
+	var yyhl2633 bool = l >= 0
+	yyj2633++
+	if yyhl2633 {
+		yyb2633 = yyj2633 > l
 	} else {
-		yyb2628 = r.CheckBreak()
+		yyb2633 = r.CheckBreak()
 	}
-	if yyb2628 {
+	if yyb2633 {
 		r.ReadEnd()
 		return
 	}
@@ -30907,13 +30944,13 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2628++
-	if yyhl2628 {
-		yyb2628 = yyj2628 > l
+	yyj2633++
+	if yyhl2633 {
+		yyb2633 = yyj2633 > l
 	} else {
-		yyb2628 = r.CheckBreak()
+		yyb2633 = r.CheckBreak()
 	}
-	if yyb2628 {
+	if yyb2633 {
 		r.ReadEnd()
 		return
 	}
@@ -30922,57 +30959,57 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2628++
-	if yyhl2628 {
-		yyb2628 = yyj2628 > l
+	yyj2633++
+	if yyhl2633 {
+		yyb2633 = yyj2633 > l
 	} else {
-		yyb2628 = r.CheckBreak()
+		yyb2633 = r.CheckBreak()
 	}
-	if yyb2628 {
+	if yyb2633 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.LabelSelector = nil
 	} else {
-		yyv2631 := &x.LabelSelector
-		yym2632 := z.DecBinary()
-		_ = yym2632
+		yyv2636 := &x.LabelSelector
+		yym2637 := z.DecBinary()
+		_ = yym2637
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2631) {
+		} else if z.HasExtensions() && z.DecExt(yyv2636) {
 		} else {
-			z.DecFallback(yyv2631, true)
+			z.DecFallback(yyv2636, true)
 		}
 	}
-	yyj2628++
-	if yyhl2628 {
-		yyb2628 = yyj2628 > l
+	yyj2633++
+	if yyhl2633 {
+		yyb2633 = yyj2633 > l
 	} else {
-		yyb2628 = r.CheckBreak()
+		yyb2633 = r.CheckBreak()
 	}
-	if yyb2628 {
+	if yyb2633 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.FieldSelector = nil
 	} else {
-		yyv2633 := &x.FieldSelector
-		yym2634 := z.DecBinary()
-		_ = yym2634
+		yyv2638 := &x.FieldSelector
+		yym2639 := z.DecBinary()
+		_ = yym2639
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2633) {
+		} else if z.HasExtensions() && z.DecExt(yyv2638) {
 		} else {
-			z.DecFallback(yyv2633, true)
+			z.DecFallback(yyv2638, true)
 		}
 	}
-	yyj2628++
-	if yyhl2628 {
-		yyb2628 = yyj2628 > l
+	yyj2633++
+	if yyhl2633 {
+		yyb2633 = yyj2633 > l
 	} else {
-		yyb2628 = r.CheckBreak()
+		yyb2633 = r.CheckBreak()
 	}
-	if yyb2628 {
+	if yyb2633 {
 		r.ReadEnd()
 		return
 	}
@@ -30981,13 +31018,13 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Watch = bool(r.DecodeBool())
 	}
-	yyj2628++
-	if yyhl2628 {
-		yyb2628 = yyj2628 > l
+	yyj2633++
+	if yyhl2633 {
+		yyb2633 = yyj2633 > l
 	} else {
-		yyb2628 = r.CheckBreak()
+		yyb2633 = r.CheckBreak()
 	}
-	if yyb2628 {
+	if yyb2633 {
 		r.ReadEnd()
 		return
 	}
@@ -30996,13 +31033,13 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.ResourceVersion = string(r.DecodeString())
 	}
-	yyj2628++
-	if yyhl2628 {
-		yyb2628 = yyj2628 > l
+	yyj2633++
+	if yyhl2633 {
+		yyb2633 = yyj2633 > l
 	} else {
-		yyb2628 = r.CheckBreak()
+		yyb2633 = r.CheckBreak()
 	}
-	if yyb2628 {
+	if yyb2633 {
 		r.ReadEnd()
 		return
 	}
@@ -31014,24 +31051,24 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TimeoutSeconds == nil {
 			x.TimeoutSeconds = new(int64)
 		}
-		yym2638 := z.DecBinary()
-		_ = yym2638
+		yym2643 := z.DecBinary()
+		_ = yym2643
 		if false {
 		} else {
 			*((*int64)(x.TimeoutSeconds)) = int64(r.DecodeInt(64))
 		}
 	}
 	for {
-		yyj2628++
-		if yyhl2628 {
-			yyb2628 = yyj2628 > l
+		yyj2633++
+		if yyhl2633 {
+			yyb2633 = yyj2633 > l
 		} else {
-			yyb2628 = r.CheckBreak()
+			yyb2633 = r.CheckBreak()
 		}
-		if yyb2628 {
+		if yyb2633 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2628-1, "")
+		z.DecStructFieldNotFound(yyj2633-1, "")
 	}
 	r.ReadEnd()
 }
@@ -31043,33 +31080,33 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2639 := z.EncBinary()
-		_ = yym2639
+		yym2644 := z.EncBinary()
+		_ = yym2644
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2640 := !z.EncBinary()
-			yy2arr2640 := z.EncBasicHandle().StructToArray
-			var yyq2640 [10]bool
-			_, _, _ = yysep2640, yyq2640, yy2arr2640
-			const yyr2640 bool = false
-			yyq2640[0] = x.Kind != ""
-			yyq2640[1] = x.APIVersion != ""
-			if yyr2640 || yy2arr2640 {
+			yysep2645 := !z.EncBinary()
+			yy2arr2645 := z.EncBasicHandle().StructToArray
+			var yyq2645 [10]bool
+			_, _, _ = yysep2645, yyq2645, yy2arr2645
+			const yyr2645 bool = false
+			yyq2645[0] = x.Kind != ""
+			yyq2645[1] = x.APIVersion != ""
+			if yyr2645 || yy2arr2645 {
 				r.EncodeArrayStart(10)
 			} else {
-				var yynn2640 int = 8
-				for _, b := range yyq2640 {
+				var yynn2645 int = 8
+				for _, b := range yyq2645 {
 					if b {
-						yynn2640++
+						yynn2645++
 					}
 				}
-				r.EncodeMapStart(yynn2640)
+				r.EncodeMapStart(yynn2645)
 			}
-			if yyr2640 || yy2arr2640 {
-				if yyq2640[0] {
-					yym2642 := z.EncBinary()
-					_ = yym2642
+			if yyr2645 || yy2arr2645 {
+				if yyq2645[0] {
+					yym2647 := z.EncBinary()
+					_ = yym2647
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -31078,20 +31115,20 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2640[0] {
+				if yyq2645[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2643 := z.EncBinary()
-					_ = yym2643
+					yym2648 := z.EncBinary()
+					_ = yym2648
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2640 || yy2arr2640 {
-				if yyq2640[1] {
-					yym2645 := z.EncBinary()
-					_ = yym2645
+			if yyr2645 || yy2arr2645 {
+				if yyq2645[1] {
+					yym2650 := z.EncBinary()
+					_ = yym2650
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -31100,74 +31137,74 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2640[1] {
+				if yyq2645[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2646 := z.EncBinary()
-					_ = yym2646
+					yym2651 := z.EncBinary()
+					_ = yym2651
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2640 || yy2arr2640 {
-				yym2648 := z.EncBinary()
-				_ = yym2648
+			if yyr2645 || yy2arr2645 {
+				yym2653 := z.EncBinary()
+				_ = yym2653
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Container))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("Container"))
-				yym2649 := z.EncBinary()
-				_ = yym2649
+				yym2654 := z.EncBinary()
+				_ = yym2654
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Container))
 				}
 			}
-			if yyr2640 || yy2arr2640 {
-				yym2651 := z.EncBinary()
-				_ = yym2651
+			if yyr2645 || yy2arr2645 {
+				yym2656 := z.EncBinary()
+				_ = yym2656
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Follow))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("Follow"))
-				yym2652 := z.EncBinary()
-				_ = yym2652
+				yym2657 := z.EncBinary()
+				_ = yym2657
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Follow))
 				}
 			}
-			if yyr2640 || yy2arr2640 {
-				yym2654 := z.EncBinary()
-				_ = yym2654
+			if yyr2645 || yy2arr2645 {
+				yym2659 := z.EncBinary()
+				_ = yym2659
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Previous))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("Previous"))
-				yym2655 := z.EncBinary()
-				_ = yym2655
+				yym2660 := z.EncBinary()
+				_ = yym2660
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Previous))
 				}
 			}
-			if yyr2640 || yy2arr2640 {
+			if yyr2645 || yy2arr2645 {
 				if x.SinceSeconds == nil {
 					r.EncodeNil()
 				} else {
-					yy2657 := *x.SinceSeconds
-					yym2658 := z.EncBinary()
-					_ = yym2658
+					yy2662 := *x.SinceSeconds
+					yym2663 := z.EncBinary()
+					_ = yym2663
 					if false {
 					} else {
-						r.EncodeInt(int64(yy2657))
+						r.EncodeInt(int64(yy2662))
 					}
 				}
 			} else {
@@ -31175,26 +31212,26 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.SinceSeconds == nil {
 					r.EncodeNil()
 				} else {
-					yy2659 := *x.SinceSeconds
-					yym2660 := z.EncBinary()
-					_ = yym2660
+					yy2664 := *x.SinceSeconds
+					yym2665 := z.EncBinary()
+					_ = yym2665
 					if false {
 					} else {
-						r.EncodeInt(int64(yy2659))
+						r.EncodeInt(int64(yy2664))
 					}
 				}
 			}
-			if yyr2640 || yy2arr2640 {
+			if yyr2645 || yy2arr2645 {
 				if x.SinceTime == nil {
 					r.EncodeNil()
 				} else {
-					yym2662 := z.EncBinary()
-					_ = yym2662
+					yym2667 := z.EncBinary()
+					_ = yym2667
 					if false {
 					} else if z.HasExtensions() && z.EncExt(x.SinceTime) {
-					} else if yym2662 {
+					} else if yym2667 {
 						z.EncBinaryMarshal(x.SinceTime)
-					} else if !yym2662 && z.IsJSONHandle() {
+					} else if !yym2667 && z.IsJSONHandle() {
 						z.EncJSONMarshal(x.SinceTime)
 					} else {
 						z.EncFallback(x.SinceTime)
@@ -31205,66 +31242,40 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.SinceTime == nil {
 					r.EncodeNil()
 				} else {
-					yym2663 := z.EncBinary()
-					_ = yym2663
+					yym2668 := z.EncBinary()
+					_ = yym2668
 					if false {
 					} else if z.HasExtensions() && z.EncExt(x.SinceTime) {
-					} else if yym2663 {
+					} else if yym2668 {
 						z.EncBinaryMarshal(x.SinceTime)
-					} else if !yym2663 && z.IsJSONHandle() {
+					} else if !yym2668 && z.IsJSONHandle() {
 						z.EncJSONMarshal(x.SinceTime)
 					} else {
 						z.EncFallback(x.SinceTime)
 					}
 				}
 			}
-			if yyr2640 || yy2arr2640 {
-				yym2665 := z.EncBinary()
-				_ = yym2665
+			if yyr2645 || yy2arr2645 {
+				yym2670 := z.EncBinary()
+				_ = yym2670
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Timestamps))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("Timestamps"))
-				yym2666 := z.EncBinary()
-				_ = yym2666
+				yym2671 := z.EncBinary()
+				_ = yym2671
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Timestamps))
 				}
 			}
-			if yyr2640 || yy2arr2640 {
+			if yyr2645 || yy2arr2645 {
 				if x.TailLines == nil {
 					r.EncodeNil()
 				} else {
-					yy2668 := *x.TailLines
-					yym2669 := z.EncBinary()
-					_ = yym2669
-					if false {
-					} else {
-						r.EncodeInt(int64(yy2668))
-					}
-				}
-			} else {
-				r.EncodeString(codecSelferC_UTF81234, string("TailLines"))
-				if x.TailLines == nil {
-					r.EncodeNil()
-				} else {
-					yy2670 := *x.TailLines
-					yym2671 := z.EncBinary()
-					_ = yym2671
-					if false {
-					} else {
-						r.EncodeInt(int64(yy2670))
-					}
-				}
-			}
-			if yyr2640 || yy2arr2640 {
-				if x.LimitBytes == nil {
-					r.EncodeNil()
-				} else {
-					yy2673 := *x.LimitBytes
+					yy2673 := *x.TailLines
 					yym2674 := z.EncBinary()
 					_ = yym2674
 					if false {
@@ -31273,11 +31284,11 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
-				r.EncodeString(codecSelferC_UTF81234, string("LimitBytes"))
-				if x.LimitBytes == nil {
+				r.EncodeString(codecSelferC_UTF81234, string("TailLines"))
+				if x.TailLines == nil {
 					r.EncodeNil()
 				} else {
-					yy2675 := *x.LimitBytes
+					yy2675 := *x.TailLines
 					yym2676 := z.EncBinary()
 					_ = yym2676
 					if false {
@@ -31286,7 +31297,33 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2640 {
+			if yyr2645 || yy2arr2645 {
+				if x.LimitBytes == nil {
+					r.EncodeNil()
+				} else {
+					yy2678 := *x.LimitBytes
+					yym2679 := z.EncBinary()
+					_ = yym2679
+					if false {
+					} else {
+						r.EncodeInt(int64(yy2678))
+					}
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("LimitBytes"))
+				if x.LimitBytes == nil {
+					r.EncodeNil()
+				} else {
+					yy2680 := *x.LimitBytes
+					yym2681 := z.EncBinary()
+					_ = yym2681
+					if false {
+					} else {
+						r.EncodeInt(int64(yy2680))
+					}
+				}
+			}
+			if yysep2645 {
 				r.EncodeEnd()
 			}
 		}
@@ -31297,24 +31334,24 @@ func (x *PodLogOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2677 := z.DecBinary()
-	_ = yym2677
+	yym2682 := z.DecBinary()
+	_ = yym2682
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2678 := r.ReadMapStart()
-			if yyl2678 == 0 {
+			yyl2683 := r.ReadMapStart()
+			if yyl2683 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2678, d)
+				x.codecDecodeSelfFromMap(yyl2683, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2678 := r.ReadArrayStart()
-			if yyl2678 == 0 {
+			yyl2683 := r.ReadArrayStart()
+			if yyl2683 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2678, d)
+				x.codecDecodeSelfFromArray(yyl2683, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -31326,12 +31363,12 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2679Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2679Slc
-	var yyhl2679 bool = l >= 0
-	for yyj2679 := 0; ; yyj2679++ {
-		if yyhl2679 {
-			if yyj2679 >= l {
+	var yys2684Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2684Slc
+	var yyhl2684 bool = l >= 0
+	for yyj2684 := 0; ; yyj2684++ {
+		if yyhl2684 {
+			if yyj2684 >= l {
 				break
 			}
 		} else {
@@ -31339,9 +31376,9 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2679Slc = r.DecodeBytes(yys2679Slc, true, true)
-		yys2679 := string(yys2679Slc)
-		switch yys2679 {
+		yys2684Slc = r.DecodeBytes(yys2684Slc, true, true)
+		yys2684 := string(yys2684Slc)
+		switch yys2684 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -31381,8 +31418,8 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.SinceSeconds == nil {
 					x.SinceSeconds = new(int64)
 				}
-				yym2686 := z.DecBinary()
-				_ = yym2686
+				yym2691 := z.DecBinary()
+				_ = yym2691
 				if false {
 				} else {
 					*((*int64)(x.SinceSeconds)) = int64(r.DecodeInt(64))
@@ -31397,13 +31434,13 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.SinceTime == nil {
 					x.SinceTime = new(pkg2_unversioned.Time)
 				}
-				yym2688 := z.DecBinary()
-				_ = yym2688
+				yym2693 := z.DecBinary()
+				_ = yym2693
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.SinceTime) {
-				} else if yym2688 {
+				} else if yym2693 {
 					z.DecBinaryUnmarshal(x.SinceTime)
-				} else if !yym2688 && z.IsJSONHandle() {
+				} else if !yym2693 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.SinceTime)
 				} else {
 					z.DecFallback(x.SinceTime, false)
@@ -31424,8 +31461,8 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TailLines == nil {
 					x.TailLines = new(int64)
 				}
-				yym2691 := z.DecBinary()
-				_ = yym2691
+				yym2696 := z.DecBinary()
+				_ = yym2696
 				if false {
 				} else {
 					*((*int64)(x.TailLines)) = int64(r.DecodeInt(64))
@@ -31440,18 +31477,18 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.LimitBytes == nil {
 					x.LimitBytes = new(int64)
 				}
-				yym2693 := z.DecBinary()
-				_ = yym2693
+				yym2698 := z.DecBinary()
+				_ = yym2698
 				if false {
 				} else {
 					*((*int64)(x.LimitBytes)) = int64(r.DecodeInt(64))
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2679)
-		} // end switch yys2679
-	} // end for yyj2679
-	if !yyhl2679 {
+			z.DecStructFieldNotFound(-1, yys2684)
+		} // end switch yys2684
+	} // end for yyj2684
+	if !yyhl2684 {
 		r.ReadEnd()
 	}
 }
@@ -31460,16 +31497,16 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2694 int
-	var yyb2694 bool
-	var yyhl2694 bool = l >= 0
-	yyj2694++
-	if yyhl2694 {
-		yyb2694 = yyj2694 > l
+	var yyj2699 int
+	var yyb2699 bool
+	var yyhl2699 bool = l >= 0
+	yyj2699++
+	if yyhl2699 {
+		yyb2699 = yyj2699 > l
 	} else {
-		yyb2694 = r.CheckBreak()
+		yyb2699 = r.CheckBreak()
 	}
-	if yyb2694 {
+	if yyb2699 {
 		r.ReadEnd()
 		return
 	}
@@ -31478,13 +31515,13 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2694++
-	if yyhl2694 {
-		yyb2694 = yyj2694 > l
+	yyj2699++
+	if yyhl2699 {
+		yyb2699 = yyj2699 > l
 	} else {
-		yyb2694 = r.CheckBreak()
+		yyb2699 = r.CheckBreak()
 	}
-	if yyb2694 {
+	if yyb2699 {
 		r.ReadEnd()
 		return
 	}
@@ -31493,13 +31530,13 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2694++
-	if yyhl2694 {
-		yyb2694 = yyj2694 > l
+	yyj2699++
+	if yyhl2699 {
+		yyb2699 = yyj2699 > l
 	} else {
-		yyb2694 = r.CheckBreak()
+		yyb2699 = r.CheckBreak()
 	}
-	if yyb2694 {
+	if yyb2699 {
 		r.ReadEnd()
 		return
 	}
@@ -31508,13 +31545,13 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Container = string(r.DecodeString())
 	}
-	yyj2694++
-	if yyhl2694 {
-		yyb2694 = yyj2694 > l
+	yyj2699++
+	if yyhl2699 {
+		yyb2699 = yyj2699 > l
 	} else {
-		yyb2694 = r.CheckBreak()
+		yyb2699 = r.CheckBreak()
 	}
-	if yyb2694 {
+	if yyb2699 {
 		r.ReadEnd()
 		return
 	}
@@ -31523,13 +31560,13 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Follow = bool(r.DecodeBool())
 	}
-	yyj2694++
-	if yyhl2694 {
-		yyb2694 = yyj2694 > l
+	yyj2699++
+	if yyhl2699 {
+		yyb2699 = yyj2699 > l
 	} else {
-		yyb2694 = r.CheckBreak()
+		yyb2699 = r.CheckBreak()
 	}
-	if yyb2694 {
+	if yyb2699 {
 		r.ReadEnd()
 		return
 	}
@@ -31538,13 +31575,13 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Previous = bool(r.DecodeBool())
 	}
-	yyj2694++
-	if yyhl2694 {
-		yyb2694 = yyj2694 > l
+	yyj2699++
+	if yyhl2699 {
+		yyb2699 = yyj2699 > l
 	} else {
-		yyb2694 = r.CheckBreak()
+		yyb2699 = r.CheckBreak()
 	}
-	if yyb2694 {
+	if yyb2699 {
 		r.ReadEnd()
 		return
 	}
@@ -31556,20 +31593,20 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.SinceSeconds == nil {
 			x.SinceSeconds = new(int64)
 		}
-		yym2701 := z.DecBinary()
-		_ = yym2701
+		yym2706 := z.DecBinary()
+		_ = yym2706
 		if false {
 		} else {
 			*((*int64)(x.SinceSeconds)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj2694++
-	if yyhl2694 {
-		yyb2694 = yyj2694 > l
+	yyj2699++
+	if yyhl2699 {
+		yyb2699 = yyj2699 > l
 	} else {
-		yyb2694 = r.CheckBreak()
+		yyb2699 = r.CheckBreak()
 	}
-	if yyb2694 {
+	if yyb2699 {
 		r.ReadEnd()
 		return
 	}
@@ -31581,25 +31618,25 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.SinceTime == nil {
 			x.SinceTime = new(pkg2_unversioned.Time)
 		}
-		yym2703 := z.DecBinary()
-		_ = yym2703
+		yym2708 := z.DecBinary()
+		_ = yym2708
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.SinceTime) {
-		} else if yym2703 {
+		} else if yym2708 {
 			z.DecBinaryUnmarshal(x.SinceTime)
-		} else if !yym2703 && z.IsJSONHandle() {
+		} else if !yym2708 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.SinceTime)
 		} else {
 			z.DecFallback(x.SinceTime, false)
 		}
 	}
-	yyj2694++
-	if yyhl2694 {
-		yyb2694 = yyj2694 > l
+	yyj2699++
+	if yyhl2699 {
+		yyb2699 = yyj2699 > l
 	} else {
-		yyb2694 = r.CheckBreak()
+		yyb2699 = r.CheckBreak()
 	}
-	if yyb2694 {
+	if yyb2699 {
 		r.ReadEnd()
 		return
 	}
@@ -31608,13 +31645,13 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Timestamps = bool(r.DecodeBool())
 	}
-	yyj2694++
-	if yyhl2694 {
-		yyb2694 = yyj2694 > l
+	yyj2699++
+	if yyhl2699 {
+		yyb2699 = yyj2699 > l
 	} else {
-		yyb2694 = r.CheckBreak()
+		yyb2699 = r.CheckBreak()
 	}
-	if yyb2694 {
+	if yyb2699 {
 		r.ReadEnd()
 		return
 	}
@@ -31626,20 +31663,20 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TailLines == nil {
 			x.TailLines = new(int64)
 		}
-		yym2706 := z.DecBinary()
-		_ = yym2706
+		yym2711 := z.DecBinary()
+		_ = yym2711
 		if false {
 		} else {
 			*((*int64)(x.TailLines)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj2694++
-	if yyhl2694 {
-		yyb2694 = yyj2694 > l
+	yyj2699++
+	if yyhl2699 {
+		yyb2699 = yyj2699 > l
 	} else {
-		yyb2694 = r.CheckBreak()
+		yyb2699 = r.CheckBreak()
 	}
-	if yyb2694 {
+	if yyb2699 {
 		r.ReadEnd()
 		return
 	}
@@ -31651,24 +31688,24 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.LimitBytes == nil {
 			x.LimitBytes = new(int64)
 		}
-		yym2708 := z.DecBinary()
-		_ = yym2708
+		yym2713 := z.DecBinary()
+		_ = yym2713
 		if false {
 		} else {
 			*((*int64)(x.LimitBytes)) = int64(r.DecodeInt(64))
 		}
 	}
 	for {
-		yyj2694++
-		if yyhl2694 {
-			yyb2694 = yyj2694 > l
+		yyj2699++
+		if yyhl2699 {
+			yyb2699 = yyj2699 > l
 		} else {
-			yyb2694 = r.CheckBreak()
+			yyb2699 = r.CheckBreak()
 		}
-		if yyb2694 {
+		if yyb2699 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2694-1, "")
+		z.DecStructFieldNotFound(yyj2699-1, "")
 	}
 	r.ReadEnd()
 }
@@ -31680,38 +31717,38 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2709 := z.EncBinary()
-		_ = yym2709
+		yym2714 := z.EncBinary()
+		_ = yym2714
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2710 := !z.EncBinary()
-			yy2arr2710 := z.EncBasicHandle().StructToArray
-			var yyq2710 [7]bool
-			_, _, _ = yysep2710, yyq2710, yy2arr2710
-			const yyr2710 bool = false
-			yyq2710[0] = x.Kind != ""
-			yyq2710[1] = x.APIVersion != ""
-			yyq2710[2] = x.Stdin != false
-			yyq2710[3] = x.Stdout != false
-			yyq2710[4] = x.Stderr != false
-			yyq2710[5] = x.TTY != false
-			yyq2710[6] = x.Container != ""
-			if yyr2710 || yy2arr2710 {
+			yysep2715 := !z.EncBinary()
+			yy2arr2715 := z.EncBasicHandle().StructToArray
+			var yyq2715 [7]bool
+			_, _, _ = yysep2715, yyq2715, yy2arr2715
+			const yyr2715 bool = false
+			yyq2715[0] = x.Kind != ""
+			yyq2715[1] = x.APIVersion != ""
+			yyq2715[2] = x.Stdin != false
+			yyq2715[3] = x.Stdout != false
+			yyq2715[4] = x.Stderr != false
+			yyq2715[5] = x.TTY != false
+			yyq2715[6] = x.Container != ""
+			if yyr2715 || yy2arr2715 {
 				r.EncodeArrayStart(7)
 			} else {
-				var yynn2710 int = 0
-				for _, b := range yyq2710 {
+				var yynn2715 int = 0
+				for _, b := range yyq2715 {
 					if b {
-						yynn2710++
+						yynn2715++
 					}
 				}
-				r.EncodeMapStart(yynn2710)
+				r.EncodeMapStart(yynn2715)
 			}
-			if yyr2710 || yy2arr2710 {
-				if yyq2710[0] {
-					yym2712 := z.EncBinary()
-					_ = yym2712
+			if yyr2715 || yy2arr2715 {
+				if yyq2715[0] {
+					yym2717 := z.EncBinary()
+					_ = yym2717
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -31720,130 +31757,130 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2710[0] {
+				if yyq2715[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2713 := z.EncBinary()
-					_ = yym2713
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2710 || yy2arr2710 {
-				if yyq2710[1] {
-					yym2715 := z.EncBinary()
-					_ = yym2715
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2710[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2716 := z.EncBinary()
-					_ = yym2716
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2710 || yy2arr2710 {
-				if yyq2710[2] {
 					yym2718 := z.EncBinary()
 					_ = yym2718
 					if false {
 					} else {
-						r.EncodeBool(bool(x.Stdin))
-					}
-				} else {
-					r.EncodeBool(false)
-				}
-			} else {
-				if yyq2710[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("stdin"))
-					yym2719 := z.EncBinary()
-					_ = yym2719
-					if false {
-					} else {
-						r.EncodeBool(bool(x.Stdin))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2710 || yy2arr2710 {
-				if yyq2710[3] {
+			if yyr2715 || yy2arr2715 {
+				if yyq2715[1] {
+					yym2720 := z.EncBinary()
+					_ = yym2720
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2715[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					yym2721 := z.EncBinary()
 					_ = yym2721
 					if false {
 					} else {
-						r.EncodeBool(bool(x.Stdout))
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr2715 || yy2arr2715 {
+				if yyq2715[2] {
+					yym2723 := z.EncBinary()
+					_ = yym2723
+					if false {
+					} else {
+						r.EncodeBool(bool(x.Stdin))
 					}
 				} else {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq2710[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("stdout"))
-					yym2722 := z.EncBinary()
-					_ = yym2722
-					if false {
-					} else {
-						r.EncodeBool(bool(x.Stdout))
-					}
-				}
-			}
-			if yyr2710 || yy2arr2710 {
-				if yyq2710[4] {
+				if yyq2715[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("stdin"))
 					yym2724 := z.EncBinary()
 					_ = yym2724
 					if false {
 					} else {
-						r.EncodeBool(bool(x.Stderr))
+						r.EncodeBool(bool(x.Stdin))
+					}
+				}
+			}
+			if yyr2715 || yy2arr2715 {
+				if yyq2715[3] {
+					yym2726 := z.EncBinary()
+					_ = yym2726
+					if false {
+					} else {
+						r.EncodeBool(bool(x.Stdout))
 					}
 				} else {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq2710[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("stderr"))
-					yym2725 := z.EncBinary()
-					_ = yym2725
-					if false {
-					} else {
-						r.EncodeBool(bool(x.Stderr))
-					}
-				}
-			}
-			if yyr2710 || yy2arr2710 {
-				if yyq2710[5] {
+				if yyq2715[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("stdout"))
 					yym2727 := z.EncBinary()
 					_ = yym2727
 					if false {
 					} else {
+						r.EncodeBool(bool(x.Stdout))
+					}
+				}
+			}
+			if yyr2715 || yy2arr2715 {
+				if yyq2715[4] {
+					yym2729 := z.EncBinary()
+					_ = yym2729
+					if false {
+					} else {
+						r.EncodeBool(bool(x.Stderr))
+					}
+				} else {
+					r.EncodeBool(false)
+				}
+			} else {
+				if yyq2715[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("stderr"))
+					yym2730 := z.EncBinary()
+					_ = yym2730
+					if false {
+					} else {
+						r.EncodeBool(bool(x.Stderr))
+					}
+				}
+			}
+			if yyr2715 || yy2arr2715 {
+				if yyq2715[5] {
+					yym2732 := z.EncBinary()
+					_ = yym2732
+					if false {
+					} else {
 						r.EncodeBool(bool(x.TTY))
 					}
 				} else {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq2710[5] {
+				if yyq2715[5] {
 					r.EncodeString(codecSelferC_UTF81234, string("tty"))
-					yym2728 := z.EncBinary()
-					_ = yym2728
+					yym2733 := z.EncBinary()
+					_ = yym2733
 					if false {
 					} else {
 						r.EncodeBool(bool(x.TTY))
 					}
 				}
 			}
-			if yyr2710 || yy2arr2710 {
-				if yyq2710[6] {
-					yym2730 := z.EncBinary()
-					_ = yym2730
+			if yyr2715 || yy2arr2715 {
+				if yyq2715[6] {
+					yym2735 := z.EncBinary()
+					_ = yym2735
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Container))
@@ -31852,17 +31889,17 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2710[6] {
+				if yyq2715[6] {
 					r.EncodeString(codecSelferC_UTF81234, string("container"))
-					yym2731 := z.EncBinary()
-					_ = yym2731
+					yym2736 := z.EncBinary()
+					_ = yym2736
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Container))
 					}
 				}
 			}
-			if yysep2710 {
+			if yysep2715 {
 				r.EncodeEnd()
 			}
 		}
@@ -31873,24 +31910,24 @@ func (x *PodAttachOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2732 := z.DecBinary()
-	_ = yym2732
+	yym2737 := z.DecBinary()
+	_ = yym2737
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2733 := r.ReadMapStart()
-			if yyl2733 == 0 {
+			yyl2738 := r.ReadMapStart()
+			if yyl2738 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2733, d)
+				x.codecDecodeSelfFromMap(yyl2738, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2733 := r.ReadArrayStart()
-			if yyl2733 == 0 {
+			yyl2738 := r.ReadArrayStart()
+			if yyl2738 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2733, d)
+				x.codecDecodeSelfFromArray(yyl2738, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -31902,12 +31939,12 @@ func (x *PodAttachOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2734Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2734Slc
-	var yyhl2734 bool = l >= 0
-	for yyj2734 := 0; ; yyj2734++ {
-		if yyhl2734 {
-			if yyj2734 >= l {
+	var yys2739Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2739Slc
+	var yyhl2739 bool = l >= 0
+	for yyj2739 := 0; ; yyj2739++ {
+		if yyhl2739 {
+			if yyj2739 >= l {
 				break
 			}
 		} else {
@@ -31915,9 +31952,9 @@ func (x *PodAttachOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2734Slc = r.DecodeBytes(yys2734Slc, true, true)
-		yys2734 := string(yys2734Slc)
-		switch yys2734 {
+		yys2739Slc = r.DecodeBytes(yys2739Slc, true, true)
+		yys2739 := string(yys2739Slc)
+		switch yys2739 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -31961,10 +31998,10 @@ func (x *PodAttachOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Container = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2734)
-		} // end switch yys2734
-	} // end for yyj2734
-	if !yyhl2734 {
+			z.DecStructFieldNotFound(-1, yys2739)
+		} // end switch yys2739
+	} // end for yyj2739
+	if !yyhl2739 {
 		r.ReadEnd()
 	}
 }
@@ -31973,16 +32010,16 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2742 int
-	var yyb2742 bool
-	var yyhl2742 bool = l >= 0
-	yyj2742++
-	if yyhl2742 {
-		yyb2742 = yyj2742 > l
+	var yyj2747 int
+	var yyb2747 bool
+	var yyhl2747 bool = l >= 0
+	yyj2747++
+	if yyhl2747 {
+		yyb2747 = yyj2747 > l
 	} else {
-		yyb2742 = r.CheckBreak()
+		yyb2747 = r.CheckBreak()
 	}
-	if yyb2742 {
+	if yyb2747 {
 		r.ReadEnd()
 		return
 	}
@@ -31991,13 +32028,13 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2742++
-	if yyhl2742 {
-		yyb2742 = yyj2742 > l
+	yyj2747++
+	if yyhl2747 {
+		yyb2747 = yyj2747 > l
 	} else {
-		yyb2742 = r.CheckBreak()
+		yyb2747 = r.CheckBreak()
 	}
-	if yyb2742 {
+	if yyb2747 {
 		r.ReadEnd()
 		return
 	}
@@ -32006,13 +32043,13 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2742++
-	if yyhl2742 {
-		yyb2742 = yyj2742 > l
+	yyj2747++
+	if yyhl2747 {
+		yyb2747 = yyj2747 > l
 	} else {
-		yyb2742 = r.CheckBreak()
+		yyb2747 = r.CheckBreak()
 	}
-	if yyb2742 {
+	if yyb2747 {
 		r.ReadEnd()
 		return
 	}
@@ -32021,13 +32058,13 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.Stdin = bool(r.DecodeBool())
 	}
-	yyj2742++
-	if yyhl2742 {
-		yyb2742 = yyj2742 > l
+	yyj2747++
+	if yyhl2747 {
+		yyb2747 = yyj2747 > l
 	} else {
-		yyb2742 = r.CheckBreak()
+		yyb2747 = r.CheckBreak()
 	}
-	if yyb2742 {
+	if yyb2747 {
 		r.ReadEnd()
 		return
 	}
@@ -32036,13 +32073,13 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.Stdout = bool(r.DecodeBool())
 	}
-	yyj2742++
-	if yyhl2742 {
-		yyb2742 = yyj2742 > l
+	yyj2747++
+	if yyhl2747 {
+		yyb2747 = yyj2747 > l
 	} else {
-		yyb2742 = r.CheckBreak()
+		yyb2747 = r.CheckBreak()
 	}
-	if yyb2742 {
+	if yyb2747 {
 		r.ReadEnd()
 		return
 	}
@@ -32051,13 +32088,13 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.Stderr = bool(r.DecodeBool())
 	}
-	yyj2742++
-	if yyhl2742 {
-		yyb2742 = yyj2742 > l
+	yyj2747++
+	if yyhl2747 {
+		yyb2747 = yyj2747 > l
 	} else {
-		yyb2742 = r.CheckBreak()
+		yyb2747 = r.CheckBreak()
 	}
-	if yyb2742 {
+	if yyb2747 {
 		r.ReadEnd()
 		return
 	}
@@ -32066,13 +32103,13 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.TTY = bool(r.DecodeBool())
 	}
-	yyj2742++
-	if yyhl2742 {
-		yyb2742 = yyj2742 > l
+	yyj2747++
+	if yyhl2747 {
+		yyb2747 = yyj2747 > l
 	} else {
-		yyb2742 = r.CheckBreak()
+		yyb2747 = r.CheckBreak()
 	}
-	if yyb2742 {
+	if yyb2747 {
 		r.ReadEnd()
 		return
 	}
@@ -32082,16 +32119,16 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		x.Container = string(r.DecodeString())
 	}
 	for {
-		yyj2742++
-		if yyhl2742 {
-			yyb2742 = yyj2742 > l
+		yyj2747++
+		if yyhl2747 {
+			yyb2747 = yyj2747 > l
 		} else {
-			yyb2742 = r.CheckBreak()
+			yyb2747 = r.CheckBreak()
 		}
-		if yyb2742 {
+		if yyb2747 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2742-1, "")
+		z.DecStructFieldNotFound(yyj2747-1, "")
 	}
 	r.ReadEnd()
 }
@@ -32103,33 +32140,33 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2750 := z.EncBinary()
-		_ = yym2750
+		yym2755 := z.EncBinary()
+		_ = yym2755
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2751 := !z.EncBinary()
-			yy2arr2751 := z.EncBasicHandle().StructToArray
-			var yyq2751 [8]bool
-			_, _, _ = yysep2751, yyq2751, yy2arr2751
-			const yyr2751 bool = false
-			yyq2751[0] = x.Kind != ""
-			yyq2751[1] = x.APIVersion != ""
-			if yyr2751 || yy2arr2751 {
+			yysep2756 := !z.EncBinary()
+			yy2arr2756 := z.EncBasicHandle().StructToArray
+			var yyq2756 [8]bool
+			_, _, _ = yysep2756, yyq2756, yy2arr2756
+			const yyr2756 bool = false
+			yyq2756[0] = x.Kind != ""
+			yyq2756[1] = x.APIVersion != ""
+			if yyr2756 || yy2arr2756 {
 				r.EncodeArrayStart(8)
 			} else {
-				var yynn2751 int = 6
-				for _, b := range yyq2751 {
+				var yynn2756 int = 6
+				for _, b := range yyq2756 {
 					if b {
-						yynn2751++
+						yynn2756++
 					}
 				}
-				r.EncodeMapStart(yynn2751)
+				r.EncodeMapStart(yynn2756)
 			}
-			if yyr2751 || yy2arr2751 {
-				if yyq2751[0] {
-					yym2753 := z.EncBinary()
-					_ = yym2753
+			if yyr2756 || yy2arr2756 {
+				if yyq2756[0] {
+					yym2758 := z.EncBinary()
+					_ = yym2758
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -32138,20 +32175,20 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2751[0] {
+				if yyq2756[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2754 := z.EncBinary()
-					_ = yym2754
+					yym2759 := z.EncBinary()
+					_ = yym2759
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2751 || yy2arr2751 {
-				if yyq2751[1] {
-					yym2756 := z.EncBinary()
-					_ = yym2756
+			if yyr2756 || yy2arr2756 {
+				if yyq2756[1] {
+					yym2761 := z.EncBinary()
+					_ = yym2761
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -32160,102 +32197,102 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2751[1] {
+				if yyq2756[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2757 := z.EncBinary()
-					_ = yym2757
+					yym2762 := z.EncBinary()
+					_ = yym2762
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2751 || yy2arr2751 {
-				yym2759 := z.EncBinary()
-				_ = yym2759
+			if yyr2756 || yy2arr2756 {
+				yym2764 := z.EncBinary()
+				_ = yym2764
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Stdin))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("Stdin"))
-				yym2760 := z.EncBinary()
-				_ = yym2760
+				yym2765 := z.EncBinary()
+				_ = yym2765
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Stdin))
 				}
 			}
-			if yyr2751 || yy2arr2751 {
-				yym2762 := z.EncBinary()
-				_ = yym2762
+			if yyr2756 || yy2arr2756 {
+				yym2767 := z.EncBinary()
+				_ = yym2767
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Stdout))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("Stdout"))
-				yym2763 := z.EncBinary()
-				_ = yym2763
+				yym2768 := z.EncBinary()
+				_ = yym2768
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Stdout))
 				}
 			}
-			if yyr2751 || yy2arr2751 {
-				yym2765 := z.EncBinary()
-				_ = yym2765
+			if yyr2756 || yy2arr2756 {
+				yym2770 := z.EncBinary()
+				_ = yym2770
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Stderr))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("Stderr"))
-				yym2766 := z.EncBinary()
-				_ = yym2766
+				yym2771 := z.EncBinary()
+				_ = yym2771
 				if false {
 				} else {
 					r.EncodeBool(bool(x.Stderr))
 				}
 			}
-			if yyr2751 || yy2arr2751 {
-				yym2768 := z.EncBinary()
-				_ = yym2768
+			if yyr2756 || yy2arr2756 {
+				yym2773 := z.EncBinary()
+				_ = yym2773
 				if false {
 				} else {
 					r.EncodeBool(bool(x.TTY))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("TTY"))
-				yym2769 := z.EncBinary()
-				_ = yym2769
+				yym2774 := z.EncBinary()
+				_ = yym2774
 				if false {
 				} else {
 					r.EncodeBool(bool(x.TTY))
 				}
 			}
-			if yyr2751 || yy2arr2751 {
-				yym2771 := z.EncBinary()
-				_ = yym2771
+			if yyr2756 || yy2arr2756 {
+				yym2776 := z.EncBinary()
+				_ = yym2776
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Container))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("Container"))
-				yym2772 := z.EncBinary()
-				_ = yym2772
+				yym2777 := z.EncBinary()
+				_ = yym2777
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Container))
 				}
 			}
-			if yyr2751 || yy2arr2751 {
+			if yyr2756 || yy2arr2756 {
 				if x.Command == nil {
 					r.EncodeNil()
 				} else {
-					yym2774 := z.EncBinary()
-					_ = yym2774
+					yym2779 := z.EncBinary()
+					_ = yym2779
 					if false {
 					} else {
 						z.F.EncSliceStringV(x.Command, false, e)
@@ -32266,15 +32303,15 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Command == nil {
 					r.EncodeNil()
 				} else {
-					yym2775 := z.EncBinary()
-					_ = yym2775
+					yym2780 := z.EncBinary()
+					_ = yym2780
 					if false {
 					} else {
 						z.F.EncSliceStringV(x.Command, false, e)
 					}
 				}
 			}
-			if yysep2751 {
+			if yysep2756 {
 				r.EncodeEnd()
 			}
 		}
@@ -32285,24 +32322,24 @@ func (x *PodExecOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2776 := z.DecBinary()
-	_ = yym2776
+	yym2781 := z.DecBinary()
+	_ = yym2781
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2777 := r.ReadMapStart()
-			if yyl2777 == 0 {
+			yyl2782 := r.ReadMapStart()
+			if yyl2782 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2777, d)
+				x.codecDecodeSelfFromMap(yyl2782, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2777 := r.ReadArrayStart()
-			if yyl2777 == 0 {
+			yyl2782 := r.ReadArrayStart()
+			if yyl2782 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2777, d)
+				x.codecDecodeSelfFromArray(yyl2782, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -32314,12 +32351,12 @@ func (x *PodExecOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2778Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2778Slc
-	var yyhl2778 bool = l >= 0
-	for yyj2778 := 0; ; yyj2778++ {
-		if yyhl2778 {
-			if yyj2778 >= l {
+	var yys2783Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2783Slc
+	var yyhl2783 bool = l >= 0
+	for yyj2783 := 0; ; yyj2783++ {
+		if yyhl2783 {
+			if yyj2783 >= l {
 				break
 			}
 		} else {
@@ -32327,9 +32364,9 @@ func (x *PodExecOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2778Slc = r.DecodeBytes(yys2778Slc, true, true)
-		yys2778 := string(yys2778Slc)
-		switch yys2778 {
+		yys2783Slc = r.DecodeBytes(yys2783Slc, true, true)
+		yys2783 := string(yys2783Slc)
+		switch yys2783 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -32376,19 +32413,19 @@ func (x *PodExecOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Command = nil
 			} else {
-				yyv2786 := &x.Command
-				yym2787 := z.DecBinary()
-				_ = yym2787
+				yyv2791 := &x.Command
+				yym2792 := z.DecBinary()
+				_ = yym2792
 				if false {
 				} else {
-					z.F.DecSliceStringX(yyv2786, false, d)
+					z.F.DecSliceStringX(yyv2791, false, d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2778)
-		} // end switch yys2778
-	} // end for yyj2778
-	if !yyhl2778 {
+			z.DecStructFieldNotFound(-1, yys2783)
+		} // end switch yys2783
+	} // end for yyj2783
+	if !yyhl2783 {
 		r.ReadEnd()
 	}
 }
@@ -32397,16 +32434,16 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2788 int
-	var yyb2788 bool
-	var yyhl2788 bool = l >= 0
-	yyj2788++
-	if yyhl2788 {
-		yyb2788 = yyj2788 > l
+	var yyj2793 int
+	var yyb2793 bool
+	var yyhl2793 bool = l >= 0
+	yyj2793++
+	if yyhl2793 {
+		yyb2793 = yyj2793 > l
 	} else {
-		yyb2788 = r.CheckBreak()
+		yyb2793 = r.CheckBreak()
 	}
-	if yyb2788 {
+	if yyb2793 {
 		r.ReadEnd()
 		return
 	}
@@ -32415,13 +32452,13 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2788++
-	if yyhl2788 {
-		yyb2788 = yyj2788 > l
+	yyj2793++
+	if yyhl2793 {
+		yyb2793 = yyj2793 > l
 	} else {
-		yyb2788 = r.CheckBreak()
+		yyb2793 = r.CheckBreak()
 	}
-	if yyb2788 {
+	if yyb2793 {
 		r.ReadEnd()
 		return
 	}
@@ -32430,13 +32467,13 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2788++
-	if yyhl2788 {
-		yyb2788 = yyj2788 > l
+	yyj2793++
+	if yyhl2793 {
+		yyb2793 = yyj2793 > l
 	} else {
-		yyb2788 = r.CheckBreak()
+		yyb2793 = r.CheckBreak()
 	}
-	if yyb2788 {
+	if yyb2793 {
 		r.ReadEnd()
 		return
 	}
@@ -32445,13 +32482,13 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Stdin = bool(r.DecodeBool())
 	}
-	yyj2788++
-	if yyhl2788 {
-		yyb2788 = yyj2788 > l
+	yyj2793++
+	if yyhl2793 {
+		yyb2793 = yyj2793 > l
 	} else {
-		yyb2788 = r.CheckBreak()
+		yyb2793 = r.CheckBreak()
 	}
-	if yyb2788 {
+	if yyb2793 {
 		r.ReadEnd()
 		return
 	}
@@ -32460,13 +32497,13 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Stdout = bool(r.DecodeBool())
 	}
-	yyj2788++
-	if yyhl2788 {
-		yyb2788 = yyj2788 > l
+	yyj2793++
+	if yyhl2793 {
+		yyb2793 = yyj2793 > l
 	} else {
-		yyb2788 = r.CheckBreak()
+		yyb2793 = r.CheckBreak()
 	}
-	if yyb2788 {
+	if yyb2793 {
 		r.ReadEnd()
 		return
 	}
@@ -32475,13 +32512,13 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Stderr = bool(r.DecodeBool())
 	}
-	yyj2788++
-	if yyhl2788 {
-		yyb2788 = yyj2788 > l
+	yyj2793++
+	if yyhl2793 {
+		yyb2793 = yyj2793 > l
 	} else {
-		yyb2788 = r.CheckBreak()
+		yyb2793 = r.CheckBreak()
 	}
-	if yyb2788 {
+	if yyb2793 {
 		r.ReadEnd()
 		return
 	}
@@ -32490,13 +32527,13 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.TTY = bool(r.DecodeBool())
 	}
-	yyj2788++
-	if yyhl2788 {
-		yyb2788 = yyj2788 > l
+	yyj2793++
+	if yyhl2793 {
+		yyb2793 = yyj2793 > l
 	} else {
-		yyb2788 = r.CheckBreak()
+		yyb2793 = r.CheckBreak()
 	}
-	if yyb2788 {
+	if yyb2793 {
 		r.ReadEnd()
 		return
 	}
@@ -32505,38 +32542,38 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Container = string(r.DecodeString())
 	}
-	yyj2788++
-	if yyhl2788 {
-		yyb2788 = yyj2788 > l
+	yyj2793++
+	if yyhl2793 {
+		yyb2793 = yyj2793 > l
 	} else {
-		yyb2788 = r.CheckBreak()
+		yyb2793 = r.CheckBreak()
 	}
-	if yyb2788 {
+	if yyb2793 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Command = nil
 	} else {
-		yyv2796 := &x.Command
-		yym2797 := z.DecBinary()
-		_ = yym2797
+		yyv2801 := &x.Command
+		yym2802 := z.DecBinary()
+		_ = yym2802
 		if false {
 		} else {
-			z.F.DecSliceStringX(yyv2796, false, d)
+			z.F.DecSliceStringX(yyv2801, false, d)
 		}
 	}
 	for {
-		yyj2788++
-		if yyhl2788 {
-			yyb2788 = yyj2788 > l
+		yyj2793++
+		if yyhl2793 {
+			yyb2793 = yyj2793 > l
 		} else {
-			yyb2788 = r.CheckBreak()
+			yyb2793 = r.CheckBreak()
 		}
-		if yyb2788 {
+		if yyb2793 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2788-1, "")
+		z.DecStructFieldNotFound(yyj2793-1, "")
 	}
 	r.ReadEnd()
 }
@@ -32548,33 +32585,33 @@ func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2798 := z.EncBinary()
-		_ = yym2798
+		yym2803 := z.EncBinary()
+		_ = yym2803
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2799 := !z.EncBinary()
-			yy2arr2799 := z.EncBasicHandle().StructToArray
-			var yyq2799 [3]bool
-			_, _, _ = yysep2799, yyq2799, yy2arr2799
-			const yyr2799 bool = false
-			yyq2799[0] = x.Kind != ""
-			yyq2799[1] = x.APIVersion != ""
-			if yyr2799 || yy2arr2799 {
+			yysep2804 := !z.EncBinary()
+			yy2arr2804 := z.EncBasicHandle().StructToArray
+			var yyq2804 [3]bool
+			_, _, _ = yysep2804, yyq2804, yy2arr2804
+			const yyr2804 bool = false
+			yyq2804[0] = x.Kind != ""
+			yyq2804[1] = x.APIVersion != ""
+			if yyr2804 || yy2arr2804 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn2799 int = 1
-				for _, b := range yyq2799 {
+				var yynn2804 int = 1
+				for _, b := range yyq2804 {
 					if b {
-						yynn2799++
+						yynn2804++
 					}
 				}
-				r.EncodeMapStart(yynn2799)
+				r.EncodeMapStart(yynn2804)
 			}
-			if yyr2799 || yy2arr2799 {
-				if yyq2799[0] {
-					yym2801 := z.EncBinary()
-					_ = yym2801
+			if yyr2804 || yy2arr2804 {
+				if yyq2804[0] {
+					yym2806 := z.EncBinary()
+					_ = yym2806
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -32583,20 +32620,20 @@ func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2799[0] {
+				if yyq2804[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2802 := z.EncBinary()
-					_ = yym2802
+					yym2807 := z.EncBinary()
+					_ = yym2807
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2799 || yy2arr2799 {
-				if yyq2799[1] {
-					yym2804 := z.EncBinary()
-					_ = yym2804
+			if yyr2804 || yy2arr2804 {
+				if yyq2804[1] {
+					yym2809 := z.EncBinary()
+					_ = yym2809
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -32605,33 +32642,33 @@ func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2799[1] {
+				if yyq2804[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2805 := z.EncBinary()
-					_ = yym2805
+					yym2810 := z.EncBinary()
+					_ = yym2810
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2799 || yy2arr2799 {
-				yym2807 := z.EncBinary()
-				_ = yym2807
+			if yyr2804 || yy2arr2804 {
+				yym2812 := z.EncBinary()
+				_ = yym2812
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("Path"))
-				yym2808 := z.EncBinary()
-				_ = yym2808
+				yym2813 := z.EncBinary()
+				_ = yym2813
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 				}
 			}
-			if yysep2799 {
+			if yysep2804 {
 				r.EncodeEnd()
 			}
 		}
@@ -32642,24 +32679,24 @@ func (x *PodProxyOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2809 := z.DecBinary()
-	_ = yym2809
+	yym2814 := z.DecBinary()
+	_ = yym2814
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2810 := r.ReadMapStart()
-			if yyl2810 == 0 {
+			yyl2815 := r.ReadMapStart()
+			if yyl2815 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2810, d)
+				x.codecDecodeSelfFromMap(yyl2815, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2810 := r.ReadArrayStart()
-			if yyl2810 == 0 {
+			yyl2815 := r.ReadArrayStart()
+			if yyl2815 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2810, d)
+				x.codecDecodeSelfFromArray(yyl2815, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -32671,12 +32708,12 @@ func (x *PodProxyOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2811Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2811Slc
-	var yyhl2811 bool = l >= 0
-	for yyj2811 := 0; ; yyj2811++ {
-		if yyhl2811 {
-			if yyj2811 >= l {
+	var yys2816Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2816Slc
+	var yyhl2816 bool = l >= 0
+	for yyj2816 := 0; ; yyj2816++ {
+		if yyhl2816 {
+			if yyj2816 >= l {
 				break
 			}
 		} else {
@@ -32684,9 +32721,9 @@ func (x *PodProxyOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2811Slc = r.DecodeBytes(yys2811Slc, true, true)
-		yys2811 := string(yys2811Slc)
-		switch yys2811 {
+		yys2816Slc = r.DecodeBytes(yys2816Slc, true, true)
+		yys2816 := string(yys2816Slc)
+		switch yys2816 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -32706,10 +32743,10 @@ func (x *PodProxyOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Path = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2811)
-		} // end switch yys2811
-	} // end for yyj2811
-	if !yyhl2811 {
+			z.DecStructFieldNotFound(-1, yys2816)
+		} // end switch yys2816
+	} // end for yyj2816
+	if !yyhl2816 {
 		r.ReadEnd()
 	}
 }
@@ -32718,16 +32755,16 @@ func (x *PodProxyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2815 int
-	var yyb2815 bool
-	var yyhl2815 bool = l >= 0
-	yyj2815++
-	if yyhl2815 {
-		yyb2815 = yyj2815 > l
+	var yyj2820 int
+	var yyb2820 bool
+	var yyhl2820 bool = l >= 0
+	yyj2820++
+	if yyhl2820 {
+		yyb2820 = yyj2820 > l
 	} else {
-		yyb2815 = r.CheckBreak()
+		yyb2820 = r.CheckBreak()
 	}
-	if yyb2815 {
+	if yyb2820 {
 		r.ReadEnd()
 		return
 	}
@@ -32736,13 +32773,13 @@ func (x *PodProxyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2815++
-	if yyhl2815 {
-		yyb2815 = yyj2815 > l
+	yyj2820++
+	if yyhl2820 {
+		yyb2820 = yyj2820 > l
 	} else {
-		yyb2815 = r.CheckBreak()
+		yyb2820 = r.CheckBreak()
 	}
-	if yyb2815 {
+	if yyb2820 {
 		r.ReadEnd()
 		return
 	}
@@ -32751,13 +32788,13 @@ func (x *PodProxyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2815++
-	if yyhl2815 {
-		yyb2815 = yyj2815 > l
+	yyj2820++
+	if yyhl2820 {
+		yyb2820 = yyj2820 > l
 	} else {
-		yyb2815 = r.CheckBreak()
+		yyb2820 = r.CheckBreak()
 	}
-	if yyb2815 {
+	if yyb2820 {
 		r.ReadEnd()
 		return
 	}
@@ -32767,16 +32804,16 @@ func (x *PodProxyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.Path = string(r.DecodeString())
 	}
 	for {
-		yyj2815++
-		if yyhl2815 {
-			yyb2815 = yyj2815 > l
+		yyj2820++
+		if yyhl2820 {
+			yyb2820 = yyj2820 > l
 		} else {
-			yyb2815 = r.CheckBreak()
+			yyb2820 = r.CheckBreak()
 		}
-		if yyb2815 {
+		if yyb2820 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2815-1, "")
+		z.DecStructFieldNotFound(yyj2820-1, "")
 	}
 	r.ReadEnd()
 }
@@ -32788,38 +32825,38 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2819 := z.EncBinary()
-		_ = yym2819
+		yym2824 := z.EncBinary()
+		_ = yym2824
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2820 := !z.EncBinary()
-			yy2arr2820 := z.EncBasicHandle().StructToArray
-			var yyq2820 [7]bool
-			_, _, _ = yysep2820, yyq2820, yy2arr2820
-			const yyr2820 bool = false
-			yyq2820[0] = x.Kind != ""
-			yyq2820[1] = x.Namespace != ""
-			yyq2820[2] = x.Name != ""
-			yyq2820[3] = x.UID != ""
-			yyq2820[4] = x.APIVersion != ""
-			yyq2820[5] = x.ResourceVersion != ""
-			yyq2820[6] = x.FieldPath != ""
-			if yyr2820 || yy2arr2820 {
+			yysep2825 := !z.EncBinary()
+			yy2arr2825 := z.EncBasicHandle().StructToArray
+			var yyq2825 [7]bool
+			_, _, _ = yysep2825, yyq2825, yy2arr2825
+			const yyr2825 bool = false
+			yyq2825[0] = x.Kind != ""
+			yyq2825[1] = x.Namespace != ""
+			yyq2825[2] = x.Name != ""
+			yyq2825[3] = x.UID != ""
+			yyq2825[4] = x.APIVersion != ""
+			yyq2825[5] = x.ResourceVersion != ""
+			yyq2825[6] = x.FieldPath != ""
+			if yyr2825 || yy2arr2825 {
 				r.EncodeArrayStart(7)
 			} else {
-				var yynn2820 int = 0
-				for _, b := range yyq2820 {
+				var yynn2825 int = 0
+				for _, b := range yyq2825 {
 					if b {
-						yynn2820++
+						yynn2825++
 					}
 				}
-				r.EncodeMapStart(yynn2820)
+				r.EncodeMapStart(yynn2825)
 			}
-			if yyr2820 || yy2arr2820 {
-				if yyq2820[0] {
-					yym2822 := z.EncBinary()
-					_ = yym2822
+			if yyr2825 || yy2arr2825 {
+				if yyq2825[0] {
+					yym2827 := z.EncBinary()
+					_ = yym2827
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -32828,151 +32865,151 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2820[0] {
+				if yyq2825[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2823 := z.EncBinary()
-					_ = yym2823
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2820 || yy2arr2820 {
-				if yyq2820[1] {
-					yym2825 := z.EncBinary()
-					_ = yym2825
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Namespace))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2820[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("namespace"))
-					yym2826 := z.EncBinary()
-					_ = yym2826
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Namespace))
-					}
-				}
-			}
-			if yyr2820 || yy2arr2820 {
-				if yyq2820[2] {
 					yym2828 := z.EncBinary()
 					_ = yym2828
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2825 || yy2arr2825 {
+				if yyq2825[1] {
+					yym2830 := z.EncBinary()
+					_ = yym2830
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Namespace))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2820[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("name"))
-					yym2829 := z.EncBinary()
-					_ = yym2829
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
-					}
-				}
-			}
-			if yyr2820 || yy2arr2820 {
-				if yyq2820[3] {
+				if yyq2825[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("namespace"))
 					yym2831 := z.EncBinary()
 					_ = yym2831
 					if false {
-					} else if z.HasExtensions() && z.EncExt(x.UID) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.UID))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Namespace))
+					}
+				}
+			}
+			if yyr2825 || yy2arr2825 {
+				if yyq2825[2] {
+					yym2833 := z.EncBinary()
+					_ = yym2833
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2820[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("uid"))
-					yym2832 := z.EncBinary()
-					_ = yym2832
-					if false {
-					} else if z.HasExtensions() && z.EncExt(x.UID) {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.UID))
-					}
-				}
-			}
-			if yyr2820 || yy2arr2820 {
-				if yyq2820[4] {
+				if yyq2825[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("name"))
 					yym2834 := z.EncBinary()
 					_ = yym2834
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+					}
+				}
+			}
+			if yyr2825 || yy2arr2825 {
+				if yyq2825[3] {
+					yym2836 := z.EncBinary()
+					_ = yym2836
+					if false {
+					} else if z.HasExtensions() && z.EncExt(x.UID) {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.UID))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2820[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2835 := z.EncBinary()
-					_ = yym2835
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2820 || yy2arr2820 {
-				if yyq2820[5] {
+				if yyq2825[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("uid"))
 					yym2837 := z.EncBinary()
 					_ = yym2837
 					if false {
+					} else if z.HasExtensions() && z.EncExt(x.UID) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
+						r.EncodeString(codecSelferC_UTF81234, string(x.UID))
+					}
+				}
+			}
+			if yyr2825 || yy2arr2825 {
+				if yyq2825[4] {
+					yym2839 := z.EncBinary()
+					_ = yym2839
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2820[5] {
-					r.EncodeString(codecSelferC_UTF81234, string("resourceVersion"))
-					yym2838 := z.EncBinary()
-					_ = yym2838
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
-					}
-				}
-			}
-			if yyr2820 || yy2arr2820 {
-				if yyq2820[6] {
+				if yyq2825[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					yym2840 := z.EncBinary()
 					_ = yym2840
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr2825 || yy2arr2825 {
+				if yyq2825[5] {
+					yym2842 := z.EncBinary()
+					_ = yym2842
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2825[5] {
+					r.EncodeString(codecSelferC_UTF81234, string("resourceVersion"))
+					yym2843 := z.EncBinary()
+					_ = yym2843
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
+					}
+				}
+			}
+			if yyr2825 || yy2arr2825 {
+				if yyq2825[6] {
+					yym2845 := z.EncBinary()
+					_ = yym2845
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.FieldPath))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2820[6] {
+				if yyq2825[6] {
 					r.EncodeString(codecSelferC_UTF81234, string("fieldPath"))
-					yym2841 := z.EncBinary()
-					_ = yym2841
+					yym2846 := z.EncBinary()
+					_ = yym2846
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.FieldPath))
 					}
 				}
 			}
-			if yysep2820 {
+			if yysep2825 {
 				r.EncodeEnd()
 			}
 		}
@@ -32983,24 +33020,24 @@ func (x *ObjectReference) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2842 := z.DecBinary()
-	_ = yym2842
+	yym2847 := z.DecBinary()
+	_ = yym2847
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2843 := r.ReadMapStart()
-			if yyl2843 == 0 {
+			yyl2848 := r.ReadMapStart()
+			if yyl2848 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2843, d)
+				x.codecDecodeSelfFromMap(yyl2848, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2843 := r.ReadArrayStart()
-			if yyl2843 == 0 {
+			yyl2848 := r.ReadArrayStart()
+			if yyl2848 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2843, d)
+				x.codecDecodeSelfFromArray(yyl2848, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -33012,12 +33049,12 @@ func (x *ObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2844Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2844Slc
-	var yyhl2844 bool = l >= 0
-	for yyj2844 := 0; ; yyj2844++ {
-		if yyhl2844 {
-			if yyj2844 >= l {
+	var yys2849Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2849Slc
+	var yyhl2849 bool = l >= 0
+	for yyj2849 := 0; ; yyj2849++ {
+		if yyhl2849 {
+			if yyj2849 >= l {
 				break
 			}
 		} else {
@@ -33025,9 +33062,9 @@ func (x *ObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2844Slc = r.DecodeBytes(yys2844Slc, true, true)
-		yys2844 := string(yys2844Slc)
-		switch yys2844 {
+		yys2849Slc = r.DecodeBytes(yys2849Slc, true, true)
+		yys2849 := string(yys2849Slc)
+		switch yys2849 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -33071,10 +33108,10 @@ func (x *ObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.FieldPath = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2844)
-		} // end switch yys2844
-	} // end for yyj2844
-	if !yyhl2844 {
+			z.DecStructFieldNotFound(-1, yys2849)
+		} // end switch yys2849
+	} // end for yyj2849
+	if !yyhl2849 {
 		r.ReadEnd()
 	}
 }
@@ -33083,16 +33120,16 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2852 int
-	var yyb2852 bool
-	var yyhl2852 bool = l >= 0
-	yyj2852++
-	if yyhl2852 {
-		yyb2852 = yyj2852 > l
+	var yyj2857 int
+	var yyb2857 bool
+	var yyhl2857 bool = l >= 0
+	yyj2857++
+	if yyhl2857 {
+		yyb2857 = yyj2857 > l
 	} else {
-		yyb2852 = r.CheckBreak()
+		yyb2857 = r.CheckBreak()
 	}
-	if yyb2852 {
+	if yyb2857 {
 		r.ReadEnd()
 		return
 	}
@@ -33101,13 +33138,13 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2852++
-	if yyhl2852 {
-		yyb2852 = yyj2852 > l
+	yyj2857++
+	if yyhl2857 {
+		yyb2857 = yyj2857 > l
 	} else {
-		yyb2852 = r.CheckBreak()
+		yyb2857 = r.CheckBreak()
 	}
-	if yyb2852 {
+	if yyb2857 {
 		r.ReadEnd()
 		return
 	}
@@ -33116,13 +33153,13 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Namespace = string(r.DecodeString())
 	}
-	yyj2852++
-	if yyhl2852 {
-		yyb2852 = yyj2852 > l
+	yyj2857++
+	if yyhl2857 {
+		yyb2857 = yyj2857 > l
 	} else {
-		yyb2852 = r.CheckBreak()
+		yyb2857 = r.CheckBreak()
 	}
-	if yyb2852 {
+	if yyb2857 {
 		r.ReadEnd()
 		return
 	}
@@ -33131,13 +33168,13 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Name = string(r.DecodeString())
 	}
-	yyj2852++
-	if yyhl2852 {
-		yyb2852 = yyj2852 > l
+	yyj2857++
+	if yyhl2857 {
+		yyb2857 = yyj2857 > l
 	} else {
-		yyb2852 = r.CheckBreak()
+		yyb2857 = r.CheckBreak()
 	}
-	if yyb2852 {
+	if yyb2857 {
 		r.ReadEnd()
 		return
 	}
@@ -33146,13 +33183,13 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.UID = pkg1_types.UID(r.DecodeString())
 	}
-	yyj2852++
-	if yyhl2852 {
-		yyb2852 = yyj2852 > l
+	yyj2857++
+	if yyhl2857 {
+		yyb2857 = yyj2857 > l
 	} else {
-		yyb2852 = r.CheckBreak()
+		yyb2857 = r.CheckBreak()
 	}
-	if yyb2852 {
+	if yyb2857 {
 		r.ReadEnd()
 		return
 	}
@@ -33161,13 +33198,13 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2852++
-	if yyhl2852 {
-		yyb2852 = yyj2852 > l
+	yyj2857++
+	if yyhl2857 {
+		yyb2857 = yyj2857 > l
 	} else {
-		yyb2852 = r.CheckBreak()
+		yyb2857 = r.CheckBreak()
 	}
-	if yyb2852 {
+	if yyb2857 {
 		r.ReadEnd()
 		return
 	}
@@ -33176,13 +33213,13 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.ResourceVersion = string(r.DecodeString())
 	}
-	yyj2852++
-	if yyhl2852 {
-		yyb2852 = yyj2852 > l
+	yyj2857++
+	if yyhl2857 {
+		yyb2857 = yyj2857 > l
 	} else {
-		yyb2852 = r.CheckBreak()
+		yyb2857 = r.CheckBreak()
 	}
-	if yyb2852 {
+	if yyb2857 {
 		r.ReadEnd()
 		return
 	}
@@ -33192,16 +33229,16 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.FieldPath = string(r.DecodeString())
 	}
 	for {
-		yyj2852++
-		if yyhl2852 {
-			yyb2852 = yyj2852 > l
+		yyj2857++
+		if yyhl2857 {
+			yyb2857 = yyj2857 > l
 		} else {
-			yyb2852 = r.CheckBreak()
+			yyb2857 = r.CheckBreak()
 		}
-		if yyb2852 {
+		if yyb2857 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2852-1, "")
+		z.DecStructFieldNotFound(yyj2857-1, "")
 	}
 	r.ReadEnd()
 }
@@ -33213,44 +33250,44 @@ func (x *LocalObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2860 := z.EncBinary()
-		_ = yym2860
+		yym2865 := z.EncBinary()
+		_ = yym2865
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2861 := !z.EncBinary()
-			yy2arr2861 := z.EncBasicHandle().StructToArray
-			var yyq2861 [1]bool
-			_, _, _ = yysep2861, yyq2861, yy2arr2861
-			const yyr2861 bool = false
-			if yyr2861 || yy2arr2861 {
+			yysep2866 := !z.EncBinary()
+			yy2arr2866 := z.EncBasicHandle().StructToArray
+			var yyq2866 [1]bool
+			_, _, _ = yysep2866, yyq2866, yy2arr2866
+			const yyr2866 bool = false
+			if yyr2866 || yy2arr2866 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn2861 int = 1
-				for _, b := range yyq2861 {
+				var yynn2866 int = 1
+				for _, b := range yyq2866 {
 					if b {
-						yynn2861++
+						yynn2866++
 					}
 				}
-				r.EncodeMapStart(yynn2861)
+				r.EncodeMapStart(yynn2866)
 			}
-			if yyr2861 || yy2arr2861 {
-				yym2863 := z.EncBinary()
-				_ = yym2863
+			if yyr2866 || yy2arr2866 {
+				yym2868 := z.EncBinary()
+				_ = yym2868
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("Name"))
-				yym2864 := z.EncBinary()
-				_ = yym2864
+				yym2869 := z.EncBinary()
+				_ = yym2869
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 				}
 			}
-			if yysep2861 {
+			if yysep2866 {
 				r.EncodeEnd()
 			}
 		}
@@ -33261,24 +33298,24 @@ func (x *LocalObjectReference) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2865 := z.DecBinary()
-	_ = yym2865
+	yym2870 := z.DecBinary()
+	_ = yym2870
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2866 := r.ReadMapStart()
-			if yyl2866 == 0 {
+			yyl2871 := r.ReadMapStart()
+			if yyl2871 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2866, d)
+				x.codecDecodeSelfFromMap(yyl2871, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2866 := r.ReadArrayStart()
-			if yyl2866 == 0 {
+			yyl2871 := r.ReadArrayStart()
+			if yyl2871 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2866, d)
+				x.codecDecodeSelfFromArray(yyl2871, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -33290,12 +33327,12 @@ func (x *LocalObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2867Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2867Slc
-	var yyhl2867 bool = l >= 0
-	for yyj2867 := 0; ; yyj2867++ {
-		if yyhl2867 {
-			if yyj2867 >= l {
+	var yys2872Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2872Slc
+	var yyhl2872 bool = l >= 0
+	for yyj2872 := 0; ; yyj2872++ {
+		if yyhl2872 {
+			if yyj2872 >= l {
 				break
 			}
 		} else {
@@ -33303,9 +33340,9 @@ func (x *LocalObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
-		yys2867Slc = r.DecodeBytes(yys2867Slc, true, true)
-		yys2867 := string(yys2867Slc)
-		switch yys2867 {
+		yys2872Slc = r.DecodeBytes(yys2872Slc, true, true)
+		yys2872 := string(yys2872Slc)
+		switch yys2872 {
 		case "Name":
 			if r.TryDecodeAsNil() {
 				x.Name = ""
@@ -33313,10 +33350,10 @@ func (x *LocalObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				x.Name = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2867)
-		} // end switch yys2867
-	} // end for yyj2867
-	if !yyhl2867 {
+			z.DecStructFieldNotFound(-1, yys2872)
+		} // end switch yys2872
+	} // end for yyj2872
+	if !yyhl2872 {
 		r.ReadEnd()
 	}
 }
@@ -33325,16 +33362,16 @@ func (x *LocalObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2869 int
-	var yyb2869 bool
-	var yyhl2869 bool = l >= 0
-	yyj2869++
-	if yyhl2869 {
-		yyb2869 = yyj2869 > l
+	var yyj2874 int
+	var yyb2874 bool
+	var yyhl2874 bool = l >= 0
+	yyj2874++
+	if yyhl2874 {
+		yyb2874 = yyj2874 > l
 	} else {
-		yyb2869 = r.CheckBreak()
+		yyb2874 = r.CheckBreak()
 	}
-	if yyb2869 {
+	if yyb2874 {
 		r.ReadEnd()
 		return
 	}
@@ -33344,16 +33381,16 @@ func (x *LocalObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		x.Name = string(r.DecodeString())
 	}
 	for {
-		yyj2869++
-		if yyhl2869 {
-			yyb2869 = yyj2869 > l
+		yyj2874++
+		if yyhl2874 {
+			yyb2874 = yyj2874 > l
 		} else {
-			yyb2869 = r.CheckBreak()
+			yyb2874 = r.CheckBreak()
 		}
-		if yyb2869 {
+		if yyb2874 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2869-1, "")
+		z.DecStructFieldNotFound(yyj2874-1, "")
 	}
 	r.ReadEnd()
 }
@@ -33365,34 +33402,34 @@ func (x *SerializedReference) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2871 := z.EncBinary()
-		_ = yym2871
+		yym2876 := z.EncBinary()
+		_ = yym2876
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2872 := !z.EncBinary()
-			yy2arr2872 := z.EncBasicHandle().StructToArray
-			var yyq2872 [3]bool
-			_, _, _ = yysep2872, yyq2872, yy2arr2872
-			const yyr2872 bool = false
-			yyq2872[0] = x.Kind != ""
-			yyq2872[1] = x.APIVersion != ""
-			yyq2872[2] = true
-			if yyr2872 || yy2arr2872 {
+			yysep2877 := !z.EncBinary()
+			yy2arr2877 := z.EncBasicHandle().StructToArray
+			var yyq2877 [3]bool
+			_, _, _ = yysep2877, yyq2877, yy2arr2877
+			const yyr2877 bool = false
+			yyq2877[0] = x.Kind != ""
+			yyq2877[1] = x.APIVersion != ""
+			yyq2877[2] = true
+			if yyr2877 || yy2arr2877 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn2872 int = 0
-				for _, b := range yyq2872 {
+				var yynn2877 int = 0
+				for _, b := range yyq2877 {
 					if b {
-						yynn2872++
+						yynn2877++
 					}
 				}
-				r.EncodeMapStart(yynn2872)
+				r.EncodeMapStart(yynn2877)
 			}
-			if yyr2872 || yy2arr2872 {
-				if yyq2872[0] {
-					yym2874 := z.EncBinary()
-					_ = yym2874
+			if yyr2877 || yy2arr2877 {
+				if yyq2877[0] {
+					yym2879 := z.EncBinary()
+					_ = yym2879
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -33401,20 +33438,20 @@ func (x *SerializedReference) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2872[0] {
+				if yyq2877[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2875 := z.EncBinary()
-					_ = yym2875
+					yym2880 := z.EncBinary()
+					_ = yym2880
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2872 || yy2arr2872 {
-				if yyq2872[1] {
-					yym2877 := z.EncBinary()
-					_ = yym2877
+			if yyr2877 || yy2arr2877 {
+				if yyq2877[1] {
+					yym2882 := z.EncBinary()
+					_ = yym2882
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -33423,31 +33460,31 @@ func (x *SerializedReference) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2872[1] {
+				if yyq2877[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2878 := z.EncBinary()
-					_ = yym2878
+					yym2883 := z.EncBinary()
+					_ = yym2883
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2872 || yy2arr2872 {
-				if yyq2872[2] {
-					yy2880 := &x.Reference
-					yy2880.CodecEncodeSelf(e)
+			if yyr2877 || yy2arr2877 {
+				if yyq2877[2] {
+					yy2885 := &x.Reference
+					yy2885.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2872[2] {
+				if yyq2877[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("reference"))
-					yy2881 := &x.Reference
-					yy2881.CodecEncodeSelf(e)
+					yy2886 := &x.Reference
+					yy2886.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2872 {
+			if yysep2877 {
 				r.EncodeEnd()
 			}
 		}
@@ -33458,24 +33495,24 @@ func (x *SerializedReference) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2882 := z.DecBinary()
-	_ = yym2882
+	yym2887 := z.DecBinary()
+	_ = yym2887
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2883 := r.ReadMapStart()
-			if yyl2883 == 0 {
+			yyl2888 := r.ReadMapStart()
+			if yyl2888 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2883, d)
+				x.codecDecodeSelfFromMap(yyl2888, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2883 := r.ReadArrayStart()
-			if yyl2883 == 0 {
+			yyl2888 := r.ReadArrayStart()
+			if yyl2888 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2883, d)
+				x.codecDecodeSelfFromArray(yyl2888, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -33487,12 +33524,12 @@ func (x *SerializedReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2884Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2884Slc
-	var yyhl2884 bool = l >= 0
-	for yyj2884 := 0; ; yyj2884++ {
-		if yyhl2884 {
-			if yyj2884 >= l {
+	var yys2889Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2889Slc
+	var yyhl2889 bool = l >= 0
+	for yyj2889 := 0; ; yyj2889++ {
+		if yyhl2889 {
+			if yyj2889 >= l {
 				break
 			}
 		} else {
@@ -33500,9 +33537,9 @@ func (x *SerializedReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				break
 			}
 		}
-		yys2884Slc = r.DecodeBytes(yys2884Slc, true, true)
-		yys2884 := string(yys2884Slc)
-		switch yys2884 {
+		yys2889Slc = r.DecodeBytes(yys2889Slc, true, true)
+		yys2889 := string(yys2889Slc)
+		switch yys2889 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -33519,14 +33556,14 @@ func (x *SerializedReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 			if r.TryDecodeAsNil() {
 				x.Reference = ObjectReference{}
 			} else {
-				yyv2887 := &x.Reference
-				yyv2887.CodecDecodeSelf(d)
+				yyv2892 := &x.Reference
+				yyv2892.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2884)
-		} // end switch yys2884
-	} // end for yyj2884
-	if !yyhl2884 {
+			z.DecStructFieldNotFound(-1, yys2889)
+		} // end switch yys2889
+	} // end for yyj2889
+	if !yyhl2889 {
 		r.ReadEnd()
 	}
 }
@@ -33535,16 +33572,16 @@ func (x *SerializedReference) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2888 int
-	var yyb2888 bool
-	var yyhl2888 bool = l >= 0
-	yyj2888++
-	if yyhl2888 {
-		yyb2888 = yyj2888 > l
+	var yyj2893 int
+	var yyb2893 bool
+	var yyhl2893 bool = l >= 0
+	yyj2893++
+	if yyhl2893 {
+		yyb2893 = yyj2893 > l
 	} else {
-		yyb2888 = r.CheckBreak()
+		yyb2893 = r.CheckBreak()
 	}
-	if yyb2888 {
+	if yyb2893 {
 		r.ReadEnd()
 		return
 	}
@@ -33553,13 +33590,13 @@ func (x *SerializedReference) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2888++
-	if yyhl2888 {
-		yyb2888 = yyj2888 > l
+	yyj2893++
+	if yyhl2893 {
+		yyb2893 = yyj2893 > l
 	} else {
-		yyb2888 = r.CheckBreak()
+		yyb2893 = r.CheckBreak()
 	}
-	if yyb2888 {
+	if yyb2893 {
 		r.ReadEnd()
 		return
 	}
@@ -33568,33 +33605,33 @@ func (x *SerializedReference) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2888++
-	if yyhl2888 {
-		yyb2888 = yyj2888 > l
+	yyj2893++
+	if yyhl2893 {
+		yyb2893 = yyj2893 > l
 	} else {
-		yyb2888 = r.CheckBreak()
+		yyb2893 = r.CheckBreak()
 	}
-	if yyb2888 {
+	if yyb2893 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Reference = ObjectReference{}
 	} else {
-		yyv2891 := &x.Reference
-		yyv2891.CodecDecodeSelf(d)
+		yyv2896 := &x.Reference
+		yyv2896.CodecDecodeSelf(d)
 	}
 	for {
-		yyj2888++
-		if yyhl2888 {
-			yyb2888 = yyj2888 > l
+		yyj2893++
+		if yyhl2893 {
+			yyb2893 = yyj2893 > l
 		} else {
-			yyb2888 = r.CheckBreak()
+			yyb2893 = r.CheckBreak()
 		}
-		if yyb2888 {
+		if yyb2893 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2888-1, "")
+		z.DecStructFieldNotFound(yyj2893-1, "")
 	}
 	r.ReadEnd()
 }
@@ -33606,33 +33643,33 @@ func (x *EventSource) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2892 := z.EncBinary()
-		_ = yym2892
+		yym2897 := z.EncBinary()
+		_ = yym2897
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2893 := !z.EncBinary()
-			yy2arr2893 := z.EncBasicHandle().StructToArray
-			var yyq2893 [2]bool
-			_, _, _ = yysep2893, yyq2893, yy2arr2893
-			const yyr2893 bool = false
-			yyq2893[0] = x.Component != ""
-			yyq2893[1] = x.Host != ""
-			if yyr2893 || yy2arr2893 {
+			yysep2898 := !z.EncBinary()
+			yy2arr2898 := z.EncBasicHandle().StructToArray
+			var yyq2898 [2]bool
+			_, _, _ = yysep2898, yyq2898, yy2arr2898
+			const yyr2898 bool = false
+			yyq2898[0] = x.Component != ""
+			yyq2898[1] = x.Host != ""
+			if yyr2898 || yy2arr2898 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn2893 int = 0
-				for _, b := range yyq2893 {
+				var yynn2898 int = 0
+				for _, b := range yyq2898 {
 					if b {
-						yynn2893++
+						yynn2898++
 					}
 				}
-				r.EncodeMapStart(yynn2893)
+				r.EncodeMapStart(yynn2898)
 			}
-			if yyr2893 || yy2arr2893 {
-				if yyq2893[0] {
-					yym2895 := z.EncBinary()
-					_ = yym2895
+			if yyr2898 || yy2arr2898 {
+				if yyq2898[0] {
+					yym2900 := z.EncBinary()
+					_ = yym2900
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Component))
@@ -33641,20 +33678,20 @@ func (x *EventSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2893[0] {
+				if yyq2898[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("component"))
-					yym2896 := z.EncBinary()
-					_ = yym2896
+					yym2901 := z.EncBinary()
+					_ = yym2901
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Component))
 					}
 				}
 			}
-			if yyr2893 || yy2arr2893 {
-				if yyq2893[1] {
-					yym2898 := z.EncBinary()
-					_ = yym2898
+			if yyr2898 || yy2arr2898 {
+				if yyq2898[1] {
+					yym2903 := z.EncBinary()
+					_ = yym2903
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Host))
@@ -33663,17 +33700,17 @@ func (x *EventSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2893[1] {
+				if yyq2898[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("host"))
-					yym2899 := z.EncBinary()
-					_ = yym2899
+					yym2904 := z.EncBinary()
+					_ = yym2904
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Host))
 					}
 				}
 			}
-			if yysep2893 {
+			if yysep2898 {
 				r.EncodeEnd()
 			}
 		}
@@ -33684,24 +33721,24 @@ func (x *EventSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2900 := z.DecBinary()
-	_ = yym2900
+	yym2905 := z.DecBinary()
+	_ = yym2905
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2901 := r.ReadMapStart()
-			if yyl2901 == 0 {
+			yyl2906 := r.ReadMapStart()
+			if yyl2906 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2901, d)
+				x.codecDecodeSelfFromMap(yyl2906, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2901 := r.ReadArrayStart()
-			if yyl2901 == 0 {
+			yyl2906 := r.ReadArrayStart()
+			if yyl2906 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2901, d)
+				x.codecDecodeSelfFromArray(yyl2906, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -33713,12 +33750,12 @@ func (x *EventSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2902Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2902Slc
-	var yyhl2902 bool = l >= 0
-	for yyj2902 := 0; ; yyj2902++ {
-		if yyhl2902 {
-			if yyj2902 >= l {
+	var yys2907Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2907Slc
+	var yyhl2907 bool = l >= 0
+	for yyj2907 := 0; ; yyj2907++ {
+		if yyhl2907 {
+			if yyj2907 >= l {
 				break
 			}
 		} else {
@@ -33726,9 +33763,9 @@ func (x *EventSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2902Slc = r.DecodeBytes(yys2902Slc, true, true)
-		yys2902 := string(yys2902Slc)
-		switch yys2902 {
+		yys2907Slc = r.DecodeBytes(yys2907Slc, true, true)
+		yys2907 := string(yys2907Slc)
+		switch yys2907 {
 		case "component":
 			if r.TryDecodeAsNil() {
 				x.Component = ""
@@ -33742,10 +33779,10 @@ func (x *EventSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Host = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2902)
-		} // end switch yys2902
-	} // end for yyj2902
-	if !yyhl2902 {
+			z.DecStructFieldNotFound(-1, yys2907)
+		} // end switch yys2907
+	} // end for yyj2907
+	if !yyhl2907 {
 		r.ReadEnd()
 	}
 }
@@ -33754,16 +33791,16 @@ func (x *EventSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2905 int
-	var yyb2905 bool
-	var yyhl2905 bool = l >= 0
-	yyj2905++
-	if yyhl2905 {
-		yyb2905 = yyj2905 > l
+	var yyj2910 int
+	var yyb2910 bool
+	var yyhl2910 bool = l >= 0
+	yyj2910++
+	if yyhl2910 {
+		yyb2910 = yyj2910 > l
 	} else {
-		yyb2905 = r.CheckBreak()
+		yyb2910 = r.CheckBreak()
 	}
-	if yyb2905 {
+	if yyb2910 {
 		r.ReadEnd()
 		return
 	}
@@ -33772,13 +33809,13 @@ func (x *EventSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Component = string(r.DecodeString())
 	}
-	yyj2905++
-	if yyhl2905 {
-		yyb2905 = yyj2905 > l
+	yyj2910++
+	if yyhl2910 {
+		yyb2910 = yyj2910 > l
 	} else {
-		yyb2905 = r.CheckBreak()
+		yyb2910 = r.CheckBreak()
 	}
-	if yyb2905 {
+	if yyb2910 {
 		r.ReadEnd()
 		return
 	}
@@ -33788,16 +33825,16 @@ func (x *EventSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Host = string(r.DecodeString())
 	}
 	for {
-		yyj2905++
-		if yyhl2905 {
-			yyb2905 = yyj2905 > l
+		yyj2910++
+		if yyhl2910 {
+			yyb2910 = yyj2910 > l
 		} else {
-			yyb2905 = r.CheckBreak()
+			yyb2910 = r.CheckBreak()
 		}
-		if yyb2905 {
+		if yyb2910 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2905-1, "")
+		z.DecStructFieldNotFound(yyj2910-1, "")
 	}
 	r.ReadEnd()
 }
@@ -33809,41 +33846,41 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2908 := z.EncBinary()
-		_ = yym2908
+		yym2913 := z.EncBinary()
+		_ = yym2913
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2909 := !z.EncBinary()
-			yy2arr2909 := z.EncBasicHandle().StructToArray
-			var yyq2909 [10]bool
-			_, _, _ = yysep2909, yyq2909, yy2arr2909
-			const yyr2909 bool = false
-			yyq2909[0] = x.Kind != ""
-			yyq2909[1] = x.APIVersion != ""
-			yyq2909[2] = true
-			yyq2909[3] = true
-			yyq2909[4] = x.Reason != ""
-			yyq2909[5] = x.Message != ""
-			yyq2909[6] = true
-			yyq2909[7] = true
-			yyq2909[8] = true
-			yyq2909[9] = x.Count != 0
-			if yyr2909 || yy2arr2909 {
+			yysep2914 := !z.EncBinary()
+			yy2arr2914 := z.EncBasicHandle().StructToArray
+			var yyq2914 [10]bool
+			_, _, _ = yysep2914, yyq2914, yy2arr2914
+			const yyr2914 bool = false
+			yyq2914[0] = x.Kind != ""
+			yyq2914[1] = x.APIVersion != ""
+			yyq2914[2] = true
+			yyq2914[3] = true
+			yyq2914[4] = x.Reason != ""
+			yyq2914[5] = x.Message != ""
+			yyq2914[6] = true
+			yyq2914[7] = true
+			yyq2914[8] = true
+			yyq2914[9] = x.Count != 0
+			if yyr2914 || yy2arr2914 {
 				r.EncodeArrayStart(10)
 			} else {
-				var yynn2909 int = 0
-				for _, b := range yyq2909 {
+				var yynn2914 int = 0
+				for _, b := range yyq2914 {
 					if b {
-						yynn2909++
+						yynn2914++
 					}
 				}
-				r.EncodeMapStart(yynn2909)
+				r.EncodeMapStart(yynn2914)
 			}
-			if yyr2909 || yy2arr2909 {
-				if yyq2909[0] {
-					yym2911 := z.EncBinary()
-					_ = yym2911
+			if yyr2914 || yy2arr2914 {
+				if yyq2914[0] {
+					yym2916 := z.EncBinary()
+					_ = yym2916
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -33852,20 +33889,20 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2909[0] {
+				if yyq2914[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2912 := z.EncBinary()
-					_ = yym2912
+					yym2917 := z.EncBinary()
+					_ = yym2917
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2909 || yy2arr2909 {
-				if yyq2909[1] {
-					yym2914 := z.EncBinary()
-					_ = yym2914
+			if yyr2914 || yy2arr2914 {
+				if yyq2914[1] {
+					yym2919 := z.EncBinary()
+					_ = yym2919
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -33874,48 +33911,48 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2909[1] {
+				if yyq2914[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2915 := z.EncBinary()
-					_ = yym2915
+					yym2920 := z.EncBinary()
+					_ = yym2920
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2909 || yy2arr2909 {
-				if yyq2909[2] {
-					yy2917 := &x.ObjectMeta
-					yy2917.CodecEncodeSelf(e)
+			if yyr2914 || yy2arr2914 {
+				if yyq2914[2] {
+					yy2922 := &x.ObjectMeta
+					yy2922.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2909[2] {
+				if yyq2914[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy2918 := &x.ObjectMeta
-					yy2918.CodecEncodeSelf(e)
+					yy2923 := &x.ObjectMeta
+					yy2923.CodecEncodeSelf(e)
 				}
 			}
-			if yyr2909 || yy2arr2909 {
-				if yyq2909[3] {
-					yy2920 := &x.InvolvedObject
-					yy2920.CodecEncodeSelf(e)
+			if yyr2914 || yy2arr2914 {
+				if yyq2914[3] {
+					yy2925 := &x.InvolvedObject
+					yy2925.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2909[3] {
+				if yyq2914[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("involvedObject"))
-					yy2921 := &x.InvolvedObject
-					yy2921.CodecEncodeSelf(e)
+					yy2926 := &x.InvolvedObject
+					yy2926.CodecEncodeSelf(e)
 				}
 			}
-			if yyr2909 || yy2arr2909 {
-				if yyq2909[4] {
-					yym2923 := z.EncBinary()
-					_ = yym2923
+			if yyr2914 || yy2arr2914 {
+				if yyq2914[4] {
+					yym2928 := z.EncBinary()
+					_ = yym2928
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
@@ -33924,20 +33961,20 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2909[4] {
+				if yyq2914[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("reason"))
-					yym2924 := z.EncBinary()
-					_ = yym2924
+					yym2929 := z.EncBinary()
+					_ = yym2929
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
 					}
 				}
 			}
-			if yyr2909 || yy2arr2909 {
-				if yyq2909[5] {
-					yym2926 := z.EncBinary()
-					_ = yym2926
+			if yyr2914 || yy2arr2914 {
+				if yyq2914[5] {
+					yym2931 := z.EncBinary()
+					_ = yym2931
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
@@ -33946,67 +33983,33 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2909[5] {
+				if yyq2914[5] {
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
-					yym2927 := z.EncBinary()
-					_ = yym2927
+					yym2932 := z.EncBinary()
+					_ = yym2932
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
 					}
 				}
 			}
-			if yyr2909 || yy2arr2909 {
-				if yyq2909[6] {
-					yy2929 := &x.Source
-					yy2929.CodecEncodeSelf(e)
+			if yyr2914 || yy2arr2914 {
+				if yyq2914[6] {
+					yy2934 := &x.Source
+					yy2934.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2909[6] {
+				if yyq2914[6] {
 					r.EncodeString(codecSelferC_UTF81234, string("source"))
-					yy2930 := &x.Source
-					yy2930.CodecEncodeSelf(e)
+					yy2935 := &x.Source
+					yy2935.CodecEncodeSelf(e)
 				}
 			}
-			if yyr2909 || yy2arr2909 {
-				if yyq2909[7] {
-					yy2932 := &x.FirstTimestamp
-					yym2933 := z.EncBinary()
-					_ = yym2933
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2932) {
-					} else if yym2933 {
-						z.EncBinaryMarshal(yy2932)
-					} else if !yym2933 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy2932)
-					} else {
-						z.EncFallback(yy2932)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2909[7] {
-					r.EncodeString(codecSelferC_UTF81234, string("firstTimestamp"))
-					yy2934 := &x.FirstTimestamp
-					yym2935 := z.EncBinary()
-					_ = yym2935
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2934) {
-					} else if yym2935 {
-						z.EncBinaryMarshal(yy2934)
-					} else if !yym2935 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy2934)
-					} else {
-						z.EncFallback(yy2934)
-					}
-				}
-			}
-			if yyr2909 || yy2arr2909 {
-				if yyq2909[8] {
-					yy2937 := &x.LastTimestamp
+			if yyr2914 || yy2arr2914 {
+				if yyq2914[7] {
+					yy2937 := &x.FirstTimestamp
 					yym2938 := z.EncBinary()
 					_ = yym2938
 					if false {
@@ -34022,9 +34025,9 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2909[8] {
-					r.EncodeString(codecSelferC_UTF81234, string("lastTimestamp"))
-					yy2939 := &x.LastTimestamp
+				if yyq2914[7] {
+					r.EncodeString(codecSelferC_UTF81234, string("firstTimestamp"))
+					yy2939 := &x.FirstTimestamp
 					yym2940 := z.EncBinary()
 					_ = yym2940
 					if false {
@@ -34038,10 +34041,44 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr2909 || yy2arr2909 {
-				if yyq2909[9] {
-					yym2942 := z.EncBinary()
-					_ = yym2942
+			if yyr2914 || yy2arr2914 {
+				if yyq2914[8] {
+					yy2942 := &x.LastTimestamp
+					yym2943 := z.EncBinary()
+					_ = yym2943
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2942) {
+					} else if yym2943 {
+						z.EncBinaryMarshal(yy2942)
+					} else if !yym2943 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy2942)
+					} else {
+						z.EncFallback(yy2942)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq2914[8] {
+					r.EncodeString(codecSelferC_UTF81234, string("lastTimestamp"))
+					yy2944 := &x.LastTimestamp
+					yym2945 := z.EncBinary()
+					_ = yym2945
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2944) {
+					} else if yym2945 {
+						z.EncBinaryMarshal(yy2944)
+					} else if !yym2945 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy2944)
+					} else {
+						z.EncFallback(yy2944)
+					}
+				}
+			}
+			if yyr2914 || yy2arr2914 {
+				if yyq2914[9] {
+					yym2947 := z.EncBinary()
+					_ = yym2947
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Count))
@@ -34050,17 +34087,17 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq2909[9] {
+				if yyq2914[9] {
 					r.EncodeString(codecSelferC_UTF81234, string("count"))
-					yym2943 := z.EncBinary()
-					_ = yym2943
+					yym2948 := z.EncBinary()
+					_ = yym2948
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Count))
 					}
 				}
 			}
-			if yysep2909 {
+			if yysep2914 {
 				r.EncodeEnd()
 			}
 		}
@@ -34071,24 +34108,24 @@ func (x *Event) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2944 := z.DecBinary()
-	_ = yym2944
+	yym2949 := z.DecBinary()
+	_ = yym2949
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2945 := r.ReadMapStart()
-			if yyl2945 == 0 {
+			yyl2950 := r.ReadMapStart()
+			if yyl2950 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2945, d)
+				x.codecDecodeSelfFromMap(yyl2950, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2945 := r.ReadArrayStart()
-			if yyl2945 == 0 {
+			yyl2950 := r.ReadArrayStart()
+			if yyl2950 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2945, d)
+				x.codecDecodeSelfFromArray(yyl2950, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -34100,12 +34137,12 @@ func (x *Event) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2946Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2946Slc
-	var yyhl2946 bool = l >= 0
-	for yyj2946 := 0; ; yyj2946++ {
-		if yyhl2946 {
-			if yyj2946 >= l {
+	var yys2951Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2951Slc
+	var yyhl2951 bool = l >= 0
+	for yyj2951 := 0; ; yyj2951++ {
+		if yyhl2951 {
+			if yyj2951 >= l {
 				break
 			}
 		} else {
@@ -34113,9 +34150,9 @@ func (x *Event) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2946Slc = r.DecodeBytes(yys2946Slc, true, true)
-		yys2946 := string(yys2946Slc)
-		switch yys2946 {
+		yys2951Slc = r.DecodeBytes(yys2951Slc, true, true)
+		yys2951 := string(yys2951Slc)
+		switch yys2951 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -34132,15 +34169,15 @@ func (x *Event) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv2949 := &x.ObjectMeta
-				yyv2949.CodecDecodeSelf(d)
+				yyv2954 := &x.ObjectMeta
+				yyv2954.CodecDecodeSelf(d)
 			}
 		case "involvedObject":
 			if r.TryDecodeAsNil() {
 				x.InvolvedObject = ObjectReference{}
 			} else {
-				yyv2950 := &x.InvolvedObject
-				yyv2950.CodecDecodeSelf(d)
+				yyv2955 := &x.InvolvedObject
+				yyv2955.CodecDecodeSelf(d)
 			}
 		case "reason":
 			if r.TryDecodeAsNil() {
@@ -34158,41 +34195,41 @@ func (x *Event) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Source = EventSource{}
 			} else {
-				yyv2953 := &x.Source
-				yyv2953.CodecDecodeSelf(d)
+				yyv2958 := &x.Source
+				yyv2958.CodecDecodeSelf(d)
 			}
 		case "firstTimestamp":
 			if r.TryDecodeAsNil() {
 				x.FirstTimestamp = pkg2_unversioned.Time{}
 			} else {
-				yyv2954 := &x.FirstTimestamp
-				yym2955 := z.DecBinary()
-				_ = yym2955
+				yyv2959 := &x.FirstTimestamp
+				yym2960 := z.DecBinary()
+				_ = yym2960
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2954) {
-				} else if yym2955 {
-					z.DecBinaryUnmarshal(yyv2954)
-				} else if !yym2955 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv2954)
+				} else if z.HasExtensions() && z.DecExt(yyv2959) {
+				} else if yym2960 {
+					z.DecBinaryUnmarshal(yyv2959)
+				} else if !yym2960 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv2959)
 				} else {
-					z.DecFallback(yyv2954, false)
+					z.DecFallback(yyv2959, false)
 				}
 			}
 		case "lastTimestamp":
 			if r.TryDecodeAsNil() {
 				x.LastTimestamp = pkg2_unversioned.Time{}
 			} else {
-				yyv2956 := &x.LastTimestamp
-				yym2957 := z.DecBinary()
-				_ = yym2957
+				yyv2961 := &x.LastTimestamp
+				yym2962 := z.DecBinary()
+				_ = yym2962
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2956) {
-				} else if yym2957 {
-					z.DecBinaryUnmarshal(yyv2956)
-				} else if !yym2957 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv2956)
+				} else if z.HasExtensions() && z.DecExt(yyv2961) {
+				} else if yym2962 {
+					z.DecBinaryUnmarshal(yyv2961)
+				} else if !yym2962 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv2961)
 				} else {
-					z.DecFallback(yyv2956, false)
+					z.DecFallback(yyv2961, false)
 				}
 			}
 		case "count":
@@ -34202,10 +34239,10 @@ func (x *Event) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Count = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2946)
-		} // end switch yys2946
-	} // end for yyj2946
-	if !yyhl2946 {
+			z.DecStructFieldNotFound(-1, yys2951)
+		} // end switch yys2951
+	} // end for yyj2951
+	if !yyhl2951 {
 		r.ReadEnd()
 	}
 }
@@ -34214,16 +34251,16 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2959 int
-	var yyb2959 bool
-	var yyhl2959 bool = l >= 0
-	yyj2959++
-	if yyhl2959 {
-		yyb2959 = yyj2959 > l
+	var yyj2964 int
+	var yyb2964 bool
+	var yyhl2964 bool = l >= 0
+	yyj2964++
+	if yyhl2964 {
+		yyb2964 = yyj2964 > l
 	} else {
-		yyb2959 = r.CheckBreak()
+		yyb2964 = r.CheckBreak()
 	}
-	if yyb2959 {
+	if yyb2964 {
 		r.ReadEnd()
 		return
 	}
@@ -34232,13 +34269,13 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2959++
-	if yyhl2959 {
-		yyb2959 = yyj2959 > l
+	yyj2964++
+	if yyhl2964 {
+		yyb2964 = yyj2964 > l
 	} else {
-		yyb2959 = r.CheckBreak()
+		yyb2964 = r.CheckBreak()
 	}
-	if yyb2959 {
+	if yyb2964 {
 		r.ReadEnd()
 		return
 	}
@@ -34247,45 +34284,45 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2959++
-	if yyhl2959 {
-		yyb2959 = yyj2959 > l
+	yyj2964++
+	if yyhl2964 {
+		yyb2964 = yyj2964 > l
 	} else {
-		yyb2959 = r.CheckBreak()
+		yyb2964 = r.CheckBreak()
 	}
-	if yyb2959 {
+	if yyb2964 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv2962 := &x.ObjectMeta
-		yyv2962.CodecDecodeSelf(d)
+		yyv2967 := &x.ObjectMeta
+		yyv2967.CodecDecodeSelf(d)
 	}
-	yyj2959++
-	if yyhl2959 {
-		yyb2959 = yyj2959 > l
+	yyj2964++
+	if yyhl2964 {
+		yyb2964 = yyj2964 > l
 	} else {
-		yyb2959 = r.CheckBreak()
+		yyb2964 = r.CheckBreak()
 	}
-	if yyb2959 {
+	if yyb2964 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.InvolvedObject = ObjectReference{}
 	} else {
-		yyv2963 := &x.InvolvedObject
-		yyv2963.CodecDecodeSelf(d)
+		yyv2968 := &x.InvolvedObject
+		yyv2968.CodecDecodeSelf(d)
 	}
-	yyj2959++
-	if yyhl2959 {
-		yyb2959 = yyj2959 > l
+	yyj2964++
+	if yyhl2964 {
+		yyb2964 = yyj2964 > l
 	} else {
-		yyb2959 = r.CheckBreak()
+		yyb2964 = r.CheckBreak()
 	}
-	if yyb2959 {
+	if yyb2964 {
 		r.ReadEnd()
 		return
 	}
@@ -34294,13 +34331,13 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Reason = string(r.DecodeString())
 	}
-	yyj2959++
-	if yyhl2959 {
-		yyb2959 = yyj2959 > l
+	yyj2964++
+	if yyhl2964 {
+		yyb2964 = yyj2964 > l
 	} else {
-		yyb2959 = r.CheckBreak()
+		yyb2964 = r.CheckBreak()
 	}
-	if yyb2959 {
+	if yyb2964 {
 		r.ReadEnd()
 		return
 	}
@@ -34309,81 +34346,81 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Message = string(r.DecodeString())
 	}
-	yyj2959++
-	if yyhl2959 {
-		yyb2959 = yyj2959 > l
+	yyj2964++
+	if yyhl2964 {
+		yyb2964 = yyj2964 > l
 	} else {
-		yyb2959 = r.CheckBreak()
+		yyb2964 = r.CheckBreak()
 	}
-	if yyb2959 {
+	if yyb2964 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Source = EventSource{}
 	} else {
-		yyv2966 := &x.Source
-		yyv2966.CodecDecodeSelf(d)
+		yyv2971 := &x.Source
+		yyv2971.CodecDecodeSelf(d)
 	}
-	yyj2959++
-	if yyhl2959 {
-		yyb2959 = yyj2959 > l
+	yyj2964++
+	if yyhl2964 {
+		yyb2964 = yyj2964 > l
 	} else {
-		yyb2959 = r.CheckBreak()
+		yyb2964 = r.CheckBreak()
 	}
-	if yyb2959 {
+	if yyb2964 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.FirstTimestamp = pkg2_unversioned.Time{}
 	} else {
-		yyv2967 := &x.FirstTimestamp
-		yym2968 := z.DecBinary()
-		_ = yym2968
+		yyv2972 := &x.FirstTimestamp
+		yym2973 := z.DecBinary()
+		_ = yym2973
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2967) {
-		} else if yym2968 {
-			z.DecBinaryUnmarshal(yyv2967)
-		} else if !yym2968 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv2967)
+		} else if z.HasExtensions() && z.DecExt(yyv2972) {
+		} else if yym2973 {
+			z.DecBinaryUnmarshal(yyv2972)
+		} else if !yym2973 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv2972)
 		} else {
-			z.DecFallback(yyv2967, false)
+			z.DecFallback(yyv2972, false)
 		}
 	}
-	yyj2959++
-	if yyhl2959 {
-		yyb2959 = yyj2959 > l
+	yyj2964++
+	if yyhl2964 {
+		yyb2964 = yyj2964 > l
 	} else {
-		yyb2959 = r.CheckBreak()
+		yyb2964 = r.CheckBreak()
 	}
-	if yyb2959 {
+	if yyb2964 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.LastTimestamp = pkg2_unversioned.Time{}
 	} else {
-		yyv2969 := &x.LastTimestamp
-		yym2970 := z.DecBinary()
-		_ = yym2970
+		yyv2974 := &x.LastTimestamp
+		yym2975 := z.DecBinary()
+		_ = yym2975
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2969) {
-		} else if yym2970 {
-			z.DecBinaryUnmarshal(yyv2969)
-		} else if !yym2970 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv2969)
+		} else if z.HasExtensions() && z.DecExt(yyv2974) {
+		} else if yym2975 {
+			z.DecBinaryUnmarshal(yyv2974)
+		} else if !yym2975 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv2974)
 		} else {
-			z.DecFallback(yyv2969, false)
+			z.DecFallback(yyv2974, false)
 		}
 	}
-	yyj2959++
-	if yyhl2959 {
-		yyb2959 = yyj2959 > l
+	yyj2964++
+	if yyhl2964 {
+		yyb2964 = yyj2964 > l
 	} else {
-		yyb2959 = r.CheckBreak()
+		yyb2964 = r.CheckBreak()
 	}
-	if yyb2959 {
+	if yyb2964 {
 		r.ReadEnd()
 		return
 	}
@@ -34393,16 +34430,16 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Count = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj2959++
-		if yyhl2959 {
-			yyb2959 = yyj2959 > l
+		yyj2964++
+		if yyhl2964 {
+			yyb2964 = yyj2964 > l
 		} else {
-			yyb2959 = r.CheckBreak()
+			yyb2964 = r.CheckBreak()
 		}
-		if yyb2959 {
+		if yyb2964 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2959-1, "")
+		z.DecStructFieldNotFound(yyj2964-1, "")
 	}
 	r.ReadEnd()
 }
@@ -34414,34 +34451,34 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2972 := z.EncBinary()
-		_ = yym2972
+		yym2977 := z.EncBinary()
+		_ = yym2977
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2973 := !z.EncBinary()
-			yy2arr2973 := z.EncBasicHandle().StructToArray
-			var yyq2973 [4]bool
-			_, _, _ = yysep2973, yyq2973, yy2arr2973
-			const yyr2973 bool = false
-			yyq2973[0] = x.Kind != ""
-			yyq2973[1] = x.APIVersion != ""
-			yyq2973[2] = true
-			if yyr2973 || yy2arr2973 {
+			yysep2978 := !z.EncBinary()
+			yy2arr2978 := z.EncBasicHandle().StructToArray
+			var yyq2978 [4]bool
+			_, _, _ = yysep2978, yyq2978, yy2arr2978
+			const yyr2978 bool = false
+			yyq2978[0] = x.Kind != ""
+			yyq2978[1] = x.APIVersion != ""
+			yyq2978[2] = true
+			if yyr2978 || yy2arr2978 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2973 int = 1
-				for _, b := range yyq2973 {
+				var yynn2978 int = 1
+				for _, b := range yyq2978 {
 					if b {
-						yynn2973++
+						yynn2978++
 					}
 				}
-				r.EncodeMapStart(yynn2973)
+				r.EncodeMapStart(yynn2978)
 			}
-			if yyr2973 || yy2arr2973 {
-				if yyq2973[0] {
-					yym2975 := z.EncBinary()
-					_ = yym2975
+			if yyr2978 || yy2arr2978 {
+				if yyq2978[0] {
+					yym2980 := z.EncBinary()
+					_ = yym2980
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -34450,20 +34487,20 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2973[0] {
+				if yyq2978[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2976 := z.EncBinary()
-					_ = yym2976
+					yym2981 := z.EncBinary()
+					_ = yym2981
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2973 || yy2arr2973 {
-				if yyq2973[1] {
-					yym2978 := z.EncBinary()
-					_ = yym2978
+			if yyr2978 || yy2arr2978 {
+				if yyq2978[1] {
+					yym2983 := z.EncBinary()
+					_ = yym2983
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -34472,48 +34509,48 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2973[1] {
+				if yyq2978[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2979 := z.EncBinary()
-					_ = yym2979
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2973 || yy2arr2973 {
-				if yyq2973[2] {
-					yy2981 := &x.ListMeta
-					yym2982 := z.EncBinary()
-					_ = yym2982
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2981) {
-					} else {
-						z.EncFallback(yy2981)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2973[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy2983 := &x.ListMeta
 					yym2984 := z.EncBinary()
 					_ = yym2984
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2983) {
 					} else {
-						z.EncFallback(yy2983)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2973 || yy2arr2973 {
+			if yyr2978 || yy2arr2978 {
+				if yyq2978[2] {
+					yy2986 := &x.ListMeta
+					yym2987 := z.EncBinary()
+					_ = yym2987
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2986) {
+					} else {
+						z.EncFallback(yy2986)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq2978[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy2988 := &x.ListMeta
+					yym2989 := z.EncBinary()
+					_ = yym2989
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2988) {
+					} else {
+						z.EncFallback(yy2988)
+					}
+				}
+			}
+			if yyr2978 || yy2arr2978 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2986 := z.EncBinary()
-					_ = yym2986
+					yym2991 := z.EncBinary()
+					_ = yym2991
 					if false {
 					} else {
 						h.encSliceEvent(([]Event)(x.Items), e)
@@ -34524,15 +34561,15 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2987 := z.EncBinary()
-					_ = yym2987
+					yym2992 := z.EncBinary()
+					_ = yym2992
 					if false {
 					} else {
 						h.encSliceEvent(([]Event)(x.Items), e)
 					}
 				}
 			}
-			if yysep2973 {
+			if yysep2978 {
 				r.EncodeEnd()
 			}
 		}
@@ -34543,24 +34580,24 @@ func (x *EventList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2988 := z.DecBinary()
-	_ = yym2988
+	yym2993 := z.DecBinary()
+	_ = yym2993
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2989 := r.ReadMapStart()
-			if yyl2989 == 0 {
+			yyl2994 := r.ReadMapStart()
+			if yyl2994 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2989, d)
+				x.codecDecodeSelfFromMap(yyl2994, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2989 := r.ReadArrayStart()
-			if yyl2989 == 0 {
+			yyl2994 := r.ReadArrayStart()
+			if yyl2994 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2989, d)
+				x.codecDecodeSelfFromArray(yyl2994, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -34572,12 +34609,12 @@ func (x *EventList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2990Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2990Slc
-	var yyhl2990 bool = l >= 0
-	for yyj2990 := 0; ; yyj2990++ {
-		if yyhl2990 {
-			if yyj2990 >= l {
+	var yys2995Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2995Slc
+	var yyhl2995 bool = l >= 0
+	for yyj2995 := 0; ; yyj2995++ {
+		if yyhl2995 {
+			if yyj2995 >= l {
 				break
 			}
 		} else {
@@ -34585,9 +34622,9 @@ func (x *EventList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2990Slc = r.DecodeBytes(yys2990Slc, true, true)
-		yys2990 := string(yys2990Slc)
-		switch yys2990 {
+		yys2995Slc = r.DecodeBytes(yys2995Slc, true, true)
+		yys2995 := string(yys2995Slc)
+		switch yys2995 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -34604,32 +34641,32 @@ func (x *EventList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv2993 := &x.ListMeta
-				yym2994 := z.DecBinary()
-				_ = yym2994
+				yyv2998 := &x.ListMeta
+				yym2999 := z.DecBinary()
+				_ = yym2999
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2993) {
+				} else if z.HasExtensions() && z.DecExt(yyv2998) {
 				} else {
-					z.DecFallback(yyv2993, false)
+					z.DecFallback(yyv2998, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv2995 := &x.Items
-				yym2996 := z.DecBinary()
-				_ = yym2996
+				yyv3000 := &x.Items
+				yym3001 := z.DecBinary()
+				_ = yym3001
 				if false {
 				} else {
-					h.decSliceEvent((*[]Event)(yyv2995), d)
+					h.decSliceEvent((*[]Event)(yyv3000), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2990)
-		} // end switch yys2990
-	} // end for yyj2990
-	if !yyhl2990 {
+			z.DecStructFieldNotFound(-1, yys2995)
+		} // end switch yys2995
+	} // end for yyj2995
+	if !yyhl2995 {
 		r.ReadEnd()
 	}
 }
@@ -34638,16 +34675,16 @@ func (x *EventList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2997 int
-	var yyb2997 bool
-	var yyhl2997 bool = l >= 0
-	yyj2997++
-	if yyhl2997 {
-		yyb2997 = yyj2997 > l
+	var yyj3002 int
+	var yyb3002 bool
+	var yyhl3002 bool = l >= 0
+	yyj3002++
+	if yyhl3002 {
+		yyb3002 = yyj3002 > l
 	} else {
-		yyb2997 = r.CheckBreak()
+		yyb3002 = r.CheckBreak()
 	}
-	if yyb2997 {
+	if yyb3002 {
 		r.ReadEnd()
 		return
 	}
@@ -34656,13 +34693,13 @@ func (x *EventList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2997++
-	if yyhl2997 {
-		yyb2997 = yyj2997 > l
+	yyj3002++
+	if yyhl3002 {
+		yyb3002 = yyj3002 > l
 	} else {
-		yyb2997 = r.CheckBreak()
+		yyb3002 = r.CheckBreak()
 	}
-	if yyb2997 {
+	if yyb3002 {
 		r.ReadEnd()
 		return
 	}
@@ -34671,60 +34708,60 @@ func (x *EventList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2997++
-	if yyhl2997 {
-		yyb2997 = yyj2997 > l
+	yyj3002++
+	if yyhl3002 {
+		yyb3002 = yyj3002 > l
 	} else {
-		yyb2997 = r.CheckBreak()
+		yyb3002 = r.CheckBreak()
 	}
-	if yyb2997 {
+	if yyb3002 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv3000 := &x.ListMeta
-		yym3001 := z.DecBinary()
-		_ = yym3001
+		yyv3005 := &x.ListMeta
+		yym3006 := z.DecBinary()
+		_ = yym3006
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3000) {
+		} else if z.HasExtensions() && z.DecExt(yyv3005) {
 		} else {
-			z.DecFallback(yyv3000, false)
+			z.DecFallback(yyv3005, false)
 		}
 	}
-	yyj2997++
-	if yyhl2997 {
-		yyb2997 = yyj2997 > l
+	yyj3002++
+	if yyhl3002 {
+		yyb3002 = yyj3002 > l
 	} else {
-		yyb2997 = r.CheckBreak()
+		yyb3002 = r.CheckBreak()
 	}
-	if yyb2997 {
+	if yyb3002 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv3002 := &x.Items
-		yym3003 := z.DecBinary()
-		_ = yym3003
+		yyv3007 := &x.Items
+		yym3008 := z.DecBinary()
+		_ = yym3008
 		if false {
 		} else {
-			h.decSliceEvent((*[]Event)(yyv3002), d)
+			h.decSliceEvent((*[]Event)(yyv3007), d)
 		}
 	}
 	for {
-		yyj2997++
-		if yyhl2997 {
-			yyb2997 = yyj2997 > l
+		yyj3002++
+		if yyhl3002 {
+			yyb3002 = yyj3002 > l
 		} else {
-			yyb2997 = r.CheckBreak()
+			yyb3002 = r.CheckBreak()
 		}
-		if yyb2997 {
+		if yyb3002 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2997-1, "")
+		z.DecStructFieldNotFound(yyj3002-1, "")
 	}
 	r.ReadEnd()
 }
@@ -34736,34 +34773,34 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3004 := z.EncBinary()
-		_ = yym3004
+		yym3009 := z.EncBinary()
+		_ = yym3009
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3005 := !z.EncBinary()
-			yy2arr3005 := z.EncBasicHandle().StructToArray
-			var yyq3005 [4]bool
-			_, _, _ = yysep3005, yyq3005, yy2arr3005
-			const yyr3005 bool = false
-			yyq3005[0] = x.Kind != ""
-			yyq3005[1] = x.APIVersion != ""
-			yyq3005[2] = true
-			if yyr3005 || yy2arr3005 {
+			yysep3010 := !z.EncBinary()
+			yy2arr3010 := z.EncBasicHandle().StructToArray
+			var yyq3010 [4]bool
+			_, _, _ = yysep3010, yyq3010, yy2arr3010
+			const yyr3010 bool = false
+			yyq3010[0] = x.Kind != ""
+			yyq3010[1] = x.APIVersion != ""
+			yyq3010[2] = true
+			if yyr3010 || yy2arr3010 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3005 int = 1
-				for _, b := range yyq3005 {
+				var yynn3010 int = 1
+				for _, b := range yyq3010 {
 					if b {
-						yynn3005++
+						yynn3010++
 					}
 				}
-				r.EncodeMapStart(yynn3005)
+				r.EncodeMapStart(yynn3010)
 			}
-			if yyr3005 || yy2arr3005 {
-				if yyq3005[0] {
-					yym3007 := z.EncBinary()
-					_ = yym3007
+			if yyr3010 || yy2arr3010 {
+				if yyq3010[0] {
+					yym3012 := z.EncBinary()
+					_ = yym3012
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -34772,20 +34809,20 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3005[0] {
+				if yyq3010[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3008 := z.EncBinary()
-					_ = yym3008
+					yym3013 := z.EncBinary()
+					_ = yym3013
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr3005 || yy2arr3005 {
-				if yyq3005[1] {
-					yym3010 := z.EncBinary()
-					_ = yym3010
+			if yyr3010 || yy2arr3010 {
+				if yyq3010[1] {
+					yym3015 := z.EncBinary()
+					_ = yym3015
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -34794,48 +34831,48 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3005[1] {
+				if yyq3010[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym3011 := z.EncBinary()
-					_ = yym3011
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3005 || yy2arr3005 {
-				if yyq3005[2] {
-					yy3013 := &x.ListMeta
-					yym3014 := z.EncBinary()
-					_ = yym3014
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3013) {
-					} else {
-						z.EncFallback(yy3013)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq3005[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3015 := &x.ListMeta
 					yym3016 := z.EncBinary()
 					_ = yym3016
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3015) {
 					} else {
-						z.EncFallback(yy3015)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr3005 || yy2arr3005 {
+			if yyr3010 || yy2arr3010 {
+				if yyq3010[2] {
+					yy3018 := &x.ListMeta
+					yym3019 := z.EncBinary()
+					_ = yym3019
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3018) {
+					} else {
+						z.EncFallback(yy3018)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq3010[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy3020 := &x.ListMeta
+					yym3021 := z.EncBinary()
+					_ = yym3021
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3020) {
+					} else {
+						z.EncFallback(yy3020)
+					}
+				}
+			}
+			if yyr3010 || yy2arr3010 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3018 := z.EncBinary()
-					_ = yym3018
+					yym3023 := z.EncBinary()
+					_ = yym3023
 					if false {
 					} else {
 						h.encSliceruntime_Object(([]pkg8_runtime.Object)(x.Items), e)
@@ -34846,15 +34883,15 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3019 := z.EncBinary()
-					_ = yym3019
+					yym3024 := z.EncBinary()
+					_ = yym3024
 					if false {
 					} else {
 						h.encSliceruntime_Object(([]pkg8_runtime.Object)(x.Items), e)
 					}
 				}
 			}
-			if yysep3005 {
+			if yysep3010 {
 				r.EncodeEnd()
 			}
 		}
@@ -34865,24 +34902,24 @@ func (x *List) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3020 := z.DecBinary()
-	_ = yym3020
+	yym3025 := z.DecBinary()
+	_ = yym3025
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3021 := r.ReadMapStart()
-			if yyl3021 == 0 {
+			yyl3026 := r.ReadMapStart()
+			if yyl3026 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3021, d)
+				x.codecDecodeSelfFromMap(yyl3026, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3021 := r.ReadArrayStart()
-			if yyl3021 == 0 {
+			yyl3026 := r.ReadArrayStart()
+			if yyl3026 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3021, d)
+				x.codecDecodeSelfFromArray(yyl3026, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -34894,12 +34931,12 @@ func (x *List) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3022Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3022Slc
-	var yyhl3022 bool = l >= 0
-	for yyj3022 := 0; ; yyj3022++ {
-		if yyhl3022 {
-			if yyj3022 >= l {
+	var yys3027Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3027Slc
+	var yyhl3027 bool = l >= 0
+	for yyj3027 := 0; ; yyj3027++ {
+		if yyhl3027 {
+			if yyj3027 >= l {
 				break
 			}
 		} else {
@@ -34907,9 +34944,9 @@ func (x *List) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3022Slc = r.DecodeBytes(yys3022Slc, true, true)
-		yys3022 := string(yys3022Slc)
-		switch yys3022 {
+		yys3027Slc = r.DecodeBytes(yys3027Slc, true, true)
+		yys3027 := string(yys3027Slc)
+		switch yys3027 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -34926,32 +34963,32 @@ func (x *List) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv3025 := &x.ListMeta
-				yym3026 := z.DecBinary()
-				_ = yym3026
+				yyv3030 := &x.ListMeta
+				yym3031 := z.DecBinary()
+				_ = yym3031
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3025) {
+				} else if z.HasExtensions() && z.DecExt(yyv3030) {
 				} else {
-					z.DecFallback(yyv3025, false)
+					z.DecFallback(yyv3030, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv3027 := &x.Items
-				yym3028 := z.DecBinary()
-				_ = yym3028
+				yyv3032 := &x.Items
+				yym3033 := z.DecBinary()
+				_ = yym3033
 				if false {
 				} else {
-					h.decSliceruntime_Object((*[]pkg8_runtime.Object)(yyv3027), d)
+					h.decSliceruntime_Object((*[]pkg8_runtime.Object)(yyv3032), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3022)
-		} // end switch yys3022
-	} // end for yyj3022
-	if !yyhl3022 {
+			z.DecStructFieldNotFound(-1, yys3027)
+		} // end switch yys3027
+	} // end for yyj3027
+	if !yyhl3027 {
 		r.ReadEnd()
 	}
 }
@@ -34960,16 +34997,16 @@ func (x *List) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3029 int
-	var yyb3029 bool
-	var yyhl3029 bool = l >= 0
-	yyj3029++
-	if yyhl3029 {
-		yyb3029 = yyj3029 > l
+	var yyj3034 int
+	var yyb3034 bool
+	var yyhl3034 bool = l >= 0
+	yyj3034++
+	if yyhl3034 {
+		yyb3034 = yyj3034 > l
 	} else {
-		yyb3029 = r.CheckBreak()
+		yyb3034 = r.CheckBreak()
 	}
-	if yyb3029 {
+	if yyb3034 {
 		r.ReadEnd()
 		return
 	}
@@ -34978,13 +35015,13 @@ func (x *List) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3029++
-	if yyhl3029 {
-		yyb3029 = yyj3029 > l
+	yyj3034++
+	if yyhl3034 {
+		yyb3034 = yyj3034 > l
 	} else {
-		yyb3029 = r.CheckBreak()
+		yyb3034 = r.CheckBreak()
 	}
-	if yyb3029 {
+	if yyb3034 {
 		r.ReadEnd()
 		return
 	}
@@ -34993,60 +35030,60 @@ func (x *List) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3029++
-	if yyhl3029 {
-		yyb3029 = yyj3029 > l
+	yyj3034++
+	if yyhl3034 {
+		yyb3034 = yyj3034 > l
 	} else {
-		yyb3029 = r.CheckBreak()
+		yyb3034 = r.CheckBreak()
 	}
-	if yyb3029 {
+	if yyb3034 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv3032 := &x.ListMeta
-		yym3033 := z.DecBinary()
-		_ = yym3033
+		yyv3037 := &x.ListMeta
+		yym3038 := z.DecBinary()
+		_ = yym3038
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3032) {
+		} else if z.HasExtensions() && z.DecExt(yyv3037) {
 		} else {
-			z.DecFallback(yyv3032, false)
+			z.DecFallback(yyv3037, false)
 		}
 	}
-	yyj3029++
-	if yyhl3029 {
-		yyb3029 = yyj3029 > l
+	yyj3034++
+	if yyhl3034 {
+		yyb3034 = yyj3034 > l
 	} else {
-		yyb3029 = r.CheckBreak()
+		yyb3034 = r.CheckBreak()
 	}
-	if yyb3029 {
+	if yyb3034 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv3034 := &x.Items
-		yym3035 := z.DecBinary()
-		_ = yym3035
+		yyv3039 := &x.Items
+		yym3040 := z.DecBinary()
+		_ = yym3040
 		if false {
 		} else {
-			h.decSliceruntime_Object((*[]pkg8_runtime.Object)(yyv3034), d)
+			h.decSliceruntime_Object((*[]pkg8_runtime.Object)(yyv3039), d)
 		}
 	}
 	for {
-		yyj3029++
-		if yyhl3029 {
-			yyb3029 = yyj3029 > l
+		yyj3034++
+		if yyhl3034 {
+			yyb3034 = yyj3034 > l
 		} else {
-			yyb3029 = r.CheckBreak()
+			yyb3034 = r.CheckBreak()
 		}
-		if yyb3029 {
+		if yyb3034 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3029-1, "")
+		z.DecStructFieldNotFound(yyj3034-1, "")
 	}
 	r.ReadEnd()
 }
@@ -35055,8 +35092,8 @@ func (x LimitType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym3036 := z.EncBinary()
-	_ = yym3036
+	yym3041 := z.EncBinary()
+	_ = yym3041
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -35068,8 +35105,8 @@ func (x *LimitType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3037 := z.DecBinary()
-	_ = yym3037
+	yym3042 := z.DecBinary()
+	_ = yym3042
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -35084,47 +35121,47 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3038 := z.EncBinary()
-		_ = yym3038
+		yym3043 := z.EncBinary()
+		_ = yym3043
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3039 := !z.EncBinary()
-			yy2arr3039 := z.EncBasicHandle().StructToArray
-			var yyq3039 [6]bool
-			_, _, _ = yysep3039, yyq3039, yy2arr3039
-			const yyr3039 bool = false
-			yyq3039[0] = x.Type != ""
-			yyq3039[1] = len(x.Max) != 0
-			yyq3039[2] = len(x.Min) != 0
-			yyq3039[3] = len(x.Default) != 0
-			yyq3039[4] = len(x.DefaultRequest) != 0
-			yyq3039[5] = len(x.MaxLimitRequestRatio) != 0
-			if yyr3039 || yy2arr3039 {
+			yysep3044 := !z.EncBinary()
+			yy2arr3044 := z.EncBasicHandle().StructToArray
+			var yyq3044 [6]bool
+			_, _, _ = yysep3044, yyq3044, yy2arr3044
+			const yyr3044 bool = false
+			yyq3044[0] = x.Type != ""
+			yyq3044[1] = len(x.Max) != 0
+			yyq3044[2] = len(x.Min) != 0
+			yyq3044[3] = len(x.Default) != 0
+			yyq3044[4] = len(x.DefaultRequest) != 0
+			yyq3044[5] = len(x.MaxLimitRequestRatio) != 0
+			if yyr3044 || yy2arr3044 {
 				r.EncodeArrayStart(6)
 			} else {
-				var yynn3039 int = 0
-				for _, b := range yyq3039 {
+				var yynn3044 int = 0
+				for _, b := range yyq3044 {
 					if b {
-						yynn3039++
+						yynn3044++
 					}
 				}
-				r.EncodeMapStart(yynn3039)
+				r.EncodeMapStart(yynn3044)
 			}
-			if yyr3039 || yy2arr3039 {
-				if yyq3039[0] {
+			if yyr3044 || yy2arr3044 {
+				if yyq3044[0] {
 					x.Type.CodecEncodeSelf(e)
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3039[0] {
+				if yyq3044[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("type"))
 					x.Type.CodecEncodeSelf(e)
 				}
 			}
-			if yyr3039 || yy2arr3039 {
-				if yyq3039[1] {
+			if yyr3044 || yy2arr3044 {
+				if yyq3044[1] {
 					if x.Max == nil {
 						r.EncodeNil()
 					} else {
@@ -35134,7 +35171,7 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3039[1] {
+				if yyq3044[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("max"))
 					if x.Max == nil {
 						r.EncodeNil()
@@ -35143,8 +35180,8 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr3039 || yy2arr3039 {
-				if yyq3039[2] {
+			if yyr3044 || yy2arr3044 {
+				if yyq3044[2] {
 					if x.Min == nil {
 						r.EncodeNil()
 					} else {
@@ -35154,7 +35191,7 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3039[2] {
+				if yyq3044[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("min"))
 					if x.Min == nil {
 						r.EncodeNil()
@@ -35163,8 +35200,8 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr3039 || yy2arr3039 {
-				if yyq3039[3] {
+			if yyr3044 || yy2arr3044 {
+				if yyq3044[3] {
 					if x.Default == nil {
 						r.EncodeNil()
 					} else {
@@ -35174,7 +35211,7 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3039[3] {
+				if yyq3044[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("default"))
 					if x.Default == nil {
 						r.EncodeNil()
@@ -35183,8 +35220,8 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr3039 || yy2arr3039 {
-				if yyq3039[4] {
+			if yyr3044 || yy2arr3044 {
+				if yyq3044[4] {
 					if x.DefaultRequest == nil {
 						r.EncodeNil()
 					} else {
@@ -35194,7 +35231,7 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3039[4] {
+				if yyq3044[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("defaultRequest"))
 					if x.DefaultRequest == nil {
 						r.EncodeNil()
@@ -35203,8 +35240,8 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr3039 || yy2arr3039 {
-				if yyq3039[5] {
+			if yyr3044 || yy2arr3044 {
+				if yyq3044[5] {
 					if x.MaxLimitRequestRatio == nil {
 						r.EncodeNil()
 					} else {
@@ -35214,7 +35251,7 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3039[5] {
+				if yyq3044[5] {
 					r.EncodeString(codecSelferC_UTF81234, string("maxLimitRequestRatio"))
 					if x.MaxLimitRequestRatio == nil {
 						r.EncodeNil()
@@ -35223,7 +35260,7 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3039 {
+			if yysep3044 {
 				r.EncodeEnd()
 			}
 		}
@@ -35234,24 +35271,24 @@ func (x *LimitRangeItem) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3046 := z.DecBinary()
-	_ = yym3046
+	yym3051 := z.DecBinary()
+	_ = yym3051
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3047 := r.ReadMapStart()
-			if yyl3047 == 0 {
+			yyl3052 := r.ReadMapStart()
+			if yyl3052 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3047, d)
+				x.codecDecodeSelfFromMap(yyl3052, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3047 := r.ReadArrayStart()
-			if yyl3047 == 0 {
+			yyl3052 := r.ReadArrayStart()
+			if yyl3052 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3047, d)
+				x.codecDecodeSelfFromArray(yyl3052, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -35263,12 +35300,12 @@ func (x *LimitRangeItem) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3048Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3048Slc
-	var yyhl3048 bool = l >= 0
-	for yyj3048 := 0; ; yyj3048++ {
-		if yyhl3048 {
-			if yyj3048 >= l {
+	var yys3053Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3053Slc
+	var yyhl3053 bool = l >= 0
+	for yyj3053 := 0; ; yyj3053++ {
+		if yyhl3053 {
+			if yyj3053 >= l {
 				break
 			}
 		} else {
@@ -35276,9 +35313,9 @@ func (x *LimitRangeItem) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3048Slc = r.DecodeBytes(yys3048Slc, true, true)
-		yys3048 := string(yys3048Slc)
-		switch yys3048 {
+		yys3053Slc = r.DecodeBytes(yys3053Slc, true, true)
+		yys3053 := string(yys3053Slc)
+		switch yys3053 {
 		case "type":
 			if r.TryDecodeAsNil() {
 				x.Type = ""
@@ -35289,42 +35326,42 @@ func (x *LimitRangeItem) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Max = nil
 			} else {
-				yyv3050 := &x.Max
-				yyv3050.CodecDecodeSelf(d)
+				yyv3055 := &x.Max
+				yyv3055.CodecDecodeSelf(d)
 			}
 		case "min":
 			if r.TryDecodeAsNil() {
 				x.Min = nil
 			} else {
-				yyv3051 := &x.Min
-				yyv3051.CodecDecodeSelf(d)
+				yyv3056 := &x.Min
+				yyv3056.CodecDecodeSelf(d)
 			}
 		case "default":
 			if r.TryDecodeAsNil() {
 				x.Default = nil
 			} else {
-				yyv3052 := &x.Default
-				yyv3052.CodecDecodeSelf(d)
+				yyv3057 := &x.Default
+				yyv3057.CodecDecodeSelf(d)
 			}
 		case "defaultRequest":
 			if r.TryDecodeAsNil() {
 				x.DefaultRequest = nil
 			} else {
-				yyv3053 := &x.DefaultRequest
-				yyv3053.CodecDecodeSelf(d)
+				yyv3058 := &x.DefaultRequest
+				yyv3058.CodecDecodeSelf(d)
 			}
 		case "maxLimitRequestRatio":
 			if r.TryDecodeAsNil() {
 				x.MaxLimitRequestRatio = nil
 			} else {
-				yyv3054 := &x.MaxLimitRequestRatio
-				yyv3054.CodecDecodeSelf(d)
+				yyv3059 := &x.MaxLimitRequestRatio
+				yyv3059.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3048)
-		} // end switch yys3048
-	} // end for yyj3048
-	if !yyhl3048 {
+			z.DecStructFieldNotFound(-1, yys3053)
+		} // end switch yys3053
+	} // end for yyj3053
+	if !yyhl3053 {
 		r.ReadEnd()
 	}
 }
@@ -35333,16 +35370,16 @@ func (x *LimitRangeItem) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3055 int
-	var yyb3055 bool
-	var yyhl3055 bool = l >= 0
-	yyj3055++
-	if yyhl3055 {
-		yyb3055 = yyj3055 > l
+	var yyj3060 int
+	var yyb3060 bool
+	var yyhl3060 bool = l >= 0
+	yyj3060++
+	if yyhl3060 {
+		yyb3060 = yyj3060 > l
 	} else {
-		yyb3055 = r.CheckBreak()
+		yyb3060 = r.CheckBreak()
 	}
-	if yyb3055 {
+	if yyb3060 {
 		r.ReadEnd()
 		return
 	}
@@ -35351,97 +35388,97 @@ func (x *LimitRangeItem) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Type = LimitType(r.DecodeString())
 	}
-	yyj3055++
-	if yyhl3055 {
-		yyb3055 = yyj3055 > l
+	yyj3060++
+	if yyhl3060 {
+		yyb3060 = yyj3060 > l
 	} else {
-		yyb3055 = r.CheckBreak()
+		yyb3060 = r.CheckBreak()
 	}
-	if yyb3055 {
+	if yyb3060 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Max = nil
 	} else {
-		yyv3057 := &x.Max
-		yyv3057.CodecDecodeSelf(d)
+		yyv3062 := &x.Max
+		yyv3062.CodecDecodeSelf(d)
 	}
-	yyj3055++
-	if yyhl3055 {
-		yyb3055 = yyj3055 > l
+	yyj3060++
+	if yyhl3060 {
+		yyb3060 = yyj3060 > l
 	} else {
-		yyb3055 = r.CheckBreak()
+		yyb3060 = r.CheckBreak()
 	}
-	if yyb3055 {
+	if yyb3060 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Min = nil
 	} else {
-		yyv3058 := &x.Min
-		yyv3058.CodecDecodeSelf(d)
+		yyv3063 := &x.Min
+		yyv3063.CodecDecodeSelf(d)
 	}
-	yyj3055++
-	if yyhl3055 {
-		yyb3055 = yyj3055 > l
+	yyj3060++
+	if yyhl3060 {
+		yyb3060 = yyj3060 > l
 	} else {
-		yyb3055 = r.CheckBreak()
+		yyb3060 = r.CheckBreak()
 	}
-	if yyb3055 {
+	if yyb3060 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Default = nil
 	} else {
-		yyv3059 := &x.Default
-		yyv3059.CodecDecodeSelf(d)
+		yyv3064 := &x.Default
+		yyv3064.CodecDecodeSelf(d)
 	}
-	yyj3055++
-	if yyhl3055 {
-		yyb3055 = yyj3055 > l
+	yyj3060++
+	if yyhl3060 {
+		yyb3060 = yyj3060 > l
 	} else {
-		yyb3055 = r.CheckBreak()
+		yyb3060 = r.CheckBreak()
 	}
-	if yyb3055 {
+	if yyb3060 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.DefaultRequest = nil
 	} else {
-		yyv3060 := &x.DefaultRequest
-		yyv3060.CodecDecodeSelf(d)
+		yyv3065 := &x.DefaultRequest
+		yyv3065.CodecDecodeSelf(d)
 	}
-	yyj3055++
-	if yyhl3055 {
-		yyb3055 = yyj3055 > l
+	yyj3060++
+	if yyhl3060 {
+		yyb3060 = yyj3060 > l
 	} else {
-		yyb3055 = r.CheckBreak()
+		yyb3060 = r.CheckBreak()
 	}
-	if yyb3055 {
+	if yyb3060 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.MaxLimitRequestRatio = nil
 	} else {
-		yyv3061 := &x.MaxLimitRequestRatio
-		yyv3061.CodecDecodeSelf(d)
+		yyv3066 := &x.MaxLimitRequestRatio
+		yyv3066.CodecDecodeSelf(d)
 	}
 	for {
-		yyj3055++
-		if yyhl3055 {
-			yyb3055 = yyj3055 > l
+		yyj3060++
+		if yyhl3060 {
+			yyb3060 = yyj3060 > l
 		} else {
-			yyb3055 = r.CheckBreak()
+			yyb3060 = r.CheckBreak()
 		}
-		if yyb3055 {
+		if yyb3060 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3055-1, "")
+		z.DecStructFieldNotFound(yyj3060-1, "")
 	}
 	r.ReadEnd()
 }
@@ -35453,33 +35490,33 @@ func (x *LimitRangeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3062 := z.EncBinary()
-		_ = yym3062
+		yym3067 := z.EncBinary()
+		_ = yym3067
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3063 := !z.EncBinary()
-			yy2arr3063 := z.EncBasicHandle().StructToArray
-			var yyq3063 [1]bool
-			_, _, _ = yysep3063, yyq3063, yy2arr3063
-			const yyr3063 bool = false
-			if yyr3063 || yy2arr3063 {
+			yysep3068 := !z.EncBinary()
+			yy2arr3068 := z.EncBasicHandle().StructToArray
+			var yyq3068 [1]bool
+			_, _, _ = yysep3068, yyq3068, yy2arr3068
+			const yyr3068 bool = false
+			if yyr3068 || yy2arr3068 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn3063 int = 1
-				for _, b := range yyq3063 {
+				var yynn3068 int = 1
+				for _, b := range yyq3068 {
 					if b {
-						yynn3063++
+						yynn3068++
 					}
 				}
-				r.EncodeMapStart(yynn3063)
+				r.EncodeMapStart(yynn3068)
 			}
-			if yyr3063 || yy2arr3063 {
+			if yyr3068 || yy2arr3068 {
 				if x.Limits == nil {
 					r.EncodeNil()
 				} else {
-					yym3065 := z.EncBinary()
-					_ = yym3065
+					yym3070 := z.EncBinary()
+					_ = yym3070
 					if false {
 					} else {
 						h.encSliceLimitRangeItem(([]LimitRangeItem)(x.Limits), e)
@@ -35490,15 +35527,15 @@ func (x *LimitRangeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Limits == nil {
 					r.EncodeNil()
 				} else {
-					yym3066 := z.EncBinary()
-					_ = yym3066
+					yym3071 := z.EncBinary()
+					_ = yym3071
 					if false {
 					} else {
 						h.encSliceLimitRangeItem(([]LimitRangeItem)(x.Limits), e)
 					}
 				}
 			}
-			if yysep3063 {
+			if yysep3068 {
 				r.EncodeEnd()
 			}
 		}
@@ -35509,24 +35546,24 @@ func (x *LimitRangeSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3067 := z.DecBinary()
-	_ = yym3067
+	yym3072 := z.DecBinary()
+	_ = yym3072
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3068 := r.ReadMapStart()
-			if yyl3068 == 0 {
+			yyl3073 := r.ReadMapStart()
+			if yyl3073 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3068, d)
+				x.codecDecodeSelfFromMap(yyl3073, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3068 := r.ReadArrayStart()
-			if yyl3068 == 0 {
+			yyl3073 := r.ReadArrayStart()
+			if yyl3073 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3068, d)
+				x.codecDecodeSelfFromArray(yyl3073, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -35538,12 +35575,12 @@ func (x *LimitRangeSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3069Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3069Slc
-	var yyhl3069 bool = l >= 0
-	for yyj3069 := 0; ; yyj3069++ {
-		if yyhl3069 {
-			if yyj3069 >= l {
+	var yys3074Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3074Slc
+	var yyhl3074 bool = l >= 0
+	for yyj3074 := 0; ; yyj3074++ {
+		if yyhl3074 {
+			if yyj3074 >= l {
 				break
 			}
 		} else {
@@ -35551,26 +35588,26 @@ func (x *LimitRangeSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3069Slc = r.DecodeBytes(yys3069Slc, true, true)
-		yys3069 := string(yys3069Slc)
-		switch yys3069 {
+		yys3074Slc = r.DecodeBytes(yys3074Slc, true, true)
+		yys3074 := string(yys3074Slc)
+		switch yys3074 {
 		case "limits":
 			if r.TryDecodeAsNil() {
 				x.Limits = nil
 			} else {
-				yyv3070 := &x.Limits
-				yym3071 := z.DecBinary()
-				_ = yym3071
+				yyv3075 := &x.Limits
+				yym3076 := z.DecBinary()
+				_ = yym3076
 				if false {
 				} else {
-					h.decSliceLimitRangeItem((*[]LimitRangeItem)(yyv3070), d)
+					h.decSliceLimitRangeItem((*[]LimitRangeItem)(yyv3075), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3069)
-		} // end switch yys3069
-	} // end for yyj3069
-	if !yyhl3069 {
+			z.DecStructFieldNotFound(-1, yys3074)
+		} // end switch yys3074
+	} // end for yyj3074
+	if !yyhl3074 {
 		r.ReadEnd()
 	}
 }
@@ -35579,41 +35616,41 @@ func (x *LimitRangeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3072 int
-	var yyb3072 bool
-	var yyhl3072 bool = l >= 0
-	yyj3072++
-	if yyhl3072 {
-		yyb3072 = yyj3072 > l
+	var yyj3077 int
+	var yyb3077 bool
+	var yyhl3077 bool = l >= 0
+	yyj3077++
+	if yyhl3077 {
+		yyb3077 = yyj3077 > l
 	} else {
-		yyb3072 = r.CheckBreak()
+		yyb3077 = r.CheckBreak()
 	}
-	if yyb3072 {
+	if yyb3077 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Limits = nil
 	} else {
-		yyv3073 := &x.Limits
-		yym3074 := z.DecBinary()
-		_ = yym3074
+		yyv3078 := &x.Limits
+		yym3079 := z.DecBinary()
+		_ = yym3079
 		if false {
 		} else {
-			h.decSliceLimitRangeItem((*[]LimitRangeItem)(yyv3073), d)
+			h.decSliceLimitRangeItem((*[]LimitRangeItem)(yyv3078), d)
 		}
 	}
 	for {
-		yyj3072++
-		if yyhl3072 {
-			yyb3072 = yyj3072 > l
+		yyj3077++
+		if yyhl3077 {
+			yyb3077 = yyj3077 > l
 		} else {
-			yyb3072 = r.CheckBreak()
+			yyb3077 = r.CheckBreak()
 		}
-		if yyb3072 {
+		if yyb3077 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3072-1, "")
+		z.DecStructFieldNotFound(yyj3077-1, "")
 	}
 	r.ReadEnd()
 }
@@ -35625,35 +35662,35 @@ func (x *LimitRange) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3075 := z.EncBinary()
-		_ = yym3075
+		yym3080 := z.EncBinary()
+		_ = yym3080
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3076 := !z.EncBinary()
-			yy2arr3076 := z.EncBasicHandle().StructToArray
-			var yyq3076 [4]bool
-			_, _, _ = yysep3076, yyq3076, yy2arr3076
-			const yyr3076 bool = false
-			yyq3076[0] = x.Kind != ""
-			yyq3076[1] = x.APIVersion != ""
-			yyq3076[2] = true
-			yyq3076[3] = true
-			if yyr3076 || yy2arr3076 {
+			yysep3081 := !z.EncBinary()
+			yy2arr3081 := z.EncBasicHandle().StructToArray
+			var yyq3081 [4]bool
+			_, _, _ = yysep3081, yyq3081, yy2arr3081
+			const yyr3081 bool = false
+			yyq3081[0] = x.Kind != ""
+			yyq3081[1] = x.APIVersion != ""
+			yyq3081[2] = true
+			yyq3081[3] = true
+			if yyr3081 || yy2arr3081 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3076 int = 0
-				for _, b := range yyq3076 {
+				var yynn3081 int = 0
+				for _, b := range yyq3081 {
 					if b {
-						yynn3076++
+						yynn3081++
 					}
 				}
-				r.EncodeMapStart(yynn3076)
+				r.EncodeMapStart(yynn3081)
 			}
-			if yyr3076 || yy2arr3076 {
-				if yyq3076[0] {
-					yym3078 := z.EncBinary()
-					_ = yym3078
+			if yyr3081 || yy2arr3081 {
+				if yyq3081[0] {
+					yym3083 := z.EncBinary()
+					_ = yym3083
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -35662,20 +35699,20 @@ func (x *LimitRange) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3076[0] {
+				if yyq3081[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3079 := z.EncBinary()
-					_ = yym3079
+					yym3084 := z.EncBinary()
+					_ = yym3084
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr3076 || yy2arr3076 {
-				if yyq3076[1] {
-					yym3081 := z.EncBinary()
-					_ = yym3081
+			if yyr3081 || yy2arr3081 {
+				if yyq3081[1] {
+					yym3086 := z.EncBinary()
+					_ = yym3086
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -35684,45 +35721,45 @@ func (x *LimitRange) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3076[1] {
+				if yyq3081[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym3082 := z.EncBinary()
-					_ = yym3082
+					yym3087 := z.EncBinary()
+					_ = yym3087
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr3076 || yy2arr3076 {
-				if yyq3076[2] {
-					yy3084 := &x.ObjectMeta
-					yy3084.CodecEncodeSelf(e)
+			if yyr3081 || yy2arr3081 {
+				if yyq3081[2] {
+					yy3089 := &x.ObjectMeta
+					yy3089.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3076[2] {
+				if yyq3081[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3085 := &x.ObjectMeta
-					yy3085.CodecEncodeSelf(e)
+					yy3090 := &x.ObjectMeta
+					yy3090.CodecEncodeSelf(e)
 				}
 			}
-			if yyr3076 || yy2arr3076 {
-				if yyq3076[3] {
-					yy3087 := &x.Spec
-					yy3087.CodecEncodeSelf(e)
+			if yyr3081 || yy2arr3081 {
+				if yyq3081[3] {
+					yy3092 := &x.Spec
+					yy3092.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3076[3] {
+				if yyq3081[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy3088 := &x.Spec
-					yy3088.CodecEncodeSelf(e)
+					yy3093 := &x.Spec
+					yy3093.CodecEncodeSelf(e)
 				}
 			}
-			if yysep3076 {
+			if yysep3081 {
 				r.EncodeEnd()
 			}
 		}
@@ -35733,24 +35770,24 @@ func (x *LimitRange) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3089 := z.DecBinary()
-	_ = yym3089
+	yym3094 := z.DecBinary()
+	_ = yym3094
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3090 := r.ReadMapStart()
-			if yyl3090 == 0 {
+			yyl3095 := r.ReadMapStart()
+			if yyl3095 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3090, d)
+				x.codecDecodeSelfFromMap(yyl3095, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3090 := r.ReadArrayStart()
-			if yyl3090 == 0 {
+			yyl3095 := r.ReadArrayStart()
+			if yyl3095 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3090, d)
+				x.codecDecodeSelfFromArray(yyl3095, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -35762,12 +35799,12 @@ func (x *LimitRange) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3091Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3091Slc
-	var yyhl3091 bool = l >= 0
-	for yyj3091 := 0; ; yyj3091++ {
-		if yyhl3091 {
-			if yyj3091 >= l {
+	var yys3096Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3096Slc
+	var yyhl3096 bool = l >= 0
+	for yyj3096 := 0; ; yyj3096++ {
+		if yyhl3096 {
+			if yyj3096 >= l {
 				break
 			}
 		} else {
@@ -35775,9 +35812,9 @@ func (x *LimitRange) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3091Slc = r.DecodeBytes(yys3091Slc, true, true)
-		yys3091 := string(yys3091Slc)
-		switch yys3091 {
+		yys3096Slc = r.DecodeBytes(yys3096Slc, true, true)
+		yys3096 := string(yys3096Slc)
+		switch yys3096 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -35794,21 +35831,21 @@ func (x *LimitRange) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv3094 := &x.ObjectMeta
-				yyv3094.CodecDecodeSelf(d)
+				yyv3099 := &x.ObjectMeta
+				yyv3099.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = LimitRangeSpec{}
 			} else {
-				yyv3095 := &x.Spec
-				yyv3095.CodecDecodeSelf(d)
+				yyv3100 := &x.Spec
+				yyv3100.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3091)
-		} // end switch yys3091
-	} // end for yyj3091
-	if !yyhl3091 {
+			z.DecStructFieldNotFound(-1, yys3096)
+		} // end switch yys3096
+	} // end for yyj3096
+	if !yyhl3096 {
 		r.ReadEnd()
 	}
 }
@@ -35817,16 +35854,16 @@ func (x *LimitRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3096 int
-	var yyb3096 bool
-	var yyhl3096 bool = l >= 0
-	yyj3096++
-	if yyhl3096 {
-		yyb3096 = yyj3096 > l
+	var yyj3101 int
+	var yyb3101 bool
+	var yyhl3101 bool = l >= 0
+	yyj3101++
+	if yyhl3101 {
+		yyb3101 = yyj3101 > l
 	} else {
-		yyb3096 = r.CheckBreak()
+		yyb3101 = r.CheckBreak()
 	}
-	if yyb3096 {
+	if yyb3101 {
 		r.ReadEnd()
 		return
 	}
@@ -35835,13 +35872,13 @@ func (x *LimitRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3096++
-	if yyhl3096 {
-		yyb3096 = yyj3096 > l
+	yyj3101++
+	if yyhl3101 {
+		yyb3101 = yyj3101 > l
 	} else {
-		yyb3096 = r.CheckBreak()
+		yyb3101 = r.CheckBreak()
 	}
-	if yyb3096 {
+	if yyb3101 {
 		r.ReadEnd()
 		return
 	}
@@ -35850,49 +35887,49 @@ func (x *LimitRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3096++
-	if yyhl3096 {
-		yyb3096 = yyj3096 > l
+	yyj3101++
+	if yyhl3101 {
+		yyb3101 = yyj3101 > l
 	} else {
-		yyb3096 = r.CheckBreak()
+		yyb3101 = r.CheckBreak()
 	}
-	if yyb3096 {
+	if yyb3101 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv3099 := &x.ObjectMeta
-		yyv3099.CodecDecodeSelf(d)
+		yyv3104 := &x.ObjectMeta
+		yyv3104.CodecDecodeSelf(d)
 	}
-	yyj3096++
-	if yyhl3096 {
-		yyb3096 = yyj3096 > l
+	yyj3101++
+	if yyhl3101 {
+		yyb3101 = yyj3101 > l
 	} else {
-		yyb3096 = r.CheckBreak()
+		yyb3101 = r.CheckBreak()
 	}
-	if yyb3096 {
+	if yyb3101 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = LimitRangeSpec{}
 	} else {
-		yyv3100 := &x.Spec
-		yyv3100.CodecDecodeSelf(d)
+		yyv3105 := &x.Spec
+		yyv3105.CodecDecodeSelf(d)
 	}
 	for {
-		yyj3096++
-		if yyhl3096 {
-			yyb3096 = yyj3096 > l
+		yyj3101++
+		if yyhl3101 {
+			yyb3101 = yyj3101 > l
 		} else {
-			yyb3096 = r.CheckBreak()
+			yyb3101 = r.CheckBreak()
 		}
-		if yyb3096 {
+		if yyb3101 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3096-1, "")
+		z.DecStructFieldNotFound(yyj3101-1, "")
 	}
 	r.ReadEnd()
 }
@@ -35904,34 +35941,34 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3101 := z.EncBinary()
-		_ = yym3101
+		yym3106 := z.EncBinary()
+		_ = yym3106
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3102 := !z.EncBinary()
-			yy2arr3102 := z.EncBasicHandle().StructToArray
-			var yyq3102 [4]bool
-			_, _, _ = yysep3102, yyq3102, yy2arr3102
-			const yyr3102 bool = false
-			yyq3102[0] = x.Kind != ""
-			yyq3102[1] = x.APIVersion != ""
-			yyq3102[2] = true
-			if yyr3102 || yy2arr3102 {
+			yysep3107 := !z.EncBinary()
+			yy2arr3107 := z.EncBasicHandle().StructToArray
+			var yyq3107 [4]bool
+			_, _, _ = yysep3107, yyq3107, yy2arr3107
+			const yyr3107 bool = false
+			yyq3107[0] = x.Kind != ""
+			yyq3107[1] = x.APIVersion != ""
+			yyq3107[2] = true
+			if yyr3107 || yy2arr3107 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3102 int = 1
-				for _, b := range yyq3102 {
+				var yynn3107 int = 1
+				for _, b := range yyq3107 {
 					if b {
-						yynn3102++
+						yynn3107++
 					}
 				}
-				r.EncodeMapStart(yynn3102)
+				r.EncodeMapStart(yynn3107)
 			}
-			if yyr3102 || yy2arr3102 {
-				if yyq3102[0] {
-					yym3104 := z.EncBinary()
-					_ = yym3104
+			if yyr3107 || yy2arr3107 {
+				if yyq3107[0] {
+					yym3109 := z.EncBinary()
+					_ = yym3109
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -35940,20 +35977,20 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3102[0] {
+				if yyq3107[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3105 := z.EncBinary()
-					_ = yym3105
+					yym3110 := z.EncBinary()
+					_ = yym3110
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr3102 || yy2arr3102 {
-				if yyq3102[1] {
-					yym3107 := z.EncBinary()
-					_ = yym3107
+			if yyr3107 || yy2arr3107 {
+				if yyq3107[1] {
+					yym3112 := z.EncBinary()
+					_ = yym3112
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -35962,48 +35999,48 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3102[1] {
+				if yyq3107[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym3108 := z.EncBinary()
-					_ = yym3108
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3102 || yy2arr3102 {
-				if yyq3102[2] {
-					yy3110 := &x.ListMeta
-					yym3111 := z.EncBinary()
-					_ = yym3111
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3110) {
-					} else {
-						z.EncFallback(yy3110)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq3102[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3112 := &x.ListMeta
 					yym3113 := z.EncBinary()
 					_ = yym3113
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3112) {
 					} else {
-						z.EncFallback(yy3112)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr3102 || yy2arr3102 {
+			if yyr3107 || yy2arr3107 {
+				if yyq3107[2] {
+					yy3115 := &x.ListMeta
+					yym3116 := z.EncBinary()
+					_ = yym3116
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3115) {
+					} else {
+						z.EncFallback(yy3115)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq3107[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy3117 := &x.ListMeta
+					yym3118 := z.EncBinary()
+					_ = yym3118
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3117) {
+					} else {
+						z.EncFallback(yy3117)
+					}
+				}
+			}
+			if yyr3107 || yy2arr3107 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3115 := z.EncBinary()
-					_ = yym3115
+					yym3120 := z.EncBinary()
+					_ = yym3120
 					if false {
 					} else {
 						h.encSliceLimitRange(([]LimitRange)(x.Items), e)
@@ -36014,15 +36051,15 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3116 := z.EncBinary()
-					_ = yym3116
+					yym3121 := z.EncBinary()
+					_ = yym3121
 					if false {
 					} else {
 						h.encSliceLimitRange(([]LimitRange)(x.Items), e)
 					}
 				}
 			}
-			if yysep3102 {
+			if yysep3107 {
 				r.EncodeEnd()
 			}
 		}
@@ -36033,24 +36070,24 @@ func (x *LimitRangeList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3117 := z.DecBinary()
-	_ = yym3117
+	yym3122 := z.DecBinary()
+	_ = yym3122
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3118 := r.ReadMapStart()
-			if yyl3118 == 0 {
+			yyl3123 := r.ReadMapStart()
+			if yyl3123 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3118, d)
+				x.codecDecodeSelfFromMap(yyl3123, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3118 := r.ReadArrayStart()
-			if yyl3118 == 0 {
+			yyl3123 := r.ReadArrayStart()
+			if yyl3123 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3118, d)
+				x.codecDecodeSelfFromArray(yyl3123, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -36062,12 +36099,12 @@ func (x *LimitRangeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3119Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3119Slc
-	var yyhl3119 bool = l >= 0
-	for yyj3119 := 0; ; yyj3119++ {
-		if yyhl3119 {
-			if yyj3119 >= l {
+	var yys3124Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3124Slc
+	var yyhl3124 bool = l >= 0
+	for yyj3124 := 0; ; yyj3124++ {
+		if yyhl3124 {
+			if yyj3124 >= l {
 				break
 			}
 		} else {
@@ -36075,9 +36112,9 @@ func (x *LimitRangeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3119Slc = r.DecodeBytes(yys3119Slc, true, true)
-		yys3119 := string(yys3119Slc)
-		switch yys3119 {
+		yys3124Slc = r.DecodeBytes(yys3124Slc, true, true)
+		yys3124 := string(yys3124Slc)
+		switch yys3124 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -36094,32 +36131,32 @@ func (x *LimitRangeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv3122 := &x.ListMeta
-				yym3123 := z.DecBinary()
-				_ = yym3123
+				yyv3127 := &x.ListMeta
+				yym3128 := z.DecBinary()
+				_ = yym3128
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3122) {
+				} else if z.HasExtensions() && z.DecExt(yyv3127) {
 				} else {
-					z.DecFallback(yyv3122, false)
+					z.DecFallback(yyv3127, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv3124 := &x.Items
-				yym3125 := z.DecBinary()
-				_ = yym3125
+				yyv3129 := &x.Items
+				yym3130 := z.DecBinary()
+				_ = yym3130
 				if false {
 				} else {
-					h.decSliceLimitRange((*[]LimitRange)(yyv3124), d)
+					h.decSliceLimitRange((*[]LimitRange)(yyv3129), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3119)
-		} // end switch yys3119
-	} // end for yyj3119
-	if !yyhl3119 {
+			z.DecStructFieldNotFound(-1, yys3124)
+		} // end switch yys3124
+	} // end for yyj3124
+	if !yyhl3124 {
 		r.ReadEnd()
 	}
 }
@@ -36128,16 +36165,16 @@ func (x *LimitRangeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3126 int
-	var yyb3126 bool
-	var yyhl3126 bool = l >= 0
-	yyj3126++
-	if yyhl3126 {
-		yyb3126 = yyj3126 > l
+	var yyj3131 int
+	var yyb3131 bool
+	var yyhl3131 bool = l >= 0
+	yyj3131++
+	if yyhl3131 {
+		yyb3131 = yyj3131 > l
 	} else {
-		yyb3126 = r.CheckBreak()
+		yyb3131 = r.CheckBreak()
 	}
-	if yyb3126 {
+	if yyb3131 {
 		r.ReadEnd()
 		return
 	}
@@ -36146,13 +36183,13 @@ func (x *LimitRangeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3126++
-	if yyhl3126 {
-		yyb3126 = yyj3126 > l
+	yyj3131++
+	if yyhl3131 {
+		yyb3131 = yyj3131 > l
 	} else {
-		yyb3126 = r.CheckBreak()
+		yyb3131 = r.CheckBreak()
 	}
-	if yyb3126 {
+	if yyb3131 {
 		r.ReadEnd()
 		return
 	}
@@ -36161,60 +36198,60 @@ func (x *LimitRangeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3126++
-	if yyhl3126 {
-		yyb3126 = yyj3126 > l
+	yyj3131++
+	if yyhl3131 {
+		yyb3131 = yyj3131 > l
 	} else {
-		yyb3126 = r.CheckBreak()
+		yyb3131 = r.CheckBreak()
 	}
-	if yyb3126 {
+	if yyb3131 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv3129 := &x.ListMeta
-		yym3130 := z.DecBinary()
-		_ = yym3130
+		yyv3134 := &x.ListMeta
+		yym3135 := z.DecBinary()
+		_ = yym3135
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3129) {
+		} else if z.HasExtensions() && z.DecExt(yyv3134) {
 		} else {
-			z.DecFallback(yyv3129, false)
+			z.DecFallback(yyv3134, false)
 		}
 	}
-	yyj3126++
-	if yyhl3126 {
-		yyb3126 = yyj3126 > l
+	yyj3131++
+	if yyhl3131 {
+		yyb3131 = yyj3131 > l
 	} else {
-		yyb3126 = r.CheckBreak()
+		yyb3131 = r.CheckBreak()
 	}
-	if yyb3126 {
+	if yyb3131 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv3131 := &x.Items
-		yym3132 := z.DecBinary()
-		_ = yym3132
+		yyv3136 := &x.Items
+		yym3137 := z.DecBinary()
+		_ = yym3137
 		if false {
 		} else {
-			h.decSliceLimitRange((*[]LimitRange)(yyv3131), d)
+			h.decSliceLimitRange((*[]LimitRange)(yyv3136), d)
 		}
 	}
 	for {
-		yyj3126++
-		if yyhl3126 {
-			yyb3126 = yyj3126 > l
+		yyj3131++
+		if yyhl3131 {
+			yyb3131 = yyj3131 > l
 		} else {
-			yyb3126 = r.CheckBreak()
+			yyb3131 = r.CheckBreak()
 		}
-		if yyb3126 {
+		if yyb3131 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3126-1, "")
+		z.DecStructFieldNotFound(yyj3131-1, "")
 	}
 	r.ReadEnd()
 }
@@ -36226,30 +36263,30 @@ func (x *ResourceQuotaSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3133 := z.EncBinary()
-		_ = yym3133
+		yym3138 := z.EncBinary()
+		_ = yym3138
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3134 := !z.EncBinary()
-			yy2arr3134 := z.EncBasicHandle().StructToArray
-			var yyq3134 [1]bool
-			_, _, _ = yysep3134, yyq3134, yy2arr3134
-			const yyr3134 bool = false
-			yyq3134[0] = len(x.Hard) != 0
-			if yyr3134 || yy2arr3134 {
+			yysep3139 := !z.EncBinary()
+			yy2arr3139 := z.EncBasicHandle().StructToArray
+			var yyq3139 [1]bool
+			_, _, _ = yysep3139, yyq3139, yy2arr3139
+			const yyr3139 bool = false
+			yyq3139[0] = len(x.Hard) != 0
+			if yyr3139 || yy2arr3139 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn3134 int = 0
-				for _, b := range yyq3134 {
+				var yynn3139 int = 0
+				for _, b := range yyq3139 {
 					if b {
-						yynn3134++
+						yynn3139++
 					}
 				}
-				r.EncodeMapStart(yynn3134)
+				r.EncodeMapStart(yynn3139)
 			}
-			if yyr3134 || yy2arr3134 {
-				if yyq3134[0] {
+			if yyr3139 || yy2arr3139 {
+				if yyq3139[0] {
 					if x.Hard == nil {
 						r.EncodeNil()
 					} else {
@@ -36259,7 +36296,7 @@ func (x *ResourceQuotaSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3134[0] {
+				if yyq3139[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("hard"))
 					if x.Hard == nil {
 						r.EncodeNil()
@@ -36268,7 +36305,7 @@ func (x *ResourceQuotaSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3134 {
+			if yysep3139 {
 				r.EncodeEnd()
 			}
 		}
@@ -36279,24 +36316,24 @@ func (x *ResourceQuotaSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3136 := z.DecBinary()
-	_ = yym3136
+	yym3141 := z.DecBinary()
+	_ = yym3141
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3137 := r.ReadMapStart()
-			if yyl3137 == 0 {
+			yyl3142 := r.ReadMapStart()
+			if yyl3142 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3137, d)
+				x.codecDecodeSelfFromMap(yyl3142, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3137 := r.ReadArrayStart()
-			if yyl3137 == 0 {
+			yyl3142 := r.ReadArrayStart()
+			if yyl3142 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3137, d)
+				x.codecDecodeSelfFromArray(yyl3142, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -36308,12 +36345,12 @@ func (x *ResourceQuotaSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3138Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3138Slc
-	var yyhl3138 bool = l >= 0
-	for yyj3138 := 0; ; yyj3138++ {
-		if yyhl3138 {
-			if yyj3138 >= l {
+	var yys3143Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3143Slc
+	var yyhl3143 bool = l >= 0
+	for yyj3143 := 0; ; yyj3143++ {
+		if yyhl3143 {
+			if yyj3143 >= l {
 				break
 			}
 		} else {
@@ -36321,21 +36358,21 @@ func (x *ResourceQuotaSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				break
 			}
 		}
-		yys3138Slc = r.DecodeBytes(yys3138Slc, true, true)
-		yys3138 := string(yys3138Slc)
-		switch yys3138 {
+		yys3143Slc = r.DecodeBytes(yys3143Slc, true, true)
+		yys3143 := string(yys3143Slc)
+		switch yys3143 {
 		case "hard":
 			if r.TryDecodeAsNil() {
 				x.Hard = nil
 			} else {
-				yyv3139 := &x.Hard
-				yyv3139.CodecDecodeSelf(d)
+				yyv3144 := &x.Hard
+				yyv3144.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3138)
-		} // end switch yys3138
-	} // end for yyj3138
-	if !yyhl3138 {
+			z.DecStructFieldNotFound(-1, yys3143)
+		} // end switch yys3143
+	} // end for yyj3143
+	if !yyhl3143 {
 		r.ReadEnd()
 	}
 }
@@ -36344,36 +36381,36 @@ func (x *ResourceQuotaSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3140 int
-	var yyb3140 bool
-	var yyhl3140 bool = l >= 0
-	yyj3140++
-	if yyhl3140 {
-		yyb3140 = yyj3140 > l
+	var yyj3145 int
+	var yyb3145 bool
+	var yyhl3145 bool = l >= 0
+	yyj3145++
+	if yyhl3145 {
+		yyb3145 = yyj3145 > l
 	} else {
-		yyb3140 = r.CheckBreak()
+		yyb3145 = r.CheckBreak()
 	}
-	if yyb3140 {
+	if yyb3145 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Hard = nil
 	} else {
-		yyv3141 := &x.Hard
-		yyv3141.CodecDecodeSelf(d)
+		yyv3146 := &x.Hard
+		yyv3146.CodecDecodeSelf(d)
 	}
 	for {
-		yyj3140++
-		if yyhl3140 {
-			yyb3140 = yyj3140 > l
+		yyj3145++
+		if yyhl3145 {
+			yyb3145 = yyj3145 > l
 		} else {
-			yyb3140 = r.CheckBreak()
+			yyb3145 = r.CheckBreak()
 		}
-		if yyb3140 {
+		if yyb3145 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3140-1, "")
+		z.DecStructFieldNotFound(yyj3145-1, "")
 	}
 	r.ReadEnd()
 }
@@ -36385,31 +36422,31 @@ func (x *ResourceQuotaStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3142 := z.EncBinary()
-		_ = yym3142
+		yym3147 := z.EncBinary()
+		_ = yym3147
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3143 := !z.EncBinary()
-			yy2arr3143 := z.EncBasicHandle().StructToArray
-			var yyq3143 [2]bool
-			_, _, _ = yysep3143, yyq3143, yy2arr3143
-			const yyr3143 bool = false
-			yyq3143[0] = len(x.Hard) != 0
-			yyq3143[1] = len(x.Used) != 0
-			if yyr3143 || yy2arr3143 {
+			yysep3148 := !z.EncBinary()
+			yy2arr3148 := z.EncBasicHandle().StructToArray
+			var yyq3148 [2]bool
+			_, _, _ = yysep3148, yyq3148, yy2arr3148
+			const yyr3148 bool = false
+			yyq3148[0] = len(x.Hard) != 0
+			yyq3148[1] = len(x.Used) != 0
+			if yyr3148 || yy2arr3148 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn3143 int = 0
-				for _, b := range yyq3143 {
+				var yynn3148 int = 0
+				for _, b := range yyq3148 {
 					if b {
-						yynn3143++
+						yynn3148++
 					}
 				}
-				r.EncodeMapStart(yynn3143)
+				r.EncodeMapStart(yynn3148)
 			}
-			if yyr3143 || yy2arr3143 {
-				if yyq3143[0] {
+			if yyr3148 || yy2arr3148 {
+				if yyq3148[0] {
 					if x.Hard == nil {
 						r.EncodeNil()
 					} else {
@@ -36419,7 +36456,7 @@ func (x *ResourceQuotaStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3143[0] {
+				if yyq3148[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("hard"))
 					if x.Hard == nil {
 						r.EncodeNil()
@@ -36428,8 +36465,8 @@ func (x *ResourceQuotaStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr3143 || yy2arr3143 {
-				if yyq3143[1] {
+			if yyr3148 || yy2arr3148 {
+				if yyq3148[1] {
 					if x.Used == nil {
 						r.EncodeNil()
 					} else {
@@ -36439,7 +36476,7 @@ func (x *ResourceQuotaStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3143[1] {
+				if yyq3148[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("used"))
 					if x.Used == nil {
 						r.EncodeNil()
@@ -36448,7 +36485,7 @@ func (x *ResourceQuotaStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3143 {
+			if yysep3148 {
 				r.EncodeEnd()
 			}
 		}
@@ -36459,24 +36496,24 @@ func (x *ResourceQuotaStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3146 := z.DecBinary()
-	_ = yym3146
+	yym3151 := z.DecBinary()
+	_ = yym3151
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3147 := r.ReadMapStart()
-			if yyl3147 == 0 {
+			yyl3152 := r.ReadMapStart()
+			if yyl3152 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3147, d)
+				x.codecDecodeSelfFromMap(yyl3152, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3147 := r.ReadArrayStart()
-			if yyl3147 == 0 {
+			yyl3152 := r.ReadArrayStart()
+			if yyl3152 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3147, d)
+				x.codecDecodeSelfFromArray(yyl3152, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -36488,12 +36525,12 @@ func (x *ResourceQuotaStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3148Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3148Slc
-	var yyhl3148 bool = l >= 0
-	for yyj3148 := 0; ; yyj3148++ {
-		if yyhl3148 {
-			if yyj3148 >= l {
+	var yys3153Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3153Slc
+	var yyhl3153 bool = l >= 0
+	for yyj3153 := 0; ; yyj3153++ {
+		if yyhl3153 {
+			if yyj3153 >= l {
 				break
 			}
 		} else {
@@ -36501,28 +36538,28 @@ func (x *ResourceQuotaStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				break
 			}
 		}
-		yys3148Slc = r.DecodeBytes(yys3148Slc, true, true)
-		yys3148 := string(yys3148Slc)
-		switch yys3148 {
+		yys3153Slc = r.DecodeBytes(yys3153Slc, true, true)
+		yys3153 := string(yys3153Slc)
+		switch yys3153 {
 		case "hard":
 			if r.TryDecodeAsNil() {
 				x.Hard = nil
 			} else {
-				yyv3149 := &x.Hard
-				yyv3149.CodecDecodeSelf(d)
+				yyv3154 := &x.Hard
+				yyv3154.CodecDecodeSelf(d)
 			}
 		case "used":
 			if r.TryDecodeAsNil() {
 				x.Used = nil
 			} else {
-				yyv3150 := &x.Used
-				yyv3150.CodecDecodeSelf(d)
+				yyv3155 := &x.Used
+				yyv3155.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3148)
-		} // end switch yys3148
-	} // end for yyj3148
-	if !yyhl3148 {
+			z.DecStructFieldNotFound(-1, yys3153)
+		} // end switch yys3153
+	} // end for yyj3153
+	if !yyhl3153 {
 		r.ReadEnd()
 	}
 }
@@ -36531,52 +36568,52 @@ func (x *ResourceQuotaStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3151 int
-	var yyb3151 bool
-	var yyhl3151 bool = l >= 0
-	yyj3151++
-	if yyhl3151 {
-		yyb3151 = yyj3151 > l
+	var yyj3156 int
+	var yyb3156 bool
+	var yyhl3156 bool = l >= 0
+	yyj3156++
+	if yyhl3156 {
+		yyb3156 = yyj3156 > l
 	} else {
-		yyb3151 = r.CheckBreak()
+		yyb3156 = r.CheckBreak()
 	}
-	if yyb3151 {
+	if yyb3156 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Hard = nil
 	} else {
-		yyv3152 := &x.Hard
-		yyv3152.CodecDecodeSelf(d)
+		yyv3157 := &x.Hard
+		yyv3157.CodecDecodeSelf(d)
 	}
-	yyj3151++
-	if yyhl3151 {
-		yyb3151 = yyj3151 > l
+	yyj3156++
+	if yyhl3156 {
+		yyb3156 = yyj3156 > l
 	} else {
-		yyb3151 = r.CheckBreak()
+		yyb3156 = r.CheckBreak()
 	}
-	if yyb3151 {
+	if yyb3156 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Used = nil
 	} else {
-		yyv3153 := &x.Used
-		yyv3153.CodecDecodeSelf(d)
+		yyv3158 := &x.Used
+		yyv3158.CodecDecodeSelf(d)
 	}
 	for {
-		yyj3151++
-		if yyhl3151 {
-			yyb3151 = yyj3151 > l
+		yyj3156++
+		if yyhl3156 {
+			yyb3156 = yyj3156 > l
 		} else {
-			yyb3151 = r.CheckBreak()
+			yyb3156 = r.CheckBreak()
 		}
-		if yyb3151 {
+		if yyb3156 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3151-1, "")
+		z.DecStructFieldNotFound(yyj3156-1, "")
 	}
 	r.ReadEnd()
 }
@@ -36588,36 +36625,36 @@ func (x *ResourceQuota) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3154 := z.EncBinary()
-		_ = yym3154
+		yym3159 := z.EncBinary()
+		_ = yym3159
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3155 := !z.EncBinary()
-			yy2arr3155 := z.EncBasicHandle().StructToArray
-			var yyq3155 [5]bool
-			_, _, _ = yysep3155, yyq3155, yy2arr3155
-			const yyr3155 bool = false
-			yyq3155[0] = x.Kind != ""
-			yyq3155[1] = x.APIVersion != ""
-			yyq3155[2] = true
-			yyq3155[3] = true
-			yyq3155[4] = true
-			if yyr3155 || yy2arr3155 {
+			yysep3160 := !z.EncBinary()
+			yy2arr3160 := z.EncBasicHandle().StructToArray
+			var yyq3160 [5]bool
+			_, _, _ = yysep3160, yyq3160, yy2arr3160
+			const yyr3160 bool = false
+			yyq3160[0] = x.Kind != ""
+			yyq3160[1] = x.APIVersion != ""
+			yyq3160[2] = true
+			yyq3160[3] = true
+			yyq3160[4] = true
+			if yyr3160 || yy2arr3160 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn3155 int = 0
-				for _, b := range yyq3155 {
+				var yynn3160 int = 0
+				for _, b := range yyq3160 {
 					if b {
-						yynn3155++
+						yynn3160++
 					}
 				}
-				r.EncodeMapStart(yynn3155)
+				r.EncodeMapStart(yynn3160)
 			}
-			if yyr3155 || yy2arr3155 {
-				if yyq3155[0] {
-					yym3157 := z.EncBinary()
-					_ = yym3157
+			if yyr3160 || yy2arr3160 {
+				if yyq3160[0] {
+					yym3162 := z.EncBinary()
+					_ = yym3162
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -36626,20 +36663,20 @@ func (x *ResourceQuota) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3155[0] {
+				if yyq3160[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3158 := z.EncBinary()
-					_ = yym3158
+					yym3163 := z.EncBinary()
+					_ = yym3163
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr3155 || yy2arr3155 {
-				if yyq3155[1] {
-					yym3160 := z.EncBinary()
-					_ = yym3160
+			if yyr3160 || yy2arr3160 {
+				if yyq3160[1] {
+					yym3165 := z.EncBinary()
+					_ = yym3165
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -36648,59 +36685,59 @@ func (x *ResourceQuota) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3155[1] {
+				if yyq3160[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym3161 := z.EncBinary()
-					_ = yym3161
+					yym3166 := z.EncBinary()
+					_ = yym3166
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr3155 || yy2arr3155 {
-				if yyq3155[2] {
-					yy3163 := &x.ObjectMeta
-					yy3163.CodecEncodeSelf(e)
+			if yyr3160 || yy2arr3160 {
+				if yyq3160[2] {
+					yy3168 := &x.ObjectMeta
+					yy3168.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3155[2] {
+				if yyq3160[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3164 := &x.ObjectMeta
-					yy3164.CodecEncodeSelf(e)
-				}
-			}
-			if yyr3155 || yy2arr3155 {
-				if yyq3155[3] {
-					yy3166 := &x.Spec
-					yy3166.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq3155[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy3167 := &x.Spec
-					yy3167.CodecEncodeSelf(e)
-				}
-			}
-			if yyr3155 || yy2arr3155 {
-				if yyq3155[4] {
-					yy3169 := &x.Status
+					yy3169 := &x.ObjectMeta
 					yy3169.CodecEncodeSelf(e)
+				}
+			}
+			if yyr3160 || yy2arr3160 {
+				if yyq3160[3] {
+					yy3171 := &x.Spec
+					yy3171.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3155[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy3170 := &x.Status
-					yy3170.CodecEncodeSelf(e)
+				if yyq3160[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					yy3172 := &x.Spec
+					yy3172.CodecEncodeSelf(e)
 				}
 			}
-			if yysep3155 {
+			if yyr3160 || yy2arr3160 {
+				if yyq3160[4] {
+					yy3174 := &x.Status
+					yy3174.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq3160[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					yy3175 := &x.Status
+					yy3175.CodecEncodeSelf(e)
+				}
+			}
+			if yysep3160 {
 				r.EncodeEnd()
 			}
 		}
@@ -36711,24 +36748,24 @@ func (x *ResourceQuota) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3171 := z.DecBinary()
-	_ = yym3171
+	yym3176 := z.DecBinary()
+	_ = yym3176
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3172 := r.ReadMapStart()
-			if yyl3172 == 0 {
+			yyl3177 := r.ReadMapStart()
+			if yyl3177 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3172, d)
+				x.codecDecodeSelfFromMap(yyl3177, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3172 := r.ReadArrayStart()
-			if yyl3172 == 0 {
+			yyl3177 := r.ReadArrayStart()
+			if yyl3177 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3172, d)
+				x.codecDecodeSelfFromArray(yyl3177, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -36740,12 +36777,12 @@ func (x *ResourceQuota) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3173Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3173Slc
-	var yyhl3173 bool = l >= 0
-	for yyj3173 := 0; ; yyj3173++ {
-		if yyhl3173 {
-			if yyj3173 >= l {
+	var yys3178Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3178Slc
+	var yyhl3178 bool = l >= 0
+	for yyj3178 := 0; ; yyj3178++ {
+		if yyhl3178 {
+			if yyj3178 >= l {
 				break
 			}
 		} else {
@@ -36753,9 +36790,9 @@ func (x *ResourceQuota) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3173Slc = r.DecodeBytes(yys3173Slc, true, true)
-		yys3173 := string(yys3173Slc)
-		switch yys3173 {
+		yys3178Slc = r.DecodeBytes(yys3178Slc, true, true)
+		yys3178 := string(yys3178Slc)
+		switch yys3178 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -36772,28 +36809,28 @@ func (x *ResourceQuota) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv3176 := &x.ObjectMeta
-				yyv3176.CodecDecodeSelf(d)
+				yyv3181 := &x.ObjectMeta
+				yyv3181.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = ResourceQuotaSpec{}
 			} else {
-				yyv3177 := &x.Spec
-				yyv3177.CodecDecodeSelf(d)
+				yyv3182 := &x.Spec
+				yyv3182.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = ResourceQuotaStatus{}
 			} else {
-				yyv3178 := &x.Status
-				yyv3178.CodecDecodeSelf(d)
+				yyv3183 := &x.Status
+				yyv3183.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3173)
-		} // end switch yys3173
-	} // end for yyj3173
-	if !yyhl3173 {
+			z.DecStructFieldNotFound(-1, yys3178)
+		} // end switch yys3178
+	} // end for yyj3178
+	if !yyhl3178 {
 		r.ReadEnd()
 	}
 }
@@ -36802,16 +36839,16 @@ func (x *ResourceQuota) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3179 int
-	var yyb3179 bool
-	var yyhl3179 bool = l >= 0
-	yyj3179++
-	if yyhl3179 {
-		yyb3179 = yyj3179 > l
+	var yyj3184 int
+	var yyb3184 bool
+	var yyhl3184 bool = l >= 0
+	yyj3184++
+	if yyhl3184 {
+		yyb3184 = yyj3184 > l
 	} else {
-		yyb3179 = r.CheckBreak()
+		yyb3184 = r.CheckBreak()
 	}
-	if yyb3179 {
+	if yyb3184 {
 		r.ReadEnd()
 		return
 	}
@@ -36820,13 +36857,13 @@ func (x *ResourceQuota) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3179++
-	if yyhl3179 {
-		yyb3179 = yyj3179 > l
+	yyj3184++
+	if yyhl3184 {
+		yyb3184 = yyj3184 > l
 	} else {
-		yyb3179 = r.CheckBreak()
+		yyb3184 = r.CheckBreak()
 	}
-	if yyb3179 {
+	if yyb3184 {
 		r.ReadEnd()
 		return
 	}
@@ -36835,65 +36872,65 @@ func (x *ResourceQuota) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3179++
-	if yyhl3179 {
-		yyb3179 = yyj3179 > l
+	yyj3184++
+	if yyhl3184 {
+		yyb3184 = yyj3184 > l
 	} else {
-		yyb3179 = r.CheckBreak()
+		yyb3184 = r.CheckBreak()
 	}
-	if yyb3179 {
+	if yyb3184 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv3182 := &x.ObjectMeta
-		yyv3182.CodecDecodeSelf(d)
+		yyv3187 := &x.ObjectMeta
+		yyv3187.CodecDecodeSelf(d)
 	}
-	yyj3179++
-	if yyhl3179 {
-		yyb3179 = yyj3179 > l
+	yyj3184++
+	if yyhl3184 {
+		yyb3184 = yyj3184 > l
 	} else {
-		yyb3179 = r.CheckBreak()
+		yyb3184 = r.CheckBreak()
 	}
-	if yyb3179 {
+	if yyb3184 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = ResourceQuotaSpec{}
 	} else {
-		yyv3183 := &x.Spec
-		yyv3183.CodecDecodeSelf(d)
+		yyv3188 := &x.Spec
+		yyv3188.CodecDecodeSelf(d)
 	}
-	yyj3179++
-	if yyhl3179 {
-		yyb3179 = yyj3179 > l
+	yyj3184++
+	if yyhl3184 {
+		yyb3184 = yyj3184 > l
 	} else {
-		yyb3179 = r.CheckBreak()
+		yyb3184 = r.CheckBreak()
 	}
-	if yyb3179 {
+	if yyb3184 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = ResourceQuotaStatus{}
 	} else {
-		yyv3184 := &x.Status
-		yyv3184.CodecDecodeSelf(d)
+		yyv3189 := &x.Status
+		yyv3189.CodecDecodeSelf(d)
 	}
 	for {
-		yyj3179++
-		if yyhl3179 {
-			yyb3179 = yyj3179 > l
+		yyj3184++
+		if yyhl3184 {
+			yyb3184 = yyj3184 > l
 		} else {
-			yyb3179 = r.CheckBreak()
+			yyb3184 = r.CheckBreak()
 		}
-		if yyb3179 {
+		if yyb3184 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3179-1, "")
+		z.DecStructFieldNotFound(yyj3184-1, "")
 	}
 	r.ReadEnd()
 }
@@ -36905,34 +36942,34 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3185 := z.EncBinary()
-		_ = yym3185
+		yym3190 := z.EncBinary()
+		_ = yym3190
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3186 := !z.EncBinary()
-			yy2arr3186 := z.EncBasicHandle().StructToArray
-			var yyq3186 [4]bool
-			_, _, _ = yysep3186, yyq3186, yy2arr3186
-			const yyr3186 bool = false
-			yyq3186[0] = x.Kind != ""
-			yyq3186[1] = x.APIVersion != ""
-			yyq3186[2] = true
-			if yyr3186 || yy2arr3186 {
+			yysep3191 := !z.EncBinary()
+			yy2arr3191 := z.EncBasicHandle().StructToArray
+			var yyq3191 [4]bool
+			_, _, _ = yysep3191, yyq3191, yy2arr3191
+			const yyr3191 bool = false
+			yyq3191[0] = x.Kind != ""
+			yyq3191[1] = x.APIVersion != ""
+			yyq3191[2] = true
+			if yyr3191 || yy2arr3191 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3186 int = 1
-				for _, b := range yyq3186 {
+				var yynn3191 int = 1
+				for _, b := range yyq3191 {
 					if b {
-						yynn3186++
+						yynn3191++
 					}
 				}
-				r.EncodeMapStart(yynn3186)
+				r.EncodeMapStart(yynn3191)
 			}
-			if yyr3186 || yy2arr3186 {
-				if yyq3186[0] {
-					yym3188 := z.EncBinary()
-					_ = yym3188
+			if yyr3191 || yy2arr3191 {
+				if yyq3191[0] {
+					yym3193 := z.EncBinary()
+					_ = yym3193
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -36941,20 +36978,20 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3186[0] {
+				if yyq3191[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3189 := z.EncBinary()
-					_ = yym3189
+					yym3194 := z.EncBinary()
+					_ = yym3194
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr3186 || yy2arr3186 {
-				if yyq3186[1] {
-					yym3191 := z.EncBinary()
-					_ = yym3191
+			if yyr3191 || yy2arr3191 {
+				if yyq3191[1] {
+					yym3196 := z.EncBinary()
+					_ = yym3196
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -36963,48 +37000,48 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3186[1] {
+				if yyq3191[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym3192 := z.EncBinary()
-					_ = yym3192
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3186 || yy2arr3186 {
-				if yyq3186[2] {
-					yy3194 := &x.ListMeta
-					yym3195 := z.EncBinary()
-					_ = yym3195
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3194) {
-					} else {
-						z.EncFallback(yy3194)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq3186[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3196 := &x.ListMeta
 					yym3197 := z.EncBinary()
 					_ = yym3197
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3196) {
 					} else {
-						z.EncFallback(yy3196)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr3186 || yy2arr3186 {
+			if yyr3191 || yy2arr3191 {
+				if yyq3191[2] {
+					yy3199 := &x.ListMeta
+					yym3200 := z.EncBinary()
+					_ = yym3200
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3199) {
+					} else {
+						z.EncFallback(yy3199)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq3191[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy3201 := &x.ListMeta
+					yym3202 := z.EncBinary()
+					_ = yym3202
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3201) {
+					} else {
+						z.EncFallback(yy3201)
+					}
+				}
+			}
+			if yyr3191 || yy2arr3191 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3199 := z.EncBinary()
-					_ = yym3199
+					yym3204 := z.EncBinary()
+					_ = yym3204
 					if false {
 					} else {
 						h.encSliceResourceQuota(([]ResourceQuota)(x.Items), e)
@@ -37015,15 +37052,15 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3200 := z.EncBinary()
-					_ = yym3200
+					yym3205 := z.EncBinary()
+					_ = yym3205
 					if false {
 					} else {
 						h.encSliceResourceQuota(([]ResourceQuota)(x.Items), e)
 					}
 				}
 			}
-			if yysep3186 {
+			if yysep3191 {
 				r.EncodeEnd()
 			}
 		}
@@ -37034,24 +37071,24 @@ func (x *ResourceQuotaList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3201 := z.DecBinary()
-	_ = yym3201
+	yym3206 := z.DecBinary()
+	_ = yym3206
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3202 := r.ReadMapStart()
-			if yyl3202 == 0 {
+			yyl3207 := r.ReadMapStart()
+			if yyl3207 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3202, d)
+				x.codecDecodeSelfFromMap(yyl3207, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3202 := r.ReadArrayStart()
-			if yyl3202 == 0 {
+			yyl3207 := r.ReadArrayStart()
+			if yyl3207 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3202, d)
+				x.codecDecodeSelfFromArray(yyl3207, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -37063,12 +37100,12 @@ func (x *ResourceQuotaList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3203Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3203Slc
-	var yyhl3203 bool = l >= 0
-	for yyj3203 := 0; ; yyj3203++ {
-		if yyhl3203 {
-			if yyj3203 >= l {
+	var yys3208Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3208Slc
+	var yyhl3208 bool = l >= 0
+	for yyj3208 := 0; ; yyj3208++ {
+		if yyhl3208 {
+			if yyj3208 >= l {
 				break
 			}
 		} else {
@@ -37076,9 +37113,9 @@ func (x *ResourceQuotaList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				break
 			}
 		}
-		yys3203Slc = r.DecodeBytes(yys3203Slc, true, true)
-		yys3203 := string(yys3203Slc)
-		switch yys3203 {
+		yys3208Slc = r.DecodeBytes(yys3208Slc, true, true)
+		yys3208 := string(yys3208Slc)
+		switch yys3208 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -37095,32 +37132,32 @@ func (x *ResourceQuotaList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv3206 := &x.ListMeta
-				yym3207 := z.DecBinary()
-				_ = yym3207
+				yyv3211 := &x.ListMeta
+				yym3212 := z.DecBinary()
+				_ = yym3212
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3206) {
+				} else if z.HasExtensions() && z.DecExt(yyv3211) {
 				} else {
-					z.DecFallback(yyv3206, false)
+					z.DecFallback(yyv3211, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv3208 := &x.Items
-				yym3209 := z.DecBinary()
-				_ = yym3209
+				yyv3213 := &x.Items
+				yym3214 := z.DecBinary()
+				_ = yym3214
 				if false {
 				} else {
-					h.decSliceResourceQuota((*[]ResourceQuota)(yyv3208), d)
+					h.decSliceResourceQuota((*[]ResourceQuota)(yyv3213), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3203)
-		} // end switch yys3203
-	} // end for yyj3203
-	if !yyhl3203 {
+			z.DecStructFieldNotFound(-1, yys3208)
+		} // end switch yys3208
+	} // end for yyj3208
+	if !yyhl3208 {
 		r.ReadEnd()
 	}
 }
@@ -37129,16 +37166,16 @@ func (x *ResourceQuotaList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3210 int
-	var yyb3210 bool
-	var yyhl3210 bool = l >= 0
-	yyj3210++
-	if yyhl3210 {
-		yyb3210 = yyj3210 > l
+	var yyj3215 int
+	var yyb3215 bool
+	var yyhl3215 bool = l >= 0
+	yyj3215++
+	if yyhl3215 {
+		yyb3215 = yyj3215 > l
 	} else {
-		yyb3210 = r.CheckBreak()
+		yyb3215 = r.CheckBreak()
 	}
-	if yyb3210 {
+	if yyb3215 {
 		r.ReadEnd()
 		return
 	}
@@ -37147,13 +37184,13 @@ func (x *ResourceQuotaList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3210++
-	if yyhl3210 {
-		yyb3210 = yyj3210 > l
+	yyj3215++
+	if yyhl3215 {
+		yyb3215 = yyj3215 > l
 	} else {
-		yyb3210 = r.CheckBreak()
+		yyb3215 = r.CheckBreak()
 	}
-	if yyb3210 {
+	if yyb3215 {
 		r.ReadEnd()
 		return
 	}
@@ -37162,60 +37199,60 @@ func (x *ResourceQuotaList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3210++
-	if yyhl3210 {
-		yyb3210 = yyj3210 > l
+	yyj3215++
+	if yyhl3215 {
+		yyb3215 = yyj3215 > l
 	} else {
-		yyb3210 = r.CheckBreak()
+		yyb3215 = r.CheckBreak()
 	}
-	if yyb3210 {
+	if yyb3215 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv3213 := &x.ListMeta
-		yym3214 := z.DecBinary()
-		_ = yym3214
+		yyv3218 := &x.ListMeta
+		yym3219 := z.DecBinary()
+		_ = yym3219
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3213) {
+		} else if z.HasExtensions() && z.DecExt(yyv3218) {
 		} else {
-			z.DecFallback(yyv3213, false)
+			z.DecFallback(yyv3218, false)
 		}
 	}
-	yyj3210++
-	if yyhl3210 {
-		yyb3210 = yyj3210 > l
+	yyj3215++
+	if yyhl3215 {
+		yyb3215 = yyj3215 > l
 	} else {
-		yyb3210 = r.CheckBreak()
+		yyb3215 = r.CheckBreak()
 	}
-	if yyb3210 {
+	if yyb3215 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv3215 := &x.Items
-		yym3216 := z.DecBinary()
-		_ = yym3216
+		yyv3220 := &x.Items
+		yym3221 := z.DecBinary()
+		_ = yym3221
 		if false {
 		} else {
-			h.decSliceResourceQuota((*[]ResourceQuota)(yyv3215), d)
+			h.decSliceResourceQuota((*[]ResourceQuota)(yyv3220), d)
 		}
 	}
 	for {
-		yyj3210++
-		if yyhl3210 {
-			yyb3210 = yyj3210 > l
+		yyj3215++
+		if yyhl3215 {
+			yyb3215 = yyj3215 > l
 		} else {
-			yyb3210 = r.CheckBreak()
+			yyb3215 = r.CheckBreak()
 		}
-		if yyb3210 {
+		if yyb3215 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3210-1, "")
+		z.DecStructFieldNotFound(yyj3215-1, "")
 	}
 	r.ReadEnd()
 }
@@ -37227,36 +37264,36 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3217 := z.EncBinary()
-		_ = yym3217
+		yym3222 := z.EncBinary()
+		_ = yym3222
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3218 := !z.EncBinary()
-			yy2arr3218 := z.EncBasicHandle().StructToArray
-			var yyq3218 [5]bool
-			_, _, _ = yysep3218, yyq3218, yy2arr3218
-			const yyr3218 bool = false
-			yyq3218[0] = x.Kind != ""
-			yyq3218[1] = x.APIVersion != ""
-			yyq3218[2] = true
-			yyq3218[3] = len(x.Data) != 0
-			yyq3218[4] = x.Type != ""
-			if yyr3218 || yy2arr3218 {
+			yysep3223 := !z.EncBinary()
+			yy2arr3223 := z.EncBasicHandle().StructToArray
+			var yyq3223 [5]bool
+			_, _, _ = yysep3223, yyq3223, yy2arr3223
+			const yyr3223 bool = false
+			yyq3223[0] = x.Kind != ""
+			yyq3223[1] = x.APIVersion != ""
+			yyq3223[2] = true
+			yyq3223[3] = len(x.Data) != 0
+			yyq3223[4] = x.Type != ""
+			if yyr3223 || yy2arr3223 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn3218 int = 0
-				for _, b := range yyq3218 {
+				var yynn3223 int = 0
+				for _, b := range yyq3223 {
 					if b {
-						yynn3218++
+						yynn3223++
 					}
 				}
-				r.EncodeMapStart(yynn3218)
+				r.EncodeMapStart(yynn3223)
 			}
-			if yyr3218 || yy2arr3218 {
-				if yyq3218[0] {
-					yym3220 := z.EncBinary()
-					_ = yym3220
+			if yyr3223 || yy2arr3223 {
+				if yyq3223[0] {
+					yym3225 := z.EncBinary()
+					_ = yym3225
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -37265,20 +37302,20 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3218[0] {
+				if yyq3223[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3221 := z.EncBinary()
-					_ = yym3221
+					yym3226 := z.EncBinary()
+					_ = yym3226
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr3218 || yy2arr3218 {
-				if yyq3218[1] {
-					yym3223 := z.EncBinary()
-					_ = yym3223
+			if yyr3223 || yy2arr3223 {
+				if yyq3223[1] {
+					yym3228 := z.EncBinary()
+					_ = yym3228
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -37287,37 +37324,37 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3218[1] {
+				if yyq3223[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym3224 := z.EncBinary()
-					_ = yym3224
+					yym3229 := z.EncBinary()
+					_ = yym3229
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr3218 || yy2arr3218 {
-				if yyq3218[2] {
-					yy3226 := &x.ObjectMeta
-					yy3226.CodecEncodeSelf(e)
+			if yyr3223 || yy2arr3223 {
+				if yyq3223[2] {
+					yy3231 := &x.ObjectMeta
+					yy3231.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3218[2] {
+				if yyq3223[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3227 := &x.ObjectMeta
-					yy3227.CodecEncodeSelf(e)
+					yy3232 := &x.ObjectMeta
+					yy3232.CodecEncodeSelf(e)
 				}
 			}
-			if yyr3218 || yy2arr3218 {
-				if yyq3218[3] {
+			if yyr3223 || yy2arr3223 {
+				if yyq3223[3] {
 					if x.Data == nil {
 						r.EncodeNil()
 					} else {
-						yym3229 := z.EncBinary()
-						_ = yym3229
+						yym3234 := z.EncBinary()
+						_ = yym3234
 						if false {
 						} else {
 							h.encMapstringSliceuint8((map[string][]uint8)(x.Data), e)
@@ -37327,13 +37364,13 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3218[3] {
+				if yyq3223[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("data"))
 					if x.Data == nil {
 						r.EncodeNil()
 					} else {
-						yym3230 := z.EncBinary()
-						_ = yym3230
+						yym3235 := z.EncBinary()
+						_ = yym3235
 						if false {
 						} else {
 							h.encMapstringSliceuint8((map[string][]uint8)(x.Data), e)
@@ -37341,19 +37378,19 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr3218 || yy2arr3218 {
-				if yyq3218[4] {
+			if yyr3223 || yy2arr3223 {
+				if yyq3223[4] {
 					x.Type.CodecEncodeSelf(e)
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3218[4] {
+				if yyq3223[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("type"))
 					x.Type.CodecEncodeSelf(e)
 				}
 			}
-			if yysep3218 {
+			if yysep3223 {
 				r.EncodeEnd()
 			}
 		}
@@ -37364,24 +37401,24 @@ func (x *Secret) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3232 := z.DecBinary()
-	_ = yym3232
+	yym3237 := z.DecBinary()
+	_ = yym3237
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3233 := r.ReadMapStart()
-			if yyl3233 == 0 {
+			yyl3238 := r.ReadMapStart()
+			if yyl3238 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3233, d)
+				x.codecDecodeSelfFromMap(yyl3238, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3233 := r.ReadArrayStart()
-			if yyl3233 == 0 {
+			yyl3238 := r.ReadArrayStart()
+			if yyl3238 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3233, d)
+				x.codecDecodeSelfFromArray(yyl3238, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -37393,12 +37430,12 @@ func (x *Secret) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3234Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3234Slc
-	var yyhl3234 bool = l >= 0
-	for yyj3234 := 0; ; yyj3234++ {
-		if yyhl3234 {
-			if yyj3234 >= l {
+	var yys3239Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3239Slc
+	var yyhl3239 bool = l >= 0
+	for yyj3239 := 0; ; yyj3239++ {
+		if yyhl3239 {
+			if yyj3239 >= l {
 				break
 			}
 		} else {
@@ -37406,9 +37443,9 @@ func (x *Secret) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3234Slc = r.DecodeBytes(yys3234Slc, true, true)
-		yys3234 := string(yys3234Slc)
-		switch yys3234 {
+		yys3239Slc = r.DecodeBytes(yys3239Slc, true, true)
+		yys3239 := string(yys3239Slc)
+		switch yys3239 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -37425,19 +37462,19 @@ func (x *Secret) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv3237 := &x.ObjectMeta
-				yyv3237.CodecDecodeSelf(d)
+				yyv3242 := &x.ObjectMeta
+				yyv3242.CodecDecodeSelf(d)
 			}
 		case "data":
 			if r.TryDecodeAsNil() {
 				x.Data = nil
 			} else {
-				yyv3238 := &x.Data
-				yym3239 := z.DecBinary()
-				_ = yym3239
+				yyv3243 := &x.Data
+				yym3244 := z.DecBinary()
+				_ = yym3244
 				if false {
 				} else {
-					h.decMapstringSliceuint8((*map[string][]uint8)(yyv3238), d)
+					h.decMapstringSliceuint8((*map[string][]uint8)(yyv3243), d)
 				}
 			}
 		case "type":
@@ -37447,10 +37484,10 @@ func (x *Secret) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Type = SecretType(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3234)
-		} // end switch yys3234
-	} // end for yyj3234
-	if !yyhl3234 {
+			z.DecStructFieldNotFound(-1, yys3239)
+		} // end switch yys3239
+	} // end for yyj3239
+	if !yyhl3239 {
 		r.ReadEnd()
 	}
 }
@@ -37459,16 +37496,16 @@ func (x *Secret) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3241 int
-	var yyb3241 bool
-	var yyhl3241 bool = l >= 0
-	yyj3241++
-	if yyhl3241 {
-		yyb3241 = yyj3241 > l
+	var yyj3246 int
+	var yyb3246 bool
+	var yyhl3246 bool = l >= 0
+	yyj3246++
+	if yyhl3246 {
+		yyb3246 = yyj3246 > l
 	} else {
-		yyb3241 = r.CheckBreak()
+		yyb3246 = r.CheckBreak()
 	}
-	if yyb3241 {
+	if yyb3246 {
 		r.ReadEnd()
 		return
 	}
@@ -37477,13 +37514,13 @@ func (x *Secret) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3241++
-	if yyhl3241 {
-		yyb3241 = yyj3241 > l
+	yyj3246++
+	if yyhl3246 {
+		yyb3246 = yyj3246 > l
 	} else {
-		yyb3241 = r.CheckBreak()
+		yyb3246 = r.CheckBreak()
 	}
-	if yyb3241 {
+	if yyb3246 {
 		r.ReadEnd()
 		return
 	}
@@ -37492,50 +37529,50 @@ func (x *Secret) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3241++
-	if yyhl3241 {
-		yyb3241 = yyj3241 > l
+	yyj3246++
+	if yyhl3246 {
+		yyb3246 = yyj3246 > l
 	} else {
-		yyb3241 = r.CheckBreak()
+		yyb3246 = r.CheckBreak()
 	}
-	if yyb3241 {
+	if yyb3246 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv3244 := &x.ObjectMeta
-		yyv3244.CodecDecodeSelf(d)
+		yyv3249 := &x.ObjectMeta
+		yyv3249.CodecDecodeSelf(d)
 	}
-	yyj3241++
-	if yyhl3241 {
-		yyb3241 = yyj3241 > l
+	yyj3246++
+	if yyhl3246 {
+		yyb3246 = yyj3246 > l
 	} else {
-		yyb3241 = r.CheckBreak()
+		yyb3246 = r.CheckBreak()
 	}
-	if yyb3241 {
+	if yyb3246 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Data = nil
 	} else {
-		yyv3245 := &x.Data
-		yym3246 := z.DecBinary()
-		_ = yym3246
+		yyv3250 := &x.Data
+		yym3251 := z.DecBinary()
+		_ = yym3251
 		if false {
 		} else {
-			h.decMapstringSliceuint8((*map[string][]uint8)(yyv3245), d)
+			h.decMapstringSliceuint8((*map[string][]uint8)(yyv3250), d)
 		}
 	}
-	yyj3241++
-	if yyhl3241 {
-		yyb3241 = yyj3241 > l
+	yyj3246++
+	if yyhl3246 {
+		yyb3246 = yyj3246 > l
 	} else {
-		yyb3241 = r.CheckBreak()
+		yyb3246 = r.CheckBreak()
 	}
-	if yyb3241 {
+	if yyb3246 {
 		r.ReadEnd()
 		return
 	}
@@ -37545,16 +37582,16 @@ func (x *Secret) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Type = SecretType(r.DecodeString())
 	}
 	for {
-		yyj3241++
-		if yyhl3241 {
-			yyb3241 = yyj3241 > l
+		yyj3246++
+		if yyhl3246 {
+			yyb3246 = yyj3246 > l
 		} else {
-			yyb3241 = r.CheckBreak()
+			yyb3246 = r.CheckBreak()
 		}
-		if yyb3241 {
+		if yyb3246 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3241-1, "")
+		z.DecStructFieldNotFound(yyj3246-1, "")
 	}
 	r.ReadEnd()
 }
@@ -37563,8 +37600,8 @@ func (x SecretType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym3248 := z.EncBinary()
-	_ = yym3248
+	yym3253 := z.EncBinary()
+	_ = yym3253
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -37576,8 +37613,8 @@ func (x *SecretType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3249 := z.DecBinary()
-	_ = yym3249
+	yym3254 := z.DecBinary()
+	_ = yym3254
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -37592,34 +37629,34 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3250 := z.EncBinary()
-		_ = yym3250
+		yym3255 := z.EncBinary()
+		_ = yym3255
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3251 := !z.EncBinary()
-			yy2arr3251 := z.EncBasicHandle().StructToArray
-			var yyq3251 [4]bool
-			_, _, _ = yysep3251, yyq3251, yy2arr3251
-			const yyr3251 bool = false
-			yyq3251[0] = x.Kind != ""
-			yyq3251[1] = x.APIVersion != ""
-			yyq3251[2] = true
-			if yyr3251 || yy2arr3251 {
+			yysep3256 := !z.EncBinary()
+			yy2arr3256 := z.EncBasicHandle().StructToArray
+			var yyq3256 [4]bool
+			_, _, _ = yysep3256, yyq3256, yy2arr3256
+			const yyr3256 bool = false
+			yyq3256[0] = x.Kind != ""
+			yyq3256[1] = x.APIVersion != ""
+			yyq3256[2] = true
+			if yyr3256 || yy2arr3256 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3251 int = 1
-				for _, b := range yyq3251 {
+				var yynn3256 int = 1
+				for _, b := range yyq3256 {
 					if b {
-						yynn3251++
+						yynn3256++
 					}
 				}
-				r.EncodeMapStart(yynn3251)
+				r.EncodeMapStart(yynn3256)
 			}
-			if yyr3251 || yy2arr3251 {
-				if yyq3251[0] {
-					yym3253 := z.EncBinary()
-					_ = yym3253
+			if yyr3256 || yy2arr3256 {
+				if yyq3256[0] {
+					yym3258 := z.EncBinary()
+					_ = yym3258
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -37628,20 +37665,20 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3251[0] {
+				if yyq3256[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3254 := z.EncBinary()
-					_ = yym3254
+					yym3259 := z.EncBinary()
+					_ = yym3259
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr3251 || yy2arr3251 {
-				if yyq3251[1] {
-					yym3256 := z.EncBinary()
-					_ = yym3256
+			if yyr3256 || yy2arr3256 {
+				if yyq3256[1] {
+					yym3261 := z.EncBinary()
+					_ = yym3261
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -37650,48 +37687,48 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3251[1] {
+				if yyq3256[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym3257 := z.EncBinary()
-					_ = yym3257
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3251 || yy2arr3251 {
-				if yyq3251[2] {
-					yy3259 := &x.ListMeta
-					yym3260 := z.EncBinary()
-					_ = yym3260
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3259) {
-					} else {
-						z.EncFallback(yy3259)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq3251[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3261 := &x.ListMeta
 					yym3262 := z.EncBinary()
 					_ = yym3262
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3261) {
 					} else {
-						z.EncFallback(yy3261)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr3251 || yy2arr3251 {
+			if yyr3256 || yy2arr3256 {
+				if yyq3256[2] {
+					yy3264 := &x.ListMeta
+					yym3265 := z.EncBinary()
+					_ = yym3265
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3264) {
+					} else {
+						z.EncFallback(yy3264)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq3256[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy3266 := &x.ListMeta
+					yym3267 := z.EncBinary()
+					_ = yym3267
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3266) {
+					} else {
+						z.EncFallback(yy3266)
+					}
+				}
+			}
+			if yyr3256 || yy2arr3256 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3264 := z.EncBinary()
-					_ = yym3264
+					yym3269 := z.EncBinary()
+					_ = yym3269
 					if false {
 					} else {
 						h.encSliceSecret(([]Secret)(x.Items), e)
@@ -37702,15 +37739,15 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3265 := z.EncBinary()
-					_ = yym3265
+					yym3270 := z.EncBinary()
+					_ = yym3270
 					if false {
 					} else {
 						h.encSliceSecret(([]Secret)(x.Items), e)
 					}
 				}
 			}
-			if yysep3251 {
+			if yysep3256 {
 				r.EncodeEnd()
 			}
 		}
@@ -37721,24 +37758,24 @@ func (x *SecretList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3266 := z.DecBinary()
-	_ = yym3266
+	yym3271 := z.DecBinary()
+	_ = yym3271
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3267 := r.ReadMapStart()
-			if yyl3267 == 0 {
+			yyl3272 := r.ReadMapStart()
+			if yyl3272 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3267, d)
+				x.codecDecodeSelfFromMap(yyl3272, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3267 := r.ReadArrayStart()
-			if yyl3267 == 0 {
+			yyl3272 := r.ReadArrayStart()
+			if yyl3272 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3267, d)
+				x.codecDecodeSelfFromArray(yyl3272, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -37750,12 +37787,12 @@ func (x *SecretList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3268Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3268Slc
-	var yyhl3268 bool = l >= 0
-	for yyj3268 := 0; ; yyj3268++ {
-		if yyhl3268 {
-			if yyj3268 >= l {
+	var yys3273Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3273Slc
+	var yyhl3273 bool = l >= 0
+	for yyj3273 := 0; ; yyj3273++ {
+		if yyhl3273 {
+			if yyj3273 >= l {
 				break
 			}
 		} else {
@@ -37763,9 +37800,9 @@ func (x *SecretList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3268Slc = r.DecodeBytes(yys3268Slc, true, true)
-		yys3268 := string(yys3268Slc)
-		switch yys3268 {
+		yys3273Slc = r.DecodeBytes(yys3273Slc, true, true)
+		yys3273 := string(yys3273Slc)
+		switch yys3273 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -37782,32 +37819,32 @@ func (x *SecretList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv3271 := &x.ListMeta
-				yym3272 := z.DecBinary()
-				_ = yym3272
+				yyv3276 := &x.ListMeta
+				yym3277 := z.DecBinary()
+				_ = yym3277
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3271) {
+				} else if z.HasExtensions() && z.DecExt(yyv3276) {
 				} else {
-					z.DecFallback(yyv3271, false)
+					z.DecFallback(yyv3276, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv3273 := &x.Items
-				yym3274 := z.DecBinary()
-				_ = yym3274
+				yyv3278 := &x.Items
+				yym3279 := z.DecBinary()
+				_ = yym3279
 				if false {
 				} else {
-					h.decSliceSecret((*[]Secret)(yyv3273), d)
+					h.decSliceSecret((*[]Secret)(yyv3278), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3268)
-		} // end switch yys3268
-	} // end for yyj3268
-	if !yyhl3268 {
+			z.DecStructFieldNotFound(-1, yys3273)
+		} // end switch yys3273
+	} // end for yyj3273
+	if !yyhl3273 {
 		r.ReadEnd()
 	}
 }
@@ -37816,16 +37853,16 @@ func (x *SecretList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3275 int
-	var yyb3275 bool
-	var yyhl3275 bool = l >= 0
-	yyj3275++
-	if yyhl3275 {
-		yyb3275 = yyj3275 > l
+	var yyj3280 int
+	var yyb3280 bool
+	var yyhl3280 bool = l >= 0
+	yyj3280++
+	if yyhl3280 {
+		yyb3280 = yyj3280 > l
 	} else {
-		yyb3275 = r.CheckBreak()
+		yyb3280 = r.CheckBreak()
 	}
-	if yyb3275 {
+	if yyb3280 {
 		r.ReadEnd()
 		return
 	}
@@ -37834,13 +37871,13 @@ func (x *SecretList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3275++
-	if yyhl3275 {
-		yyb3275 = yyj3275 > l
+	yyj3280++
+	if yyhl3280 {
+		yyb3280 = yyj3280 > l
 	} else {
-		yyb3275 = r.CheckBreak()
+		yyb3280 = r.CheckBreak()
 	}
-	if yyb3275 {
+	if yyb3280 {
 		r.ReadEnd()
 		return
 	}
@@ -37849,60 +37886,60 @@ func (x *SecretList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3275++
-	if yyhl3275 {
-		yyb3275 = yyj3275 > l
+	yyj3280++
+	if yyhl3280 {
+		yyb3280 = yyj3280 > l
 	} else {
-		yyb3275 = r.CheckBreak()
+		yyb3280 = r.CheckBreak()
 	}
-	if yyb3275 {
+	if yyb3280 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv3278 := &x.ListMeta
-		yym3279 := z.DecBinary()
-		_ = yym3279
+		yyv3283 := &x.ListMeta
+		yym3284 := z.DecBinary()
+		_ = yym3284
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3278) {
+		} else if z.HasExtensions() && z.DecExt(yyv3283) {
 		} else {
-			z.DecFallback(yyv3278, false)
+			z.DecFallback(yyv3283, false)
 		}
 	}
-	yyj3275++
-	if yyhl3275 {
-		yyb3275 = yyj3275 > l
+	yyj3280++
+	if yyhl3280 {
+		yyb3280 = yyj3280 > l
 	} else {
-		yyb3275 = r.CheckBreak()
+		yyb3280 = r.CheckBreak()
 	}
-	if yyb3275 {
+	if yyb3280 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv3280 := &x.Items
-		yym3281 := z.DecBinary()
-		_ = yym3281
+		yyv3285 := &x.Items
+		yym3286 := z.DecBinary()
+		_ = yym3286
 		if false {
 		} else {
-			h.decSliceSecret((*[]Secret)(yyv3280), d)
+			h.decSliceSecret((*[]Secret)(yyv3285), d)
 		}
 	}
 	for {
-		yyj3275++
-		if yyhl3275 {
-			yyb3275 = yyj3275 > l
+		yyj3280++
+		if yyhl3280 {
+			yyb3280 = yyj3280 > l
 		} else {
-			yyb3275 = r.CheckBreak()
+			yyb3280 = r.CheckBreak()
 		}
-		if yyb3275 {
+		if yyb3280 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3275-1, "")
+		z.DecStructFieldNotFound(yyj3280-1, "")
 	}
 	r.ReadEnd()
 }
@@ -37911,8 +37948,8 @@ func (x PatchType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym3282 := z.EncBinary()
-	_ = yym3282
+	yym3287 := z.EncBinary()
+	_ = yym3287
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -37924,8 +37961,8 @@ func (x *PatchType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3283 := z.DecBinary()
-	_ = yym3283
+	yym3288 := z.DecBinary()
+	_ = yym3288
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -37937,8 +37974,8 @@ func (x ComponentConditionType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym3284 := z.EncBinary()
-	_ = yym3284
+	yym3289 := z.EncBinary()
+	_ = yym3289
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -37950,8 +37987,8 @@ func (x *ComponentConditionType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3285 := z.DecBinary()
-	_ = yym3285
+	yym3290 := z.DecBinary()
+	_ = yym3290
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -37966,45 +38003,45 @@ func (x *ComponentCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3286 := z.EncBinary()
-		_ = yym3286
+		yym3291 := z.EncBinary()
+		_ = yym3291
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3287 := !z.EncBinary()
-			yy2arr3287 := z.EncBasicHandle().StructToArray
-			var yyq3287 [4]bool
-			_, _, _ = yysep3287, yyq3287, yy2arr3287
-			const yyr3287 bool = false
-			yyq3287[2] = x.Message != ""
-			yyq3287[3] = x.Error != ""
-			if yyr3287 || yy2arr3287 {
+			yysep3292 := !z.EncBinary()
+			yy2arr3292 := z.EncBasicHandle().StructToArray
+			var yyq3292 [4]bool
+			_, _, _ = yysep3292, yyq3292, yy2arr3292
+			const yyr3292 bool = false
+			yyq3292[2] = x.Message != ""
+			yyq3292[3] = x.Error != ""
+			if yyr3292 || yy2arr3292 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3287 int = 2
-				for _, b := range yyq3287 {
+				var yynn3292 int = 2
+				for _, b := range yyq3292 {
 					if b {
-						yynn3287++
+						yynn3292++
 					}
 				}
-				r.EncodeMapStart(yynn3287)
+				r.EncodeMapStart(yynn3292)
 			}
-			if yyr3287 || yy2arr3287 {
+			if yyr3292 || yy2arr3292 {
 				x.Type.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("type"))
 				x.Type.CodecEncodeSelf(e)
 			}
-			if yyr3287 || yy2arr3287 {
+			if yyr3292 || yy2arr3292 {
 				x.Status.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("status"))
 				x.Status.CodecEncodeSelf(e)
 			}
-			if yyr3287 || yy2arr3287 {
-				if yyq3287[2] {
-					yym3291 := z.EncBinary()
-					_ = yym3291
+			if yyr3292 || yy2arr3292 {
+				if yyq3292[2] {
+					yym3296 := z.EncBinary()
+					_ = yym3296
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
@@ -38013,20 +38050,20 @@ func (x *ComponentCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3287[2] {
+				if yyq3292[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
-					yym3292 := z.EncBinary()
-					_ = yym3292
+					yym3297 := z.EncBinary()
+					_ = yym3297
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
 					}
 				}
 			}
-			if yyr3287 || yy2arr3287 {
-				if yyq3287[3] {
-					yym3294 := z.EncBinary()
-					_ = yym3294
+			if yyr3292 || yy2arr3292 {
+				if yyq3292[3] {
+					yym3299 := z.EncBinary()
+					_ = yym3299
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Error))
@@ -38035,17 +38072,17 @@ func (x *ComponentCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3287[3] {
+				if yyq3292[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("error"))
-					yym3295 := z.EncBinary()
-					_ = yym3295
+					yym3300 := z.EncBinary()
+					_ = yym3300
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Error))
 					}
 				}
 			}
-			if yysep3287 {
+			if yysep3292 {
 				r.EncodeEnd()
 			}
 		}
@@ -38056,24 +38093,24 @@ func (x *ComponentCondition) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3296 := z.DecBinary()
-	_ = yym3296
+	yym3301 := z.DecBinary()
+	_ = yym3301
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3297 := r.ReadMapStart()
-			if yyl3297 == 0 {
+			yyl3302 := r.ReadMapStart()
+			if yyl3302 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3297, d)
+				x.codecDecodeSelfFromMap(yyl3302, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3297 := r.ReadArrayStart()
-			if yyl3297 == 0 {
+			yyl3302 := r.ReadArrayStart()
+			if yyl3302 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3297, d)
+				x.codecDecodeSelfFromArray(yyl3302, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -38085,12 +38122,12 @@ func (x *ComponentCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3298Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3298Slc
-	var yyhl3298 bool = l >= 0
-	for yyj3298 := 0; ; yyj3298++ {
-		if yyhl3298 {
-			if yyj3298 >= l {
+	var yys3303Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3303Slc
+	var yyhl3303 bool = l >= 0
+	for yyj3303 := 0; ; yyj3303++ {
+		if yyhl3303 {
+			if yyj3303 >= l {
 				break
 			}
 		} else {
@@ -38098,9 +38135,9 @@ func (x *ComponentCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
-		yys3298Slc = r.DecodeBytes(yys3298Slc, true, true)
-		yys3298 := string(yys3298Slc)
-		switch yys3298 {
+		yys3303Slc = r.DecodeBytes(yys3303Slc, true, true)
+		yys3303 := string(yys3303Slc)
+		switch yys3303 {
 		case "type":
 			if r.TryDecodeAsNil() {
 				x.Type = ""
@@ -38126,10 +38163,10 @@ func (x *ComponentCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				x.Error = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3298)
-		} // end switch yys3298
-	} // end for yyj3298
-	if !yyhl3298 {
+			z.DecStructFieldNotFound(-1, yys3303)
+		} // end switch yys3303
+	} // end for yyj3303
+	if !yyhl3303 {
 		r.ReadEnd()
 	}
 }
@@ -38138,16 +38175,16 @@ func (x *ComponentCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3303 int
-	var yyb3303 bool
-	var yyhl3303 bool = l >= 0
-	yyj3303++
-	if yyhl3303 {
-		yyb3303 = yyj3303 > l
+	var yyj3308 int
+	var yyb3308 bool
+	var yyhl3308 bool = l >= 0
+	yyj3308++
+	if yyhl3308 {
+		yyb3308 = yyj3308 > l
 	} else {
-		yyb3303 = r.CheckBreak()
+		yyb3308 = r.CheckBreak()
 	}
-	if yyb3303 {
+	if yyb3308 {
 		r.ReadEnd()
 		return
 	}
@@ -38156,13 +38193,13 @@ func (x *ComponentCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.Type = ComponentConditionType(r.DecodeString())
 	}
-	yyj3303++
-	if yyhl3303 {
-		yyb3303 = yyj3303 > l
+	yyj3308++
+	if yyhl3308 {
+		yyb3308 = yyj3308 > l
 	} else {
-		yyb3303 = r.CheckBreak()
+		yyb3308 = r.CheckBreak()
 	}
-	if yyb3303 {
+	if yyb3308 {
 		r.ReadEnd()
 		return
 	}
@@ -38171,13 +38208,13 @@ func (x *ComponentCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.Status = ConditionStatus(r.DecodeString())
 	}
-	yyj3303++
-	if yyhl3303 {
-		yyb3303 = yyj3303 > l
+	yyj3308++
+	if yyhl3308 {
+		yyb3308 = yyj3308 > l
 	} else {
-		yyb3303 = r.CheckBreak()
+		yyb3308 = r.CheckBreak()
 	}
-	if yyb3303 {
+	if yyb3308 {
 		r.ReadEnd()
 		return
 	}
@@ -38186,13 +38223,13 @@ func (x *ComponentCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.Message = string(r.DecodeString())
 	}
-	yyj3303++
-	if yyhl3303 {
-		yyb3303 = yyj3303 > l
+	yyj3308++
+	if yyhl3308 {
+		yyb3308 = yyj3308 > l
 	} else {
-		yyb3303 = r.CheckBreak()
+		yyb3308 = r.CheckBreak()
 	}
-	if yyb3303 {
+	if yyb3308 {
 		r.ReadEnd()
 		return
 	}
@@ -38202,16 +38239,16 @@ func (x *ComponentCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		x.Error = string(r.DecodeString())
 	}
 	for {
-		yyj3303++
-		if yyhl3303 {
-			yyb3303 = yyj3303 > l
+		yyj3308++
+		if yyhl3308 {
+			yyb3308 = yyj3308 > l
 		} else {
-			yyb3303 = r.CheckBreak()
+			yyb3308 = r.CheckBreak()
 		}
-		if yyb3303 {
+		if yyb3308 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3303-1, "")
+		z.DecStructFieldNotFound(yyj3308-1, "")
 	}
 	r.ReadEnd()
 }
@@ -38223,35 +38260,35 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3308 := z.EncBinary()
-		_ = yym3308
+		yym3313 := z.EncBinary()
+		_ = yym3313
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3309 := !z.EncBinary()
-			yy2arr3309 := z.EncBasicHandle().StructToArray
-			var yyq3309 [4]bool
-			_, _, _ = yysep3309, yyq3309, yy2arr3309
-			const yyr3309 bool = false
-			yyq3309[0] = x.Kind != ""
-			yyq3309[1] = x.APIVersion != ""
-			yyq3309[2] = true
-			yyq3309[3] = len(x.Conditions) != 0
-			if yyr3309 || yy2arr3309 {
+			yysep3314 := !z.EncBinary()
+			yy2arr3314 := z.EncBasicHandle().StructToArray
+			var yyq3314 [4]bool
+			_, _, _ = yysep3314, yyq3314, yy2arr3314
+			const yyr3314 bool = false
+			yyq3314[0] = x.Kind != ""
+			yyq3314[1] = x.APIVersion != ""
+			yyq3314[2] = true
+			yyq3314[3] = len(x.Conditions) != 0
+			if yyr3314 || yy2arr3314 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3309 int = 0
-				for _, b := range yyq3309 {
+				var yynn3314 int = 0
+				for _, b := range yyq3314 {
 					if b {
-						yynn3309++
+						yynn3314++
 					}
 				}
-				r.EncodeMapStart(yynn3309)
+				r.EncodeMapStart(yynn3314)
 			}
-			if yyr3309 || yy2arr3309 {
-				if yyq3309[0] {
-					yym3311 := z.EncBinary()
-					_ = yym3311
+			if yyr3314 || yy2arr3314 {
+				if yyq3314[0] {
+					yym3316 := z.EncBinary()
+					_ = yym3316
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -38260,20 +38297,20 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3309[0] {
+				if yyq3314[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3312 := z.EncBinary()
-					_ = yym3312
+					yym3317 := z.EncBinary()
+					_ = yym3317
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr3309 || yy2arr3309 {
-				if yyq3309[1] {
-					yym3314 := z.EncBinary()
-					_ = yym3314
+			if yyr3314 || yy2arr3314 {
+				if yyq3314[1] {
+					yym3319 := z.EncBinary()
+					_ = yym3319
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -38282,37 +38319,37 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3309[1] {
+				if yyq3314[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym3315 := z.EncBinary()
-					_ = yym3315
+					yym3320 := z.EncBinary()
+					_ = yym3320
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr3309 || yy2arr3309 {
-				if yyq3309[2] {
-					yy3317 := &x.ObjectMeta
-					yy3317.CodecEncodeSelf(e)
+			if yyr3314 || yy2arr3314 {
+				if yyq3314[2] {
+					yy3322 := &x.ObjectMeta
+					yy3322.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3309[2] {
+				if yyq3314[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3318 := &x.ObjectMeta
-					yy3318.CodecEncodeSelf(e)
+					yy3323 := &x.ObjectMeta
+					yy3323.CodecEncodeSelf(e)
 				}
 			}
-			if yyr3309 || yy2arr3309 {
-				if yyq3309[3] {
+			if yyr3314 || yy2arr3314 {
+				if yyq3314[3] {
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
-						yym3320 := z.EncBinary()
-						_ = yym3320
+						yym3325 := z.EncBinary()
+						_ = yym3325
 						if false {
 						} else {
 							h.encSliceComponentCondition(([]ComponentCondition)(x.Conditions), e)
@@ -38322,13 +38359,13 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3309[3] {
+				if yyq3314[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("conditions"))
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
-						yym3321 := z.EncBinary()
-						_ = yym3321
+						yym3326 := z.EncBinary()
+						_ = yym3326
 						if false {
 						} else {
 							h.encSliceComponentCondition(([]ComponentCondition)(x.Conditions), e)
@@ -38336,7 +38373,7 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3309 {
+			if yysep3314 {
 				r.EncodeEnd()
 			}
 		}
@@ -38347,24 +38384,24 @@ func (x *ComponentStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3322 := z.DecBinary()
-	_ = yym3322
+	yym3327 := z.DecBinary()
+	_ = yym3327
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3323 := r.ReadMapStart()
-			if yyl3323 == 0 {
+			yyl3328 := r.ReadMapStart()
+			if yyl3328 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3323, d)
+				x.codecDecodeSelfFromMap(yyl3328, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3323 := r.ReadArrayStart()
-			if yyl3323 == 0 {
+			yyl3328 := r.ReadArrayStart()
+			if yyl3328 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3323, d)
+				x.codecDecodeSelfFromArray(yyl3328, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -38376,12 +38413,12 @@ func (x *ComponentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3324Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3324Slc
-	var yyhl3324 bool = l >= 0
-	for yyj3324 := 0; ; yyj3324++ {
-		if yyhl3324 {
-			if yyj3324 >= l {
+	var yys3329Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3329Slc
+	var yyhl3329 bool = l >= 0
+	for yyj3329 := 0; ; yyj3329++ {
+		if yyhl3329 {
+			if yyj3329 >= l {
 				break
 			}
 		} else {
@@ -38389,9 +38426,9 @@ func (x *ComponentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3324Slc = r.DecodeBytes(yys3324Slc, true, true)
-		yys3324 := string(yys3324Slc)
-		switch yys3324 {
+		yys3329Slc = r.DecodeBytes(yys3329Slc, true, true)
+		yys3329 := string(yys3329Slc)
+		switch yys3329 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -38408,26 +38445,26 @@ func (x *ComponentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv3327 := &x.ObjectMeta
-				yyv3327.CodecDecodeSelf(d)
+				yyv3332 := &x.ObjectMeta
+				yyv3332.CodecDecodeSelf(d)
 			}
 		case "conditions":
 			if r.TryDecodeAsNil() {
 				x.Conditions = nil
 			} else {
-				yyv3328 := &x.Conditions
-				yym3329 := z.DecBinary()
-				_ = yym3329
+				yyv3333 := &x.Conditions
+				yym3334 := z.DecBinary()
+				_ = yym3334
 				if false {
 				} else {
-					h.decSliceComponentCondition((*[]ComponentCondition)(yyv3328), d)
+					h.decSliceComponentCondition((*[]ComponentCondition)(yyv3333), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3324)
-		} // end switch yys3324
-	} // end for yyj3324
-	if !yyhl3324 {
+			z.DecStructFieldNotFound(-1, yys3329)
+		} // end switch yys3329
+	} // end for yyj3329
+	if !yyhl3329 {
 		r.ReadEnd()
 	}
 }
@@ -38436,16 +38473,16 @@ func (x *ComponentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3330 int
-	var yyb3330 bool
-	var yyhl3330 bool = l >= 0
-	yyj3330++
-	if yyhl3330 {
-		yyb3330 = yyj3330 > l
+	var yyj3335 int
+	var yyb3335 bool
+	var yyhl3335 bool = l >= 0
+	yyj3335++
+	if yyhl3335 {
+		yyb3335 = yyj3335 > l
 	} else {
-		yyb3330 = r.CheckBreak()
+		yyb3335 = r.CheckBreak()
 	}
-	if yyb3330 {
+	if yyb3335 {
 		r.ReadEnd()
 		return
 	}
@@ -38454,13 +38491,13 @@ func (x *ComponentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3330++
-	if yyhl3330 {
-		yyb3330 = yyj3330 > l
+	yyj3335++
+	if yyhl3335 {
+		yyb3335 = yyj3335 > l
 	} else {
-		yyb3330 = r.CheckBreak()
+		yyb3335 = r.CheckBreak()
 	}
-	if yyb3330 {
+	if yyb3335 {
 		r.ReadEnd()
 		return
 	}
@@ -38469,54 +38506,54 @@ func (x *ComponentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3330++
-	if yyhl3330 {
-		yyb3330 = yyj3330 > l
+	yyj3335++
+	if yyhl3335 {
+		yyb3335 = yyj3335 > l
 	} else {
-		yyb3330 = r.CheckBreak()
+		yyb3335 = r.CheckBreak()
 	}
-	if yyb3330 {
+	if yyb3335 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv3333 := &x.ObjectMeta
-		yyv3333.CodecDecodeSelf(d)
+		yyv3338 := &x.ObjectMeta
+		yyv3338.CodecDecodeSelf(d)
 	}
-	yyj3330++
-	if yyhl3330 {
-		yyb3330 = yyj3330 > l
+	yyj3335++
+	if yyhl3335 {
+		yyb3335 = yyj3335 > l
 	} else {
-		yyb3330 = r.CheckBreak()
+		yyb3335 = r.CheckBreak()
 	}
-	if yyb3330 {
+	if yyb3335 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Conditions = nil
 	} else {
-		yyv3334 := &x.Conditions
-		yym3335 := z.DecBinary()
-		_ = yym3335
+		yyv3339 := &x.Conditions
+		yym3340 := z.DecBinary()
+		_ = yym3340
 		if false {
 		} else {
-			h.decSliceComponentCondition((*[]ComponentCondition)(yyv3334), d)
+			h.decSliceComponentCondition((*[]ComponentCondition)(yyv3339), d)
 		}
 	}
 	for {
-		yyj3330++
-		if yyhl3330 {
-			yyb3330 = yyj3330 > l
+		yyj3335++
+		if yyhl3335 {
+			yyb3335 = yyj3335 > l
 		} else {
-			yyb3330 = r.CheckBreak()
+			yyb3335 = r.CheckBreak()
 		}
-		if yyb3330 {
+		if yyb3335 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3330-1, "")
+		z.DecStructFieldNotFound(yyj3335-1, "")
 	}
 	r.ReadEnd()
 }
@@ -38528,34 +38565,34 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3336 := z.EncBinary()
-		_ = yym3336
+		yym3341 := z.EncBinary()
+		_ = yym3341
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3337 := !z.EncBinary()
-			yy2arr3337 := z.EncBasicHandle().StructToArray
-			var yyq3337 [4]bool
-			_, _, _ = yysep3337, yyq3337, yy2arr3337
-			const yyr3337 bool = false
-			yyq3337[0] = x.Kind != ""
-			yyq3337[1] = x.APIVersion != ""
-			yyq3337[2] = true
-			if yyr3337 || yy2arr3337 {
+			yysep3342 := !z.EncBinary()
+			yy2arr3342 := z.EncBasicHandle().StructToArray
+			var yyq3342 [4]bool
+			_, _, _ = yysep3342, yyq3342, yy2arr3342
+			const yyr3342 bool = false
+			yyq3342[0] = x.Kind != ""
+			yyq3342[1] = x.APIVersion != ""
+			yyq3342[2] = true
+			if yyr3342 || yy2arr3342 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3337 int = 1
-				for _, b := range yyq3337 {
+				var yynn3342 int = 1
+				for _, b := range yyq3342 {
 					if b {
-						yynn3337++
+						yynn3342++
 					}
 				}
-				r.EncodeMapStart(yynn3337)
+				r.EncodeMapStart(yynn3342)
 			}
-			if yyr3337 || yy2arr3337 {
-				if yyq3337[0] {
-					yym3339 := z.EncBinary()
-					_ = yym3339
+			if yyr3342 || yy2arr3342 {
+				if yyq3342[0] {
+					yym3344 := z.EncBinary()
+					_ = yym3344
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -38564,20 +38601,20 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3337[0] {
+				if yyq3342[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3340 := z.EncBinary()
-					_ = yym3340
+					yym3345 := z.EncBinary()
+					_ = yym3345
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr3337 || yy2arr3337 {
-				if yyq3337[1] {
-					yym3342 := z.EncBinary()
-					_ = yym3342
+			if yyr3342 || yy2arr3342 {
+				if yyq3342[1] {
+					yym3347 := z.EncBinary()
+					_ = yym3347
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -38586,48 +38623,48 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3337[1] {
+				if yyq3342[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym3343 := z.EncBinary()
-					_ = yym3343
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3337 || yy2arr3337 {
-				if yyq3337[2] {
-					yy3345 := &x.ListMeta
-					yym3346 := z.EncBinary()
-					_ = yym3346
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3345) {
-					} else {
-						z.EncFallback(yy3345)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq3337[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3347 := &x.ListMeta
 					yym3348 := z.EncBinary()
 					_ = yym3348
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3347) {
 					} else {
-						z.EncFallback(yy3347)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr3337 || yy2arr3337 {
+			if yyr3342 || yy2arr3342 {
+				if yyq3342[2] {
+					yy3350 := &x.ListMeta
+					yym3351 := z.EncBinary()
+					_ = yym3351
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3350) {
+					} else {
+						z.EncFallback(yy3350)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq3342[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy3352 := &x.ListMeta
+					yym3353 := z.EncBinary()
+					_ = yym3353
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3352) {
+					} else {
+						z.EncFallback(yy3352)
+					}
+				}
+			}
+			if yyr3342 || yy2arr3342 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3350 := z.EncBinary()
-					_ = yym3350
+					yym3355 := z.EncBinary()
+					_ = yym3355
 					if false {
 					} else {
 						h.encSliceComponentStatus(([]ComponentStatus)(x.Items), e)
@@ -38638,15 +38675,15 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3351 := z.EncBinary()
-					_ = yym3351
+					yym3356 := z.EncBinary()
+					_ = yym3356
 					if false {
 					} else {
 						h.encSliceComponentStatus(([]ComponentStatus)(x.Items), e)
 					}
 				}
 			}
-			if yysep3337 {
+			if yysep3342 {
 				r.EncodeEnd()
 			}
 		}
@@ -38657,24 +38694,24 @@ func (x *ComponentStatusList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3352 := z.DecBinary()
-	_ = yym3352
+	yym3357 := z.DecBinary()
+	_ = yym3357
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3353 := r.ReadMapStart()
-			if yyl3353 == 0 {
+			yyl3358 := r.ReadMapStart()
+			if yyl3358 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3353, d)
+				x.codecDecodeSelfFromMap(yyl3358, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3353 := r.ReadArrayStart()
-			if yyl3353 == 0 {
+			yyl3358 := r.ReadArrayStart()
+			if yyl3358 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3353, d)
+				x.codecDecodeSelfFromArray(yyl3358, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -38686,12 +38723,12 @@ func (x *ComponentStatusList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3354Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3354Slc
-	var yyhl3354 bool = l >= 0
-	for yyj3354 := 0; ; yyj3354++ {
-		if yyhl3354 {
-			if yyj3354 >= l {
+	var yys3359Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3359Slc
+	var yyhl3359 bool = l >= 0
+	for yyj3359 := 0; ; yyj3359++ {
+		if yyhl3359 {
+			if yyj3359 >= l {
 				break
 			}
 		} else {
@@ -38699,9 +38736,9 @@ func (x *ComponentStatusList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				break
 			}
 		}
-		yys3354Slc = r.DecodeBytes(yys3354Slc, true, true)
-		yys3354 := string(yys3354Slc)
-		switch yys3354 {
+		yys3359Slc = r.DecodeBytes(yys3359Slc, true, true)
+		yys3359 := string(yys3359Slc)
+		switch yys3359 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -38718,32 +38755,32 @@ func (x *ComponentStatusList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv3357 := &x.ListMeta
-				yym3358 := z.DecBinary()
-				_ = yym3358
+				yyv3362 := &x.ListMeta
+				yym3363 := z.DecBinary()
+				_ = yym3363
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3357) {
+				} else if z.HasExtensions() && z.DecExt(yyv3362) {
 				} else {
-					z.DecFallback(yyv3357, false)
+					z.DecFallback(yyv3362, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv3359 := &x.Items
-				yym3360 := z.DecBinary()
-				_ = yym3360
+				yyv3364 := &x.Items
+				yym3365 := z.DecBinary()
+				_ = yym3365
 				if false {
 				} else {
-					h.decSliceComponentStatus((*[]ComponentStatus)(yyv3359), d)
+					h.decSliceComponentStatus((*[]ComponentStatus)(yyv3364), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3354)
-		} // end switch yys3354
-	} // end for yyj3354
-	if !yyhl3354 {
+			z.DecStructFieldNotFound(-1, yys3359)
+		} // end switch yys3359
+	} // end for yyj3359
+	if !yyhl3359 {
 		r.ReadEnd()
 	}
 }
@@ -38752,16 +38789,16 @@ func (x *ComponentStatusList) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3361 int
-	var yyb3361 bool
-	var yyhl3361 bool = l >= 0
-	yyj3361++
-	if yyhl3361 {
-		yyb3361 = yyj3361 > l
+	var yyj3366 int
+	var yyb3366 bool
+	var yyhl3366 bool = l >= 0
+	yyj3366++
+	if yyhl3366 {
+		yyb3366 = yyj3366 > l
 	} else {
-		yyb3361 = r.CheckBreak()
+		yyb3366 = r.CheckBreak()
 	}
-	if yyb3361 {
+	if yyb3366 {
 		r.ReadEnd()
 		return
 	}
@@ -38770,13 +38807,13 @@ func (x *ComponentStatusList) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3361++
-	if yyhl3361 {
-		yyb3361 = yyj3361 > l
+	yyj3366++
+	if yyhl3366 {
+		yyb3366 = yyj3366 > l
 	} else {
-		yyb3361 = r.CheckBreak()
+		yyb3366 = r.CheckBreak()
 	}
-	if yyb3361 {
+	if yyb3366 {
 		r.ReadEnd()
 		return
 	}
@@ -38785,60 +38822,60 @@ func (x *ComponentStatusList) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3361++
-	if yyhl3361 {
-		yyb3361 = yyj3361 > l
+	yyj3366++
+	if yyhl3366 {
+		yyb3366 = yyj3366 > l
 	} else {
-		yyb3361 = r.CheckBreak()
+		yyb3366 = r.CheckBreak()
 	}
-	if yyb3361 {
+	if yyb3366 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv3364 := &x.ListMeta
-		yym3365 := z.DecBinary()
-		_ = yym3365
+		yyv3369 := &x.ListMeta
+		yym3370 := z.DecBinary()
+		_ = yym3370
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3364) {
+		} else if z.HasExtensions() && z.DecExt(yyv3369) {
 		} else {
-			z.DecFallback(yyv3364, false)
+			z.DecFallback(yyv3369, false)
 		}
 	}
-	yyj3361++
-	if yyhl3361 {
-		yyb3361 = yyj3361 > l
+	yyj3366++
+	if yyhl3366 {
+		yyb3366 = yyj3366 > l
 	} else {
-		yyb3361 = r.CheckBreak()
+		yyb3366 = r.CheckBreak()
 	}
-	if yyb3361 {
+	if yyb3366 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv3366 := &x.Items
-		yym3367 := z.DecBinary()
-		_ = yym3367
+		yyv3371 := &x.Items
+		yym3372 := z.DecBinary()
+		_ = yym3372
 		if false {
 		} else {
-			h.decSliceComponentStatus((*[]ComponentStatus)(yyv3366), d)
+			h.decSliceComponentStatus((*[]ComponentStatus)(yyv3371), d)
 		}
 	}
 	for {
-		yyj3361++
-		if yyhl3361 {
-			yyb3361 = yyj3361 > l
+		yyj3366++
+		if yyhl3366 {
+			yyb3366 = yyj3366 > l
 		} else {
-			yyb3361 = r.CheckBreak()
+			yyb3366 = r.CheckBreak()
 		}
-		if yyb3361 {
+		if yyb3366 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3361-1, "")
+		z.DecStructFieldNotFound(yyj3366-1, "")
 	}
 	r.ReadEnd()
 }
@@ -38850,34 +38887,34 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3368 := z.EncBinary()
-		_ = yym3368
+		yym3373 := z.EncBinary()
+		_ = yym3373
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3369 := !z.EncBinary()
-			yy2arr3369 := z.EncBasicHandle().StructToArray
-			var yyq3369 [5]bool
-			_, _, _ = yysep3369, yyq3369, yy2arr3369
-			const yyr3369 bool = false
-			yyq3369[0] = x.Capabilities != nil
-			yyq3369[1] = x.Privileged != nil
-			yyq3369[2] = x.SELinuxOptions != nil
-			yyq3369[3] = x.RunAsUser != nil
-			yyq3369[4] = x.RunAsNonRoot != nil
-			if yyr3369 || yy2arr3369 {
+			yysep3374 := !z.EncBinary()
+			yy2arr3374 := z.EncBasicHandle().StructToArray
+			var yyq3374 [5]bool
+			_, _, _ = yysep3374, yyq3374, yy2arr3374
+			const yyr3374 bool = false
+			yyq3374[0] = x.Capabilities != nil
+			yyq3374[1] = x.Privileged != nil
+			yyq3374[2] = x.SELinuxOptions != nil
+			yyq3374[3] = x.RunAsUser != nil
+			yyq3374[4] = x.RunAsNonRoot != nil
+			if yyr3374 || yy2arr3374 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn3369 int = 0
-				for _, b := range yyq3369 {
+				var yynn3374 int = 0
+				for _, b := range yyq3374 {
 					if b {
-						yynn3369++
+						yynn3374++
 					}
 				}
-				r.EncodeMapStart(yynn3369)
+				r.EncodeMapStart(yynn3374)
 			}
-			if yyr3369 || yy2arr3369 {
-				if yyq3369[0] {
+			if yyr3374 || yy2arr3374 {
+				if yyq3374[0] {
 					if x.Capabilities == nil {
 						r.EncodeNil()
 					} else {
@@ -38887,7 +38924,7 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3369[0] {
+				if yyq3374[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("capabilities"))
 					if x.Capabilities == nil {
 						r.EncodeNil()
@@ -38896,40 +38933,40 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr3369 || yy2arr3369 {
-				if yyq3369[1] {
+			if yyr3374 || yy2arr3374 {
+				if yyq3374[1] {
 					if x.Privileged == nil {
 						r.EncodeNil()
 					} else {
-						yy3372 := *x.Privileged
-						yym3373 := z.EncBinary()
-						_ = yym3373
+						yy3377 := *x.Privileged
+						yym3378 := z.EncBinary()
+						_ = yym3378
 						if false {
 						} else {
-							r.EncodeBool(bool(yy3372))
+							r.EncodeBool(bool(yy3377))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3369[1] {
+				if yyq3374[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("privileged"))
 					if x.Privileged == nil {
 						r.EncodeNil()
 					} else {
-						yy3374 := *x.Privileged
-						yym3375 := z.EncBinary()
-						_ = yym3375
+						yy3379 := *x.Privileged
+						yym3380 := z.EncBinary()
+						_ = yym3380
 						if false {
 						} else {
-							r.EncodeBool(bool(yy3374))
+							r.EncodeBool(bool(yy3379))
 						}
 					}
 				}
 			}
-			if yyr3369 || yy2arr3369 {
-				if yyq3369[2] {
+			if yyr3374 || yy2arr3374 {
+				if yyq3374[2] {
 					if x.SELinuxOptions == nil {
 						r.EncodeNil()
 					} else {
@@ -38939,7 +38976,7 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3369[2] {
+				if yyq3374[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("seLinuxOptions"))
 					if x.SELinuxOptions == nil {
 						r.EncodeNil()
@@ -38948,71 +38985,71 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr3369 || yy2arr3369 {
-				if yyq3369[3] {
+			if yyr3374 || yy2arr3374 {
+				if yyq3374[3] {
 					if x.RunAsUser == nil {
 						r.EncodeNil()
 					} else {
-						yy3378 := *x.RunAsUser
-						yym3379 := z.EncBinary()
-						_ = yym3379
-						if false {
-						} else {
-							r.EncodeInt(int64(yy3378))
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq3369[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("runAsUser"))
-					if x.RunAsUser == nil {
-						r.EncodeNil()
-					} else {
-						yy3380 := *x.RunAsUser
-						yym3381 := z.EncBinary()
-						_ = yym3381
-						if false {
-						} else {
-							r.EncodeInt(int64(yy3380))
-						}
-					}
-				}
-			}
-			if yyr3369 || yy2arr3369 {
-				if yyq3369[4] {
-					if x.RunAsNonRoot == nil {
-						r.EncodeNil()
-					} else {
-						yy3383 := *x.RunAsNonRoot
+						yy3383 := *x.RunAsUser
 						yym3384 := z.EncBinary()
 						_ = yym3384
 						if false {
 						} else {
-							r.EncodeBool(bool(yy3383))
+							r.EncodeInt(int64(yy3383))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3369[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("runAsNonRoot"))
-					if x.RunAsNonRoot == nil {
+				if yyq3374[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("runAsUser"))
+					if x.RunAsUser == nil {
 						r.EncodeNil()
 					} else {
-						yy3385 := *x.RunAsNonRoot
+						yy3385 := *x.RunAsUser
 						yym3386 := z.EncBinary()
 						_ = yym3386
 						if false {
 						} else {
-							r.EncodeBool(bool(yy3385))
+							r.EncodeInt(int64(yy3385))
 						}
 					}
 				}
 			}
-			if yysep3369 {
+			if yyr3374 || yy2arr3374 {
+				if yyq3374[4] {
+					if x.RunAsNonRoot == nil {
+						r.EncodeNil()
+					} else {
+						yy3388 := *x.RunAsNonRoot
+						yym3389 := z.EncBinary()
+						_ = yym3389
+						if false {
+						} else {
+							r.EncodeBool(bool(yy3388))
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq3374[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("runAsNonRoot"))
+					if x.RunAsNonRoot == nil {
+						r.EncodeNil()
+					} else {
+						yy3390 := *x.RunAsNonRoot
+						yym3391 := z.EncBinary()
+						_ = yym3391
+						if false {
+						} else {
+							r.EncodeBool(bool(yy3390))
+						}
+					}
+				}
+			}
+			if yysep3374 {
 				r.EncodeEnd()
 			}
 		}
@@ -39023,24 +39060,24 @@ func (x *SecurityContext) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3387 := z.DecBinary()
-	_ = yym3387
+	yym3392 := z.DecBinary()
+	_ = yym3392
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3388 := r.ReadMapStart()
-			if yyl3388 == 0 {
+			yyl3393 := r.ReadMapStart()
+			if yyl3393 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3388, d)
+				x.codecDecodeSelfFromMap(yyl3393, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3388 := r.ReadArrayStart()
-			if yyl3388 == 0 {
+			yyl3393 := r.ReadArrayStart()
+			if yyl3393 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3388, d)
+				x.codecDecodeSelfFromArray(yyl3393, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -39052,12 +39089,12 @@ func (x *SecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3389Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3389Slc
-	var yyhl3389 bool = l >= 0
-	for yyj3389 := 0; ; yyj3389++ {
-		if yyhl3389 {
-			if yyj3389 >= l {
+	var yys3394Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3394Slc
+	var yyhl3394 bool = l >= 0
+	for yyj3394 := 0; ; yyj3394++ {
+		if yyhl3394 {
+			if yyj3394 >= l {
 				break
 			}
 		} else {
@@ -39065,9 +39102,9 @@ func (x *SecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3389Slc = r.DecodeBytes(yys3389Slc, true, true)
-		yys3389 := string(yys3389Slc)
-		switch yys3389 {
+		yys3394Slc = r.DecodeBytes(yys3394Slc, true, true)
+		yys3394 := string(yys3394Slc)
+		switch yys3394 {
 		case "capabilities":
 			if r.TryDecodeAsNil() {
 				if x.Capabilities != nil {
@@ -39088,8 +39125,8 @@ func (x *SecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.Privileged == nil {
 					x.Privileged = new(bool)
 				}
-				yym3392 := z.DecBinary()
-				_ = yym3392
+				yym3397 := z.DecBinary()
+				_ = yym3397
 				if false {
 				} else {
 					*((*bool)(x.Privileged)) = r.DecodeBool()
@@ -39115,8 +39152,8 @@ func (x *SecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.RunAsUser == nil {
 					x.RunAsUser = new(int64)
 				}
-				yym3395 := z.DecBinary()
-				_ = yym3395
+				yym3400 := z.DecBinary()
+				_ = yym3400
 				if false {
 				} else {
 					*((*int64)(x.RunAsUser)) = int64(r.DecodeInt(64))
@@ -39131,18 +39168,18 @@ func (x *SecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.RunAsNonRoot == nil {
 					x.RunAsNonRoot = new(bool)
 				}
-				yym3397 := z.DecBinary()
-				_ = yym3397
+				yym3402 := z.DecBinary()
+				_ = yym3402
 				if false {
 				} else {
 					*((*bool)(x.RunAsNonRoot)) = r.DecodeBool()
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3389)
-		} // end switch yys3389
-	} // end for yyj3389
-	if !yyhl3389 {
+			z.DecStructFieldNotFound(-1, yys3394)
+		} // end switch yys3394
+	} // end for yyj3394
+	if !yyhl3394 {
 		r.ReadEnd()
 	}
 }
@@ -39151,16 +39188,16 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3398 int
-	var yyb3398 bool
-	var yyhl3398 bool = l >= 0
-	yyj3398++
-	if yyhl3398 {
-		yyb3398 = yyj3398 > l
+	var yyj3403 int
+	var yyb3403 bool
+	var yyhl3403 bool = l >= 0
+	yyj3403++
+	if yyhl3403 {
+		yyb3403 = yyj3403 > l
 	} else {
-		yyb3398 = r.CheckBreak()
+		yyb3403 = r.CheckBreak()
 	}
-	if yyb3398 {
+	if yyb3403 {
 		r.ReadEnd()
 		return
 	}
@@ -39174,13 +39211,13 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		}
 		x.Capabilities.CodecDecodeSelf(d)
 	}
-	yyj3398++
-	if yyhl3398 {
-		yyb3398 = yyj3398 > l
+	yyj3403++
+	if yyhl3403 {
+		yyb3403 = yyj3403 > l
 	} else {
-		yyb3398 = r.CheckBreak()
+		yyb3403 = r.CheckBreak()
 	}
-	if yyb3398 {
+	if yyb3403 {
 		r.ReadEnd()
 		return
 	}
@@ -39192,20 +39229,20 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if x.Privileged == nil {
 			x.Privileged = new(bool)
 		}
-		yym3401 := z.DecBinary()
-		_ = yym3401
+		yym3406 := z.DecBinary()
+		_ = yym3406
 		if false {
 		} else {
 			*((*bool)(x.Privileged)) = r.DecodeBool()
 		}
 	}
-	yyj3398++
-	if yyhl3398 {
-		yyb3398 = yyj3398 > l
+	yyj3403++
+	if yyhl3403 {
+		yyb3403 = yyj3403 > l
 	} else {
-		yyb3398 = r.CheckBreak()
+		yyb3403 = r.CheckBreak()
 	}
-	if yyb3398 {
+	if yyb3403 {
 		r.ReadEnd()
 		return
 	}
@@ -39219,13 +39256,13 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		}
 		x.SELinuxOptions.CodecDecodeSelf(d)
 	}
-	yyj3398++
-	if yyhl3398 {
-		yyb3398 = yyj3398 > l
+	yyj3403++
+	if yyhl3403 {
+		yyb3403 = yyj3403 > l
 	} else {
-		yyb3398 = r.CheckBreak()
+		yyb3403 = r.CheckBreak()
 	}
-	if yyb3398 {
+	if yyb3403 {
 		r.ReadEnd()
 		return
 	}
@@ -39237,20 +39274,20 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if x.RunAsUser == nil {
 			x.RunAsUser = new(int64)
 		}
-		yym3404 := z.DecBinary()
-		_ = yym3404
+		yym3409 := z.DecBinary()
+		_ = yym3409
 		if false {
 		} else {
 			*((*int64)(x.RunAsUser)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj3398++
-	if yyhl3398 {
-		yyb3398 = yyj3398 > l
+	yyj3403++
+	if yyhl3403 {
+		yyb3403 = yyj3403 > l
 	} else {
-		yyb3398 = r.CheckBreak()
+		yyb3403 = r.CheckBreak()
 	}
-	if yyb3398 {
+	if yyb3403 {
 		r.ReadEnd()
 		return
 	}
@@ -39262,24 +39299,24 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if x.RunAsNonRoot == nil {
 			x.RunAsNonRoot = new(bool)
 		}
-		yym3406 := z.DecBinary()
-		_ = yym3406
+		yym3411 := z.DecBinary()
+		_ = yym3411
 		if false {
 		} else {
 			*((*bool)(x.RunAsNonRoot)) = r.DecodeBool()
 		}
 	}
 	for {
-		yyj3398++
-		if yyhl3398 {
-			yyb3398 = yyj3398 > l
+		yyj3403++
+		if yyhl3403 {
+			yyb3403 = yyj3403 > l
 		} else {
-			yyb3398 = r.CheckBreak()
+			yyb3403 = r.CheckBreak()
 		}
-		if yyb3398 {
+		if yyb3403 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3398-1, "")
+		z.DecStructFieldNotFound(yyj3403-1, "")
 	}
 	r.ReadEnd()
 }
@@ -39291,35 +39328,35 @@ func (x *SELinuxOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3407 := z.EncBinary()
-		_ = yym3407
+		yym3412 := z.EncBinary()
+		_ = yym3412
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3408 := !z.EncBinary()
-			yy2arr3408 := z.EncBasicHandle().StructToArray
-			var yyq3408 [4]bool
-			_, _, _ = yysep3408, yyq3408, yy2arr3408
-			const yyr3408 bool = false
-			yyq3408[0] = x.User != ""
-			yyq3408[1] = x.Role != ""
-			yyq3408[2] = x.Type != ""
-			yyq3408[3] = x.Level != ""
-			if yyr3408 || yy2arr3408 {
+			yysep3413 := !z.EncBinary()
+			yy2arr3413 := z.EncBasicHandle().StructToArray
+			var yyq3413 [4]bool
+			_, _, _ = yysep3413, yyq3413, yy2arr3413
+			const yyr3413 bool = false
+			yyq3413[0] = x.User != ""
+			yyq3413[1] = x.Role != ""
+			yyq3413[2] = x.Type != ""
+			yyq3413[3] = x.Level != ""
+			if yyr3413 || yy2arr3413 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3408 int = 0
-				for _, b := range yyq3408 {
+				var yynn3413 int = 0
+				for _, b := range yyq3413 {
 					if b {
-						yynn3408++
+						yynn3413++
 					}
 				}
-				r.EncodeMapStart(yynn3408)
+				r.EncodeMapStart(yynn3413)
 			}
-			if yyr3408 || yy2arr3408 {
-				if yyq3408[0] {
-					yym3410 := z.EncBinary()
-					_ = yym3410
+			if yyr3413 || yy2arr3413 {
+				if yyq3413[0] {
+					yym3415 := z.EncBinary()
+					_ = yym3415
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.User))
@@ -39328,83 +39365,83 @@ func (x *SELinuxOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3408[0] {
+				if yyq3413[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("user"))
-					yym3411 := z.EncBinary()
-					_ = yym3411
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.User))
-					}
-				}
-			}
-			if yyr3408 || yy2arr3408 {
-				if yyq3408[1] {
-					yym3413 := z.EncBinary()
-					_ = yym3413
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Role))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3408[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("role"))
-					yym3414 := z.EncBinary()
-					_ = yym3414
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Role))
-					}
-				}
-			}
-			if yyr3408 || yy2arr3408 {
-				if yyq3408[2] {
 					yym3416 := z.EncBinary()
 					_ = yym3416
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Type))
+						r.EncodeString(codecSelferC_UTF81234, string(x.User))
+					}
+				}
+			}
+			if yyr3413 || yy2arr3413 {
+				if yyq3413[1] {
+					yym3418 := z.EncBinary()
+					_ = yym3418
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Role))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3408[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("type"))
-					yym3417 := z.EncBinary()
-					_ = yym3417
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Type))
-					}
-				}
-			}
-			if yyr3408 || yy2arr3408 {
-				if yyq3408[3] {
+				if yyq3413[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("role"))
 					yym3419 := z.EncBinary()
 					_ = yym3419
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Role))
+					}
+				}
+			}
+			if yyr3413 || yy2arr3413 {
+				if yyq3413[2] {
+					yym3421 := z.EncBinary()
+					_ = yym3421
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Type))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3413[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("type"))
+					yym3422 := z.EncBinary()
+					_ = yym3422
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Type))
+					}
+				}
+			}
+			if yyr3413 || yy2arr3413 {
+				if yyq3413[3] {
+					yym3424 := z.EncBinary()
+					_ = yym3424
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Level))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3408[3] {
+				if yyq3413[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("level"))
-					yym3420 := z.EncBinary()
-					_ = yym3420
+					yym3425 := z.EncBinary()
+					_ = yym3425
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Level))
 					}
 				}
 			}
-			if yysep3408 {
+			if yysep3413 {
 				r.EncodeEnd()
 			}
 		}
@@ -39415,24 +39452,24 @@ func (x *SELinuxOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3421 := z.DecBinary()
-	_ = yym3421
+	yym3426 := z.DecBinary()
+	_ = yym3426
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3422 := r.ReadMapStart()
-			if yyl3422 == 0 {
+			yyl3427 := r.ReadMapStart()
+			if yyl3427 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3422, d)
+				x.codecDecodeSelfFromMap(yyl3427, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3422 := r.ReadArrayStart()
-			if yyl3422 == 0 {
+			yyl3427 := r.ReadArrayStart()
+			if yyl3427 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3422, d)
+				x.codecDecodeSelfFromArray(yyl3427, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -39444,12 +39481,12 @@ func (x *SELinuxOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3423Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3423Slc
-	var yyhl3423 bool = l >= 0
-	for yyj3423 := 0; ; yyj3423++ {
-		if yyhl3423 {
-			if yyj3423 >= l {
+	var yys3428Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3428Slc
+	var yyhl3428 bool = l >= 0
+	for yyj3428 := 0; ; yyj3428++ {
+		if yyhl3428 {
+			if yyj3428 >= l {
 				break
 			}
 		} else {
@@ -39457,9 +39494,9 @@ func (x *SELinuxOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3423Slc = r.DecodeBytes(yys3423Slc, true, true)
-		yys3423 := string(yys3423Slc)
-		switch yys3423 {
+		yys3428Slc = r.DecodeBytes(yys3428Slc, true, true)
+		yys3428 := string(yys3428Slc)
+		switch yys3428 {
 		case "user":
 			if r.TryDecodeAsNil() {
 				x.User = ""
@@ -39485,10 +39522,10 @@ func (x *SELinuxOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Level = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3423)
-		} // end switch yys3423
-	} // end for yyj3423
-	if !yyhl3423 {
+			z.DecStructFieldNotFound(-1, yys3428)
+		} // end switch yys3428
+	} // end for yyj3428
+	if !yyhl3428 {
 		r.ReadEnd()
 	}
 }
@@ -39497,16 +39534,16 @@ func (x *SELinuxOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3428 int
-	var yyb3428 bool
-	var yyhl3428 bool = l >= 0
-	yyj3428++
-	if yyhl3428 {
-		yyb3428 = yyj3428 > l
+	var yyj3433 int
+	var yyb3433 bool
+	var yyhl3433 bool = l >= 0
+	yyj3433++
+	if yyhl3433 {
+		yyb3433 = yyj3433 > l
 	} else {
-		yyb3428 = r.CheckBreak()
+		yyb3433 = r.CheckBreak()
 	}
-	if yyb3428 {
+	if yyb3433 {
 		r.ReadEnd()
 		return
 	}
@@ -39515,13 +39552,13 @@ func (x *SELinuxOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.User = string(r.DecodeString())
 	}
-	yyj3428++
-	if yyhl3428 {
-		yyb3428 = yyj3428 > l
+	yyj3433++
+	if yyhl3433 {
+		yyb3433 = yyj3433 > l
 	} else {
-		yyb3428 = r.CheckBreak()
+		yyb3433 = r.CheckBreak()
 	}
-	if yyb3428 {
+	if yyb3433 {
 		r.ReadEnd()
 		return
 	}
@@ -39530,13 +39567,13 @@ func (x *SELinuxOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Role = string(r.DecodeString())
 	}
-	yyj3428++
-	if yyhl3428 {
-		yyb3428 = yyj3428 > l
+	yyj3433++
+	if yyhl3433 {
+		yyb3433 = yyj3433 > l
 	} else {
-		yyb3428 = r.CheckBreak()
+		yyb3433 = r.CheckBreak()
 	}
-	if yyb3428 {
+	if yyb3433 {
 		r.ReadEnd()
 		return
 	}
@@ -39545,13 +39582,13 @@ func (x *SELinuxOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Type = string(r.DecodeString())
 	}
-	yyj3428++
-	if yyhl3428 {
-		yyb3428 = yyj3428 > l
+	yyj3433++
+	if yyhl3433 {
+		yyb3433 = yyj3433 > l
 	} else {
-		yyb3428 = r.CheckBreak()
+		yyb3433 = r.CheckBreak()
 	}
-	if yyb3428 {
+	if yyb3433 {
 		r.ReadEnd()
 		return
 	}
@@ -39561,16 +39598,16 @@ func (x *SELinuxOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Level = string(r.DecodeString())
 	}
 	for {
-		yyj3428++
-		if yyhl3428 {
-			yyb3428 = yyj3428 > l
+		yyj3433++
+		if yyhl3433 {
+			yyb3433 = yyj3433 > l
 		} else {
-			yyb3428 = r.CheckBreak()
+			yyb3433 = r.CheckBreak()
 		}
-		if yyb3428 {
+		if yyb3433 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3428-1, "")
+		z.DecStructFieldNotFound(yyj3433-1, "")
 	}
 	r.ReadEnd()
 }
@@ -39582,34 +39619,34 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3433 := z.EncBinary()
-		_ = yym3433
+		yym3438 := z.EncBinary()
+		_ = yym3438
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3434 := !z.EncBinary()
-			yy2arr3434 := z.EncBasicHandle().StructToArray
-			var yyq3434 [5]bool
-			_, _, _ = yysep3434, yyq3434, yy2arr3434
-			const yyr3434 bool = false
-			yyq3434[0] = x.Kind != ""
-			yyq3434[1] = x.APIVersion != ""
-			yyq3434[2] = true
-			if yyr3434 || yy2arr3434 {
+			yysep3439 := !z.EncBinary()
+			yy2arr3439 := z.EncBasicHandle().StructToArray
+			var yyq3439 [5]bool
+			_, _, _ = yysep3439, yyq3439, yy2arr3439
+			const yyr3439 bool = false
+			yyq3439[0] = x.Kind != ""
+			yyq3439[1] = x.APIVersion != ""
+			yyq3439[2] = true
+			if yyr3439 || yy2arr3439 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn3434 int = 2
-				for _, b := range yyq3434 {
+				var yynn3439 int = 2
+				for _, b := range yyq3439 {
 					if b {
-						yynn3434++
+						yynn3439++
 					}
 				}
-				r.EncodeMapStart(yynn3434)
+				r.EncodeMapStart(yynn3439)
 			}
-			if yyr3434 || yy2arr3434 {
-				if yyq3434[0] {
-					yym3436 := z.EncBinary()
-					_ = yym3436
+			if yyr3439 || yy2arr3439 {
+				if yyq3439[0] {
+					yym3441 := z.EncBinary()
+					_ = yym3441
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -39618,20 +39655,20 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3434[0] {
+				if yyq3439[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3437 := z.EncBinary()
-					_ = yym3437
+					yym3442 := z.EncBinary()
+					_ = yym3442
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr3434 || yy2arr3434 {
-				if yyq3434[1] {
-					yym3439 := z.EncBinary()
-					_ = yym3439
+			if yyr3439 || yy2arr3439 {
+				if yyq3439[1] {
+					yym3444 := z.EncBinary()
+					_ = yym3444
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -39640,52 +39677,52 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3434[1] {
+				if yyq3439[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym3440 := z.EncBinary()
-					_ = yym3440
+					yym3445 := z.EncBinary()
+					_ = yym3445
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr3434 || yy2arr3434 {
-				if yyq3434[2] {
-					yy3442 := &x.ObjectMeta
-					yy3442.CodecEncodeSelf(e)
+			if yyr3439 || yy2arr3439 {
+				if yyq3439[2] {
+					yy3447 := &x.ObjectMeta
+					yy3447.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3434[2] {
+				if yyq3439[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3443 := &x.ObjectMeta
-					yy3443.CodecEncodeSelf(e)
+					yy3448 := &x.ObjectMeta
+					yy3448.CodecEncodeSelf(e)
 				}
 			}
-			if yyr3434 || yy2arr3434 {
-				yym3445 := z.EncBinary()
-				_ = yym3445
+			if yyr3439 || yy2arr3439 {
+				yym3450 := z.EncBinary()
+				_ = yym3450
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Range))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("range"))
-				yym3446 := z.EncBinary()
-				_ = yym3446
+				yym3451 := z.EncBinary()
+				_ = yym3451
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Range))
 				}
 			}
-			if yyr3434 || yy2arr3434 {
+			if yyr3439 || yy2arr3439 {
 				if x.Data == nil {
 					r.EncodeNil()
 				} else {
-					yym3448 := z.EncBinary()
-					_ = yym3448
+					yym3453 := z.EncBinary()
+					_ = yym3453
 					if false {
 					} else {
 						r.EncodeStringBytes(codecSelferC_RAW1234, []byte(x.Data))
@@ -39696,15 +39733,15 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Data == nil {
 					r.EncodeNil()
 				} else {
-					yym3449 := z.EncBinary()
-					_ = yym3449
+					yym3454 := z.EncBinary()
+					_ = yym3454
 					if false {
 					} else {
 						r.EncodeStringBytes(codecSelferC_RAW1234, []byte(x.Data))
 					}
 				}
 			}
-			if yysep3434 {
+			if yysep3439 {
 				r.EncodeEnd()
 			}
 		}
@@ -39715,24 +39752,24 @@ func (x *RangeAllocation) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3450 := z.DecBinary()
-	_ = yym3450
+	yym3455 := z.DecBinary()
+	_ = yym3455
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3451 := r.ReadMapStart()
-			if yyl3451 == 0 {
+			yyl3456 := r.ReadMapStart()
+			if yyl3456 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3451, d)
+				x.codecDecodeSelfFromMap(yyl3456, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3451 := r.ReadArrayStart()
-			if yyl3451 == 0 {
+			yyl3456 := r.ReadArrayStart()
+			if yyl3456 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3451, d)
+				x.codecDecodeSelfFromArray(yyl3456, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -39744,12 +39781,12 @@ func (x *RangeAllocation) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3452Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3452Slc
-	var yyhl3452 bool = l >= 0
-	for yyj3452 := 0; ; yyj3452++ {
-		if yyhl3452 {
-			if yyj3452 >= l {
+	var yys3457Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3457Slc
+	var yyhl3457 bool = l >= 0
+	for yyj3457 := 0; ; yyj3457++ {
+		if yyhl3457 {
+			if yyj3457 >= l {
 				break
 			}
 		} else {
@@ -39757,9 +39794,9 @@ func (x *RangeAllocation) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3452Slc = r.DecodeBytes(yys3452Slc, true, true)
-		yys3452 := string(yys3452Slc)
-		switch yys3452 {
+		yys3457Slc = r.DecodeBytes(yys3457Slc, true, true)
+		yys3457 := string(yys3457Slc)
+		switch yys3457 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -39776,8 +39813,8 @@ func (x *RangeAllocation) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv3455 := &x.ObjectMeta
-				yyv3455.CodecDecodeSelf(d)
+				yyv3460 := &x.ObjectMeta
+				yyv3460.CodecDecodeSelf(d)
 			}
 		case "range":
 			if r.TryDecodeAsNil() {
@@ -39789,19 +39826,19 @@ func (x *RangeAllocation) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Data = nil
 			} else {
-				yyv3457 := &x.Data
-				yym3458 := z.DecBinary()
-				_ = yym3458
+				yyv3462 := &x.Data
+				yym3463 := z.DecBinary()
+				_ = yym3463
 				if false {
 				} else {
-					*yyv3457 = r.DecodeBytes(*(*[]byte)(yyv3457), false, false)
+					*yyv3462 = r.DecodeBytes(*(*[]byte)(yyv3462), false, false)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3452)
-		} // end switch yys3452
-	} // end for yyj3452
-	if !yyhl3452 {
+			z.DecStructFieldNotFound(-1, yys3457)
+		} // end switch yys3457
+	} // end for yyj3457
+	if !yyhl3457 {
 		r.ReadEnd()
 	}
 }
@@ -39810,16 +39847,16 @@ func (x *RangeAllocation) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3459 int
-	var yyb3459 bool
-	var yyhl3459 bool = l >= 0
-	yyj3459++
-	if yyhl3459 {
-		yyb3459 = yyj3459 > l
+	var yyj3464 int
+	var yyb3464 bool
+	var yyhl3464 bool = l >= 0
+	yyj3464++
+	if yyhl3464 {
+		yyb3464 = yyj3464 > l
 	} else {
-		yyb3459 = r.CheckBreak()
+		yyb3464 = r.CheckBreak()
 	}
-	if yyb3459 {
+	if yyb3464 {
 		r.ReadEnd()
 		return
 	}
@@ -39828,13 +39865,13 @@ func (x *RangeAllocation) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3459++
-	if yyhl3459 {
-		yyb3459 = yyj3459 > l
+	yyj3464++
+	if yyhl3464 {
+		yyb3464 = yyj3464 > l
 	} else {
-		yyb3459 = r.CheckBreak()
+		yyb3464 = r.CheckBreak()
 	}
-	if yyb3459 {
+	if yyb3464 {
 		r.ReadEnd()
 		return
 	}
@@ -39843,29 +39880,29 @@ func (x *RangeAllocation) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3459++
-	if yyhl3459 {
-		yyb3459 = yyj3459 > l
+	yyj3464++
+	if yyhl3464 {
+		yyb3464 = yyj3464 > l
 	} else {
-		yyb3459 = r.CheckBreak()
+		yyb3464 = r.CheckBreak()
 	}
-	if yyb3459 {
+	if yyb3464 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv3462 := &x.ObjectMeta
-		yyv3462.CodecDecodeSelf(d)
+		yyv3467 := &x.ObjectMeta
+		yyv3467.CodecDecodeSelf(d)
 	}
-	yyj3459++
-	if yyhl3459 {
-		yyb3459 = yyj3459 > l
+	yyj3464++
+	if yyhl3464 {
+		yyb3464 = yyj3464 > l
 	} else {
-		yyb3459 = r.CheckBreak()
+		yyb3464 = r.CheckBreak()
 	}
-	if yyb3459 {
+	if yyb3464 {
 		r.ReadEnd()
 		return
 	}
@@ -39874,38 +39911,38 @@ func (x *RangeAllocation) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Range = string(r.DecodeString())
 	}
-	yyj3459++
-	if yyhl3459 {
-		yyb3459 = yyj3459 > l
+	yyj3464++
+	if yyhl3464 {
+		yyb3464 = yyj3464 > l
 	} else {
-		yyb3459 = r.CheckBreak()
+		yyb3464 = r.CheckBreak()
 	}
-	if yyb3459 {
+	if yyb3464 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Data = nil
 	} else {
-		yyv3464 := &x.Data
-		yym3465 := z.DecBinary()
-		_ = yym3465
+		yyv3469 := &x.Data
+		yym3470 := z.DecBinary()
+		_ = yym3470
 		if false {
 		} else {
-			*yyv3464 = r.DecodeBytes(*(*[]byte)(yyv3464), false, false)
+			*yyv3469 = r.DecodeBytes(*(*[]byte)(yyv3469), false, false)
 		}
 	}
 	for {
-		yyj3459++
-		if yyhl3459 {
-			yyb3459 = yyj3459 > l
+		yyj3464++
+		if yyhl3464 {
+			yyb3464 = yyj3464 > l
 		} else {
-			yyb3459 = r.CheckBreak()
+			yyb3464 = r.CheckBreak()
 		}
-		if yyb3459 {
+		if yyb3464 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3459-1, "")
+		z.DecStructFieldNotFound(yyj3464-1, "")
 	}
 	r.ReadEnd()
 }
@@ -39915,8 +39952,8 @@ func (x codecSelfer1234) encSlicePersistentVolumeAccessMode(v []PersistentVolume
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3466 := range v {
-		yyv3466.CodecEncodeSelf(e)
+	for _, yyv3471 := range v {
+		yyv3471.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -39926,77 +39963,77 @@ func (x codecSelfer1234) decSlicePersistentVolumeAccessMode(v *[]PersistentVolum
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3467 := *v
-	yyh3467, yyl3467 := z.DecSliceHelperStart()
+	yyv3472 := *v
+	yyh3472, yyl3472 := z.DecSliceHelperStart()
 
-	var yyrr3467, yyrl3467 int
-	var yyc3467, yyrt3467 bool
-	_, _, _ = yyc3467, yyrt3467, yyrl3467
-	yyrr3467 = yyl3467
+	var yyrr3472, yyrl3472 int
+	var yyc3472, yyrt3472 bool
+	_, _, _ = yyc3472, yyrt3472, yyrl3472
+	yyrr3472 = yyl3472
 
-	if yyv3467 == nil {
-		if yyrl3467, yyrt3467 = z.DecInferLen(yyl3467, z.DecBasicHandle().MaxInitLen, 16); yyrt3467 {
-			yyrr3467 = yyrl3467
+	if yyv3472 == nil {
+		if yyrl3472, yyrt3472 = z.DecInferLen(yyl3472, z.DecBasicHandle().MaxInitLen, 16); yyrt3472 {
+			yyrr3472 = yyrl3472
 		}
-		yyv3467 = make([]PersistentVolumeAccessMode, yyrl3467)
-		yyc3467 = true
+		yyv3472 = make([]PersistentVolumeAccessMode, yyrl3472)
+		yyc3472 = true
 	}
 
-	if yyl3467 == 0 {
-		if len(yyv3467) != 0 {
-			yyv3467 = yyv3467[:0]
-			yyc3467 = true
+	if yyl3472 == 0 {
+		if len(yyv3472) != 0 {
+			yyv3472 = yyv3472[:0]
+			yyc3472 = true
 		}
-	} else if yyl3467 > 0 {
+	} else if yyl3472 > 0 {
 
-		if yyl3467 > cap(yyv3467) {
-			yyrl3467, yyrt3467 = z.DecInferLen(yyl3467, z.DecBasicHandle().MaxInitLen, 16)
+		if yyl3472 > cap(yyv3472) {
+			yyrl3472, yyrt3472 = z.DecInferLen(yyl3472, z.DecBasicHandle().MaxInitLen, 16)
 
-			yyv23467 := yyv3467
-			yyv3467 = make([]PersistentVolumeAccessMode, yyrl3467)
-			if len(yyv3467) > 0 {
-				copy(yyv3467, yyv23467[:cap(yyv23467)])
+			yyv23472 := yyv3472
+			yyv3472 = make([]PersistentVolumeAccessMode, yyrl3472)
+			if len(yyv3472) > 0 {
+				copy(yyv3472, yyv23472[:cap(yyv23472)])
 			}
-			yyc3467 = true
+			yyc3472 = true
 
-			yyrr3467 = len(yyv3467)
-		} else if yyl3467 != len(yyv3467) {
-			yyv3467 = yyv3467[:yyl3467]
-			yyc3467 = true
+			yyrr3472 = len(yyv3472)
+		} else if yyl3472 != len(yyv3472) {
+			yyv3472 = yyv3472[:yyl3472]
+			yyc3472 = true
 		}
-		yyj3467 := 0
-		for ; yyj3467 < yyrr3467; yyj3467++ {
+		yyj3472 := 0
+		for ; yyj3472 < yyrr3472; yyj3472++ {
 			if r.TryDecodeAsNil() {
-				yyv3467[yyj3467] = ""
+				yyv3472[yyj3472] = ""
 			} else {
-				yyv3467[yyj3467] = PersistentVolumeAccessMode(r.DecodeString())
+				yyv3472[yyj3472] = PersistentVolumeAccessMode(r.DecodeString())
 			}
 
 		}
-		if yyrt3467 {
-			for ; yyj3467 < yyl3467; yyj3467++ {
-				yyv3467 = append(yyv3467, "")
+		if yyrt3472 {
+			for ; yyj3472 < yyl3472; yyj3472++ {
+				yyv3472 = append(yyv3472, "")
 				if r.TryDecodeAsNil() {
-					yyv3467[yyj3467] = ""
+					yyv3472[yyj3472] = ""
 				} else {
-					yyv3467[yyj3467] = PersistentVolumeAccessMode(r.DecodeString())
+					yyv3472[yyj3472] = PersistentVolumeAccessMode(r.DecodeString())
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3467 := 0; !r.CheckBreak(); yyj3467++ {
-			if yyj3467 >= len(yyv3467) {
-				yyv3467 = append(yyv3467, "") // var yyz3467 PersistentVolumeAccessMode
-				yyc3467 = true
+		for yyj3472 := 0; !r.CheckBreak(); yyj3472++ {
+			if yyj3472 >= len(yyv3472) {
+				yyv3472 = append(yyv3472, "") // var yyz3472 PersistentVolumeAccessMode
+				yyc3472 = true
 			}
 
-			if yyj3467 < len(yyv3467) {
+			if yyj3472 < len(yyv3472) {
 				if r.TryDecodeAsNil() {
-					yyv3467[yyj3467] = ""
+					yyv3472[yyj3472] = ""
 				} else {
-					yyv3467[yyj3467] = PersistentVolumeAccessMode(r.DecodeString())
+					yyv3472[yyj3472] = PersistentVolumeAccessMode(r.DecodeString())
 				}
 
 			} else {
@@ -40004,10 +40041,10 @@ func (x codecSelfer1234) decSlicePersistentVolumeAccessMode(v *[]PersistentVolum
 			}
 
 		}
-		yyh3467.End()
+		yyh3472.End()
 	}
-	if yyc3467 {
-		*v = yyv3467
+	if yyc3472 {
+		*v = yyv3472
 	}
 
 }
@@ -40017,9 +40054,9 @@ func (x codecSelfer1234) encSlicePersistentVolume(v []PersistentVolume, e *codec
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3471 := range v {
-		yy3472 := &yyv3471
-		yy3472.CodecEncodeSelf(e)
+	for _, yyv3476 := range v {
+		yy3477 := &yyv3476
+		yy3477.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -40029,75 +40066,75 @@ func (x codecSelfer1234) decSlicePersistentVolume(v *[]PersistentVolume, d *code
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3473 := *v
-	yyh3473, yyl3473 := z.DecSliceHelperStart()
+	yyv3478 := *v
+	yyh3478, yyl3478 := z.DecSliceHelperStart()
 
-	var yyrr3473, yyrl3473 int
-	var yyc3473, yyrt3473 bool
-	_, _, _ = yyc3473, yyrt3473, yyrl3473
-	yyrr3473 = yyl3473
+	var yyrr3478, yyrl3478 int
+	var yyc3478, yyrt3478 bool
+	_, _, _ = yyc3478, yyrt3478, yyrl3478
+	yyrr3478 = yyl3478
 
-	if yyv3473 == nil {
-		if yyrl3473, yyrt3473 = z.DecInferLen(yyl3473, z.DecBasicHandle().MaxInitLen, 384); yyrt3473 {
-			yyrr3473 = yyrl3473
+	if yyv3478 == nil {
+		if yyrl3478, yyrt3478 = z.DecInferLen(yyl3478, z.DecBasicHandle().MaxInitLen, 384); yyrt3478 {
+			yyrr3478 = yyrl3478
 		}
-		yyv3473 = make([]PersistentVolume, yyrl3473)
-		yyc3473 = true
+		yyv3478 = make([]PersistentVolume, yyrl3478)
+		yyc3478 = true
 	}
 
-	if yyl3473 == 0 {
-		if len(yyv3473) != 0 {
-			yyv3473 = yyv3473[:0]
-			yyc3473 = true
+	if yyl3478 == 0 {
+		if len(yyv3478) != 0 {
+			yyv3478 = yyv3478[:0]
+			yyc3478 = true
 		}
-	} else if yyl3473 > 0 {
+	} else if yyl3478 > 0 {
 
-		if yyl3473 > cap(yyv3473) {
-			yyrl3473, yyrt3473 = z.DecInferLen(yyl3473, z.DecBasicHandle().MaxInitLen, 384)
-			yyv3473 = make([]PersistentVolume, yyrl3473)
-			yyc3473 = true
+		if yyl3478 > cap(yyv3478) {
+			yyrl3478, yyrt3478 = z.DecInferLen(yyl3478, z.DecBasicHandle().MaxInitLen, 384)
+			yyv3478 = make([]PersistentVolume, yyrl3478)
+			yyc3478 = true
 
-			yyrr3473 = len(yyv3473)
-		} else if yyl3473 != len(yyv3473) {
-			yyv3473 = yyv3473[:yyl3473]
-			yyc3473 = true
+			yyrr3478 = len(yyv3478)
+		} else if yyl3478 != len(yyv3478) {
+			yyv3478 = yyv3478[:yyl3478]
+			yyc3478 = true
 		}
-		yyj3473 := 0
-		for ; yyj3473 < yyrr3473; yyj3473++ {
+		yyj3478 := 0
+		for ; yyj3478 < yyrr3478; yyj3478++ {
 			if r.TryDecodeAsNil() {
-				yyv3473[yyj3473] = PersistentVolume{}
+				yyv3478[yyj3478] = PersistentVolume{}
 			} else {
-				yyv3474 := &yyv3473[yyj3473]
-				yyv3474.CodecDecodeSelf(d)
+				yyv3479 := &yyv3478[yyj3478]
+				yyv3479.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3473 {
-			for ; yyj3473 < yyl3473; yyj3473++ {
-				yyv3473 = append(yyv3473, PersistentVolume{})
+		if yyrt3478 {
+			for ; yyj3478 < yyl3478; yyj3478++ {
+				yyv3478 = append(yyv3478, PersistentVolume{})
 				if r.TryDecodeAsNil() {
-					yyv3473[yyj3473] = PersistentVolume{}
+					yyv3478[yyj3478] = PersistentVolume{}
 				} else {
-					yyv3475 := &yyv3473[yyj3473]
-					yyv3475.CodecDecodeSelf(d)
+					yyv3480 := &yyv3478[yyj3478]
+					yyv3480.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3473 := 0; !r.CheckBreak(); yyj3473++ {
-			if yyj3473 >= len(yyv3473) {
-				yyv3473 = append(yyv3473, PersistentVolume{}) // var yyz3473 PersistentVolume
-				yyc3473 = true
+		for yyj3478 := 0; !r.CheckBreak(); yyj3478++ {
+			if yyj3478 >= len(yyv3478) {
+				yyv3478 = append(yyv3478, PersistentVolume{}) // var yyz3478 PersistentVolume
+				yyc3478 = true
 			}
 
-			if yyj3473 < len(yyv3473) {
+			if yyj3478 < len(yyv3478) {
 				if r.TryDecodeAsNil() {
-					yyv3473[yyj3473] = PersistentVolume{}
+					yyv3478[yyj3478] = PersistentVolume{}
 				} else {
-					yyv3476 := &yyv3473[yyj3473]
-					yyv3476.CodecDecodeSelf(d)
+					yyv3481 := &yyv3478[yyj3478]
+					yyv3481.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -40105,10 +40142,10 @@ func (x codecSelfer1234) decSlicePersistentVolume(v *[]PersistentVolume, d *code
 			}
 
 		}
-		yyh3473.End()
+		yyh3478.End()
 	}
-	if yyc3473 {
-		*v = yyv3473
+	if yyc3478 {
+		*v = yyv3478
 	}
 
 }
@@ -40118,9 +40155,9 @@ func (x codecSelfer1234) encSlicePersistentVolumeClaim(v []PersistentVolumeClaim
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3477 := range v {
-		yy3478 := &yyv3477
-		yy3478.CodecEncodeSelf(e)
+	for _, yyv3482 := range v {
+		yy3483 := &yyv3482
+		yy3483.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -40130,75 +40167,75 @@ func (x codecSelfer1234) decSlicePersistentVolumeClaim(v *[]PersistentVolumeClai
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3479 := *v
-	yyh3479, yyl3479 := z.DecSliceHelperStart()
+	yyv3484 := *v
+	yyh3484, yyl3484 := z.DecSliceHelperStart()
 
-	var yyrr3479, yyrl3479 int
-	var yyc3479, yyrt3479 bool
-	_, _, _ = yyc3479, yyrt3479, yyrl3479
-	yyrr3479 = yyl3479
+	var yyrr3484, yyrl3484 int
+	var yyc3484, yyrt3484 bool
+	_, _, _ = yyc3484, yyrt3484, yyrl3484
+	yyrr3484 = yyl3484
 
-	if yyv3479 == nil {
-		if yyrl3479, yyrt3479 = z.DecInferLen(yyl3479, z.DecBasicHandle().MaxInitLen, 296); yyrt3479 {
-			yyrr3479 = yyrl3479
+	if yyv3484 == nil {
+		if yyrl3484, yyrt3484 = z.DecInferLen(yyl3484, z.DecBasicHandle().MaxInitLen, 296); yyrt3484 {
+			yyrr3484 = yyrl3484
 		}
-		yyv3479 = make([]PersistentVolumeClaim, yyrl3479)
-		yyc3479 = true
+		yyv3484 = make([]PersistentVolumeClaim, yyrl3484)
+		yyc3484 = true
 	}
 
-	if yyl3479 == 0 {
-		if len(yyv3479) != 0 {
-			yyv3479 = yyv3479[:0]
-			yyc3479 = true
+	if yyl3484 == 0 {
+		if len(yyv3484) != 0 {
+			yyv3484 = yyv3484[:0]
+			yyc3484 = true
 		}
-	} else if yyl3479 > 0 {
+	} else if yyl3484 > 0 {
 
-		if yyl3479 > cap(yyv3479) {
-			yyrl3479, yyrt3479 = z.DecInferLen(yyl3479, z.DecBasicHandle().MaxInitLen, 296)
-			yyv3479 = make([]PersistentVolumeClaim, yyrl3479)
-			yyc3479 = true
+		if yyl3484 > cap(yyv3484) {
+			yyrl3484, yyrt3484 = z.DecInferLen(yyl3484, z.DecBasicHandle().MaxInitLen, 296)
+			yyv3484 = make([]PersistentVolumeClaim, yyrl3484)
+			yyc3484 = true
 
-			yyrr3479 = len(yyv3479)
-		} else if yyl3479 != len(yyv3479) {
-			yyv3479 = yyv3479[:yyl3479]
-			yyc3479 = true
+			yyrr3484 = len(yyv3484)
+		} else if yyl3484 != len(yyv3484) {
+			yyv3484 = yyv3484[:yyl3484]
+			yyc3484 = true
 		}
-		yyj3479 := 0
-		for ; yyj3479 < yyrr3479; yyj3479++ {
+		yyj3484 := 0
+		for ; yyj3484 < yyrr3484; yyj3484++ {
 			if r.TryDecodeAsNil() {
-				yyv3479[yyj3479] = PersistentVolumeClaim{}
+				yyv3484[yyj3484] = PersistentVolumeClaim{}
 			} else {
-				yyv3480 := &yyv3479[yyj3479]
-				yyv3480.CodecDecodeSelf(d)
+				yyv3485 := &yyv3484[yyj3484]
+				yyv3485.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3479 {
-			for ; yyj3479 < yyl3479; yyj3479++ {
-				yyv3479 = append(yyv3479, PersistentVolumeClaim{})
+		if yyrt3484 {
+			for ; yyj3484 < yyl3484; yyj3484++ {
+				yyv3484 = append(yyv3484, PersistentVolumeClaim{})
 				if r.TryDecodeAsNil() {
-					yyv3479[yyj3479] = PersistentVolumeClaim{}
+					yyv3484[yyj3484] = PersistentVolumeClaim{}
 				} else {
-					yyv3481 := &yyv3479[yyj3479]
-					yyv3481.CodecDecodeSelf(d)
+					yyv3486 := &yyv3484[yyj3484]
+					yyv3486.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3479 := 0; !r.CheckBreak(); yyj3479++ {
-			if yyj3479 >= len(yyv3479) {
-				yyv3479 = append(yyv3479, PersistentVolumeClaim{}) // var yyz3479 PersistentVolumeClaim
-				yyc3479 = true
+		for yyj3484 := 0; !r.CheckBreak(); yyj3484++ {
+			if yyj3484 >= len(yyv3484) {
+				yyv3484 = append(yyv3484, PersistentVolumeClaim{}) // var yyz3484 PersistentVolumeClaim
+				yyc3484 = true
 			}
 
-			if yyj3479 < len(yyv3479) {
+			if yyj3484 < len(yyv3484) {
 				if r.TryDecodeAsNil() {
-					yyv3479[yyj3479] = PersistentVolumeClaim{}
+					yyv3484[yyj3484] = PersistentVolumeClaim{}
 				} else {
-					yyv3482 := &yyv3479[yyj3479]
-					yyv3482.CodecDecodeSelf(d)
+					yyv3487 := &yyv3484[yyj3484]
+					yyv3487.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -40206,10 +40243,10 @@ func (x codecSelfer1234) decSlicePersistentVolumeClaim(v *[]PersistentVolumeClai
 			}
 
 		}
-		yyh3479.End()
+		yyh3484.End()
 	}
-	if yyc3479 {
-		*v = yyv3479
+	if yyc3484 {
+		*v = yyv3484
 	}
 
 }
@@ -40219,114 +40256,14 @@ func (x codecSelfer1234) encSliceDownwardAPIVolumeFile(v []DownwardAPIVolumeFile
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3483 := range v {
-		yy3484 := &yyv3483
-		yy3484.CodecEncodeSelf(e)
+	for _, yyv3488 := range v {
+		yy3489 := &yyv3488
+		yy3489.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
 
 func (x codecSelfer1234) decSliceDownwardAPIVolumeFile(v *[]DownwardAPIVolumeFile, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-
-	yyv3485 := *v
-	yyh3485, yyl3485 := z.DecSliceHelperStart()
-
-	var yyrr3485, yyrl3485 int
-	var yyc3485, yyrt3485 bool
-	_, _, _ = yyc3485, yyrt3485, yyrl3485
-	yyrr3485 = yyl3485
-
-	if yyv3485 == nil {
-		if yyrl3485, yyrt3485 = z.DecInferLen(yyl3485, z.DecBasicHandle().MaxInitLen, 48); yyrt3485 {
-			yyrr3485 = yyrl3485
-		}
-		yyv3485 = make([]DownwardAPIVolumeFile, yyrl3485)
-		yyc3485 = true
-	}
-
-	if yyl3485 == 0 {
-		if len(yyv3485) != 0 {
-			yyv3485 = yyv3485[:0]
-			yyc3485 = true
-		}
-	} else if yyl3485 > 0 {
-
-		if yyl3485 > cap(yyv3485) {
-			yyrl3485, yyrt3485 = z.DecInferLen(yyl3485, z.DecBasicHandle().MaxInitLen, 48)
-			yyv3485 = make([]DownwardAPIVolumeFile, yyrl3485)
-			yyc3485 = true
-
-			yyrr3485 = len(yyv3485)
-		} else if yyl3485 != len(yyv3485) {
-			yyv3485 = yyv3485[:yyl3485]
-			yyc3485 = true
-		}
-		yyj3485 := 0
-		for ; yyj3485 < yyrr3485; yyj3485++ {
-			if r.TryDecodeAsNil() {
-				yyv3485[yyj3485] = DownwardAPIVolumeFile{}
-			} else {
-				yyv3486 := &yyv3485[yyj3485]
-				yyv3486.CodecDecodeSelf(d)
-			}
-
-		}
-		if yyrt3485 {
-			for ; yyj3485 < yyl3485; yyj3485++ {
-				yyv3485 = append(yyv3485, DownwardAPIVolumeFile{})
-				if r.TryDecodeAsNil() {
-					yyv3485[yyj3485] = DownwardAPIVolumeFile{}
-				} else {
-					yyv3487 := &yyv3485[yyj3485]
-					yyv3487.CodecDecodeSelf(d)
-				}
-
-			}
-		}
-
-	} else {
-		for yyj3485 := 0; !r.CheckBreak(); yyj3485++ {
-			if yyj3485 >= len(yyv3485) {
-				yyv3485 = append(yyv3485, DownwardAPIVolumeFile{}) // var yyz3485 DownwardAPIVolumeFile
-				yyc3485 = true
-			}
-
-			if yyj3485 < len(yyv3485) {
-				if r.TryDecodeAsNil() {
-					yyv3485[yyj3485] = DownwardAPIVolumeFile{}
-				} else {
-					yyv3488 := &yyv3485[yyj3485]
-					yyv3488.CodecDecodeSelf(d)
-				}
-
-			} else {
-				z.DecSwallow()
-			}
-
-		}
-		yyh3485.End()
-	}
-	if yyc3485 {
-		*v = yyv3485
-	}
-
-}
-
-func (x codecSelfer1234) encSliceCapability(v []Capability, e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	r.EncodeArrayStart(len(v))
-	for _, yyv3489 := range v {
-		yyv3489.CodecEncodeSelf(e)
-	}
-	r.EncodeEnd()
-}
-
-func (x codecSelfer1234) decSliceCapability(v *[]Capability, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -40340,10 +40277,10 @@ func (x codecSelfer1234) decSliceCapability(v *[]Capability, d *codec1978.Decode
 	yyrr3490 = yyl3490
 
 	if yyv3490 == nil {
-		if yyrl3490, yyrt3490 = z.DecInferLen(yyl3490, z.DecBasicHandle().MaxInitLen, 16); yyrt3490 {
+		if yyrl3490, yyrt3490 = z.DecInferLen(yyl3490, z.DecBasicHandle().MaxInitLen, 48); yyrt3490 {
 			yyrr3490 = yyrl3490
 		}
-		yyv3490 = make([]Capability, yyrl3490)
+		yyv3490 = make([]DownwardAPIVolumeFile, yyrl3490)
 		yyc3490 = true
 	}
 
@@ -40355,13 +40292,8 @@ func (x codecSelfer1234) decSliceCapability(v *[]Capability, d *codec1978.Decode
 	} else if yyl3490 > 0 {
 
 		if yyl3490 > cap(yyv3490) {
-			yyrl3490, yyrt3490 = z.DecInferLen(yyl3490, z.DecBasicHandle().MaxInitLen, 16)
-
-			yyv23490 := yyv3490
-			yyv3490 = make([]Capability, yyrl3490)
-			if len(yyv3490) > 0 {
-				copy(yyv3490, yyv23490[:cap(yyv23490)])
-			}
+			yyrl3490, yyrt3490 = z.DecInferLen(yyl3490, z.DecBasicHandle().MaxInitLen, 48)
+			yyv3490 = make([]DownwardAPIVolumeFile, yyrl3490)
 			yyc3490 = true
 
 			yyrr3490 = len(yyv3490)
@@ -40372,19 +40304,21 @@ func (x codecSelfer1234) decSliceCapability(v *[]Capability, d *codec1978.Decode
 		yyj3490 := 0
 		for ; yyj3490 < yyrr3490; yyj3490++ {
 			if r.TryDecodeAsNil() {
-				yyv3490[yyj3490] = ""
+				yyv3490[yyj3490] = DownwardAPIVolumeFile{}
 			} else {
-				yyv3490[yyj3490] = Capability(r.DecodeString())
+				yyv3491 := &yyv3490[yyj3490]
+				yyv3491.CodecDecodeSelf(d)
 			}
 
 		}
 		if yyrt3490 {
 			for ; yyj3490 < yyl3490; yyj3490++ {
-				yyv3490 = append(yyv3490, "")
+				yyv3490 = append(yyv3490, DownwardAPIVolumeFile{})
 				if r.TryDecodeAsNil() {
-					yyv3490[yyj3490] = ""
+					yyv3490[yyj3490] = DownwardAPIVolumeFile{}
 				} else {
-					yyv3490[yyj3490] = Capability(r.DecodeString())
+					yyv3492 := &yyv3490[yyj3490]
+					yyv3492.CodecDecodeSelf(d)
 				}
 
 			}
@@ -40393,15 +40327,16 @@ func (x codecSelfer1234) decSliceCapability(v *[]Capability, d *codec1978.Decode
 	} else {
 		for yyj3490 := 0; !r.CheckBreak(); yyj3490++ {
 			if yyj3490 >= len(yyv3490) {
-				yyv3490 = append(yyv3490, "") // var yyz3490 Capability
+				yyv3490 = append(yyv3490, DownwardAPIVolumeFile{}) // var yyz3490 DownwardAPIVolumeFile
 				yyc3490 = true
 			}
 
 			if yyj3490 < len(yyv3490) {
 				if r.TryDecodeAsNil() {
-					yyv3490[yyj3490] = ""
+					yyv3490[yyj3490] = DownwardAPIVolumeFile{}
 				} else {
-					yyv3490[yyj3490] = Capability(r.DecodeString())
+					yyv3493 := &yyv3490[yyj3490]
+					yyv3493.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -40417,14 +40352,116 @@ func (x codecSelfer1234) decSliceCapability(v *[]Capability, d *codec1978.Decode
 
 }
 
-func (x codecSelfer1234) encSliceContainerPort(v []ContainerPort, e *codec1978.Encoder) {
+func (x codecSelfer1234) encSliceCapability(v []Capability, e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3494 := range v {
-		yy3495 := &yyv3494
-		yy3495.CodecEncodeSelf(e)
+		yyv3494.CodecEncodeSelf(e)
+	}
+	r.EncodeEnd()
+}
+
+func (x codecSelfer1234) decSliceCapability(v *[]Capability, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv3495 := *v
+	yyh3495, yyl3495 := z.DecSliceHelperStart()
+
+	var yyrr3495, yyrl3495 int
+	var yyc3495, yyrt3495 bool
+	_, _, _ = yyc3495, yyrt3495, yyrl3495
+	yyrr3495 = yyl3495
+
+	if yyv3495 == nil {
+		if yyrl3495, yyrt3495 = z.DecInferLen(yyl3495, z.DecBasicHandle().MaxInitLen, 16); yyrt3495 {
+			yyrr3495 = yyrl3495
+		}
+		yyv3495 = make([]Capability, yyrl3495)
+		yyc3495 = true
+	}
+
+	if yyl3495 == 0 {
+		if len(yyv3495) != 0 {
+			yyv3495 = yyv3495[:0]
+			yyc3495 = true
+		}
+	} else if yyl3495 > 0 {
+
+		if yyl3495 > cap(yyv3495) {
+			yyrl3495, yyrt3495 = z.DecInferLen(yyl3495, z.DecBasicHandle().MaxInitLen, 16)
+
+			yyv23495 := yyv3495
+			yyv3495 = make([]Capability, yyrl3495)
+			if len(yyv3495) > 0 {
+				copy(yyv3495, yyv23495[:cap(yyv23495)])
+			}
+			yyc3495 = true
+
+			yyrr3495 = len(yyv3495)
+		} else if yyl3495 != len(yyv3495) {
+			yyv3495 = yyv3495[:yyl3495]
+			yyc3495 = true
+		}
+		yyj3495 := 0
+		for ; yyj3495 < yyrr3495; yyj3495++ {
+			if r.TryDecodeAsNil() {
+				yyv3495[yyj3495] = ""
+			} else {
+				yyv3495[yyj3495] = Capability(r.DecodeString())
+			}
+
+		}
+		if yyrt3495 {
+			for ; yyj3495 < yyl3495; yyj3495++ {
+				yyv3495 = append(yyv3495, "")
+				if r.TryDecodeAsNil() {
+					yyv3495[yyj3495] = ""
+				} else {
+					yyv3495[yyj3495] = Capability(r.DecodeString())
+				}
+
+			}
+		}
+
+	} else {
+		for yyj3495 := 0; !r.CheckBreak(); yyj3495++ {
+			if yyj3495 >= len(yyv3495) {
+				yyv3495 = append(yyv3495, "") // var yyz3495 Capability
+				yyc3495 = true
+			}
+
+			if yyj3495 < len(yyv3495) {
+				if r.TryDecodeAsNil() {
+					yyv3495[yyj3495] = ""
+				} else {
+					yyv3495[yyj3495] = Capability(r.DecodeString())
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		yyh3495.End()
+	}
+	if yyc3495 {
+		*v = yyv3495
+	}
+
+}
+
+func (x codecSelfer1234) encSliceContainerPort(v []ContainerPort, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv3499 := range v {
+		yy3500 := &yyv3499
+		yy3500.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -40434,75 +40471,75 @@ func (x codecSelfer1234) decSliceContainerPort(v *[]ContainerPort, d *codec1978.
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3496 := *v
-	yyh3496, yyl3496 := z.DecSliceHelperStart()
+	yyv3501 := *v
+	yyh3501, yyl3501 := z.DecSliceHelperStart()
 
-	var yyrr3496, yyrl3496 int
-	var yyc3496, yyrt3496 bool
-	_, _, _ = yyc3496, yyrt3496, yyrl3496
-	yyrr3496 = yyl3496
+	var yyrr3501, yyrl3501 int
+	var yyc3501, yyrt3501 bool
+	_, _, _ = yyc3501, yyrt3501, yyrl3501
+	yyrr3501 = yyl3501
 
-	if yyv3496 == nil {
-		if yyrl3496, yyrt3496 = z.DecInferLen(yyl3496, z.DecBasicHandle().MaxInitLen, 64); yyrt3496 {
-			yyrr3496 = yyrl3496
+	if yyv3501 == nil {
+		if yyrl3501, yyrt3501 = z.DecInferLen(yyl3501, z.DecBasicHandle().MaxInitLen, 64); yyrt3501 {
+			yyrr3501 = yyrl3501
 		}
-		yyv3496 = make([]ContainerPort, yyrl3496)
-		yyc3496 = true
+		yyv3501 = make([]ContainerPort, yyrl3501)
+		yyc3501 = true
 	}
 
-	if yyl3496 == 0 {
-		if len(yyv3496) != 0 {
-			yyv3496 = yyv3496[:0]
-			yyc3496 = true
+	if yyl3501 == 0 {
+		if len(yyv3501) != 0 {
+			yyv3501 = yyv3501[:0]
+			yyc3501 = true
 		}
-	} else if yyl3496 > 0 {
+	} else if yyl3501 > 0 {
 
-		if yyl3496 > cap(yyv3496) {
-			yyrl3496, yyrt3496 = z.DecInferLen(yyl3496, z.DecBasicHandle().MaxInitLen, 64)
-			yyv3496 = make([]ContainerPort, yyrl3496)
-			yyc3496 = true
+		if yyl3501 > cap(yyv3501) {
+			yyrl3501, yyrt3501 = z.DecInferLen(yyl3501, z.DecBasicHandle().MaxInitLen, 64)
+			yyv3501 = make([]ContainerPort, yyrl3501)
+			yyc3501 = true
 
-			yyrr3496 = len(yyv3496)
-		} else if yyl3496 != len(yyv3496) {
-			yyv3496 = yyv3496[:yyl3496]
-			yyc3496 = true
+			yyrr3501 = len(yyv3501)
+		} else if yyl3501 != len(yyv3501) {
+			yyv3501 = yyv3501[:yyl3501]
+			yyc3501 = true
 		}
-		yyj3496 := 0
-		for ; yyj3496 < yyrr3496; yyj3496++ {
+		yyj3501 := 0
+		for ; yyj3501 < yyrr3501; yyj3501++ {
 			if r.TryDecodeAsNil() {
-				yyv3496[yyj3496] = ContainerPort{}
+				yyv3501[yyj3501] = ContainerPort{}
 			} else {
-				yyv3497 := &yyv3496[yyj3496]
-				yyv3497.CodecDecodeSelf(d)
+				yyv3502 := &yyv3501[yyj3501]
+				yyv3502.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3496 {
-			for ; yyj3496 < yyl3496; yyj3496++ {
-				yyv3496 = append(yyv3496, ContainerPort{})
+		if yyrt3501 {
+			for ; yyj3501 < yyl3501; yyj3501++ {
+				yyv3501 = append(yyv3501, ContainerPort{})
 				if r.TryDecodeAsNil() {
-					yyv3496[yyj3496] = ContainerPort{}
+					yyv3501[yyj3501] = ContainerPort{}
 				} else {
-					yyv3498 := &yyv3496[yyj3496]
-					yyv3498.CodecDecodeSelf(d)
+					yyv3503 := &yyv3501[yyj3501]
+					yyv3503.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3496 := 0; !r.CheckBreak(); yyj3496++ {
-			if yyj3496 >= len(yyv3496) {
-				yyv3496 = append(yyv3496, ContainerPort{}) // var yyz3496 ContainerPort
-				yyc3496 = true
+		for yyj3501 := 0; !r.CheckBreak(); yyj3501++ {
+			if yyj3501 >= len(yyv3501) {
+				yyv3501 = append(yyv3501, ContainerPort{}) // var yyz3501 ContainerPort
+				yyc3501 = true
 			}
 
-			if yyj3496 < len(yyv3496) {
+			if yyj3501 < len(yyv3501) {
 				if r.TryDecodeAsNil() {
-					yyv3496[yyj3496] = ContainerPort{}
+					yyv3501[yyj3501] = ContainerPort{}
 				} else {
-					yyv3499 := &yyv3496[yyj3496]
-					yyv3499.CodecDecodeSelf(d)
+					yyv3504 := &yyv3501[yyj3501]
+					yyv3504.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -40510,10 +40547,10 @@ func (x codecSelfer1234) decSliceContainerPort(v *[]ContainerPort, d *codec1978.
 			}
 
 		}
-		yyh3496.End()
+		yyh3501.End()
 	}
-	if yyc3496 {
-		*v = yyv3496
+	if yyc3501 {
+		*v = yyv3501
 	}
 
 }
@@ -40523,9 +40560,9 @@ func (x codecSelfer1234) encSliceEnvVar(v []EnvVar, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3500 := range v {
-		yy3501 := &yyv3500
-		yy3501.CodecEncodeSelf(e)
+	for _, yyv3505 := range v {
+		yy3506 := &yyv3505
+		yy3506.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -40535,75 +40572,75 @@ func (x codecSelfer1234) decSliceEnvVar(v *[]EnvVar, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3502 := *v
-	yyh3502, yyl3502 := z.DecSliceHelperStart()
+	yyv3507 := *v
+	yyh3507, yyl3507 := z.DecSliceHelperStart()
 
-	var yyrr3502, yyrl3502 int
-	var yyc3502, yyrt3502 bool
-	_, _, _ = yyc3502, yyrt3502, yyrl3502
-	yyrr3502 = yyl3502
+	var yyrr3507, yyrl3507 int
+	var yyc3507, yyrt3507 bool
+	_, _, _ = yyc3507, yyrt3507, yyrl3507
+	yyrr3507 = yyl3507
 
-	if yyv3502 == nil {
-		if yyrl3502, yyrt3502 = z.DecInferLen(yyl3502, z.DecBasicHandle().MaxInitLen, 40); yyrt3502 {
-			yyrr3502 = yyrl3502
+	if yyv3507 == nil {
+		if yyrl3507, yyrt3507 = z.DecInferLen(yyl3507, z.DecBasicHandle().MaxInitLen, 40); yyrt3507 {
+			yyrr3507 = yyrl3507
 		}
-		yyv3502 = make([]EnvVar, yyrl3502)
-		yyc3502 = true
+		yyv3507 = make([]EnvVar, yyrl3507)
+		yyc3507 = true
 	}
 
-	if yyl3502 == 0 {
-		if len(yyv3502) != 0 {
-			yyv3502 = yyv3502[:0]
-			yyc3502 = true
+	if yyl3507 == 0 {
+		if len(yyv3507) != 0 {
+			yyv3507 = yyv3507[:0]
+			yyc3507 = true
 		}
-	} else if yyl3502 > 0 {
+	} else if yyl3507 > 0 {
 
-		if yyl3502 > cap(yyv3502) {
-			yyrl3502, yyrt3502 = z.DecInferLen(yyl3502, z.DecBasicHandle().MaxInitLen, 40)
-			yyv3502 = make([]EnvVar, yyrl3502)
-			yyc3502 = true
+		if yyl3507 > cap(yyv3507) {
+			yyrl3507, yyrt3507 = z.DecInferLen(yyl3507, z.DecBasicHandle().MaxInitLen, 40)
+			yyv3507 = make([]EnvVar, yyrl3507)
+			yyc3507 = true
 
-			yyrr3502 = len(yyv3502)
-		} else if yyl3502 != len(yyv3502) {
-			yyv3502 = yyv3502[:yyl3502]
-			yyc3502 = true
+			yyrr3507 = len(yyv3507)
+		} else if yyl3507 != len(yyv3507) {
+			yyv3507 = yyv3507[:yyl3507]
+			yyc3507 = true
 		}
-		yyj3502 := 0
-		for ; yyj3502 < yyrr3502; yyj3502++ {
+		yyj3507 := 0
+		for ; yyj3507 < yyrr3507; yyj3507++ {
 			if r.TryDecodeAsNil() {
-				yyv3502[yyj3502] = EnvVar{}
+				yyv3507[yyj3507] = EnvVar{}
 			} else {
-				yyv3503 := &yyv3502[yyj3502]
-				yyv3503.CodecDecodeSelf(d)
+				yyv3508 := &yyv3507[yyj3507]
+				yyv3508.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3502 {
-			for ; yyj3502 < yyl3502; yyj3502++ {
-				yyv3502 = append(yyv3502, EnvVar{})
+		if yyrt3507 {
+			for ; yyj3507 < yyl3507; yyj3507++ {
+				yyv3507 = append(yyv3507, EnvVar{})
 				if r.TryDecodeAsNil() {
-					yyv3502[yyj3502] = EnvVar{}
+					yyv3507[yyj3507] = EnvVar{}
 				} else {
-					yyv3504 := &yyv3502[yyj3502]
-					yyv3504.CodecDecodeSelf(d)
+					yyv3509 := &yyv3507[yyj3507]
+					yyv3509.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3502 := 0; !r.CheckBreak(); yyj3502++ {
-			if yyj3502 >= len(yyv3502) {
-				yyv3502 = append(yyv3502, EnvVar{}) // var yyz3502 EnvVar
-				yyc3502 = true
+		for yyj3507 := 0; !r.CheckBreak(); yyj3507++ {
+			if yyj3507 >= len(yyv3507) {
+				yyv3507 = append(yyv3507, EnvVar{}) // var yyz3507 EnvVar
+				yyc3507 = true
 			}
 
-			if yyj3502 < len(yyv3502) {
+			if yyj3507 < len(yyv3507) {
 				if r.TryDecodeAsNil() {
-					yyv3502[yyj3502] = EnvVar{}
+					yyv3507[yyj3507] = EnvVar{}
 				} else {
-					yyv3505 := &yyv3502[yyj3502]
-					yyv3505.CodecDecodeSelf(d)
+					yyv3510 := &yyv3507[yyj3507]
+					yyv3510.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -40611,10 +40648,10 @@ func (x codecSelfer1234) decSliceEnvVar(v *[]EnvVar, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3502.End()
+		yyh3507.End()
 	}
-	if yyc3502 {
-		*v = yyv3502
+	if yyc3507 {
+		*v = yyv3507
 	}
 
 }
@@ -40624,9 +40661,9 @@ func (x codecSelfer1234) encSliceVolumeMount(v []VolumeMount, e *codec1978.Encod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3506 := range v {
-		yy3507 := &yyv3506
-		yy3507.CodecEncodeSelf(e)
+	for _, yyv3511 := range v {
+		yy3512 := &yyv3511
+		yy3512.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -40636,75 +40673,75 @@ func (x codecSelfer1234) decSliceVolumeMount(v *[]VolumeMount, d *codec1978.Deco
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3508 := *v
-	yyh3508, yyl3508 := z.DecSliceHelperStart()
+	yyv3513 := *v
+	yyh3513, yyl3513 := z.DecSliceHelperStart()
 
-	var yyrr3508, yyrl3508 int
-	var yyc3508, yyrt3508 bool
-	_, _, _ = yyc3508, yyrt3508, yyrl3508
-	yyrr3508 = yyl3508
+	var yyrr3513, yyrl3513 int
+	var yyc3513, yyrt3513 bool
+	_, _, _ = yyc3513, yyrt3513, yyrl3513
+	yyrr3513 = yyl3513
 
-	if yyv3508 == nil {
-		if yyrl3508, yyrt3508 = z.DecInferLen(yyl3508, z.DecBasicHandle().MaxInitLen, 40); yyrt3508 {
-			yyrr3508 = yyrl3508
+	if yyv3513 == nil {
+		if yyrl3513, yyrt3513 = z.DecInferLen(yyl3513, z.DecBasicHandle().MaxInitLen, 40); yyrt3513 {
+			yyrr3513 = yyrl3513
 		}
-		yyv3508 = make([]VolumeMount, yyrl3508)
-		yyc3508 = true
+		yyv3513 = make([]VolumeMount, yyrl3513)
+		yyc3513 = true
 	}
 
-	if yyl3508 == 0 {
-		if len(yyv3508) != 0 {
-			yyv3508 = yyv3508[:0]
-			yyc3508 = true
+	if yyl3513 == 0 {
+		if len(yyv3513) != 0 {
+			yyv3513 = yyv3513[:0]
+			yyc3513 = true
 		}
-	} else if yyl3508 > 0 {
+	} else if yyl3513 > 0 {
 
-		if yyl3508 > cap(yyv3508) {
-			yyrl3508, yyrt3508 = z.DecInferLen(yyl3508, z.DecBasicHandle().MaxInitLen, 40)
-			yyv3508 = make([]VolumeMount, yyrl3508)
-			yyc3508 = true
+		if yyl3513 > cap(yyv3513) {
+			yyrl3513, yyrt3513 = z.DecInferLen(yyl3513, z.DecBasicHandle().MaxInitLen, 40)
+			yyv3513 = make([]VolumeMount, yyrl3513)
+			yyc3513 = true
 
-			yyrr3508 = len(yyv3508)
-		} else if yyl3508 != len(yyv3508) {
-			yyv3508 = yyv3508[:yyl3508]
-			yyc3508 = true
+			yyrr3513 = len(yyv3513)
+		} else if yyl3513 != len(yyv3513) {
+			yyv3513 = yyv3513[:yyl3513]
+			yyc3513 = true
 		}
-		yyj3508 := 0
-		for ; yyj3508 < yyrr3508; yyj3508++ {
+		yyj3513 := 0
+		for ; yyj3513 < yyrr3513; yyj3513++ {
 			if r.TryDecodeAsNil() {
-				yyv3508[yyj3508] = VolumeMount{}
+				yyv3513[yyj3513] = VolumeMount{}
 			} else {
-				yyv3509 := &yyv3508[yyj3508]
-				yyv3509.CodecDecodeSelf(d)
+				yyv3514 := &yyv3513[yyj3513]
+				yyv3514.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3508 {
-			for ; yyj3508 < yyl3508; yyj3508++ {
-				yyv3508 = append(yyv3508, VolumeMount{})
+		if yyrt3513 {
+			for ; yyj3513 < yyl3513; yyj3513++ {
+				yyv3513 = append(yyv3513, VolumeMount{})
 				if r.TryDecodeAsNil() {
-					yyv3508[yyj3508] = VolumeMount{}
+					yyv3513[yyj3513] = VolumeMount{}
 				} else {
-					yyv3510 := &yyv3508[yyj3508]
-					yyv3510.CodecDecodeSelf(d)
+					yyv3515 := &yyv3513[yyj3513]
+					yyv3515.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3508 := 0; !r.CheckBreak(); yyj3508++ {
-			if yyj3508 >= len(yyv3508) {
-				yyv3508 = append(yyv3508, VolumeMount{}) // var yyz3508 VolumeMount
-				yyc3508 = true
+		for yyj3513 := 0; !r.CheckBreak(); yyj3513++ {
+			if yyj3513 >= len(yyv3513) {
+				yyv3513 = append(yyv3513, VolumeMount{}) // var yyz3513 VolumeMount
+				yyc3513 = true
 			}
 
-			if yyj3508 < len(yyv3508) {
+			if yyj3513 < len(yyv3513) {
 				if r.TryDecodeAsNil() {
-					yyv3508[yyj3508] = VolumeMount{}
+					yyv3513[yyj3513] = VolumeMount{}
 				} else {
-					yyv3511 := &yyv3508[yyj3508]
-					yyv3511.CodecDecodeSelf(d)
+					yyv3516 := &yyv3513[yyj3513]
+					yyv3516.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -40712,10 +40749,10 @@ func (x codecSelfer1234) decSliceVolumeMount(v *[]VolumeMount, d *codec1978.Deco
 			}
 
 		}
-		yyh3508.End()
+		yyh3513.End()
 	}
-	if yyc3508 {
-		*v = yyv3508
+	if yyc3513 {
+		*v = yyv3513
 	}
 
 }
@@ -40725,9 +40762,9 @@ func (x codecSelfer1234) encSlicePod(v []Pod, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3512 := range v {
-		yy3513 := &yyv3512
-		yy3513.CodecEncodeSelf(e)
+	for _, yyv3517 := range v {
+		yy3518 := &yyv3517
+		yy3518.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -40737,75 +40774,75 @@ func (x codecSelfer1234) decSlicePod(v *[]Pod, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3514 := *v
-	yyh3514, yyl3514 := z.DecSliceHelperStart()
+	yyv3519 := *v
+	yyh3519, yyl3519 := z.DecSliceHelperStart()
 
-	var yyrr3514, yyrl3514 int
-	var yyc3514, yyrt3514 bool
-	_, _, _ = yyc3514, yyrt3514, yyrl3514
-	yyrr3514 = yyl3514
+	var yyrr3519, yyrl3519 int
+	var yyc3519, yyrt3519 bool
+	_, _, _ = yyc3519, yyrt3519, yyrl3519
+	yyrr3519 = yyl3519
 
-	if yyv3514 == nil {
-		if yyrl3514, yyrt3514 = z.DecInferLen(yyl3514, z.DecBasicHandle().MaxInitLen, 496); yyrt3514 {
-			yyrr3514 = yyrl3514
+	if yyv3519 == nil {
+		if yyrl3519, yyrt3519 = z.DecInferLen(yyl3519, z.DecBasicHandle().MaxInitLen, 496); yyrt3519 {
+			yyrr3519 = yyrl3519
 		}
-		yyv3514 = make([]Pod, yyrl3514)
-		yyc3514 = true
+		yyv3519 = make([]Pod, yyrl3519)
+		yyc3519 = true
 	}
 
-	if yyl3514 == 0 {
-		if len(yyv3514) != 0 {
-			yyv3514 = yyv3514[:0]
-			yyc3514 = true
+	if yyl3519 == 0 {
+		if len(yyv3519) != 0 {
+			yyv3519 = yyv3519[:0]
+			yyc3519 = true
 		}
-	} else if yyl3514 > 0 {
+	} else if yyl3519 > 0 {
 
-		if yyl3514 > cap(yyv3514) {
-			yyrl3514, yyrt3514 = z.DecInferLen(yyl3514, z.DecBasicHandle().MaxInitLen, 496)
-			yyv3514 = make([]Pod, yyrl3514)
-			yyc3514 = true
+		if yyl3519 > cap(yyv3519) {
+			yyrl3519, yyrt3519 = z.DecInferLen(yyl3519, z.DecBasicHandle().MaxInitLen, 496)
+			yyv3519 = make([]Pod, yyrl3519)
+			yyc3519 = true
 
-			yyrr3514 = len(yyv3514)
-		} else if yyl3514 != len(yyv3514) {
-			yyv3514 = yyv3514[:yyl3514]
-			yyc3514 = true
+			yyrr3519 = len(yyv3519)
+		} else if yyl3519 != len(yyv3519) {
+			yyv3519 = yyv3519[:yyl3519]
+			yyc3519 = true
 		}
-		yyj3514 := 0
-		for ; yyj3514 < yyrr3514; yyj3514++ {
+		yyj3519 := 0
+		for ; yyj3519 < yyrr3519; yyj3519++ {
 			if r.TryDecodeAsNil() {
-				yyv3514[yyj3514] = Pod{}
+				yyv3519[yyj3519] = Pod{}
 			} else {
-				yyv3515 := &yyv3514[yyj3514]
-				yyv3515.CodecDecodeSelf(d)
+				yyv3520 := &yyv3519[yyj3519]
+				yyv3520.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3514 {
-			for ; yyj3514 < yyl3514; yyj3514++ {
-				yyv3514 = append(yyv3514, Pod{})
+		if yyrt3519 {
+			for ; yyj3519 < yyl3519; yyj3519++ {
+				yyv3519 = append(yyv3519, Pod{})
 				if r.TryDecodeAsNil() {
-					yyv3514[yyj3514] = Pod{}
+					yyv3519[yyj3519] = Pod{}
 				} else {
-					yyv3516 := &yyv3514[yyj3514]
-					yyv3516.CodecDecodeSelf(d)
+					yyv3521 := &yyv3519[yyj3519]
+					yyv3521.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3514 := 0; !r.CheckBreak(); yyj3514++ {
-			if yyj3514 >= len(yyv3514) {
-				yyv3514 = append(yyv3514, Pod{}) // var yyz3514 Pod
-				yyc3514 = true
+		for yyj3519 := 0; !r.CheckBreak(); yyj3519++ {
+			if yyj3519 >= len(yyv3519) {
+				yyv3519 = append(yyv3519, Pod{}) // var yyz3519 Pod
+				yyc3519 = true
 			}
 
-			if yyj3514 < len(yyv3514) {
+			if yyj3519 < len(yyv3519) {
 				if r.TryDecodeAsNil() {
-					yyv3514[yyj3514] = Pod{}
+					yyv3519[yyj3519] = Pod{}
 				} else {
-					yyv3517 := &yyv3514[yyj3514]
-					yyv3517.CodecDecodeSelf(d)
+					yyv3522 := &yyv3519[yyj3519]
+					yyv3522.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -40813,10 +40850,10 @@ func (x codecSelfer1234) decSlicePod(v *[]Pod, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3514.End()
+		yyh3519.End()
 	}
-	if yyc3514 {
-		*v = yyv3514
+	if yyc3519 {
+		*v = yyv3519
 	}
 
 }
@@ -40826,9 +40863,9 @@ func (x codecSelfer1234) encSliceVolume(v []Volume, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3518 := range v {
-		yy3519 := &yyv3518
-		yy3519.CodecEncodeSelf(e)
+	for _, yyv3523 := range v {
+		yy3524 := &yyv3523
+		yy3524.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -40838,75 +40875,75 @@ func (x codecSelfer1234) decSliceVolume(v *[]Volume, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3520 := *v
-	yyh3520, yyl3520 := z.DecSliceHelperStart()
+	yyv3525 := *v
+	yyh3525, yyl3525 := z.DecSliceHelperStart()
 
-	var yyrr3520, yyrl3520 int
-	var yyc3520, yyrt3520 bool
-	_, _, _ = yyc3520, yyrt3520, yyrl3520
-	yyrr3520 = yyl3520
+	var yyrr3525, yyrl3525 int
+	var yyc3525, yyrt3525 bool
+	_, _, _ = yyc3525, yyrt3525, yyrl3525
+	yyrr3525 = yyl3525
 
-	if yyv3520 == nil {
-		if yyrl3520, yyrt3520 = z.DecInferLen(yyl3520, z.DecBasicHandle().MaxInitLen, 144); yyrt3520 {
-			yyrr3520 = yyrl3520
+	if yyv3525 == nil {
+		if yyrl3525, yyrt3525 = z.DecInferLen(yyl3525, z.DecBasicHandle().MaxInitLen, 144); yyrt3525 {
+			yyrr3525 = yyrl3525
 		}
-		yyv3520 = make([]Volume, yyrl3520)
-		yyc3520 = true
+		yyv3525 = make([]Volume, yyrl3525)
+		yyc3525 = true
 	}
 
-	if yyl3520 == 0 {
-		if len(yyv3520) != 0 {
-			yyv3520 = yyv3520[:0]
-			yyc3520 = true
+	if yyl3525 == 0 {
+		if len(yyv3525) != 0 {
+			yyv3525 = yyv3525[:0]
+			yyc3525 = true
 		}
-	} else if yyl3520 > 0 {
+	} else if yyl3525 > 0 {
 
-		if yyl3520 > cap(yyv3520) {
-			yyrl3520, yyrt3520 = z.DecInferLen(yyl3520, z.DecBasicHandle().MaxInitLen, 144)
-			yyv3520 = make([]Volume, yyrl3520)
-			yyc3520 = true
+		if yyl3525 > cap(yyv3525) {
+			yyrl3525, yyrt3525 = z.DecInferLen(yyl3525, z.DecBasicHandle().MaxInitLen, 144)
+			yyv3525 = make([]Volume, yyrl3525)
+			yyc3525 = true
 
-			yyrr3520 = len(yyv3520)
-		} else if yyl3520 != len(yyv3520) {
-			yyv3520 = yyv3520[:yyl3520]
-			yyc3520 = true
+			yyrr3525 = len(yyv3525)
+		} else if yyl3525 != len(yyv3525) {
+			yyv3525 = yyv3525[:yyl3525]
+			yyc3525 = true
 		}
-		yyj3520 := 0
-		for ; yyj3520 < yyrr3520; yyj3520++ {
+		yyj3525 := 0
+		for ; yyj3525 < yyrr3525; yyj3525++ {
 			if r.TryDecodeAsNil() {
-				yyv3520[yyj3520] = Volume{}
+				yyv3525[yyj3525] = Volume{}
 			} else {
-				yyv3521 := &yyv3520[yyj3520]
-				yyv3521.CodecDecodeSelf(d)
+				yyv3526 := &yyv3525[yyj3525]
+				yyv3526.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3520 {
-			for ; yyj3520 < yyl3520; yyj3520++ {
-				yyv3520 = append(yyv3520, Volume{})
+		if yyrt3525 {
+			for ; yyj3525 < yyl3525; yyj3525++ {
+				yyv3525 = append(yyv3525, Volume{})
 				if r.TryDecodeAsNil() {
-					yyv3520[yyj3520] = Volume{}
+					yyv3525[yyj3525] = Volume{}
 				} else {
-					yyv3522 := &yyv3520[yyj3520]
-					yyv3522.CodecDecodeSelf(d)
+					yyv3527 := &yyv3525[yyj3525]
+					yyv3527.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3520 := 0; !r.CheckBreak(); yyj3520++ {
-			if yyj3520 >= len(yyv3520) {
-				yyv3520 = append(yyv3520, Volume{}) // var yyz3520 Volume
-				yyc3520 = true
+		for yyj3525 := 0; !r.CheckBreak(); yyj3525++ {
+			if yyj3525 >= len(yyv3525) {
+				yyv3525 = append(yyv3525, Volume{}) // var yyz3525 Volume
+				yyc3525 = true
 			}
 
-			if yyj3520 < len(yyv3520) {
+			if yyj3525 < len(yyv3525) {
 				if r.TryDecodeAsNil() {
-					yyv3520[yyj3520] = Volume{}
+					yyv3525[yyj3525] = Volume{}
 				} else {
-					yyv3523 := &yyv3520[yyj3520]
-					yyv3523.CodecDecodeSelf(d)
+					yyv3528 := &yyv3525[yyj3525]
+					yyv3528.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -40914,10 +40951,10 @@ func (x codecSelfer1234) decSliceVolume(v *[]Volume, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3520.End()
+		yyh3525.End()
 	}
-	if yyc3520 {
-		*v = yyv3520
+	if yyc3525 {
+		*v = yyv3525
 	}
 
 }
@@ -40927,9 +40964,9 @@ func (x codecSelfer1234) encSliceContainer(v []Container, e *codec1978.Encoder) 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3524 := range v {
-		yy3525 := &yyv3524
-		yy3525.CodecEncodeSelf(e)
+	for _, yyv3529 := range v {
+		yy3530 := &yyv3529
+		yy3530.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -40939,75 +40976,75 @@ func (x codecSelfer1234) decSliceContainer(v *[]Container, d *codec1978.Decoder)
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3526 := *v
-	yyh3526, yyl3526 := z.DecSliceHelperStart()
+	yyv3531 := *v
+	yyh3531, yyl3531 := z.DecSliceHelperStart()
 
-	var yyrr3526, yyrl3526 int
-	var yyc3526, yyrt3526 bool
-	_, _, _ = yyc3526, yyrt3526, yyrl3526
-	yyrr3526 = yyl3526
+	var yyrr3531, yyrl3531 int
+	var yyc3531, yyrt3531 bool
+	_, _, _ = yyc3531, yyrt3531, yyrl3531
+	yyrr3531 = yyl3531
 
-	if yyv3526 == nil {
-		if yyrl3526, yyrt3526 = z.DecInferLen(yyl3526, z.DecBasicHandle().MaxInitLen, 256); yyrt3526 {
-			yyrr3526 = yyrl3526
+	if yyv3531 == nil {
+		if yyrl3531, yyrt3531 = z.DecInferLen(yyl3531, z.DecBasicHandle().MaxInitLen, 256); yyrt3531 {
+			yyrr3531 = yyrl3531
 		}
-		yyv3526 = make([]Container, yyrl3526)
-		yyc3526 = true
+		yyv3531 = make([]Container, yyrl3531)
+		yyc3531 = true
 	}
 
-	if yyl3526 == 0 {
-		if len(yyv3526) != 0 {
-			yyv3526 = yyv3526[:0]
-			yyc3526 = true
+	if yyl3531 == 0 {
+		if len(yyv3531) != 0 {
+			yyv3531 = yyv3531[:0]
+			yyc3531 = true
 		}
-	} else if yyl3526 > 0 {
+	} else if yyl3531 > 0 {
 
-		if yyl3526 > cap(yyv3526) {
-			yyrl3526, yyrt3526 = z.DecInferLen(yyl3526, z.DecBasicHandle().MaxInitLen, 256)
-			yyv3526 = make([]Container, yyrl3526)
-			yyc3526 = true
+		if yyl3531 > cap(yyv3531) {
+			yyrl3531, yyrt3531 = z.DecInferLen(yyl3531, z.DecBasicHandle().MaxInitLen, 256)
+			yyv3531 = make([]Container, yyrl3531)
+			yyc3531 = true
 
-			yyrr3526 = len(yyv3526)
-		} else if yyl3526 != len(yyv3526) {
-			yyv3526 = yyv3526[:yyl3526]
-			yyc3526 = true
+			yyrr3531 = len(yyv3531)
+		} else if yyl3531 != len(yyv3531) {
+			yyv3531 = yyv3531[:yyl3531]
+			yyc3531 = true
 		}
-		yyj3526 := 0
-		for ; yyj3526 < yyrr3526; yyj3526++ {
+		yyj3531 := 0
+		for ; yyj3531 < yyrr3531; yyj3531++ {
 			if r.TryDecodeAsNil() {
-				yyv3526[yyj3526] = Container{}
+				yyv3531[yyj3531] = Container{}
 			} else {
-				yyv3527 := &yyv3526[yyj3526]
-				yyv3527.CodecDecodeSelf(d)
+				yyv3532 := &yyv3531[yyj3531]
+				yyv3532.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3526 {
-			for ; yyj3526 < yyl3526; yyj3526++ {
-				yyv3526 = append(yyv3526, Container{})
+		if yyrt3531 {
+			for ; yyj3531 < yyl3531; yyj3531++ {
+				yyv3531 = append(yyv3531, Container{})
 				if r.TryDecodeAsNil() {
-					yyv3526[yyj3526] = Container{}
+					yyv3531[yyj3531] = Container{}
 				} else {
-					yyv3528 := &yyv3526[yyj3526]
-					yyv3528.CodecDecodeSelf(d)
+					yyv3533 := &yyv3531[yyj3531]
+					yyv3533.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3526 := 0; !r.CheckBreak(); yyj3526++ {
-			if yyj3526 >= len(yyv3526) {
-				yyv3526 = append(yyv3526, Container{}) // var yyz3526 Container
-				yyc3526 = true
+		for yyj3531 := 0; !r.CheckBreak(); yyj3531++ {
+			if yyj3531 >= len(yyv3531) {
+				yyv3531 = append(yyv3531, Container{}) // var yyz3531 Container
+				yyc3531 = true
 			}
 
-			if yyj3526 < len(yyv3526) {
+			if yyj3531 < len(yyv3531) {
 				if r.TryDecodeAsNil() {
-					yyv3526[yyj3526] = Container{}
+					yyv3531[yyj3531] = Container{}
 				} else {
-					yyv3529 := &yyv3526[yyj3526]
-					yyv3529.CodecDecodeSelf(d)
+					yyv3534 := &yyv3531[yyj3531]
+					yyv3534.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41015,10 +41052,10 @@ func (x codecSelfer1234) decSliceContainer(v *[]Container, d *codec1978.Decoder)
 			}
 
 		}
-		yyh3526.End()
+		yyh3531.End()
 	}
-	if yyc3526 {
-		*v = yyv3526
+	if yyc3531 {
+		*v = yyv3531
 	}
 
 }
@@ -41028,9 +41065,9 @@ func (x codecSelfer1234) encSliceLocalObjectReference(v []LocalObjectReference, 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3530 := range v {
-		yy3531 := &yyv3530
-		yy3531.CodecEncodeSelf(e)
+	for _, yyv3535 := range v {
+		yy3536 := &yyv3535
+		yy3536.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41040,75 +41077,75 @@ func (x codecSelfer1234) decSliceLocalObjectReference(v *[]LocalObjectReference,
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3532 := *v
-	yyh3532, yyl3532 := z.DecSliceHelperStart()
+	yyv3537 := *v
+	yyh3537, yyl3537 := z.DecSliceHelperStart()
 
-	var yyrr3532, yyrl3532 int
-	var yyc3532, yyrt3532 bool
-	_, _, _ = yyc3532, yyrt3532, yyrl3532
-	yyrr3532 = yyl3532
+	var yyrr3537, yyrl3537 int
+	var yyc3537, yyrt3537 bool
+	_, _, _ = yyc3537, yyrt3537, yyrl3537
+	yyrr3537 = yyl3537
 
-	if yyv3532 == nil {
-		if yyrl3532, yyrt3532 = z.DecInferLen(yyl3532, z.DecBasicHandle().MaxInitLen, 16); yyrt3532 {
-			yyrr3532 = yyrl3532
+	if yyv3537 == nil {
+		if yyrl3537, yyrt3537 = z.DecInferLen(yyl3537, z.DecBasicHandle().MaxInitLen, 16); yyrt3537 {
+			yyrr3537 = yyrl3537
 		}
-		yyv3532 = make([]LocalObjectReference, yyrl3532)
-		yyc3532 = true
+		yyv3537 = make([]LocalObjectReference, yyrl3537)
+		yyc3537 = true
 	}
 
-	if yyl3532 == 0 {
-		if len(yyv3532) != 0 {
-			yyv3532 = yyv3532[:0]
-			yyc3532 = true
+	if yyl3537 == 0 {
+		if len(yyv3537) != 0 {
+			yyv3537 = yyv3537[:0]
+			yyc3537 = true
 		}
-	} else if yyl3532 > 0 {
+	} else if yyl3537 > 0 {
 
-		if yyl3532 > cap(yyv3532) {
-			yyrl3532, yyrt3532 = z.DecInferLen(yyl3532, z.DecBasicHandle().MaxInitLen, 16)
-			yyv3532 = make([]LocalObjectReference, yyrl3532)
-			yyc3532 = true
+		if yyl3537 > cap(yyv3537) {
+			yyrl3537, yyrt3537 = z.DecInferLen(yyl3537, z.DecBasicHandle().MaxInitLen, 16)
+			yyv3537 = make([]LocalObjectReference, yyrl3537)
+			yyc3537 = true
 
-			yyrr3532 = len(yyv3532)
-		} else if yyl3532 != len(yyv3532) {
-			yyv3532 = yyv3532[:yyl3532]
-			yyc3532 = true
+			yyrr3537 = len(yyv3537)
+		} else if yyl3537 != len(yyv3537) {
+			yyv3537 = yyv3537[:yyl3537]
+			yyc3537 = true
 		}
-		yyj3532 := 0
-		for ; yyj3532 < yyrr3532; yyj3532++ {
+		yyj3537 := 0
+		for ; yyj3537 < yyrr3537; yyj3537++ {
 			if r.TryDecodeAsNil() {
-				yyv3532[yyj3532] = LocalObjectReference{}
+				yyv3537[yyj3537] = LocalObjectReference{}
 			} else {
-				yyv3533 := &yyv3532[yyj3532]
-				yyv3533.CodecDecodeSelf(d)
+				yyv3538 := &yyv3537[yyj3537]
+				yyv3538.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3532 {
-			for ; yyj3532 < yyl3532; yyj3532++ {
-				yyv3532 = append(yyv3532, LocalObjectReference{})
+		if yyrt3537 {
+			for ; yyj3537 < yyl3537; yyj3537++ {
+				yyv3537 = append(yyv3537, LocalObjectReference{})
 				if r.TryDecodeAsNil() {
-					yyv3532[yyj3532] = LocalObjectReference{}
+					yyv3537[yyj3537] = LocalObjectReference{}
 				} else {
-					yyv3534 := &yyv3532[yyj3532]
-					yyv3534.CodecDecodeSelf(d)
+					yyv3539 := &yyv3537[yyj3537]
+					yyv3539.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3532 := 0; !r.CheckBreak(); yyj3532++ {
-			if yyj3532 >= len(yyv3532) {
-				yyv3532 = append(yyv3532, LocalObjectReference{}) // var yyz3532 LocalObjectReference
-				yyc3532 = true
+		for yyj3537 := 0; !r.CheckBreak(); yyj3537++ {
+			if yyj3537 >= len(yyv3537) {
+				yyv3537 = append(yyv3537, LocalObjectReference{}) // var yyz3537 LocalObjectReference
+				yyc3537 = true
 			}
 
-			if yyj3532 < len(yyv3532) {
+			if yyj3537 < len(yyv3537) {
 				if r.TryDecodeAsNil() {
-					yyv3532[yyj3532] = LocalObjectReference{}
+					yyv3537[yyj3537] = LocalObjectReference{}
 				} else {
-					yyv3535 := &yyv3532[yyj3532]
-					yyv3535.CodecDecodeSelf(d)
+					yyv3540 := &yyv3537[yyj3537]
+					yyv3540.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41116,10 +41153,10 @@ func (x codecSelfer1234) decSliceLocalObjectReference(v *[]LocalObjectReference,
 			}
 
 		}
-		yyh3532.End()
+		yyh3537.End()
 	}
-	if yyc3532 {
-		*v = yyv3532
+	if yyc3537 {
+		*v = yyv3537
 	}
 
 }
@@ -41129,9 +41166,9 @@ func (x codecSelfer1234) encSlicePodCondition(v []PodCondition, e *codec1978.Enc
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3536 := range v {
-		yy3537 := &yyv3536
-		yy3537.CodecEncodeSelf(e)
+	for _, yyv3541 := range v {
+		yy3542 := &yyv3541
+		yy3542.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41141,75 +41178,75 @@ func (x codecSelfer1234) decSlicePodCondition(v *[]PodCondition, d *codec1978.De
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3538 := *v
-	yyh3538, yyl3538 := z.DecSliceHelperStart()
+	yyv3543 := *v
+	yyh3543, yyl3543 := z.DecSliceHelperStart()
 
-	var yyrr3538, yyrl3538 int
-	var yyc3538, yyrt3538 bool
-	_, _, _ = yyc3538, yyrt3538, yyrl3538
-	yyrr3538 = yyl3538
+	var yyrr3543, yyrl3543 int
+	var yyc3543, yyrt3543 bool
+	_, _, _ = yyc3543, yyrt3543, yyrl3543
+	yyrr3543 = yyl3543
 
-	if yyv3538 == nil {
-		if yyrl3538, yyrt3538 = z.DecInferLen(yyl3538, z.DecBasicHandle().MaxInitLen, 112); yyrt3538 {
-			yyrr3538 = yyrl3538
+	if yyv3543 == nil {
+		if yyrl3543, yyrt3543 = z.DecInferLen(yyl3543, z.DecBasicHandle().MaxInitLen, 112); yyrt3543 {
+			yyrr3543 = yyrl3543
 		}
-		yyv3538 = make([]PodCondition, yyrl3538)
-		yyc3538 = true
+		yyv3543 = make([]PodCondition, yyrl3543)
+		yyc3543 = true
 	}
 
-	if yyl3538 == 0 {
-		if len(yyv3538) != 0 {
-			yyv3538 = yyv3538[:0]
-			yyc3538 = true
+	if yyl3543 == 0 {
+		if len(yyv3543) != 0 {
+			yyv3543 = yyv3543[:0]
+			yyc3543 = true
 		}
-	} else if yyl3538 > 0 {
+	} else if yyl3543 > 0 {
 
-		if yyl3538 > cap(yyv3538) {
-			yyrl3538, yyrt3538 = z.DecInferLen(yyl3538, z.DecBasicHandle().MaxInitLen, 112)
-			yyv3538 = make([]PodCondition, yyrl3538)
-			yyc3538 = true
+		if yyl3543 > cap(yyv3543) {
+			yyrl3543, yyrt3543 = z.DecInferLen(yyl3543, z.DecBasicHandle().MaxInitLen, 112)
+			yyv3543 = make([]PodCondition, yyrl3543)
+			yyc3543 = true
 
-			yyrr3538 = len(yyv3538)
-		} else if yyl3538 != len(yyv3538) {
-			yyv3538 = yyv3538[:yyl3538]
-			yyc3538 = true
+			yyrr3543 = len(yyv3543)
+		} else if yyl3543 != len(yyv3543) {
+			yyv3543 = yyv3543[:yyl3543]
+			yyc3543 = true
 		}
-		yyj3538 := 0
-		for ; yyj3538 < yyrr3538; yyj3538++ {
+		yyj3543 := 0
+		for ; yyj3543 < yyrr3543; yyj3543++ {
 			if r.TryDecodeAsNil() {
-				yyv3538[yyj3538] = PodCondition{}
+				yyv3543[yyj3543] = PodCondition{}
 			} else {
-				yyv3539 := &yyv3538[yyj3538]
-				yyv3539.CodecDecodeSelf(d)
+				yyv3544 := &yyv3543[yyj3543]
+				yyv3544.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3538 {
-			for ; yyj3538 < yyl3538; yyj3538++ {
-				yyv3538 = append(yyv3538, PodCondition{})
+		if yyrt3543 {
+			for ; yyj3543 < yyl3543; yyj3543++ {
+				yyv3543 = append(yyv3543, PodCondition{})
 				if r.TryDecodeAsNil() {
-					yyv3538[yyj3538] = PodCondition{}
+					yyv3543[yyj3543] = PodCondition{}
 				} else {
-					yyv3540 := &yyv3538[yyj3538]
-					yyv3540.CodecDecodeSelf(d)
+					yyv3545 := &yyv3543[yyj3543]
+					yyv3545.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3538 := 0; !r.CheckBreak(); yyj3538++ {
-			if yyj3538 >= len(yyv3538) {
-				yyv3538 = append(yyv3538, PodCondition{}) // var yyz3538 PodCondition
-				yyc3538 = true
+		for yyj3543 := 0; !r.CheckBreak(); yyj3543++ {
+			if yyj3543 >= len(yyv3543) {
+				yyv3543 = append(yyv3543, PodCondition{}) // var yyz3543 PodCondition
+				yyc3543 = true
 			}
 
-			if yyj3538 < len(yyv3538) {
+			if yyj3543 < len(yyv3543) {
 				if r.TryDecodeAsNil() {
-					yyv3538[yyj3538] = PodCondition{}
+					yyv3543[yyj3543] = PodCondition{}
 				} else {
-					yyv3541 := &yyv3538[yyj3538]
-					yyv3541.CodecDecodeSelf(d)
+					yyv3546 := &yyv3543[yyj3543]
+					yyv3546.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41217,10 +41254,10 @@ func (x codecSelfer1234) decSlicePodCondition(v *[]PodCondition, d *codec1978.De
 			}
 
 		}
-		yyh3538.End()
+		yyh3543.End()
 	}
-	if yyc3538 {
-		*v = yyv3538
+	if yyc3543 {
+		*v = yyv3543
 	}
 
 }
@@ -41230,9 +41267,9 @@ func (x codecSelfer1234) encSliceContainerStatus(v []ContainerStatus, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3542 := range v {
-		yy3543 := &yyv3542
-		yy3543.CodecEncodeSelf(e)
+	for _, yyv3547 := range v {
+		yy3548 := &yyv3547
+		yy3548.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41242,75 +41279,75 @@ func (x codecSelfer1234) decSliceContainerStatus(v *[]ContainerStatus, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3544 := *v
-	yyh3544, yyl3544 := z.DecSliceHelperStart()
+	yyv3549 := *v
+	yyh3549, yyl3549 := z.DecSliceHelperStart()
 
-	var yyrr3544, yyrl3544 int
-	var yyc3544, yyrt3544 bool
-	_, _, _ = yyc3544, yyrt3544, yyrl3544
-	yyrr3544 = yyl3544
+	var yyrr3549, yyrl3549 int
+	var yyc3549, yyrt3549 bool
+	_, _, _ = yyc3549, yyrt3549, yyrl3549
+	yyrr3549 = yyl3549
 
-	if yyv3544 == nil {
-		if yyrl3544, yyrt3544 = z.DecInferLen(yyl3544, z.DecBasicHandle().MaxInitLen, 128); yyrt3544 {
-			yyrr3544 = yyrl3544
+	if yyv3549 == nil {
+		if yyrl3549, yyrt3549 = z.DecInferLen(yyl3549, z.DecBasicHandle().MaxInitLen, 128); yyrt3549 {
+			yyrr3549 = yyrl3549
 		}
-		yyv3544 = make([]ContainerStatus, yyrl3544)
-		yyc3544 = true
+		yyv3549 = make([]ContainerStatus, yyrl3549)
+		yyc3549 = true
 	}
 
-	if yyl3544 == 0 {
-		if len(yyv3544) != 0 {
-			yyv3544 = yyv3544[:0]
-			yyc3544 = true
+	if yyl3549 == 0 {
+		if len(yyv3549) != 0 {
+			yyv3549 = yyv3549[:0]
+			yyc3549 = true
 		}
-	} else if yyl3544 > 0 {
+	} else if yyl3549 > 0 {
 
-		if yyl3544 > cap(yyv3544) {
-			yyrl3544, yyrt3544 = z.DecInferLen(yyl3544, z.DecBasicHandle().MaxInitLen, 128)
-			yyv3544 = make([]ContainerStatus, yyrl3544)
-			yyc3544 = true
+		if yyl3549 > cap(yyv3549) {
+			yyrl3549, yyrt3549 = z.DecInferLen(yyl3549, z.DecBasicHandle().MaxInitLen, 128)
+			yyv3549 = make([]ContainerStatus, yyrl3549)
+			yyc3549 = true
 
-			yyrr3544 = len(yyv3544)
-		} else if yyl3544 != len(yyv3544) {
-			yyv3544 = yyv3544[:yyl3544]
-			yyc3544 = true
+			yyrr3549 = len(yyv3549)
+		} else if yyl3549 != len(yyv3549) {
+			yyv3549 = yyv3549[:yyl3549]
+			yyc3549 = true
 		}
-		yyj3544 := 0
-		for ; yyj3544 < yyrr3544; yyj3544++ {
+		yyj3549 := 0
+		for ; yyj3549 < yyrr3549; yyj3549++ {
 			if r.TryDecodeAsNil() {
-				yyv3544[yyj3544] = ContainerStatus{}
+				yyv3549[yyj3549] = ContainerStatus{}
 			} else {
-				yyv3545 := &yyv3544[yyj3544]
-				yyv3545.CodecDecodeSelf(d)
+				yyv3550 := &yyv3549[yyj3549]
+				yyv3550.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3544 {
-			for ; yyj3544 < yyl3544; yyj3544++ {
-				yyv3544 = append(yyv3544, ContainerStatus{})
+		if yyrt3549 {
+			for ; yyj3549 < yyl3549; yyj3549++ {
+				yyv3549 = append(yyv3549, ContainerStatus{})
 				if r.TryDecodeAsNil() {
-					yyv3544[yyj3544] = ContainerStatus{}
+					yyv3549[yyj3549] = ContainerStatus{}
 				} else {
-					yyv3546 := &yyv3544[yyj3544]
-					yyv3546.CodecDecodeSelf(d)
+					yyv3551 := &yyv3549[yyj3549]
+					yyv3551.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3544 := 0; !r.CheckBreak(); yyj3544++ {
-			if yyj3544 >= len(yyv3544) {
-				yyv3544 = append(yyv3544, ContainerStatus{}) // var yyz3544 ContainerStatus
-				yyc3544 = true
+		for yyj3549 := 0; !r.CheckBreak(); yyj3549++ {
+			if yyj3549 >= len(yyv3549) {
+				yyv3549 = append(yyv3549, ContainerStatus{}) // var yyz3549 ContainerStatus
+				yyc3549 = true
 			}
 
-			if yyj3544 < len(yyv3544) {
+			if yyj3549 < len(yyv3549) {
 				if r.TryDecodeAsNil() {
-					yyv3544[yyj3544] = ContainerStatus{}
+					yyv3549[yyj3549] = ContainerStatus{}
 				} else {
-					yyv3547 := &yyv3544[yyj3544]
-					yyv3547.CodecDecodeSelf(d)
+					yyv3552 := &yyv3549[yyj3549]
+					yyv3552.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41318,10 +41355,10 @@ func (x codecSelfer1234) decSliceContainerStatus(v *[]ContainerStatus, d *codec1
 			}
 
 		}
-		yyh3544.End()
+		yyh3549.End()
 	}
-	if yyc3544 {
-		*v = yyv3544
+	if yyc3549 {
+		*v = yyv3549
 	}
 
 }
@@ -41331,9 +41368,9 @@ func (x codecSelfer1234) encSlicePodTemplate(v []PodTemplate, e *codec1978.Encod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3548 := range v {
-		yy3549 := &yyv3548
-		yy3549.CodecEncodeSelf(e)
+	for _, yyv3553 := range v {
+		yy3554 := &yyv3553
+		yy3554.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41343,75 +41380,75 @@ func (x codecSelfer1234) decSlicePodTemplate(v *[]PodTemplate, d *codec1978.Deco
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3550 := *v
-	yyh3550, yyl3550 := z.DecSliceHelperStart()
+	yyv3555 := *v
+	yyh3555, yyl3555 := z.DecSliceHelperStart()
 
-	var yyrr3550, yyrl3550 int
-	var yyc3550, yyrt3550 bool
-	_, _, _ = yyc3550, yyrt3550, yyrl3550
-	yyrr3550 = yyl3550
+	var yyrr3555, yyrl3555 int
+	var yyc3555, yyrt3555 bool
+	_, _, _ = yyc3555, yyrt3555, yyrl3555
+	yyrr3555 = yyl3555
 
-	if yyv3550 == nil {
-		if yyrl3550, yyrt3550 = z.DecInferLen(yyl3550, z.DecBasicHandle().MaxInitLen, 520); yyrt3550 {
-			yyrr3550 = yyrl3550
+	if yyv3555 == nil {
+		if yyrl3555, yyrt3555 = z.DecInferLen(yyl3555, z.DecBasicHandle().MaxInitLen, 520); yyrt3555 {
+			yyrr3555 = yyrl3555
 		}
-		yyv3550 = make([]PodTemplate, yyrl3550)
-		yyc3550 = true
+		yyv3555 = make([]PodTemplate, yyrl3555)
+		yyc3555 = true
 	}
 
-	if yyl3550 == 0 {
-		if len(yyv3550) != 0 {
-			yyv3550 = yyv3550[:0]
-			yyc3550 = true
+	if yyl3555 == 0 {
+		if len(yyv3555) != 0 {
+			yyv3555 = yyv3555[:0]
+			yyc3555 = true
 		}
-	} else if yyl3550 > 0 {
+	} else if yyl3555 > 0 {
 
-		if yyl3550 > cap(yyv3550) {
-			yyrl3550, yyrt3550 = z.DecInferLen(yyl3550, z.DecBasicHandle().MaxInitLen, 520)
-			yyv3550 = make([]PodTemplate, yyrl3550)
-			yyc3550 = true
+		if yyl3555 > cap(yyv3555) {
+			yyrl3555, yyrt3555 = z.DecInferLen(yyl3555, z.DecBasicHandle().MaxInitLen, 520)
+			yyv3555 = make([]PodTemplate, yyrl3555)
+			yyc3555 = true
 
-			yyrr3550 = len(yyv3550)
-		} else if yyl3550 != len(yyv3550) {
-			yyv3550 = yyv3550[:yyl3550]
-			yyc3550 = true
+			yyrr3555 = len(yyv3555)
+		} else if yyl3555 != len(yyv3555) {
+			yyv3555 = yyv3555[:yyl3555]
+			yyc3555 = true
 		}
-		yyj3550 := 0
-		for ; yyj3550 < yyrr3550; yyj3550++ {
+		yyj3555 := 0
+		for ; yyj3555 < yyrr3555; yyj3555++ {
 			if r.TryDecodeAsNil() {
-				yyv3550[yyj3550] = PodTemplate{}
+				yyv3555[yyj3555] = PodTemplate{}
 			} else {
-				yyv3551 := &yyv3550[yyj3550]
-				yyv3551.CodecDecodeSelf(d)
+				yyv3556 := &yyv3555[yyj3555]
+				yyv3556.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3550 {
-			for ; yyj3550 < yyl3550; yyj3550++ {
-				yyv3550 = append(yyv3550, PodTemplate{})
+		if yyrt3555 {
+			for ; yyj3555 < yyl3555; yyj3555++ {
+				yyv3555 = append(yyv3555, PodTemplate{})
 				if r.TryDecodeAsNil() {
-					yyv3550[yyj3550] = PodTemplate{}
+					yyv3555[yyj3555] = PodTemplate{}
 				} else {
-					yyv3552 := &yyv3550[yyj3550]
-					yyv3552.CodecDecodeSelf(d)
+					yyv3557 := &yyv3555[yyj3555]
+					yyv3557.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3550 := 0; !r.CheckBreak(); yyj3550++ {
-			if yyj3550 >= len(yyv3550) {
-				yyv3550 = append(yyv3550, PodTemplate{}) // var yyz3550 PodTemplate
-				yyc3550 = true
+		for yyj3555 := 0; !r.CheckBreak(); yyj3555++ {
+			if yyj3555 >= len(yyv3555) {
+				yyv3555 = append(yyv3555, PodTemplate{}) // var yyz3555 PodTemplate
+				yyc3555 = true
 			}
 
-			if yyj3550 < len(yyv3550) {
+			if yyj3555 < len(yyv3555) {
 				if r.TryDecodeAsNil() {
-					yyv3550[yyj3550] = PodTemplate{}
+					yyv3555[yyj3555] = PodTemplate{}
 				} else {
-					yyv3553 := &yyv3550[yyj3550]
-					yyv3553.CodecDecodeSelf(d)
+					yyv3558 := &yyv3555[yyj3555]
+					yyv3558.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41419,10 +41456,10 @@ func (x codecSelfer1234) decSlicePodTemplate(v *[]PodTemplate, d *codec1978.Deco
 			}
 
 		}
-		yyh3550.End()
+		yyh3555.End()
 	}
-	if yyc3550 {
-		*v = yyv3550
+	if yyc3555 {
+		*v = yyv3555
 	}
 
 }
@@ -41432,9 +41469,9 @@ func (x codecSelfer1234) encSliceReplicationController(v []ReplicationController
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3554 := range v {
-		yy3555 := &yyv3554
-		yy3555.CodecEncodeSelf(e)
+	for _, yyv3559 := range v {
+		yy3560 := &yyv3559
+		yy3560.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41444,75 +41481,75 @@ func (x codecSelfer1234) decSliceReplicationController(v *[]ReplicationControlle
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3556 := *v
-	yyh3556, yyl3556 := z.DecSliceHelperStart()
+	yyv3561 := *v
+	yyh3561, yyl3561 := z.DecSliceHelperStart()
 
-	var yyrr3556, yyrl3556 int
-	var yyc3556, yyrt3556 bool
-	_, _, _ = yyc3556, yyrt3556, yyrl3556
-	yyrr3556 = yyl3556
+	var yyrr3561, yyrl3561 int
+	var yyc3561, yyrt3561 bool
+	_, _, _ = yyc3561, yyrt3561, yyrl3561
+	yyrr3561 = yyl3561
 
-	if yyv3556 == nil {
-		if yyrl3556, yyrt3556 = z.DecInferLen(yyl3556, z.DecBasicHandle().MaxInitLen, 232); yyrt3556 {
-			yyrr3556 = yyrl3556
+	if yyv3561 == nil {
+		if yyrl3561, yyrt3561 = z.DecInferLen(yyl3561, z.DecBasicHandle().MaxInitLen, 232); yyrt3561 {
+			yyrr3561 = yyrl3561
 		}
-		yyv3556 = make([]ReplicationController, yyrl3556)
-		yyc3556 = true
+		yyv3561 = make([]ReplicationController, yyrl3561)
+		yyc3561 = true
 	}
 
-	if yyl3556 == 0 {
-		if len(yyv3556) != 0 {
-			yyv3556 = yyv3556[:0]
-			yyc3556 = true
+	if yyl3561 == 0 {
+		if len(yyv3561) != 0 {
+			yyv3561 = yyv3561[:0]
+			yyc3561 = true
 		}
-	} else if yyl3556 > 0 {
+	} else if yyl3561 > 0 {
 
-		if yyl3556 > cap(yyv3556) {
-			yyrl3556, yyrt3556 = z.DecInferLen(yyl3556, z.DecBasicHandle().MaxInitLen, 232)
-			yyv3556 = make([]ReplicationController, yyrl3556)
-			yyc3556 = true
+		if yyl3561 > cap(yyv3561) {
+			yyrl3561, yyrt3561 = z.DecInferLen(yyl3561, z.DecBasicHandle().MaxInitLen, 232)
+			yyv3561 = make([]ReplicationController, yyrl3561)
+			yyc3561 = true
 
-			yyrr3556 = len(yyv3556)
-		} else if yyl3556 != len(yyv3556) {
-			yyv3556 = yyv3556[:yyl3556]
-			yyc3556 = true
+			yyrr3561 = len(yyv3561)
+		} else if yyl3561 != len(yyv3561) {
+			yyv3561 = yyv3561[:yyl3561]
+			yyc3561 = true
 		}
-		yyj3556 := 0
-		for ; yyj3556 < yyrr3556; yyj3556++ {
+		yyj3561 := 0
+		for ; yyj3561 < yyrr3561; yyj3561++ {
 			if r.TryDecodeAsNil() {
-				yyv3556[yyj3556] = ReplicationController{}
+				yyv3561[yyj3561] = ReplicationController{}
 			} else {
-				yyv3557 := &yyv3556[yyj3556]
-				yyv3557.CodecDecodeSelf(d)
+				yyv3562 := &yyv3561[yyj3561]
+				yyv3562.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3556 {
-			for ; yyj3556 < yyl3556; yyj3556++ {
-				yyv3556 = append(yyv3556, ReplicationController{})
+		if yyrt3561 {
+			for ; yyj3561 < yyl3561; yyj3561++ {
+				yyv3561 = append(yyv3561, ReplicationController{})
 				if r.TryDecodeAsNil() {
-					yyv3556[yyj3556] = ReplicationController{}
+					yyv3561[yyj3561] = ReplicationController{}
 				} else {
-					yyv3558 := &yyv3556[yyj3556]
-					yyv3558.CodecDecodeSelf(d)
+					yyv3563 := &yyv3561[yyj3561]
+					yyv3563.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3556 := 0; !r.CheckBreak(); yyj3556++ {
-			if yyj3556 >= len(yyv3556) {
-				yyv3556 = append(yyv3556, ReplicationController{}) // var yyz3556 ReplicationController
-				yyc3556 = true
+		for yyj3561 := 0; !r.CheckBreak(); yyj3561++ {
+			if yyj3561 >= len(yyv3561) {
+				yyv3561 = append(yyv3561, ReplicationController{}) // var yyz3561 ReplicationController
+				yyc3561 = true
 			}
 
-			if yyj3556 < len(yyv3556) {
+			if yyj3561 < len(yyv3561) {
 				if r.TryDecodeAsNil() {
-					yyv3556[yyj3556] = ReplicationController{}
+					yyv3561[yyj3561] = ReplicationController{}
 				} else {
-					yyv3559 := &yyv3556[yyj3556]
-					yyv3559.CodecDecodeSelf(d)
+					yyv3564 := &yyv3561[yyj3561]
+					yyv3564.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41520,10 +41557,10 @@ func (x codecSelfer1234) decSliceReplicationController(v *[]ReplicationControlle
 			}
 
 		}
-		yyh3556.End()
+		yyh3561.End()
 	}
-	if yyc3556 {
-		*v = yyv3556
+	if yyc3561 {
+		*v = yyv3561
 	}
 
 }
@@ -41533,9 +41570,9 @@ func (x codecSelfer1234) encSliceService(v []Service, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3560 := range v {
-		yy3561 := &yyv3560
-		yy3561.CodecEncodeSelf(e)
+	for _, yyv3565 := range v {
+		yy3566 := &yyv3565
+		yy3566.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41545,75 +41582,75 @@ func (x codecSelfer1234) decSliceService(v *[]Service, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3562 := *v
-	yyh3562, yyl3562 := z.DecSliceHelperStart()
+	yyv3567 := *v
+	yyh3567, yyl3567 := z.DecSliceHelperStart()
 
-	var yyrr3562, yyrl3562 int
-	var yyc3562, yyrt3562 bool
-	_, _, _ = yyc3562, yyrt3562, yyrl3562
-	yyrr3562 = yyl3562
+	var yyrr3567, yyrl3567 int
+	var yyc3567, yyrt3567 bool
+	_, _, _ = yyc3567, yyrt3567, yyrl3567
+	yyrr3567 = yyl3567
 
-	if yyv3562 == nil {
-		if yyrl3562, yyrt3562 = z.DecInferLen(yyl3562, z.DecBasicHandle().MaxInitLen, 336); yyrt3562 {
-			yyrr3562 = yyrl3562
+	if yyv3567 == nil {
+		if yyrl3567, yyrt3567 = z.DecInferLen(yyl3567, z.DecBasicHandle().MaxInitLen, 336); yyrt3567 {
+			yyrr3567 = yyrl3567
 		}
-		yyv3562 = make([]Service, yyrl3562)
-		yyc3562 = true
+		yyv3567 = make([]Service, yyrl3567)
+		yyc3567 = true
 	}
 
-	if yyl3562 == 0 {
-		if len(yyv3562) != 0 {
-			yyv3562 = yyv3562[:0]
-			yyc3562 = true
+	if yyl3567 == 0 {
+		if len(yyv3567) != 0 {
+			yyv3567 = yyv3567[:0]
+			yyc3567 = true
 		}
-	} else if yyl3562 > 0 {
+	} else if yyl3567 > 0 {
 
-		if yyl3562 > cap(yyv3562) {
-			yyrl3562, yyrt3562 = z.DecInferLen(yyl3562, z.DecBasicHandle().MaxInitLen, 336)
-			yyv3562 = make([]Service, yyrl3562)
-			yyc3562 = true
+		if yyl3567 > cap(yyv3567) {
+			yyrl3567, yyrt3567 = z.DecInferLen(yyl3567, z.DecBasicHandle().MaxInitLen, 336)
+			yyv3567 = make([]Service, yyrl3567)
+			yyc3567 = true
 
-			yyrr3562 = len(yyv3562)
-		} else if yyl3562 != len(yyv3562) {
-			yyv3562 = yyv3562[:yyl3562]
-			yyc3562 = true
+			yyrr3567 = len(yyv3567)
+		} else if yyl3567 != len(yyv3567) {
+			yyv3567 = yyv3567[:yyl3567]
+			yyc3567 = true
 		}
-		yyj3562 := 0
-		for ; yyj3562 < yyrr3562; yyj3562++ {
+		yyj3567 := 0
+		for ; yyj3567 < yyrr3567; yyj3567++ {
 			if r.TryDecodeAsNil() {
-				yyv3562[yyj3562] = Service{}
+				yyv3567[yyj3567] = Service{}
 			} else {
-				yyv3563 := &yyv3562[yyj3562]
-				yyv3563.CodecDecodeSelf(d)
+				yyv3568 := &yyv3567[yyj3567]
+				yyv3568.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3562 {
-			for ; yyj3562 < yyl3562; yyj3562++ {
-				yyv3562 = append(yyv3562, Service{})
+		if yyrt3567 {
+			for ; yyj3567 < yyl3567; yyj3567++ {
+				yyv3567 = append(yyv3567, Service{})
 				if r.TryDecodeAsNil() {
-					yyv3562[yyj3562] = Service{}
+					yyv3567[yyj3567] = Service{}
 				} else {
-					yyv3564 := &yyv3562[yyj3562]
-					yyv3564.CodecDecodeSelf(d)
+					yyv3569 := &yyv3567[yyj3567]
+					yyv3569.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3562 := 0; !r.CheckBreak(); yyj3562++ {
-			if yyj3562 >= len(yyv3562) {
-				yyv3562 = append(yyv3562, Service{}) // var yyz3562 Service
-				yyc3562 = true
+		for yyj3567 := 0; !r.CheckBreak(); yyj3567++ {
+			if yyj3567 >= len(yyv3567) {
+				yyv3567 = append(yyv3567, Service{}) // var yyz3567 Service
+				yyc3567 = true
 			}
 
-			if yyj3562 < len(yyv3562) {
+			if yyj3567 < len(yyv3567) {
 				if r.TryDecodeAsNil() {
-					yyv3562[yyj3562] = Service{}
+					yyv3567[yyj3567] = Service{}
 				} else {
-					yyv3565 := &yyv3562[yyj3562]
-					yyv3565.CodecDecodeSelf(d)
+					yyv3570 := &yyv3567[yyj3567]
+					yyv3570.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41621,10 +41658,10 @@ func (x codecSelfer1234) decSliceService(v *[]Service, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3562.End()
+		yyh3567.End()
 	}
-	if yyc3562 {
-		*v = yyv3562
+	if yyc3567 {
+		*v = yyv3567
 	}
 
 }
@@ -41634,9 +41671,9 @@ func (x codecSelfer1234) encSliceLoadBalancerIngress(v []LoadBalancerIngress, e 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3566 := range v {
-		yy3567 := &yyv3566
-		yy3567.CodecEncodeSelf(e)
+	for _, yyv3571 := range v {
+		yy3572 := &yyv3571
+		yy3572.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41646,75 +41683,75 @@ func (x codecSelfer1234) decSliceLoadBalancerIngress(v *[]LoadBalancerIngress, d
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3568 := *v
-	yyh3568, yyl3568 := z.DecSliceHelperStart()
+	yyv3573 := *v
+	yyh3573, yyl3573 := z.DecSliceHelperStart()
 
-	var yyrr3568, yyrl3568 int
-	var yyc3568, yyrt3568 bool
-	_, _, _ = yyc3568, yyrt3568, yyrl3568
-	yyrr3568 = yyl3568
+	var yyrr3573, yyrl3573 int
+	var yyc3573, yyrt3573 bool
+	_, _, _ = yyc3573, yyrt3573, yyrl3573
+	yyrr3573 = yyl3573
 
-	if yyv3568 == nil {
-		if yyrl3568, yyrt3568 = z.DecInferLen(yyl3568, z.DecBasicHandle().MaxInitLen, 32); yyrt3568 {
-			yyrr3568 = yyrl3568
+	if yyv3573 == nil {
+		if yyrl3573, yyrt3573 = z.DecInferLen(yyl3573, z.DecBasicHandle().MaxInitLen, 32); yyrt3573 {
+			yyrr3573 = yyrl3573
 		}
-		yyv3568 = make([]LoadBalancerIngress, yyrl3568)
-		yyc3568 = true
+		yyv3573 = make([]LoadBalancerIngress, yyrl3573)
+		yyc3573 = true
 	}
 
-	if yyl3568 == 0 {
-		if len(yyv3568) != 0 {
-			yyv3568 = yyv3568[:0]
-			yyc3568 = true
+	if yyl3573 == 0 {
+		if len(yyv3573) != 0 {
+			yyv3573 = yyv3573[:0]
+			yyc3573 = true
 		}
-	} else if yyl3568 > 0 {
+	} else if yyl3573 > 0 {
 
-		if yyl3568 > cap(yyv3568) {
-			yyrl3568, yyrt3568 = z.DecInferLen(yyl3568, z.DecBasicHandle().MaxInitLen, 32)
-			yyv3568 = make([]LoadBalancerIngress, yyrl3568)
-			yyc3568 = true
+		if yyl3573 > cap(yyv3573) {
+			yyrl3573, yyrt3573 = z.DecInferLen(yyl3573, z.DecBasicHandle().MaxInitLen, 32)
+			yyv3573 = make([]LoadBalancerIngress, yyrl3573)
+			yyc3573 = true
 
-			yyrr3568 = len(yyv3568)
-		} else if yyl3568 != len(yyv3568) {
-			yyv3568 = yyv3568[:yyl3568]
-			yyc3568 = true
+			yyrr3573 = len(yyv3573)
+		} else if yyl3573 != len(yyv3573) {
+			yyv3573 = yyv3573[:yyl3573]
+			yyc3573 = true
 		}
-		yyj3568 := 0
-		for ; yyj3568 < yyrr3568; yyj3568++ {
+		yyj3573 := 0
+		for ; yyj3573 < yyrr3573; yyj3573++ {
 			if r.TryDecodeAsNil() {
-				yyv3568[yyj3568] = LoadBalancerIngress{}
+				yyv3573[yyj3573] = LoadBalancerIngress{}
 			} else {
-				yyv3569 := &yyv3568[yyj3568]
-				yyv3569.CodecDecodeSelf(d)
+				yyv3574 := &yyv3573[yyj3573]
+				yyv3574.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3568 {
-			for ; yyj3568 < yyl3568; yyj3568++ {
-				yyv3568 = append(yyv3568, LoadBalancerIngress{})
+		if yyrt3573 {
+			for ; yyj3573 < yyl3573; yyj3573++ {
+				yyv3573 = append(yyv3573, LoadBalancerIngress{})
 				if r.TryDecodeAsNil() {
-					yyv3568[yyj3568] = LoadBalancerIngress{}
+					yyv3573[yyj3573] = LoadBalancerIngress{}
 				} else {
-					yyv3570 := &yyv3568[yyj3568]
-					yyv3570.CodecDecodeSelf(d)
+					yyv3575 := &yyv3573[yyj3573]
+					yyv3575.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3568 := 0; !r.CheckBreak(); yyj3568++ {
-			if yyj3568 >= len(yyv3568) {
-				yyv3568 = append(yyv3568, LoadBalancerIngress{}) // var yyz3568 LoadBalancerIngress
-				yyc3568 = true
+		for yyj3573 := 0; !r.CheckBreak(); yyj3573++ {
+			if yyj3573 >= len(yyv3573) {
+				yyv3573 = append(yyv3573, LoadBalancerIngress{}) // var yyz3573 LoadBalancerIngress
+				yyc3573 = true
 			}
 
-			if yyj3568 < len(yyv3568) {
+			if yyj3573 < len(yyv3573) {
 				if r.TryDecodeAsNil() {
-					yyv3568[yyj3568] = LoadBalancerIngress{}
+					yyv3573[yyj3573] = LoadBalancerIngress{}
 				} else {
-					yyv3571 := &yyv3568[yyj3568]
-					yyv3571.CodecDecodeSelf(d)
+					yyv3576 := &yyv3573[yyj3573]
+					yyv3576.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41722,10 +41759,10 @@ func (x codecSelfer1234) decSliceLoadBalancerIngress(v *[]LoadBalancerIngress, d
 			}
 
 		}
-		yyh3568.End()
+		yyh3573.End()
 	}
-	if yyc3568 {
-		*v = yyv3568
+	if yyc3573 {
+		*v = yyv3573
 	}
 
 }
@@ -41735,9 +41772,9 @@ func (x codecSelfer1234) encSliceServicePort(v []ServicePort, e *codec1978.Encod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3572 := range v {
-		yy3573 := &yyv3572
-		yy3573.CodecEncodeSelf(e)
+	for _, yyv3577 := range v {
+		yy3578 := &yyv3577
+		yy3578.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41747,75 +41784,75 @@ func (x codecSelfer1234) decSliceServicePort(v *[]ServicePort, d *codec1978.Deco
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3574 := *v
-	yyh3574, yyl3574 := z.DecSliceHelperStart()
+	yyv3579 := *v
+	yyh3579, yyl3579 := z.DecSliceHelperStart()
 
-	var yyrr3574, yyrl3574 int
-	var yyc3574, yyrt3574 bool
-	_, _, _ = yyc3574, yyrt3574, yyrl3574
-	yyrr3574 = yyl3574
+	var yyrr3579, yyrl3579 int
+	var yyc3579, yyrt3579 bool
+	_, _, _ = yyc3579, yyrt3579, yyrl3579
+	yyrr3579 = yyl3579
 
-	if yyv3574 == nil {
-		if yyrl3574, yyrt3574 = z.DecInferLen(yyl3574, z.DecBasicHandle().MaxInitLen, 80); yyrt3574 {
-			yyrr3574 = yyrl3574
+	if yyv3579 == nil {
+		if yyrl3579, yyrt3579 = z.DecInferLen(yyl3579, z.DecBasicHandle().MaxInitLen, 80); yyrt3579 {
+			yyrr3579 = yyrl3579
 		}
-		yyv3574 = make([]ServicePort, yyrl3574)
-		yyc3574 = true
+		yyv3579 = make([]ServicePort, yyrl3579)
+		yyc3579 = true
 	}
 
-	if yyl3574 == 0 {
-		if len(yyv3574) != 0 {
-			yyv3574 = yyv3574[:0]
-			yyc3574 = true
+	if yyl3579 == 0 {
+		if len(yyv3579) != 0 {
+			yyv3579 = yyv3579[:0]
+			yyc3579 = true
 		}
-	} else if yyl3574 > 0 {
+	} else if yyl3579 > 0 {
 
-		if yyl3574 > cap(yyv3574) {
-			yyrl3574, yyrt3574 = z.DecInferLen(yyl3574, z.DecBasicHandle().MaxInitLen, 80)
-			yyv3574 = make([]ServicePort, yyrl3574)
-			yyc3574 = true
+		if yyl3579 > cap(yyv3579) {
+			yyrl3579, yyrt3579 = z.DecInferLen(yyl3579, z.DecBasicHandle().MaxInitLen, 80)
+			yyv3579 = make([]ServicePort, yyrl3579)
+			yyc3579 = true
 
-			yyrr3574 = len(yyv3574)
-		} else if yyl3574 != len(yyv3574) {
-			yyv3574 = yyv3574[:yyl3574]
-			yyc3574 = true
+			yyrr3579 = len(yyv3579)
+		} else if yyl3579 != len(yyv3579) {
+			yyv3579 = yyv3579[:yyl3579]
+			yyc3579 = true
 		}
-		yyj3574 := 0
-		for ; yyj3574 < yyrr3574; yyj3574++ {
+		yyj3579 := 0
+		for ; yyj3579 < yyrr3579; yyj3579++ {
 			if r.TryDecodeAsNil() {
-				yyv3574[yyj3574] = ServicePort{}
+				yyv3579[yyj3579] = ServicePort{}
 			} else {
-				yyv3575 := &yyv3574[yyj3574]
-				yyv3575.CodecDecodeSelf(d)
+				yyv3580 := &yyv3579[yyj3579]
+				yyv3580.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3574 {
-			for ; yyj3574 < yyl3574; yyj3574++ {
-				yyv3574 = append(yyv3574, ServicePort{})
+		if yyrt3579 {
+			for ; yyj3579 < yyl3579; yyj3579++ {
+				yyv3579 = append(yyv3579, ServicePort{})
 				if r.TryDecodeAsNil() {
-					yyv3574[yyj3574] = ServicePort{}
+					yyv3579[yyj3579] = ServicePort{}
 				} else {
-					yyv3576 := &yyv3574[yyj3574]
-					yyv3576.CodecDecodeSelf(d)
+					yyv3581 := &yyv3579[yyj3579]
+					yyv3581.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3574 := 0; !r.CheckBreak(); yyj3574++ {
-			if yyj3574 >= len(yyv3574) {
-				yyv3574 = append(yyv3574, ServicePort{}) // var yyz3574 ServicePort
-				yyc3574 = true
+		for yyj3579 := 0; !r.CheckBreak(); yyj3579++ {
+			if yyj3579 >= len(yyv3579) {
+				yyv3579 = append(yyv3579, ServicePort{}) // var yyz3579 ServicePort
+				yyc3579 = true
 			}
 
-			if yyj3574 < len(yyv3574) {
+			if yyj3579 < len(yyv3579) {
 				if r.TryDecodeAsNil() {
-					yyv3574[yyj3574] = ServicePort{}
+					yyv3579[yyj3579] = ServicePort{}
 				} else {
-					yyv3577 := &yyv3574[yyj3574]
-					yyv3577.CodecDecodeSelf(d)
+					yyv3582 := &yyv3579[yyj3579]
+					yyv3582.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41823,10 +41860,10 @@ func (x codecSelfer1234) decSliceServicePort(v *[]ServicePort, d *codec1978.Deco
 			}
 
 		}
-		yyh3574.End()
+		yyh3579.End()
 	}
-	if yyc3574 {
-		*v = yyv3574
+	if yyc3579 {
+		*v = yyv3579
 	}
 
 }
@@ -41836,9 +41873,9 @@ func (x codecSelfer1234) encSliceObjectReference(v []ObjectReference, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3578 := range v {
-		yy3579 := &yyv3578
-		yy3579.CodecEncodeSelf(e)
+	for _, yyv3583 := range v {
+		yy3584 := &yyv3583
+		yy3584.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41848,75 +41885,75 @@ func (x codecSelfer1234) decSliceObjectReference(v *[]ObjectReference, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3580 := *v
-	yyh3580, yyl3580 := z.DecSliceHelperStart()
+	yyv3585 := *v
+	yyh3585, yyl3585 := z.DecSliceHelperStart()
 
-	var yyrr3580, yyrl3580 int
-	var yyc3580, yyrt3580 bool
-	_, _, _ = yyc3580, yyrt3580, yyrl3580
-	yyrr3580 = yyl3580
+	var yyrr3585, yyrl3585 int
+	var yyc3585, yyrt3585 bool
+	_, _, _ = yyc3585, yyrt3585, yyrl3585
+	yyrr3585 = yyl3585
 
-	if yyv3580 == nil {
-		if yyrl3580, yyrt3580 = z.DecInferLen(yyl3580, z.DecBasicHandle().MaxInitLen, 112); yyrt3580 {
-			yyrr3580 = yyrl3580
+	if yyv3585 == nil {
+		if yyrl3585, yyrt3585 = z.DecInferLen(yyl3585, z.DecBasicHandle().MaxInitLen, 112); yyrt3585 {
+			yyrr3585 = yyrl3585
 		}
-		yyv3580 = make([]ObjectReference, yyrl3580)
-		yyc3580 = true
+		yyv3585 = make([]ObjectReference, yyrl3585)
+		yyc3585 = true
 	}
 
-	if yyl3580 == 0 {
-		if len(yyv3580) != 0 {
-			yyv3580 = yyv3580[:0]
-			yyc3580 = true
+	if yyl3585 == 0 {
+		if len(yyv3585) != 0 {
+			yyv3585 = yyv3585[:0]
+			yyc3585 = true
 		}
-	} else if yyl3580 > 0 {
+	} else if yyl3585 > 0 {
 
-		if yyl3580 > cap(yyv3580) {
-			yyrl3580, yyrt3580 = z.DecInferLen(yyl3580, z.DecBasicHandle().MaxInitLen, 112)
-			yyv3580 = make([]ObjectReference, yyrl3580)
-			yyc3580 = true
+		if yyl3585 > cap(yyv3585) {
+			yyrl3585, yyrt3585 = z.DecInferLen(yyl3585, z.DecBasicHandle().MaxInitLen, 112)
+			yyv3585 = make([]ObjectReference, yyrl3585)
+			yyc3585 = true
 
-			yyrr3580 = len(yyv3580)
-		} else if yyl3580 != len(yyv3580) {
-			yyv3580 = yyv3580[:yyl3580]
-			yyc3580 = true
+			yyrr3585 = len(yyv3585)
+		} else if yyl3585 != len(yyv3585) {
+			yyv3585 = yyv3585[:yyl3585]
+			yyc3585 = true
 		}
-		yyj3580 := 0
-		for ; yyj3580 < yyrr3580; yyj3580++ {
+		yyj3585 := 0
+		for ; yyj3585 < yyrr3585; yyj3585++ {
 			if r.TryDecodeAsNil() {
-				yyv3580[yyj3580] = ObjectReference{}
+				yyv3585[yyj3585] = ObjectReference{}
 			} else {
-				yyv3581 := &yyv3580[yyj3580]
-				yyv3581.CodecDecodeSelf(d)
+				yyv3586 := &yyv3585[yyj3585]
+				yyv3586.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3580 {
-			for ; yyj3580 < yyl3580; yyj3580++ {
-				yyv3580 = append(yyv3580, ObjectReference{})
+		if yyrt3585 {
+			for ; yyj3585 < yyl3585; yyj3585++ {
+				yyv3585 = append(yyv3585, ObjectReference{})
 				if r.TryDecodeAsNil() {
-					yyv3580[yyj3580] = ObjectReference{}
+					yyv3585[yyj3585] = ObjectReference{}
 				} else {
-					yyv3582 := &yyv3580[yyj3580]
-					yyv3582.CodecDecodeSelf(d)
+					yyv3587 := &yyv3585[yyj3585]
+					yyv3587.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3580 := 0; !r.CheckBreak(); yyj3580++ {
-			if yyj3580 >= len(yyv3580) {
-				yyv3580 = append(yyv3580, ObjectReference{}) // var yyz3580 ObjectReference
-				yyc3580 = true
+		for yyj3585 := 0; !r.CheckBreak(); yyj3585++ {
+			if yyj3585 >= len(yyv3585) {
+				yyv3585 = append(yyv3585, ObjectReference{}) // var yyz3585 ObjectReference
+				yyc3585 = true
 			}
 
-			if yyj3580 < len(yyv3580) {
+			if yyj3585 < len(yyv3585) {
 				if r.TryDecodeAsNil() {
-					yyv3580[yyj3580] = ObjectReference{}
+					yyv3585[yyj3585] = ObjectReference{}
 				} else {
-					yyv3583 := &yyv3580[yyj3580]
-					yyv3583.CodecDecodeSelf(d)
+					yyv3588 := &yyv3585[yyj3585]
+					yyv3588.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41924,10 +41961,10 @@ func (x codecSelfer1234) decSliceObjectReference(v *[]ObjectReference, d *codec1
 			}
 
 		}
-		yyh3580.End()
+		yyh3585.End()
 	}
-	if yyc3580 {
-		*v = yyv3580
+	if yyc3585 {
+		*v = yyv3585
 	}
 
 }
@@ -41937,9 +41974,9 @@ func (x codecSelfer1234) encSliceServiceAccount(v []ServiceAccount, e *codec1978
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3584 := range v {
-		yy3585 := &yyv3584
-		yy3585.CodecEncodeSelf(e)
+	for _, yyv3589 := range v {
+		yy3590 := &yyv3589
+		yy3590.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41949,75 +41986,75 @@ func (x codecSelfer1234) decSliceServiceAccount(v *[]ServiceAccount, d *codec197
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3586 := *v
-	yyh3586, yyl3586 := z.DecSliceHelperStart()
+	yyv3591 := *v
+	yyh3591, yyl3591 := z.DecSliceHelperStart()
 
-	var yyrr3586, yyrl3586 int
-	var yyc3586, yyrt3586 bool
-	_, _, _ = yyc3586, yyrt3586, yyrl3586
-	yyrr3586 = yyl3586
+	var yyrr3591, yyrl3591 int
+	var yyc3591, yyrt3591 bool
+	_, _, _ = yyc3591, yyrt3591, yyrl3591
+	yyrr3591 = yyl3591
 
-	if yyv3586 == nil {
-		if yyrl3586, yyrt3586 = z.DecInferLen(yyl3586, z.DecBasicHandle().MaxInitLen, 240); yyrt3586 {
-			yyrr3586 = yyrl3586
+	if yyv3591 == nil {
+		if yyrl3591, yyrt3591 = z.DecInferLen(yyl3591, z.DecBasicHandle().MaxInitLen, 240); yyrt3591 {
+			yyrr3591 = yyrl3591
 		}
-		yyv3586 = make([]ServiceAccount, yyrl3586)
-		yyc3586 = true
+		yyv3591 = make([]ServiceAccount, yyrl3591)
+		yyc3591 = true
 	}
 
-	if yyl3586 == 0 {
-		if len(yyv3586) != 0 {
-			yyv3586 = yyv3586[:0]
-			yyc3586 = true
+	if yyl3591 == 0 {
+		if len(yyv3591) != 0 {
+			yyv3591 = yyv3591[:0]
+			yyc3591 = true
 		}
-	} else if yyl3586 > 0 {
+	} else if yyl3591 > 0 {
 
-		if yyl3586 > cap(yyv3586) {
-			yyrl3586, yyrt3586 = z.DecInferLen(yyl3586, z.DecBasicHandle().MaxInitLen, 240)
-			yyv3586 = make([]ServiceAccount, yyrl3586)
-			yyc3586 = true
+		if yyl3591 > cap(yyv3591) {
+			yyrl3591, yyrt3591 = z.DecInferLen(yyl3591, z.DecBasicHandle().MaxInitLen, 240)
+			yyv3591 = make([]ServiceAccount, yyrl3591)
+			yyc3591 = true
 
-			yyrr3586 = len(yyv3586)
-		} else if yyl3586 != len(yyv3586) {
-			yyv3586 = yyv3586[:yyl3586]
-			yyc3586 = true
+			yyrr3591 = len(yyv3591)
+		} else if yyl3591 != len(yyv3591) {
+			yyv3591 = yyv3591[:yyl3591]
+			yyc3591 = true
 		}
-		yyj3586 := 0
-		for ; yyj3586 < yyrr3586; yyj3586++ {
+		yyj3591 := 0
+		for ; yyj3591 < yyrr3591; yyj3591++ {
 			if r.TryDecodeAsNil() {
-				yyv3586[yyj3586] = ServiceAccount{}
+				yyv3591[yyj3591] = ServiceAccount{}
 			} else {
-				yyv3587 := &yyv3586[yyj3586]
-				yyv3587.CodecDecodeSelf(d)
+				yyv3592 := &yyv3591[yyj3591]
+				yyv3592.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3586 {
-			for ; yyj3586 < yyl3586; yyj3586++ {
-				yyv3586 = append(yyv3586, ServiceAccount{})
+		if yyrt3591 {
+			for ; yyj3591 < yyl3591; yyj3591++ {
+				yyv3591 = append(yyv3591, ServiceAccount{})
 				if r.TryDecodeAsNil() {
-					yyv3586[yyj3586] = ServiceAccount{}
+					yyv3591[yyj3591] = ServiceAccount{}
 				} else {
-					yyv3588 := &yyv3586[yyj3586]
-					yyv3588.CodecDecodeSelf(d)
+					yyv3593 := &yyv3591[yyj3591]
+					yyv3593.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3586 := 0; !r.CheckBreak(); yyj3586++ {
-			if yyj3586 >= len(yyv3586) {
-				yyv3586 = append(yyv3586, ServiceAccount{}) // var yyz3586 ServiceAccount
-				yyc3586 = true
+		for yyj3591 := 0; !r.CheckBreak(); yyj3591++ {
+			if yyj3591 >= len(yyv3591) {
+				yyv3591 = append(yyv3591, ServiceAccount{}) // var yyz3591 ServiceAccount
+				yyc3591 = true
 			}
 
-			if yyj3586 < len(yyv3586) {
+			if yyj3591 < len(yyv3591) {
 				if r.TryDecodeAsNil() {
-					yyv3586[yyj3586] = ServiceAccount{}
+					yyv3591[yyj3591] = ServiceAccount{}
 				} else {
-					yyv3589 := &yyv3586[yyj3586]
-					yyv3589.CodecDecodeSelf(d)
+					yyv3594 := &yyv3591[yyj3591]
+					yyv3594.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -42025,10 +42062,10 @@ func (x codecSelfer1234) decSliceServiceAccount(v *[]ServiceAccount, d *codec197
 			}
 
 		}
-		yyh3586.End()
+		yyh3591.End()
 	}
-	if yyc3586 {
-		*v = yyv3586
+	if yyc3591 {
+		*v = yyv3591
 	}
 
 }
@@ -42038,9 +42075,9 @@ func (x codecSelfer1234) encSliceEndpointSubset(v []EndpointSubset, e *codec1978
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3590 := range v {
-		yy3591 := &yyv3590
-		yy3591.CodecEncodeSelf(e)
+	for _, yyv3595 := range v {
+		yy3596 := &yyv3595
+		yy3596.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -42050,75 +42087,75 @@ func (x codecSelfer1234) decSliceEndpointSubset(v *[]EndpointSubset, d *codec197
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3592 := *v
-	yyh3592, yyl3592 := z.DecSliceHelperStart()
+	yyv3597 := *v
+	yyh3597, yyl3597 := z.DecSliceHelperStart()
 
-	var yyrr3592, yyrl3592 int
-	var yyc3592, yyrt3592 bool
-	_, _, _ = yyc3592, yyrt3592, yyrl3592
-	yyrr3592 = yyl3592
+	var yyrr3597, yyrl3597 int
+	var yyc3597, yyrt3597 bool
+	_, _, _ = yyc3597, yyrt3597, yyrl3597
+	yyrr3597 = yyl3597
 
-	if yyv3592 == nil {
-		if yyrl3592, yyrt3592 = z.DecInferLen(yyl3592, z.DecBasicHandle().MaxInitLen, 72); yyrt3592 {
-			yyrr3592 = yyrl3592
+	if yyv3597 == nil {
+		if yyrl3597, yyrt3597 = z.DecInferLen(yyl3597, z.DecBasicHandle().MaxInitLen, 72); yyrt3597 {
+			yyrr3597 = yyrl3597
 		}
-		yyv3592 = make([]EndpointSubset, yyrl3592)
-		yyc3592 = true
+		yyv3597 = make([]EndpointSubset, yyrl3597)
+		yyc3597 = true
 	}
 
-	if yyl3592 == 0 {
-		if len(yyv3592) != 0 {
-			yyv3592 = yyv3592[:0]
-			yyc3592 = true
+	if yyl3597 == 0 {
+		if len(yyv3597) != 0 {
+			yyv3597 = yyv3597[:0]
+			yyc3597 = true
 		}
-	} else if yyl3592 > 0 {
+	} else if yyl3597 > 0 {
 
-		if yyl3592 > cap(yyv3592) {
-			yyrl3592, yyrt3592 = z.DecInferLen(yyl3592, z.DecBasicHandle().MaxInitLen, 72)
-			yyv3592 = make([]EndpointSubset, yyrl3592)
-			yyc3592 = true
+		if yyl3597 > cap(yyv3597) {
+			yyrl3597, yyrt3597 = z.DecInferLen(yyl3597, z.DecBasicHandle().MaxInitLen, 72)
+			yyv3597 = make([]EndpointSubset, yyrl3597)
+			yyc3597 = true
 
-			yyrr3592 = len(yyv3592)
-		} else if yyl3592 != len(yyv3592) {
-			yyv3592 = yyv3592[:yyl3592]
-			yyc3592 = true
+			yyrr3597 = len(yyv3597)
+		} else if yyl3597 != len(yyv3597) {
+			yyv3597 = yyv3597[:yyl3597]
+			yyc3597 = true
 		}
-		yyj3592 := 0
-		for ; yyj3592 < yyrr3592; yyj3592++ {
+		yyj3597 := 0
+		for ; yyj3597 < yyrr3597; yyj3597++ {
 			if r.TryDecodeAsNil() {
-				yyv3592[yyj3592] = EndpointSubset{}
+				yyv3597[yyj3597] = EndpointSubset{}
 			} else {
-				yyv3593 := &yyv3592[yyj3592]
-				yyv3593.CodecDecodeSelf(d)
+				yyv3598 := &yyv3597[yyj3597]
+				yyv3598.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3592 {
-			for ; yyj3592 < yyl3592; yyj3592++ {
-				yyv3592 = append(yyv3592, EndpointSubset{})
+		if yyrt3597 {
+			for ; yyj3597 < yyl3597; yyj3597++ {
+				yyv3597 = append(yyv3597, EndpointSubset{})
 				if r.TryDecodeAsNil() {
-					yyv3592[yyj3592] = EndpointSubset{}
+					yyv3597[yyj3597] = EndpointSubset{}
 				} else {
-					yyv3594 := &yyv3592[yyj3592]
-					yyv3594.CodecDecodeSelf(d)
+					yyv3599 := &yyv3597[yyj3597]
+					yyv3599.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3592 := 0; !r.CheckBreak(); yyj3592++ {
-			if yyj3592 >= len(yyv3592) {
-				yyv3592 = append(yyv3592, EndpointSubset{}) // var yyz3592 EndpointSubset
-				yyc3592 = true
+		for yyj3597 := 0; !r.CheckBreak(); yyj3597++ {
+			if yyj3597 >= len(yyv3597) {
+				yyv3597 = append(yyv3597, EndpointSubset{}) // var yyz3597 EndpointSubset
+				yyc3597 = true
 			}
 
-			if yyj3592 < len(yyv3592) {
+			if yyj3597 < len(yyv3597) {
 				if r.TryDecodeAsNil() {
-					yyv3592[yyj3592] = EndpointSubset{}
+					yyv3597[yyj3597] = EndpointSubset{}
 				} else {
-					yyv3595 := &yyv3592[yyj3592]
-					yyv3595.CodecDecodeSelf(d)
+					yyv3600 := &yyv3597[yyj3597]
+					yyv3600.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -42126,10 +42163,10 @@ func (x codecSelfer1234) decSliceEndpointSubset(v *[]EndpointSubset, d *codec197
 			}
 
 		}
-		yyh3592.End()
+		yyh3597.End()
 	}
-	if yyc3592 {
-		*v = yyv3592
+	if yyc3597 {
+		*v = yyv3597
 	}
 
 }
@@ -42139,9 +42176,9 @@ func (x codecSelfer1234) encSliceEndpointAddress(v []EndpointAddress, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3596 := range v {
-		yy3597 := &yyv3596
-		yy3597.CodecEncodeSelf(e)
+	for _, yyv3601 := range v {
+		yy3602 := &yyv3601
+		yy3602.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -42151,75 +42188,75 @@ func (x codecSelfer1234) decSliceEndpointAddress(v *[]EndpointAddress, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3598 := *v
-	yyh3598, yyl3598 := z.DecSliceHelperStart()
+	yyv3603 := *v
+	yyh3603, yyl3603 := z.DecSliceHelperStart()
 
-	var yyrr3598, yyrl3598 int
-	var yyc3598, yyrt3598 bool
-	_, _, _ = yyc3598, yyrt3598, yyrl3598
-	yyrr3598 = yyl3598
+	var yyrr3603, yyrl3603 int
+	var yyc3603, yyrt3603 bool
+	_, _, _ = yyc3603, yyrt3603, yyrl3603
+	yyrr3603 = yyl3603
 
-	if yyv3598 == nil {
-		if yyrl3598, yyrt3598 = z.DecInferLen(yyl3598, z.DecBasicHandle().MaxInitLen, 24); yyrt3598 {
-			yyrr3598 = yyrl3598
+	if yyv3603 == nil {
+		if yyrl3603, yyrt3603 = z.DecInferLen(yyl3603, z.DecBasicHandle().MaxInitLen, 24); yyrt3603 {
+			yyrr3603 = yyrl3603
 		}
-		yyv3598 = make([]EndpointAddress, yyrl3598)
-		yyc3598 = true
+		yyv3603 = make([]EndpointAddress, yyrl3603)
+		yyc3603 = true
 	}
 
-	if yyl3598 == 0 {
-		if len(yyv3598) != 0 {
-			yyv3598 = yyv3598[:0]
-			yyc3598 = true
+	if yyl3603 == 0 {
+		if len(yyv3603) != 0 {
+			yyv3603 = yyv3603[:0]
+			yyc3603 = true
 		}
-	} else if yyl3598 > 0 {
+	} else if yyl3603 > 0 {
 
-		if yyl3598 > cap(yyv3598) {
-			yyrl3598, yyrt3598 = z.DecInferLen(yyl3598, z.DecBasicHandle().MaxInitLen, 24)
-			yyv3598 = make([]EndpointAddress, yyrl3598)
-			yyc3598 = true
+		if yyl3603 > cap(yyv3603) {
+			yyrl3603, yyrt3603 = z.DecInferLen(yyl3603, z.DecBasicHandle().MaxInitLen, 24)
+			yyv3603 = make([]EndpointAddress, yyrl3603)
+			yyc3603 = true
 
-			yyrr3598 = len(yyv3598)
-		} else if yyl3598 != len(yyv3598) {
-			yyv3598 = yyv3598[:yyl3598]
-			yyc3598 = true
+			yyrr3603 = len(yyv3603)
+		} else if yyl3603 != len(yyv3603) {
+			yyv3603 = yyv3603[:yyl3603]
+			yyc3603 = true
 		}
-		yyj3598 := 0
-		for ; yyj3598 < yyrr3598; yyj3598++ {
+		yyj3603 := 0
+		for ; yyj3603 < yyrr3603; yyj3603++ {
 			if r.TryDecodeAsNil() {
-				yyv3598[yyj3598] = EndpointAddress{}
+				yyv3603[yyj3603] = EndpointAddress{}
 			} else {
-				yyv3599 := &yyv3598[yyj3598]
-				yyv3599.CodecDecodeSelf(d)
+				yyv3604 := &yyv3603[yyj3603]
+				yyv3604.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3598 {
-			for ; yyj3598 < yyl3598; yyj3598++ {
-				yyv3598 = append(yyv3598, EndpointAddress{})
+		if yyrt3603 {
+			for ; yyj3603 < yyl3603; yyj3603++ {
+				yyv3603 = append(yyv3603, EndpointAddress{})
 				if r.TryDecodeAsNil() {
-					yyv3598[yyj3598] = EndpointAddress{}
+					yyv3603[yyj3603] = EndpointAddress{}
 				} else {
-					yyv3600 := &yyv3598[yyj3598]
-					yyv3600.CodecDecodeSelf(d)
+					yyv3605 := &yyv3603[yyj3603]
+					yyv3605.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3598 := 0; !r.CheckBreak(); yyj3598++ {
-			if yyj3598 >= len(yyv3598) {
-				yyv3598 = append(yyv3598, EndpointAddress{}) // var yyz3598 EndpointAddress
-				yyc3598 = true
+		for yyj3603 := 0; !r.CheckBreak(); yyj3603++ {
+			if yyj3603 >= len(yyv3603) {
+				yyv3603 = append(yyv3603, EndpointAddress{}) // var yyz3603 EndpointAddress
+				yyc3603 = true
 			}
 
-			if yyj3598 < len(yyv3598) {
+			if yyj3603 < len(yyv3603) {
 				if r.TryDecodeAsNil() {
-					yyv3598[yyj3598] = EndpointAddress{}
+					yyv3603[yyj3603] = EndpointAddress{}
 				} else {
-					yyv3601 := &yyv3598[yyj3598]
-					yyv3601.CodecDecodeSelf(d)
+					yyv3606 := &yyv3603[yyj3603]
+					yyv3606.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -42227,10 +42264,10 @@ func (x codecSelfer1234) decSliceEndpointAddress(v *[]EndpointAddress, d *codec1
 			}
 
 		}
-		yyh3598.End()
+		yyh3603.End()
 	}
-	if yyc3598 {
-		*v = yyv3598
+	if yyc3603 {
+		*v = yyv3603
 	}
 
 }
@@ -42240,9 +42277,9 @@ func (x codecSelfer1234) encSliceEndpointPort(v []EndpointPort, e *codec1978.Enc
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3602 := range v {
-		yy3603 := &yyv3602
-		yy3603.CodecEncodeSelf(e)
+	for _, yyv3607 := range v {
+		yy3608 := &yyv3607
+		yy3608.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -42252,75 +42289,75 @@ func (x codecSelfer1234) decSliceEndpointPort(v *[]EndpointPort, d *codec1978.De
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3604 := *v
-	yyh3604, yyl3604 := z.DecSliceHelperStart()
+	yyv3609 := *v
+	yyh3609, yyl3609 := z.DecSliceHelperStart()
 
-	var yyrr3604, yyrl3604 int
-	var yyc3604, yyrt3604 bool
-	_, _, _ = yyc3604, yyrt3604, yyrl3604
-	yyrr3604 = yyl3604
+	var yyrr3609, yyrl3609 int
+	var yyc3609, yyrt3609 bool
+	_, _, _ = yyc3609, yyrt3609, yyrl3609
+	yyrr3609 = yyl3609
 
-	if yyv3604 == nil {
-		if yyrl3604, yyrt3604 = z.DecInferLen(yyl3604, z.DecBasicHandle().MaxInitLen, 40); yyrt3604 {
-			yyrr3604 = yyrl3604
+	if yyv3609 == nil {
+		if yyrl3609, yyrt3609 = z.DecInferLen(yyl3609, z.DecBasicHandle().MaxInitLen, 40); yyrt3609 {
+			yyrr3609 = yyrl3609
 		}
-		yyv3604 = make([]EndpointPort, yyrl3604)
-		yyc3604 = true
+		yyv3609 = make([]EndpointPort, yyrl3609)
+		yyc3609 = true
 	}
 
-	if yyl3604 == 0 {
-		if len(yyv3604) != 0 {
-			yyv3604 = yyv3604[:0]
-			yyc3604 = true
+	if yyl3609 == 0 {
+		if len(yyv3609) != 0 {
+			yyv3609 = yyv3609[:0]
+			yyc3609 = true
 		}
-	} else if yyl3604 > 0 {
+	} else if yyl3609 > 0 {
 
-		if yyl3604 > cap(yyv3604) {
-			yyrl3604, yyrt3604 = z.DecInferLen(yyl3604, z.DecBasicHandle().MaxInitLen, 40)
-			yyv3604 = make([]EndpointPort, yyrl3604)
-			yyc3604 = true
+		if yyl3609 > cap(yyv3609) {
+			yyrl3609, yyrt3609 = z.DecInferLen(yyl3609, z.DecBasicHandle().MaxInitLen, 40)
+			yyv3609 = make([]EndpointPort, yyrl3609)
+			yyc3609 = true
 
-			yyrr3604 = len(yyv3604)
-		} else if yyl3604 != len(yyv3604) {
-			yyv3604 = yyv3604[:yyl3604]
-			yyc3604 = true
+			yyrr3609 = len(yyv3609)
+		} else if yyl3609 != len(yyv3609) {
+			yyv3609 = yyv3609[:yyl3609]
+			yyc3609 = true
 		}
-		yyj3604 := 0
-		for ; yyj3604 < yyrr3604; yyj3604++ {
+		yyj3609 := 0
+		for ; yyj3609 < yyrr3609; yyj3609++ {
 			if r.TryDecodeAsNil() {
-				yyv3604[yyj3604] = EndpointPort{}
+				yyv3609[yyj3609] = EndpointPort{}
 			} else {
-				yyv3605 := &yyv3604[yyj3604]
-				yyv3605.CodecDecodeSelf(d)
+				yyv3610 := &yyv3609[yyj3609]
+				yyv3610.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3604 {
-			for ; yyj3604 < yyl3604; yyj3604++ {
-				yyv3604 = append(yyv3604, EndpointPort{})
+		if yyrt3609 {
+			for ; yyj3609 < yyl3609; yyj3609++ {
+				yyv3609 = append(yyv3609, EndpointPort{})
 				if r.TryDecodeAsNil() {
-					yyv3604[yyj3604] = EndpointPort{}
+					yyv3609[yyj3609] = EndpointPort{}
 				} else {
-					yyv3606 := &yyv3604[yyj3604]
-					yyv3606.CodecDecodeSelf(d)
+					yyv3611 := &yyv3609[yyj3609]
+					yyv3611.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3604 := 0; !r.CheckBreak(); yyj3604++ {
-			if yyj3604 >= len(yyv3604) {
-				yyv3604 = append(yyv3604, EndpointPort{}) // var yyz3604 EndpointPort
-				yyc3604 = true
+		for yyj3609 := 0; !r.CheckBreak(); yyj3609++ {
+			if yyj3609 >= len(yyv3609) {
+				yyv3609 = append(yyv3609, EndpointPort{}) // var yyz3609 EndpointPort
+				yyc3609 = true
 			}
 
-			if yyj3604 < len(yyv3604) {
+			if yyj3609 < len(yyv3609) {
 				if r.TryDecodeAsNil() {
-					yyv3604[yyj3604] = EndpointPort{}
+					yyv3609[yyj3609] = EndpointPort{}
 				} else {
-					yyv3607 := &yyv3604[yyj3604]
-					yyv3607.CodecDecodeSelf(d)
+					yyv3612 := &yyv3609[yyj3609]
+					yyv3612.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -42328,10 +42365,10 @@ func (x codecSelfer1234) decSliceEndpointPort(v *[]EndpointPort, d *codec1978.De
 			}
 
 		}
-		yyh3604.End()
+		yyh3609.End()
 	}
-	if yyc3604 {
-		*v = yyv3604
+	if yyc3609 {
+		*v = yyv3609
 	}
 
 }
@@ -42341,9 +42378,9 @@ func (x codecSelfer1234) encSliceEndpoints(v []Endpoints, e *codec1978.Encoder) 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3608 := range v {
-		yy3609 := &yyv3608
-		yy3609.CodecEncodeSelf(e)
+	for _, yyv3613 := range v {
+		yy3614 := &yyv3613
+		yy3614.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -42353,75 +42390,75 @@ func (x codecSelfer1234) decSliceEndpoints(v *[]Endpoints, d *codec1978.Decoder)
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3610 := *v
-	yyh3610, yyl3610 := z.DecSliceHelperStart()
+	yyv3615 := *v
+	yyh3615, yyl3615 := z.DecSliceHelperStart()
 
-	var yyrr3610, yyrl3610 int
-	var yyc3610, yyrt3610 bool
-	_, _, _ = yyc3610, yyrt3610, yyrl3610
-	yyrr3610 = yyl3610
+	var yyrr3615, yyrl3615 int
+	var yyc3615, yyrt3615 bool
+	_, _, _ = yyc3615, yyrt3615, yyrl3615
+	yyrr3615 = yyl3615
 
-	if yyv3610 == nil {
-		if yyrl3610, yyrt3610 = z.DecInferLen(yyl3610, z.DecBasicHandle().MaxInitLen, 216); yyrt3610 {
-			yyrr3610 = yyrl3610
+	if yyv3615 == nil {
+		if yyrl3615, yyrt3615 = z.DecInferLen(yyl3615, z.DecBasicHandle().MaxInitLen, 216); yyrt3615 {
+			yyrr3615 = yyrl3615
 		}
-		yyv3610 = make([]Endpoints, yyrl3610)
-		yyc3610 = true
+		yyv3615 = make([]Endpoints, yyrl3615)
+		yyc3615 = true
 	}
 
-	if yyl3610 == 0 {
-		if len(yyv3610) != 0 {
-			yyv3610 = yyv3610[:0]
-			yyc3610 = true
+	if yyl3615 == 0 {
+		if len(yyv3615) != 0 {
+			yyv3615 = yyv3615[:0]
+			yyc3615 = true
 		}
-	} else if yyl3610 > 0 {
+	} else if yyl3615 > 0 {
 
-		if yyl3610 > cap(yyv3610) {
-			yyrl3610, yyrt3610 = z.DecInferLen(yyl3610, z.DecBasicHandle().MaxInitLen, 216)
-			yyv3610 = make([]Endpoints, yyrl3610)
-			yyc3610 = true
+		if yyl3615 > cap(yyv3615) {
+			yyrl3615, yyrt3615 = z.DecInferLen(yyl3615, z.DecBasicHandle().MaxInitLen, 216)
+			yyv3615 = make([]Endpoints, yyrl3615)
+			yyc3615 = true
 
-			yyrr3610 = len(yyv3610)
-		} else if yyl3610 != len(yyv3610) {
-			yyv3610 = yyv3610[:yyl3610]
-			yyc3610 = true
+			yyrr3615 = len(yyv3615)
+		} else if yyl3615 != len(yyv3615) {
+			yyv3615 = yyv3615[:yyl3615]
+			yyc3615 = true
 		}
-		yyj3610 := 0
-		for ; yyj3610 < yyrr3610; yyj3610++ {
+		yyj3615 := 0
+		for ; yyj3615 < yyrr3615; yyj3615++ {
 			if r.TryDecodeAsNil() {
-				yyv3610[yyj3610] = Endpoints{}
+				yyv3615[yyj3615] = Endpoints{}
 			} else {
-				yyv3611 := &yyv3610[yyj3610]
-				yyv3611.CodecDecodeSelf(d)
+				yyv3616 := &yyv3615[yyj3615]
+				yyv3616.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3610 {
-			for ; yyj3610 < yyl3610; yyj3610++ {
-				yyv3610 = append(yyv3610, Endpoints{})
+		if yyrt3615 {
+			for ; yyj3615 < yyl3615; yyj3615++ {
+				yyv3615 = append(yyv3615, Endpoints{})
 				if r.TryDecodeAsNil() {
-					yyv3610[yyj3610] = Endpoints{}
+					yyv3615[yyj3615] = Endpoints{}
 				} else {
-					yyv3612 := &yyv3610[yyj3610]
-					yyv3612.CodecDecodeSelf(d)
+					yyv3617 := &yyv3615[yyj3615]
+					yyv3617.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3610 := 0; !r.CheckBreak(); yyj3610++ {
-			if yyj3610 >= len(yyv3610) {
-				yyv3610 = append(yyv3610, Endpoints{}) // var yyz3610 Endpoints
-				yyc3610 = true
+		for yyj3615 := 0; !r.CheckBreak(); yyj3615++ {
+			if yyj3615 >= len(yyv3615) {
+				yyv3615 = append(yyv3615, Endpoints{}) // var yyz3615 Endpoints
+				yyc3615 = true
 			}
 
-			if yyj3610 < len(yyv3610) {
+			if yyj3615 < len(yyv3615) {
 				if r.TryDecodeAsNil() {
-					yyv3610[yyj3610] = Endpoints{}
+					yyv3615[yyj3615] = Endpoints{}
 				} else {
-					yyv3613 := &yyv3610[yyj3610]
-					yyv3613.CodecDecodeSelf(d)
+					yyv3618 := &yyv3615[yyj3615]
+					yyv3618.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -42429,10 +42466,10 @@ func (x codecSelfer1234) decSliceEndpoints(v *[]Endpoints, d *codec1978.Decoder)
 			}
 
 		}
-		yyh3610.End()
+		yyh3615.End()
 	}
-	if yyc3610 {
-		*v = yyv3610
+	if yyc3615 {
+		*v = yyv3615
 	}
 
 }
@@ -42442,9 +42479,9 @@ func (x codecSelfer1234) encSliceNodeCondition(v []NodeCondition, e *codec1978.E
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3614 := range v {
-		yy3615 := &yyv3614
-		yy3615.CodecEncodeSelf(e)
+	for _, yyv3619 := range v {
+		yy3620 := &yyv3619
+		yy3620.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -42454,75 +42491,75 @@ func (x codecSelfer1234) decSliceNodeCondition(v *[]NodeCondition, d *codec1978.
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3616 := *v
-	yyh3616, yyl3616 := z.DecSliceHelperStart()
+	yyv3621 := *v
+	yyh3621, yyl3621 := z.DecSliceHelperStart()
 
-	var yyrr3616, yyrl3616 int
-	var yyc3616, yyrt3616 bool
-	_, _, _ = yyc3616, yyrt3616, yyrl3616
-	yyrr3616 = yyl3616
+	var yyrr3621, yyrl3621 int
+	var yyc3621, yyrt3621 bool
+	_, _, _ = yyc3621, yyrt3621, yyrl3621
+	yyrr3621 = yyl3621
 
-	if yyv3616 == nil {
-		if yyrl3616, yyrt3616 = z.DecInferLen(yyl3616, z.DecBasicHandle().MaxInitLen, 112); yyrt3616 {
-			yyrr3616 = yyrl3616
+	if yyv3621 == nil {
+		if yyrl3621, yyrt3621 = z.DecInferLen(yyl3621, z.DecBasicHandle().MaxInitLen, 112); yyrt3621 {
+			yyrr3621 = yyrl3621
 		}
-		yyv3616 = make([]NodeCondition, yyrl3616)
-		yyc3616 = true
+		yyv3621 = make([]NodeCondition, yyrl3621)
+		yyc3621 = true
 	}
 
-	if yyl3616 == 0 {
-		if len(yyv3616) != 0 {
-			yyv3616 = yyv3616[:0]
-			yyc3616 = true
+	if yyl3621 == 0 {
+		if len(yyv3621) != 0 {
+			yyv3621 = yyv3621[:0]
+			yyc3621 = true
 		}
-	} else if yyl3616 > 0 {
+	} else if yyl3621 > 0 {
 
-		if yyl3616 > cap(yyv3616) {
-			yyrl3616, yyrt3616 = z.DecInferLen(yyl3616, z.DecBasicHandle().MaxInitLen, 112)
-			yyv3616 = make([]NodeCondition, yyrl3616)
-			yyc3616 = true
+		if yyl3621 > cap(yyv3621) {
+			yyrl3621, yyrt3621 = z.DecInferLen(yyl3621, z.DecBasicHandle().MaxInitLen, 112)
+			yyv3621 = make([]NodeCondition, yyrl3621)
+			yyc3621 = true
 
-			yyrr3616 = len(yyv3616)
-		} else if yyl3616 != len(yyv3616) {
-			yyv3616 = yyv3616[:yyl3616]
-			yyc3616 = true
+			yyrr3621 = len(yyv3621)
+		} else if yyl3621 != len(yyv3621) {
+			yyv3621 = yyv3621[:yyl3621]
+			yyc3621 = true
 		}
-		yyj3616 := 0
-		for ; yyj3616 < yyrr3616; yyj3616++ {
+		yyj3621 := 0
+		for ; yyj3621 < yyrr3621; yyj3621++ {
 			if r.TryDecodeAsNil() {
-				yyv3616[yyj3616] = NodeCondition{}
+				yyv3621[yyj3621] = NodeCondition{}
 			} else {
-				yyv3617 := &yyv3616[yyj3616]
-				yyv3617.CodecDecodeSelf(d)
+				yyv3622 := &yyv3621[yyj3621]
+				yyv3622.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3616 {
-			for ; yyj3616 < yyl3616; yyj3616++ {
-				yyv3616 = append(yyv3616, NodeCondition{})
+		if yyrt3621 {
+			for ; yyj3621 < yyl3621; yyj3621++ {
+				yyv3621 = append(yyv3621, NodeCondition{})
 				if r.TryDecodeAsNil() {
-					yyv3616[yyj3616] = NodeCondition{}
+					yyv3621[yyj3621] = NodeCondition{}
 				} else {
-					yyv3618 := &yyv3616[yyj3616]
-					yyv3618.CodecDecodeSelf(d)
+					yyv3623 := &yyv3621[yyj3621]
+					yyv3623.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3616 := 0; !r.CheckBreak(); yyj3616++ {
-			if yyj3616 >= len(yyv3616) {
-				yyv3616 = append(yyv3616, NodeCondition{}) // var yyz3616 NodeCondition
-				yyc3616 = true
+		for yyj3621 := 0; !r.CheckBreak(); yyj3621++ {
+			if yyj3621 >= len(yyv3621) {
+				yyv3621 = append(yyv3621, NodeCondition{}) // var yyz3621 NodeCondition
+				yyc3621 = true
 			}
 
-			if yyj3616 < len(yyv3616) {
+			if yyj3621 < len(yyv3621) {
 				if r.TryDecodeAsNil() {
-					yyv3616[yyj3616] = NodeCondition{}
+					yyv3621[yyj3621] = NodeCondition{}
 				} else {
-					yyv3619 := &yyv3616[yyj3616]
-					yyv3619.CodecDecodeSelf(d)
+					yyv3624 := &yyv3621[yyj3621]
+					yyv3624.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -42530,10 +42567,10 @@ func (x codecSelfer1234) decSliceNodeCondition(v *[]NodeCondition, d *codec1978.
 			}
 
 		}
-		yyh3616.End()
+		yyh3621.End()
 	}
-	if yyc3616 {
-		*v = yyv3616
+	if yyc3621 {
+		*v = yyv3621
 	}
 
 }
@@ -42543,9 +42580,9 @@ func (x codecSelfer1234) encSliceNodeAddress(v []NodeAddress, e *codec1978.Encod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3620 := range v {
-		yy3621 := &yyv3620
-		yy3621.CodecEncodeSelf(e)
+	for _, yyv3625 := range v {
+		yy3626 := &yyv3625
+		yy3626.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -42555,75 +42592,75 @@ func (x codecSelfer1234) decSliceNodeAddress(v *[]NodeAddress, d *codec1978.Deco
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3622 := *v
-	yyh3622, yyl3622 := z.DecSliceHelperStart()
+	yyv3627 := *v
+	yyh3627, yyl3627 := z.DecSliceHelperStart()
 
-	var yyrr3622, yyrl3622 int
-	var yyc3622, yyrt3622 bool
-	_, _, _ = yyc3622, yyrt3622, yyrl3622
-	yyrr3622 = yyl3622
+	var yyrr3627, yyrl3627 int
+	var yyc3627, yyrt3627 bool
+	_, _, _ = yyc3627, yyrt3627, yyrl3627
+	yyrr3627 = yyl3627
 
-	if yyv3622 == nil {
-		if yyrl3622, yyrt3622 = z.DecInferLen(yyl3622, z.DecBasicHandle().MaxInitLen, 32); yyrt3622 {
-			yyrr3622 = yyrl3622
+	if yyv3627 == nil {
+		if yyrl3627, yyrt3627 = z.DecInferLen(yyl3627, z.DecBasicHandle().MaxInitLen, 48); yyrt3627 {
+			yyrr3627 = yyrl3627
 		}
-		yyv3622 = make([]NodeAddress, yyrl3622)
-		yyc3622 = true
+		yyv3627 = make([]NodeAddress, yyrl3627)
+		yyc3627 = true
 	}
 
-	if yyl3622 == 0 {
-		if len(yyv3622) != 0 {
-			yyv3622 = yyv3622[:0]
-			yyc3622 = true
+	if yyl3627 == 0 {
+		if len(yyv3627) != 0 {
+			yyv3627 = yyv3627[:0]
+			yyc3627 = true
 		}
-	} else if yyl3622 > 0 {
+	} else if yyl3627 > 0 {
 
-		if yyl3622 > cap(yyv3622) {
-			yyrl3622, yyrt3622 = z.DecInferLen(yyl3622, z.DecBasicHandle().MaxInitLen, 32)
-			yyv3622 = make([]NodeAddress, yyrl3622)
-			yyc3622 = true
+		if yyl3627 > cap(yyv3627) {
+			yyrl3627, yyrt3627 = z.DecInferLen(yyl3627, z.DecBasicHandle().MaxInitLen, 48)
+			yyv3627 = make([]NodeAddress, yyrl3627)
+			yyc3627 = true
 
-			yyrr3622 = len(yyv3622)
-		} else if yyl3622 != len(yyv3622) {
-			yyv3622 = yyv3622[:yyl3622]
-			yyc3622 = true
+			yyrr3627 = len(yyv3627)
+		} else if yyl3627 != len(yyv3627) {
+			yyv3627 = yyv3627[:yyl3627]
+			yyc3627 = true
 		}
-		yyj3622 := 0
-		for ; yyj3622 < yyrr3622; yyj3622++ {
+		yyj3627 := 0
+		for ; yyj3627 < yyrr3627; yyj3627++ {
 			if r.TryDecodeAsNil() {
-				yyv3622[yyj3622] = NodeAddress{}
+				yyv3627[yyj3627] = NodeAddress{}
 			} else {
-				yyv3623 := &yyv3622[yyj3622]
-				yyv3623.CodecDecodeSelf(d)
+				yyv3628 := &yyv3627[yyj3627]
+				yyv3628.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3622 {
-			for ; yyj3622 < yyl3622; yyj3622++ {
-				yyv3622 = append(yyv3622, NodeAddress{})
+		if yyrt3627 {
+			for ; yyj3627 < yyl3627; yyj3627++ {
+				yyv3627 = append(yyv3627, NodeAddress{})
 				if r.TryDecodeAsNil() {
-					yyv3622[yyj3622] = NodeAddress{}
+					yyv3627[yyj3627] = NodeAddress{}
 				} else {
-					yyv3624 := &yyv3622[yyj3622]
-					yyv3624.CodecDecodeSelf(d)
+					yyv3629 := &yyv3627[yyj3627]
+					yyv3629.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3622 := 0; !r.CheckBreak(); yyj3622++ {
-			if yyj3622 >= len(yyv3622) {
-				yyv3622 = append(yyv3622, NodeAddress{}) // var yyz3622 NodeAddress
-				yyc3622 = true
+		for yyj3627 := 0; !r.CheckBreak(); yyj3627++ {
+			if yyj3627 >= len(yyv3627) {
+				yyv3627 = append(yyv3627, NodeAddress{}) // var yyz3627 NodeAddress
+				yyc3627 = true
 			}
 
-			if yyj3622 < len(yyv3622) {
+			if yyj3627 < len(yyv3627) {
 				if r.TryDecodeAsNil() {
-					yyv3622[yyj3622] = NodeAddress{}
+					yyv3627[yyj3627] = NodeAddress{}
 				} else {
-					yyv3625 := &yyv3622[yyj3622]
-					yyv3625.CodecDecodeSelf(d)
+					yyv3630 := &yyv3627[yyj3627]
+					yyv3630.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -42631,10 +42668,10 @@ func (x codecSelfer1234) decSliceNodeAddress(v *[]NodeAddress, d *codec1978.Deco
 			}
 
 		}
-		yyh3622.End()
+		yyh3627.End()
 	}
-	if yyc3622 {
-		*v = yyv3622
+	if yyc3627 {
+		*v = yyv3627
 	}
 
 }
@@ -42644,17 +42681,17 @@ func (x codecSelfer1234) encResourceList(v ResourceList, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeMapStart(len(v))
-	for yyk3626, yyv3626 := range v {
-		yyk3626.CodecEncodeSelf(e)
-		yy3627 := &yyv3626
-		yym3628 := z.EncBinary()
-		_ = yym3628
+	for yyk3631, yyv3631 := range v {
+		yyk3631.CodecEncodeSelf(e)
+		yy3632 := &yyv3631
+		yym3633 := z.EncBinary()
+		_ = yym3633
 		if false {
-		} else if z.HasExtensions() && z.EncExt(yy3627) {
-		} else if !yym3628 && z.IsJSONHandle() {
-			z.EncJSONMarshal(yy3627)
+		} else if z.HasExtensions() && z.EncExt(yy3632) {
+		} else if !yym3633 && z.IsJSONHandle() {
+			z.EncJSONMarshal(yy3632)
 		} else {
-			z.EncFallback(yy3627)
+			z.EncFallback(yy3632)
 		}
 	}
 	r.EncodeEnd()
@@ -42665,82 +42702,82 @@ func (x codecSelfer1234) decResourceList(v *ResourceList, d *codec1978.Decoder) 
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3629 := *v
-	yyl3629 := r.ReadMapStart()
-	yybh3629 := z.DecBasicHandle()
-	if yyv3629 == nil {
-		yyrl3629, _ := z.DecInferLen(yyl3629, yybh3629.MaxInitLen, 40)
-		yyv3629 = make(map[ResourceName]pkg3_resource.Quantity, yyrl3629)
-		*v = yyv3629
+	yyv3634 := *v
+	yyl3634 := r.ReadMapStart()
+	yybh3634 := z.DecBasicHandle()
+	if yyv3634 == nil {
+		yyrl3634, _ := z.DecInferLen(yyl3634, yybh3634.MaxInitLen, 40)
+		yyv3634 = make(map[ResourceName]pkg3_resource.Quantity, yyrl3634)
+		*v = yyv3634
 	}
-	var yymk3629 ResourceName
-	var yymv3629 pkg3_resource.Quantity
-	var yymg3629 bool
-	if yybh3629.MapValueReset {
-		yymg3629 = true
+	var yymk3634 ResourceName
+	var yymv3634 pkg3_resource.Quantity
+	var yymg3634 bool
+	if yybh3634.MapValueReset {
+		yymg3634 = true
 	}
-	if yyl3629 > 0 {
-		for yyj3629 := 0; yyj3629 < yyl3629; yyj3629++ {
+	if yyl3634 > 0 {
+		for yyj3634 := 0; yyj3634 < yyl3634; yyj3634++ {
 			if r.TryDecodeAsNil() {
-				yymk3629 = ""
+				yymk3634 = ""
 			} else {
-				yymk3629 = ResourceName(r.DecodeString())
+				yymk3634 = ResourceName(r.DecodeString())
 			}
 
-			if yymg3629 {
-				yymv3629 = yyv3629[yymk3629]
+			if yymg3634 {
+				yymv3634 = yyv3634[yymk3634]
 			} else {
-				yymv3629 = pkg3_resource.Quantity{}
+				yymv3634 = pkg3_resource.Quantity{}
 			}
 			if r.TryDecodeAsNil() {
-				yymv3629 = pkg3_resource.Quantity{}
+				yymv3634 = pkg3_resource.Quantity{}
 			} else {
-				yyv3631 := &yymv3629
-				yym3632 := z.DecBinary()
-				_ = yym3632
+				yyv3636 := &yymv3634
+				yym3637 := z.DecBinary()
+				_ = yym3637
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3631) {
-				} else if !yym3632 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv3631)
+				} else if z.HasExtensions() && z.DecExt(yyv3636) {
+				} else if !yym3637 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv3636)
 				} else {
-					z.DecFallback(yyv3631, false)
+					z.DecFallback(yyv3636, false)
 				}
 			}
 
-			if yyv3629 != nil {
-				yyv3629[yymk3629] = yymv3629
+			if yyv3634 != nil {
+				yyv3634[yymk3634] = yymv3634
 			}
 		}
-	} else if yyl3629 < 0 {
-		for yyj3629 := 0; !r.CheckBreak(); yyj3629++ {
+	} else if yyl3634 < 0 {
+		for yyj3634 := 0; !r.CheckBreak(); yyj3634++ {
 			if r.TryDecodeAsNil() {
-				yymk3629 = ""
+				yymk3634 = ""
 			} else {
-				yymk3629 = ResourceName(r.DecodeString())
+				yymk3634 = ResourceName(r.DecodeString())
 			}
 
-			if yymg3629 {
-				yymv3629 = yyv3629[yymk3629]
+			if yymg3634 {
+				yymv3634 = yyv3634[yymk3634]
 			} else {
-				yymv3629 = pkg3_resource.Quantity{}
+				yymv3634 = pkg3_resource.Quantity{}
 			}
 			if r.TryDecodeAsNil() {
-				yymv3629 = pkg3_resource.Quantity{}
+				yymv3634 = pkg3_resource.Quantity{}
 			} else {
-				yyv3634 := &yymv3629
-				yym3635 := z.DecBinary()
-				_ = yym3635
+				yyv3639 := &yymv3634
+				yym3640 := z.DecBinary()
+				_ = yym3640
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3634) {
-				} else if !yym3635 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv3634)
+				} else if z.HasExtensions() && z.DecExt(yyv3639) {
+				} else if !yym3640 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv3639)
 				} else {
-					z.DecFallback(yyv3634, false)
+					z.DecFallback(yyv3639, false)
 				}
 			}
 
-			if yyv3629 != nil {
-				yyv3629[yymk3629] = yymv3629
+			if yyv3634 != nil {
+				yyv3634[yymk3634] = yymv3634
 			}
 		}
 		r.ReadEnd()
@@ -42752,114 +42789,14 @@ func (x codecSelfer1234) encSliceNode(v []Node, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3636 := range v {
-		yy3637 := &yyv3636
-		yy3637.CodecEncodeSelf(e)
+	for _, yyv3641 := range v {
+		yy3642 := &yyv3641
+		yy3642.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
 
 func (x codecSelfer1234) decSliceNode(v *[]Node, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-
-	yyv3638 := *v
-	yyh3638, yyl3638 := z.DecSliceHelperStart()
-
-	var yyrr3638, yyrl3638 int
-	var yyc3638, yyrt3638 bool
-	_, _, _ = yyc3638, yyrt3638, yyrl3638
-	yyrr3638 = yyl3638
-
-	if yyv3638 == nil {
-		if yyrl3638, yyrt3638 = z.DecInferLen(yyl3638, z.DecBasicHandle().MaxInitLen, 456); yyrt3638 {
-			yyrr3638 = yyrl3638
-		}
-		yyv3638 = make([]Node, yyrl3638)
-		yyc3638 = true
-	}
-
-	if yyl3638 == 0 {
-		if len(yyv3638) != 0 {
-			yyv3638 = yyv3638[:0]
-			yyc3638 = true
-		}
-	} else if yyl3638 > 0 {
-
-		if yyl3638 > cap(yyv3638) {
-			yyrl3638, yyrt3638 = z.DecInferLen(yyl3638, z.DecBasicHandle().MaxInitLen, 456)
-			yyv3638 = make([]Node, yyrl3638)
-			yyc3638 = true
-
-			yyrr3638 = len(yyv3638)
-		} else if yyl3638 != len(yyv3638) {
-			yyv3638 = yyv3638[:yyl3638]
-			yyc3638 = true
-		}
-		yyj3638 := 0
-		for ; yyj3638 < yyrr3638; yyj3638++ {
-			if r.TryDecodeAsNil() {
-				yyv3638[yyj3638] = Node{}
-			} else {
-				yyv3639 := &yyv3638[yyj3638]
-				yyv3639.CodecDecodeSelf(d)
-			}
-
-		}
-		if yyrt3638 {
-			for ; yyj3638 < yyl3638; yyj3638++ {
-				yyv3638 = append(yyv3638, Node{})
-				if r.TryDecodeAsNil() {
-					yyv3638[yyj3638] = Node{}
-				} else {
-					yyv3640 := &yyv3638[yyj3638]
-					yyv3640.CodecDecodeSelf(d)
-				}
-
-			}
-		}
-
-	} else {
-		for yyj3638 := 0; !r.CheckBreak(); yyj3638++ {
-			if yyj3638 >= len(yyv3638) {
-				yyv3638 = append(yyv3638, Node{}) // var yyz3638 Node
-				yyc3638 = true
-			}
-
-			if yyj3638 < len(yyv3638) {
-				if r.TryDecodeAsNil() {
-					yyv3638[yyj3638] = Node{}
-				} else {
-					yyv3641 := &yyv3638[yyj3638]
-					yyv3641.CodecDecodeSelf(d)
-				}
-
-			} else {
-				z.DecSwallow()
-			}
-
-		}
-		yyh3638.End()
-	}
-	if yyc3638 {
-		*v = yyv3638
-	}
-
-}
-
-func (x codecSelfer1234) encSliceFinalizerName(v []FinalizerName, e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	r.EncodeArrayStart(len(v))
-	for _, yyv3642 := range v {
-		yyv3642.CodecEncodeSelf(e)
-	}
-	r.EncodeEnd()
-}
-
-func (x codecSelfer1234) decSliceFinalizerName(v *[]FinalizerName, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -42873,10 +42810,10 @@ func (x codecSelfer1234) decSliceFinalizerName(v *[]FinalizerName, d *codec1978.
 	yyrr3643 = yyl3643
 
 	if yyv3643 == nil {
-		if yyrl3643, yyrt3643 = z.DecInferLen(yyl3643, z.DecBasicHandle().MaxInitLen, 16); yyrt3643 {
+		if yyrl3643, yyrt3643 = z.DecInferLen(yyl3643, z.DecBasicHandle().MaxInitLen, 456); yyrt3643 {
 			yyrr3643 = yyrl3643
 		}
-		yyv3643 = make([]FinalizerName, yyrl3643)
+		yyv3643 = make([]Node, yyrl3643)
 		yyc3643 = true
 	}
 
@@ -42888,13 +42825,8 @@ func (x codecSelfer1234) decSliceFinalizerName(v *[]FinalizerName, d *codec1978.
 	} else if yyl3643 > 0 {
 
 		if yyl3643 > cap(yyv3643) {
-			yyrl3643, yyrt3643 = z.DecInferLen(yyl3643, z.DecBasicHandle().MaxInitLen, 16)
-
-			yyv23643 := yyv3643
-			yyv3643 = make([]FinalizerName, yyrl3643)
-			if len(yyv3643) > 0 {
-				copy(yyv3643, yyv23643[:cap(yyv23643)])
-			}
+			yyrl3643, yyrt3643 = z.DecInferLen(yyl3643, z.DecBasicHandle().MaxInitLen, 456)
+			yyv3643 = make([]Node, yyrl3643)
 			yyc3643 = true
 
 			yyrr3643 = len(yyv3643)
@@ -42905,19 +42837,21 @@ func (x codecSelfer1234) decSliceFinalizerName(v *[]FinalizerName, d *codec1978.
 		yyj3643 := 0
 		for ; yyj3643 < yyrr3643; yyj3643++ {
 			if r.TryDecodeAsNil() {
-				yyv3643[yyj3643] = ""
+				yyv3643[yyj3643] = Node{}
 			} else {
-				yyv3643[yyj3643] = FinalizerName(r.DecodeString())
+				yyv3644 := &yyv3643[yyj3643]
+				yyv3644.CodecDecodeSelf(d)
 			}
 
 		}
 		if yyrt3643 {
 			for ; yyj3643 < yyl3643; yyj3643++ {
-				yyv3643 = append(yyv3643, "")
+				yyv3643 = append(yyv3643, Node{})
 				if r.TryDecodeAsNil() {
-					yyv3643[yyj3643] = ""
+					yyv3643[yyj3643] = Node{}
 				} else {
-					yyv3643[yyj3643] = FinalizerName(r.DecodeString())
+					yyv3645 := &yyv3643[yyj3643]
+					yyv3645.CodecDecodeSelf(d)
 				}
 
 			}
@@ -42926,15 +42860,16 @@ func (x codecSelfer1234) decSliceFinalizerName(v *[]FinalizerName, d *codec1978.
 	} else {
 		for yyj3643 := 0; !r.CheckBreak(); yyj3643++ {
 			if yyj3643 >= len(yyv3643) {
-				yyv3643 = append(yyv3643, "") // var yyz3643 FinalizerName
+				yyv3643 = append(yyv3643, Node{}) // var yyz3643 Node
 				yyc3643 = true
 			}
 
 			if yyj3643 < len(yyv3643) {
 				if r.TryDecodeAsNil() {
-					yyv3643[yyj3643] = ""
+					yyv3643[yyj3643] = Node{}
 				} else {
-					yyv3643[yyj3643] = FinalizerName(r.DecodeString())
+					yyv3646 := &yyv3643[yyj3643]
+					yyv3646.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -42950,14 +42885,116 @@ func (x codecSelfer1234) decSliceFinalizerName(v *[]FinalizerName, d *codec1978.
 
 }
 
-func (x codecSelfer1234) encSliceNamespace(v []Namespace, e *codec1978.Encoder) {
+func (x codecSelfer1234) encSliceFinalizerName(v []FinalizerName, e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3647 := range v {
-		yy3648 := &yyv3647
-		yy3648.CodecEncodeSelf(e)
+		yyv3647.CodecEncodeSelf(e)
+	}
+	r.EncodeEnd()
+}
+
+func (x codecSelfer1234) decSliceFinalizerName(v *[]FinalizerName, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv3648 := *v
+	yyh3648, yyl3648 := z.DecSliceHelperStart()
+
+	var yyrr3648, yyrl3648 int
+	var yyc3648, yyrt3648 bool
+	_, _, _ = yyc3648, yyrt3648, yyrl3648
+	yyrr3648 = yyl3648
+
+	if yyv3648 == nil {
+		if yyrl3648, yyrt3648 = z.DecInferLen(yyl3648, z.DecBasicHandle().MaxInitLen, 16); yyrt3648 {
+			yyrr3648 = yyrl3648
+		}
+		yyv3648 = make([]FinalizerName, yyrl3648)
+		yyc3648 = true
+	}
+
+	if yyl3648 == 0 {
+		if len(yyv3648) != 0 {
+			yyv3648 = yyv3648[:0]
+			yyc3648 = true
+		}
+	} else if yyl3648 > 0 {
+
+		if yyl3648 > cap(yyv3648) {
+			yyrl3648, yyrt3648 = z.DecInferLen(yyl3648, z.DecBasicHandle().MaxInitLen, 16)
+
+			yyv23648 := yyv3648
+			yyv3648 = make([]FinalizerName, yyrl3648)
+			if len(yyv3648) > 0 {
+				copy(yyv3648, yyv23648[:cap(yyv23648)])
+			}
+			yyc3648 = true
+
+			yyrr3648 = len(yyv3648)
+		} else if yyl3648 != len(yyv3648) {
+			yyv3648 = yyv3648[:yyl3648]
+			yyc3648 = true
+		}
+		yyj3648 := 0
+		for ; yyj3648 < yyrr3648; yyj3648++ {
+			if r.TryDecodeAsNil() {
+				yyv3648[yyj3648] = ""
+			} else {
+				yyv3648[yyj3648] = FinalizerName(r.DecodeString())
+			}
+
+		}
+		if yyrt3648 {
+			for ; yyj3648 < yyl3648; yyj3648++ {
+				yyv3648 = append(yyv3648, "")
+				if r.TryDecodeAsNil() {
+					yyv3648[yyj3648] = ""
+				} else {
+					yyv3648[yyj3648] = FinalizerName(r.DecodeString())
+				}
+
+			}
+		}
+
+	} else {
+		for yyj3648 := 0; !r.CheckBreak(); yyj3648++ {
+			if yyj3648 >= len(yyv3648) {
+				yyv3648 = append(yyv3648, "") // var yyz3648 FinalizerName
+				yyc3648 = true
+			}
+
+			if yyj3648 < len(yyv3648) {
+				if r.TryDecodeAsNil() {
+					yyv3648[yyj3648] = ""
+				} else {
+					yyv3648[yyj3648] = FinalizerName(r.DecodeString())
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		yyh3648.End()
+	}
+	if yyc3648 {
+		*v = yyv3648
+	}
+
+}
+
+func (x codecSelfer1234) encSliceNamespace(v []Namespace, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv3652 := range v {
+		yy3653 := &yyv3652
+		yy3653.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -42967,75 +43004,75 @@ func (x codecSelfer1234) decSliceNamespace(v *[]Namespace, d *codec1978.Decoder)
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3649 := *v
-	yyh3649, yyl3649 := z.DecSliceHelperStart()
+	yyv3654 := *v
+	yyh3654, yyl3654 := z.DecSliceHelperStart()
 
-	var yyrr3649, yyrl3649 int
-	var yyc3649, yyrt3649 bool
-	_, _, _ = yyc3649, yyrt3649, yyrl3649
-	yyrr3649 = yyl3649
+	var yyrr3654, yyrl3654 int
+	var yyc3654, yyrt3654 bool
+	_, _, _ = yyc3654, yyrt3654, yyrl3654
+	yyrr3654 = yyl3654
 
-	if yyv3649 == nil {
-		if yyrl3649, yyrt3649 = z.DecInferLen(yyl3649, z.DecBasicHandle().MaxInitLen, 232); yyrt3649 {
-			yyrr3649 = yyrl3649
+	if yyv3654 == nil {
+		if yyrl3654, yyrt3654 = z.DecInferLen(yyl3654, z.DecBasicHandle().MaxInitLen, 232); yyrt3654 {
+			yyrr3654 = yyrl3654
 		}
-		yyv3649 = make([]Namespace, yyrl3649)
-		yyc3649 = true
+		yyv3654 = make([]Namespace, yyrl3654)
+		yyc3654 = true
 	}
 
-	if yyl3649 == 0 {
-		if len(yyv3649) != 0 {
-			yyv3649 = yyv3649[:0]
-			yyc3649 = true
+	if yyl3654 == 0 {
+		if len(yyv3654) != 0 {
+			yyv3654 = yyv3654[:0]
+			yyc3654 = true
 		}
-	} else if yyl3649 > 0 {
+	} else if yyl3654 > 0 {
 
-		if yyl3649 > cap(yyv3649) {
-			yyrl3649, yyrt3649 = z.DecInferLen(yyl3649, z.DecBasicHandle().MaxInitLen, 232)
-			yyv3649 = make([]Namespace, yyrl3649)
-			yyc3649 = true
+		if yyl3654 > cap(yyv3654) {
+			yyrl3654, yyrt3654 = z.DecInferLen(yyl3654, z.DecBasicHandle().MaxInitLen, 232)
+			yyv3654 = make([]Namespace, yyrl3654)
+			yyc3654 = true
 
-			yyrr3649 = len(yyv3649)
-		} else if yyl3649 != len(yyv3649) {
-			yyv3649 = yyv3649[:yyl3649]
-			yyc3649 = true
+			yyrr3654 = len(yyv3654)
+		} else if yyl3654 != len(yyv3654) {
+			yyv3654 = yyv3654[:yyl3654]
+			yyc3654 = true
 		}
-		yyj3649 := 0
-		for ; yyj3649 < yyrr3649; yyj3649++ {
+		yyj3654 := 0
+		for ; yyj3654 < yyrr3654; yyj3654++ {
 			if r.TryDecodeAsNil() {
-				yyv3649[yyj3649] = Namespace{}
+				yyv3654[yyj3654] = Namespace{}
 			} else {
-				yyv3650 := &yyv3649[yyj3649]
-				yyv3650.CodecDecodeSelf(d)
+				yyv3655 := &yyv3654[yyj3654]
+				yyv3655.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3649 {
-			for ; yyj3649 < yyl3649; yyj3649++ {
-				yyv3649 = append(yyv3649, Namespace{})
+		if yyrt3654 {
+			for ; yyj3654 < yyl3654; yyj3654++ {
+				yyv3654 = append(yyv3654, Namespace{})
 				if r.TryDecodeAsNil() {
-					yyv3649[yyj3649] = Namespace{}
+					yyv3654[yyj3654] = Namespace{}
 				} else {
-					yyv3651 := &yyv3649[yyj3649]
-					yyv3651.CodecDecodeSelf(d)
+					yyv3656 := &yyv3654[yyj3654]
+					yyv3656.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3649 := 0; !r.CheckBreak(); yyj3649++ {
-			if yyj3649 >= len(yyv3649) {
-				yyv3649 = append(yyv3649, Namespace{}) // var yyz3649 Namespace
-				yyc3649 = true
+		for yyj3654 := 0; !r.CheckBreak(); yyj3654++ {
+			if yyj3654 >= len(yyv3654) {
+				yyv3654 = append(yyv3654, Namespace{}) // var yyz3654 Namespace
+				yyc3654 = true
 			}
 
-			if yyj3649 < len(yyv3649) {
+			if yyj3654 < len(yyv3654) {
 				if r.TryDecodeAsNil() {
-					yyv3649[yyj3649] = Namespace{}
+					yyv3654[yyj3654] = Namespace{}
 				} else {
-					yyv3652 := &yyv3649[yyj3649]
-					yyv3652.CodecDecodeSelf(d)
+					yyv3657 := &yyv3654[yyj3654]
+					yyv3657.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -43043,10 +43080,10 @@ func (x codecSelfer1234) decSliceNamespace(v *[]Namespace, d *codec1978.Decoder)
 			}
 
 		}
-		yyh3649.End()
+		yyh3654.End()
 	}
-	if yyc3649 {
-		*v = yyv3649
+	if yyc3654 {
+		*v = yyv3654
 	}
 
 }
@@ -43056,9 +43093,9 @@ func (x codecSelfer1234) encSliceEvent(v []Event, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3653 := range v {
-		yy3654 := &yyv3653
-		yy3654.CodecEncodeSelf(e)
+	for _, yyv3658 := range v {
+		yy3659 := &yyv3658
+		yy3659.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -43068,75 +43105,75 @@ func (x codecSelfer1234) decSliceEvent(v *[]Event, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3655 := *v
-	yyh3655, yyl3655 := z.DecSliceHelperStart()
+	yyv3660 := *v
+	yyh3660, yyl3660 := z.DecSliceHelperStart()
 
-	var yyrr3655, yyrl3655 int
-	var yyc3655, yyrt3655 bool
-	_, _, _ = yyc3655, yyrt3655, yyrl3655
-	yyrr3655 = yyl3655
+	var yyrr3660, yyrl3660 int
+	var yyc3660, yyrt3660 bool
+	_, _, _ = yyc3660, yyrt3660, yyrl3660
+	yyrr3660 = yyl3660
 
-	if yyv3655 == nil {
-		if yyrl3655, yyrt3655 = z.DecInferLen(yyl3655, z.DecBasicHandle().MaxInitLen, 424); yyrt3655 {
-			yyrr3655 = yyrl3655
+	if yyv3660 == nil {
+		if yyrl3660, yyrt3660 = z.DecInferLen(yyl3660, z.DecBasicHandle().MaxInitLen, 424); yyrt3660 {
+			yyrr3660 = yyrl3660
 		}
-		yyv3655 = make([]Event, yyrl3655)
-		yyc3655 = true
+		yyv3660 = make([]Event, yyrl3660)
+		yyc3660 = true
 	}
 
-	if yyl3655 == 0 {
-		if len(yyv3655) != 0 {
-			yyv3655 = yyv3655[:0]
-			yyc3655 = true
+	if yyl3660 == 0 {
+		if len(yyv3660) != 0 {
+			yyv3660 = yyv3660[:0]
+			yyc3660 = true
 		}
-	} else if yyl3655 > 0 {
+	} else if yyl3660 > 0 {
 
-		if yyl3655 > cap(yyv3655) {
-			yyrl3655, yyrt3655 = z.DecInferLen(yyl3655, z.DecBasicHandle().MaxInitLen, 424)
-			yyv3655 = make([]Event, yyrl3655)
-			yyc3655 = true
+		if yyl3660 > cap(yyv3660) {
+			yyrl3660, yyrt3660 = z.DecInferLen(yyl3660, z.DecBasicHandle().MaxInitLen, 424)
+			yyv3660 = make([]Event, yyrl3660)
+			yyc3660 = true
 
-			yyrr3655 = len(yyv3655)
-		} else if yyl3655 != len(yyv3655) {
-			yyv3655 = yyv3655[:yyl3655]
-			yyc3655 = true
+			yyrr3660 = len(yyv3660)
+		} else if yyl3660 != len(yyv3660) {
+			yyv3660 = yyv3660[:yyl3660]
+			yyc3660 = true
 		}
-		yyj3655 := 0
-		for ; yyj3655 < yyrr3655; yyj3655++ {
+		yyj3660 := 0
+		for ; yyj3660 < yyrr3660; yyj3660++ {
 			if r.TryDecodeAsNil() {
-				yyv3655[yyj3655] = Event{}
+				yyv3660[yyj3660] = Event{}
 			} else {
-				yyv3656 := &yyv3655[yyj3655]
-				yyv3656.CodecDecodeSelf(d)
+				yyv3661 := &yyv3660[yyj3660]
+				yyv3661.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3655 {
-			for ; yyj3655 < yyl3655; yyj3655++ {
-				yyv3655 = append(yyv3655, Event{})
+		if yyrt3660 {
+			for ; yyj3660 < yyl3660; yyj3660++ {
+				yyv3660 = append(yyv3660, Event{})
 				if r.TryDecodeAsNil() {
-					yyv3655[yyj3655] = Event{}
+					yyv3660[yyj3660] = Event{}
 				} else {
-					yyv3657 := &yyv3655[yyj3655]
-					yyv3657.CodecDecodeSelf(d)
+					yyv3662 := &yyv3660[yyj3660]
+					yyv3662.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3655 := 0; !r.CheckBreak(); yyj3655++ {
-			if yyj3655 >= len(yyv3655) {
-				yyv3655 = append(yyv3655, Event{}) // var yyz3655 Event
-				yyc3655 = true
+		for yyj3660 := 0; !r.CheckBreak(); yyj3660++ {
+			if yyj3660 >= len(yyv3660) {
+				yyv3660 = append(yyv3660, Event{}) // var yyz3660 Event
+				yyc3660 = true
 			}
 
-			if yyj3655 < len(yyv3655) {
+			if yyj3660 < len(yyv3660) {
 				if r.TryDecodeAsNil() {
-					yyv3655[yyj3655] = Event{}
+					yyv3660[yyj3660] = Event{}
 				} else {
-					yyv3658 := &yyv3655[yyj3655]
-					yyv3658.CodecDecodeSelf(d)
+					yyv3663 := &yyv3660[yyj3660]
+					yyv3663.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -43144,10 +43181,10 @@ func (x codecSelfer1234) decSliceEvent(v *[]Event, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3655.End()
+		yyh3660.End()
 	}
-	if yyc3655 {
-		*v = yyv3655
+	if yyc3660 {
+		*v = yyv3660
 	}
 
 }
@@ -43157,16 +43194,16 @@ func (x codecSelfer1234) encSliceruntime_Object(v []pkg8_runtime.Object, e *code
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3659 := range v {
-		if yyv3659 == nil {
+	for _, yyv3664 := range v {
+		if yyv3664 == nil {
 			r.EncodeNil()
 		} else {
-			yym3660 := z.EncBinary()
-			_ = yym3660
+			yym3665 := z.EncBinary()
+			_ = yym3665
 			if false {
-			} else if z.HasExtensions() && z.EncExt(yyv3659) {
+			} else if z.HasExtensions() && z.EncExt(yyv3664) {
 			} else {
-				z.EncFallback(yyv3659)
+				z.EncFallback(yyv3664)
 			}
 		}
 	}
@@ -43178,68 +43215,68 @@ func (x codecSelfer1234) decSliceruntime_Object(v *[]pkg8_runtime.Object, d *cod
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3661 := *v
-	yyh3661, yyl3661 := z.DecSliceHelperStart()
+	yyv3666 := *v
+	yyh3666, yyl3666 := z.DecSliceHelperStart()
 
-	var yyrr3661, yyrl3661 int
-	var yyc3661, yyrt3661 bool
-	_, _, _ = yyc3661, yyrt3661, yyrl3661
-	yyrr3661 = yyl3661
+	var yyrr3666, yyrl3666 int
+	var yyc3666, yyrt3666 bool
+	_, _, _ = yyc3666, yyrt3666, yyrl3666
+	yyrr3666 = yyl3666
 
-	if yyv3661 == nil {
-		if yyrl3661, yyrt3661 = z.DecInferLen(yyl3661, z.DecBasicHandle().MaxInitLen, 16); yyrt3661 {
-			yyrr3661 = yyrl3661
+	if yyv3666 == nil {
+		if yyrl3666, yyrt3666 = z.DecInferLen(yyl3666, z.DecBasicHandle().MaxInitLen, 16); yyrt3666 {
+			yyrr3666 = yyrl3666
 		}
-		yyv3661 = make([]pkg8_runtime.Object, yyrl3661)
-		yyc3661 = true
+		yyv3666 = make([]pkg8_runtime.Object, yyrl3666)
+		yyc3666 = true
 	}
 
-	if yyl3661 == 0 {
-		if len(yyv3661) != 0 {
-			yyv3661 = yyv3661[:0]
-			yyc3661 = true
+	if yyl3666 == 0 {
+		if len(yyv3666) != 0 {
+			yyv3666 = yyv3666[:0]
+			yyc3666 = true
 		}
-	} else if yyl3661 > 0 {
+	} else if yyl3666 > 0 {
 
-		if yyl3661 > cap(yyv3661) {
-			yyrl3661, yyrt3661 = z.DecInferLen(yyl3661, z.DecBasicHandle().MaxInitLen, 16)
-			yyv3661 = make([]pkg8_runtime.Object, yyrl3661)
-			yyc3661 = true
+		if yyl3666 > cap(yyv3666) {
+			yyrl3666, yyrt3666 = z.DecInferLen(yyl3666, z.DecBasicHandle().MaxInitLen, 16)
+			yyv3666 = make([]pkg8_runtime.Object, yyrl3666)
+			yyc3666 = true
 
-			yyrr3661 = len(yyv3661)
-		} else if yyl3661 != len(yyv3661) {
-			yyv3661 = yyv3661[:yyl3661]
-			yyc3661 = true
+			yyrr3666 = len(yyv3666)
+		} else if yyl3666 != len(yyv3666) {
+			yyv3666 = yyv3666[:yyl3666]
+			yyc3666 = true
 		}
-		yyj3661 := 0
-		for ; yyj3661 < yyrr3661; yyj3661++ {
+		yyj3666 := 0
+		for ; yyj3666 < yyrr3666; yyj3666++ {
 			if r.TryDecodeAsNil() {
-				yyv3661[yyj3661] = nil
+				yyv3666[yyj3666] = nil
 			} else {
-				yyv3662 := &yyv3661[yyj3661]
-				yym3663 := z.DecBinary()
-				_ = yym3663
+				yyv3667 := &yyv3666[yyj3666]
+				yym3668 := z.DecBinary()
+				_ = yym3668
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3662) {
+				} else if z.HasExtensions() && z.DecExt(yyv3667) {
 				} else {
-					z.DecFallback(yyv3662, true)
+					z.DecFallback(yyv3667, true)
 				}
 			}
 
 		}
-		if yyrt3661 {
-			for ; yyj3661 < yyl3661; yyj3661++ {
-				yyv3661 = append(yyv3661, nil)
+		if yyrt3666 {
+			for ; yyj3666 < yyl3666; yyj3666++ {
+				yyv3666 = append(yyv3666, nil)
 				if r.TryDecodeAsNil() {
-					yyv3661[yyj3661] = nil
+					yyv3666[yyj3666] = nil
 				} else {
-					yyv3664 := &yyv3661[yyj3661]
-					yym3665 := z.DecBinary()
-					_ = yym3665
+					yyv3669 := &yyv3666[yyj3666]
+					yym3670 := z.DecBinary()
+					_ = yym3670
 					if false {
-					} else if z.HasExtensions() && z.DecExt(yyv3664) {
+					} else if z.HasExtensions() && z.DecExt(yyv3669) {
 					} else {
-						z.DecFallback(yyv3664, true)
+						z.DecFallback(yyv3669, true)
 					}
 				}
 
@@ -43247,23 +43284,23 @@ func (x codecSelfer1234) decSliceruntime_Object(v *[]pkg8_runtime.Object, d *cod
 		}
 
 	} else {
-		for yyj3661 := 0; !r.CheckBreak(); yyj3661++ {
-			if yyj3661 >= len(yyv3661) {
-				yyv3661 = append(yyv3661, nil) // var yyz3661 pkg8_runtime.Object
-				yyc3661 = true
+		for yyj3666 := 0; !r.CheckBreak(); yyj3666++ {
+			if yyj3666 >= len(yyv3666) {
+				yyv3666 = append(yyv3666, nil) // var yyz3666 pkg8_runtime.Object
+				yyc3666 = true
 			}
 
-			if yyj3661 < len(yyv3661) {
+			if yyj3666 < len(yyv3666) {
 				if r.TryDecodeAsNil() {
-					yyv3661[yyj3661] = nil
+					yyv3666[yyj3666] = nil
 				} else {
-					yyv3666 := &yyv3661[yyj3661]
-					yym3667 := z.DecBinary()
-					_ = yym3667
+					yyv3671 := &yyv3666[yyj3666]
+					yym3672 := z.DecBinary()
+					_ = yym3672
 					if false {
-					} else if z.HasExtensions() && z.DecExt(yyv3666) {
+					} else if z.HasExtensions() && z.DecExt(yyv3671) {
 					} else {
-						z.DecFallback(yyv3666, true)
+						z.DecFallback(yyv3671, true)
 					}
 				}
 
@@ -43272,10 +43309,10 @@ func (x codecSelfer1234) decSliceruntime_Object(v *[]pkg8_runtime.Object, d *cod
 			}
 
 		}
-		yyh3661.End()
+		yyh3666.End()
 	}
-	if yyc3661 {
-		*v = yyv3661
+	if yyc3666 {
+		*v = yyv3666
 	}
 
 }
@@ -43285,9 +43322,9 @@ func (x codecSelfer1234) encSliceLimitRangeItem(v []LimitRangeItem, e *codec1978
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3668 := range v {
-		yy3669 := &yyv3668
-		yy3669.CodecEncodeSelf(e)
+	for _, yyv3673 := range v {
+		yy3674 := &yyv3673
+		yy3674.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -43297,75 +43334,75 @@ func (x codecSelfer1234) decSliceLimitRangeItem(v *[]LimitRangeItem, d *codec197
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3670 := *v
-	yyh3670, yyl3670 := z.DecSliceHelperStart()
+	yyv3675 := *v
+	yyh3675, yyl3675 := z.DecSliceHelperStart()
 
-	var yyrr3670, yyrl3670 int
-	var yyc3670, yyrt3670 bool
-	_, _, _ = yyc3670, yyrt3670, yyrl3670
-	yyrr3670 = yyl3670
+	var yyrr3675, yyrl3675 int
+	var yyc3675, yyrt3675 bool
+	_, _, _ = yyc3675, yyrt3675, yyrl3675
+	yyrr3675 = yyl3675
 
-	if yyv3670 == nil {
-		if yyrl3670, yyrt3670 = z.DecInferLen(yyl3670, z.DecBasicHandle().MaxInitLen, 56); yyrt3670 {
-			yyrr3670 = yyrl3670
+	if yyv3675 == nil {
+		if yyrl3675, yyrt3675 = z.DecInferLen(yyl3675, z.DecBasicHandle().MaxInitLen, 56); yyrt3675 {
+			yyrr3675 = yyrl3675
 		}
-		yyv3670 = make([]LimitRangeItem, yyrl3670)
-		yyc3670 = true
+		yyv3675 = make([]LimitRangeItem, yyrl3675)
+		yyc3675 = true
 	}
 
-	if yyl3670 == 0 {
-		if len(yyv3670) != 0 {
-			yyv3670 = yyv3670[:0]
-			yyc3670 = true
+	if yyl3675 == 0 {
+		if len(yyv3675) != 0 {
+			yyv3675 = yyv3675[:0]
+			yyc3675 = true
 		}
-	} else if yyl3670 > 0 {
+	} else if yyl3675 > 0 {
 
-		if yyl3670 > cap(yyv3670) {
-			yyrl3670, yyrt3670 = z.DecInferLen(yyl3670, z.DecBasicHandle().MaxInitLen, 56)
-			yyv3670 = make([]LimitRangeItem, yyrl3670)
-			yyc3670 = true
+		if yyl3675 > cap(yyv3675) {
+			yyrl3675, yyrt3675 = z.DecInferLen(yyl3675, z.DecBasicHandle().MaxInitLen, 56)
+			yyv3675 = make([]LimitRangeItem, yyrl3675)
+			yyc3675 = true
 
-			yyrr3670 = len(yyv3670)
-		} else if yyl3670 != len(yyv3670) {
-			yyv3670 = yyv3670[:yyl3670]
-			yyc3670 = true
+			yyrr3675 = len(yyv3675)
+		} else if yyl3675 != len(yyv3675) {
+			yyv3675 = yyv3675[:yyl3675]
+			yyc3675 = true
 		}
-		yyj3670 := 0
-		for ; yyj3670 < yyrr3670; yyj3670++ {
+		yyj3675 := 0
+		for ; yyj3675 < yyrr3675; yyj3675++ {
 			if r.TryDecodeAsNil() {
-				yyv3670[yyj3670] = LimitRangeItem{}
+				yyv3675[yyj3675] = LimitRangeItem{}
 			} else {
-				yyv3671 := &yyv3670[yyj3670]
-				yyv3671.CodecDecodeSelf(d)
+				yyv3676 := &yyv3675[yyj3675]
+				yyv3676.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3670 {
-			for ; yyj3670 < yyl3670; yyj3670++ {
-				yyv3670 = append(yyv3670, LimitRangeItem{})
+		if yyrt3675 {
+			for ; yyj3675 < yyl3675; yyj3675++ {
+				yyv3675 = append(yyv3675, LimitRangeItem{})
 				if r.TryDecodeAsNil() {
-					yyv3670[yyj3670] = LimitRangeItem{}
+					yyv3675[yyj3675] = LimitRangeItem{}
 				} else {
-					yyv3672 := &yyv3670[yyj3670]
-					yyv3672.CodecDecodeSelf(d)
+					yyv3677 := &yyv3675[yyj3675]
+					yyv3677.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3670 := 0; !r.CheckBreak(); yyj3670++ {
-			if yyj3670 >= len(yyv3670) {
-				yyv3670 = append(yyv3670, LimitRangeItem{}) // var yyz3670 LimitRangeItem
-				yyc3670 = true
+		for yyj3675 := 0; !r.CheckBreak(); yyj3675++ {
+			if yyj3675 >= len(yyv3675) {
+				yyv3675 = append(yyv3675, LimitRangeItem{}) // var yyz3675 LimitRangeItem
+				yyc3675 = true
 			}
 
-			if yyj3670 < len(yyv3670) {
+			if yyj3675 < len(yyv3675) {
 				if r.TryDecodeAsNil() {
-					yyv3670[yyj3670] = LimitRangeItem{}
+					yyv3675[yyj3675] = LimitRangeItem{}
 				} else {
-					yyv3673 := &yyv3670[yyj3670]
-					yyv3673.CodecDecodeSelf(d)
+					yyv3678 := &yyv3675[yyj3675]
+					yyv3678.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -43373,10 +43410,10 @@ func (x codecSelfer1234) decSliceLimitRangeItem(v *[]LimitRangeItem, d *codec197
 			}
 
 		}
-		yyh3670.End()
+		yyh3675.End()
 	}
-	if yyc3670 {
-		*v = yyv3670
+	if yyc3675 {
+		*v = yyv3675
 	}
 
 }
@@ -43386,9 +43423,9 @@ func (x codecSelfer1234) encSliceLimitRange(v []LimitRange, e *codec1978.Encoder
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3674 := range v {
-		yy3675 := &yyv3674
-		yy3675.CodecEncodeSelf(e)
+	for _, yyv3679 := range v {
+		yy3680 := &yyv3679
+		yy3680.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -43398,75 +43435,75 @@ func (x codecSelfer1234) decSliceLimitRange(v *[]LimitRange, d *codec1978.Decode
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3676 := *v
-	yyh3676, yyl3676 := z.DecSliceHelperStart()
+	yyv3681 := *v
+	yyh3681, yyl3681 := z.DecSliceHelperStart()
 
-	var yyrr3676, yyrl3676 int
-	var yyc3676, yyrt3676 bool
-	_, _, _ = yyc3676, yyrt3676, yyrl3676
-	yyrr3676 = yyl3676
+	var yyrr3681, yyrl3681 int
+	var yyc3681, yyrt3681 bool
+	_, _, _ = yyc3681, yyrt3681, yyrl3681
+	yyrr3681 = yyl3681
 
-	if yyv3676 == nil {
-		if yyrl3676, yyrt3676 = z.DecInferLen(yyl3676, z.DecBasicHandle().MaxInitLen, 216); yyrt3676 {
-			yyrr3676 = yyrl3676
+	if yyv3681 == nil {
+		if yyrl3681, yyrt3681 = z.DecInferLen(yyl3681, z.DecBasicHandle().MaxInitLen, 216); yyrt3681 {
+			yyrr3681 = yyrl3681
 		}
-		yyv3676 = make([]LimitRange, yyrl3676)
-		yyc3676 = true
+		yyv3681 = make([]LimitRange, yyrl3681)
+		yyc3681 = true
 	}
 
-	if yyl3676 == 0 {
-		if len(yyv3676) != 0 {
-			yyv3676 = yyv3676[:0]
-			yyc3676 = true
+	if yyl3681 == 0 {
+		if len(yyv3681) != 0 {
+			yyv3681 = yyv3681[:0]
+			yyc3681 = true
 		}
-	} else if yyl3676 > 0 {
+	} else if yyl3681 > 0 {
 
-		if yyl3676 > cap(yyv3676) {
-			yyrl3676, yyrt3676 = z.DecInferLen(yyl3676, z.DecBasicHandle().MaxInitLen, 216)
-			yyv3676 = make([]LimitRange, yyrl3676)
-			yyc3676 = true
+		if yyl3681 > cap(yyv3681) {
+			yyrl3681, yyrt3681 = z.DecInferLen(yyl3681, z.DecBasicHandle().MaxInitLen, 216)
+			yyv3681 = make([]LimitRange, yyrl3681)
+			yyc3681 = true
 
-			yyrr3676 = len(yyv3676)
-		} else if yyl3676 != len(yyv3676) {
-			yyv3676 = yyv3676[:yyl3676]
-			yyc3676 = true
+			yyrr3681 = len(yyv3681)
+		} else if yyl3681 != len(yyv3681) {
+			yyv3681 = yyv3681[:yyl3681]
+			yyc3681 = true
 		}
-		yyj3676 := 0
-		for ; yyj3676 < yyrr3676; yyj3676++ {
+		yyj3681 := 0
+		for ; yyj3681 < yyrr3681; yyj3681++ {
 			if r.TryDecodeAsNil() {
-				yyv3676[yyj3676] = LimitRange{}
+				yyv3681[yyj3681] = LimitRange{}
 			} else {
-				yyv3677 := &yyv3676[yyj3676]
-				yyv3677.CodecDecodeSelf(d)
+				yyv3682 := &yyv3681[yyj3681]
+				yyv3682.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3676 {
-			for ; yyj3676 < yyl3676; yyj3676++ {
-				yyv3676 = append(yyv3676, LimitRange{})
+		if yyrt3681 {
+			for ; yyj3681 < yyl3681; yyj3681++ {
+				yyv3681 = append(yyv3681, LimitRange{})
 				if r.TryDecodeAsNil() {
-					yyv3676[yyj3676] = LimitRange{}
+					yyv3681[yyj3681] = LimitRange{}
 				} else {
-					yyv3678 := &yyv3676[yyj3676]
-					yyv3678.CodecDecodeSelf(d)
+					yyv3683 := &yyv3681[yyj3681]
+					yyv3683.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3676 := 0; !r.CheckBreak(); yyj3676++ {
-			if yyj3676 >= len(yyv3676) {
-				yyv3676 = append(yyv3676, LimitRange{}) // var yyz3676 LimitRange
-				yyc3676 = true
+		for yyj3681 := 0; !r.CheckBreak(); yyj3681++ {
+			if yyj3681 >= len(yyv3681) {
+				yyv3681 = append(yyv3681, LimitRange{}) // var yyz3681 LimitRange
+				yyc3681 = true
 			}
 
-			if yyj3676 < len(yyv3676) {
+			if yyj3681 < len(yyv3681) {
 				if r.TryDecodeAsNil() {
-					yyv3676[yyj3676] = LimitRange{}
+					yyv3681[yyj3681] = LimitRange{}
 				} else {
-					yyv3679 := &yyv3676[yyj3676]
-					yyv3679.CodecDecodeSelf(d)
+					yyv3684 := &yyv3681[yyj3681]
+					yyv3684.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -43474,10 +43511,10 @@ func (x codecSelfer1234) decSliceLimitRange(v *[]LimitRange, d *codec1978.Decode
 			}
 
 		}
-		yyh3676.End()
+		yyh3681.End()
 	}
-	if yyc3676 {
-		*v = yyv3676
+	if yyc3681 {
+		*v = yyv3681
 	}
 
 }
@@ -43487,9 +43524,9 @@ func (x codecSelfer1234) encSliceResourceQuota(v []ResourceQuota, e *codec1978.E
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3680 := range v {
-		yy3681 := &yyv3680
-		yy3681.CodecEncodeSelf(e)
+	for _, yyv3685 := range v {
+		yy3686 := &yyv3685
+		yy3686.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -43499,75 +43536,75 @@ func (x codecSelfer1234) decSliceResourceQuota(v *[]ResourceQuota, d *codec1978.
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3682 := *v
-	yyh3682, yyl3682 := z.DecSliceHelperStart()
+	yyv3687 := *v
+	yyh3687, yyl3687 := z.DecSliceHelperStart()
 
-	var yyrr3682, yyrl3682 int
-	var yyc3682, yyrt3682 bool
-	_, _, _ = yyc3682, yyrt3682, yyrl3682
-	yyrr3682 = yyl3682
+	var yyrr3687, yyrl3687 int
+	var yyc3687, yyrt3687 bool
+	_, _, _ = yyc3687, yyrt3687, yyrl3687
+	yyrr3687 = yyl3687
 
-	if yyv3682 == nil {
-		if yyrl3682, yyrt3682 = z.DecInferLen(yyl3682, z.DecBasicHandle().MaxInitLen, 216); yyrt3682 {
-			yyrr3682 = yyrl3682
+	if yyv3687 == nil {
+		if yyrl3687, yyrt3687 = z.DecInferLen(yyl3687, z.DecBasicHandle().MaxInitLen, 216); yyrt3687 {
+			yyrr3687 = yyrl3687
 		}
-		yyv3682 = make([]ResourceQuota, yyrl3682)
-		yyc3682 = true
+		yyv3687 = make([]ResourceQuota, yyrl3687)
+		yyc3687 = true
 	}
 
-	if yyl3682 == 0 {
-		if len(yyv3682) != 0 {
-			yyv3682 = yyv3682[:0]
-			yyc3682 = true
+	if yyl3687 == 0 {
+		if len(yyv3687) != 0 {
+			yyv3687 = yyv3687[:0]
+			yyc3687 = true
 		}
-	} else if yyl3682 > 0 {
+	} else if yyl3687 > 0 {
 
-		if yyl3682 > cap(yyv3682) {
-			yyrl3682, yyrt3682 = z.DecInferLen(yyl3682, z.DecBasicHandle().MaxInitLen, 216)
-			yyv3682 = make([]ResourceQuota, yyrl3682)
-			yyc3682 = true
+		if yyl3687 > cap(yyv3687) {
+			yyrl3687, yyrt3687 = z.DecInferLen(yyl3687, z.DecBasicHandle().MaxInitLen, 216)
+			yyv3687 = make([]ResourceQuota, yyrl3687)
+			yyc3687 = true
 
-			yyrr3682 = len(yyv3682)
-		} else if yyl3682 != len(yyv3682) {
-			yyv3682 = yyv3682[:yyl3682]
-			yyc3682 = true
+			yyrr3687 = len(yyv3687)
+		} else if yyl3687 != len(yyv3687) {
+			yyv3687 = yyv3687[:yyl3687]
+			yyc3687 = true
 		}
-		yyj3682 := 0
-		for ; yyj3682 < yyrr3682; yyj3682++ {
+		yyj3687 := 0
+		for ; yyj3687 < yyrr3687; yyj3687++ {
 			if r.TryDecodeAsNil() {
-				yyv3682[yyj3682] = ResourceQuota{}
+				yyv3687[yyj3687] = ResourceQuota{}
 			} else {
-				yyv3683 := &yyv3682[yyj3682]
-				yyv3683.CodecDecodeSelf(d)
+				yyv3688 := &yyv3687[yyj3687]
+				yyv3688.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3682 {
-			for ; yyj3682 < yyl3682; yyj3682++ {
-				yyv3682 = append(yyv3682, ResourceQuota{})
+		if yyrt3687 {
+			for ; yyj3687 < yyl3687; yyj3687++ {
+				yyv3687 = append(yyv3687, ResourceQuota{})
 				if r.TryDecodeAsNil() {
-					yyv3682[yyj3682] = ResourceQuota{}
+					yyv3687[yyj3687] = ResourceQuota{}
 				} else {
-					yyv3684 := &yyv3682[yyj3682]
-					yyv3684.CodecDecodeSelf(d)
+					yyv3689 := &yyv3687[yyj3687]
+					yyv3689.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3682 := 0; !r.CheckBreak(); yyj3682++ {
-			if yyj3682 >= len(yyv3682) {
-				yyv3682 = append(yyv3682, ResourceQuota{}) // var yyz3682 ResourceQuota
-				yyc3682 = true
+		for yyj3687 := 0; !r.CheckBreak(); yyj3687++ {
+			if yyj3687 >= len(yyv3687) {
+				yyv3687 = append(yyv3687, ResourceQuota{}) // var yyz3687 ResourceQuota
+				yyc3687 = true
 			}
 
-			if yyj3682 < len(yyv3682) {
+			if yyj3687 < len(yyv3687) {
 				if r.TryDecodeAsNil() {
-					yyv3682[yyj3682] = ResourceQuota{}
+					yyv3687[yyj3687] = ResourceQuota{}
 				} else {
-					yyv3685 := &yyv3682[yyj3682]
-					yyv3685.CodecDecodeSelf(d)
+					yyv3690 := &yyv3687[yyj3687]
+					yyv3690.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -43575,10 +43612,10 @@ func (x codecSelfer1234) decSliceResourceQuota(v *[]ResourceQuota, d *codec1978.
 			}
 
 		}
-		yyh3682.End()
+		yyh3687.End()
 	}
-	if yyc3682 {
-		*v = yyv3682
+	if yyc3687 {
+		*v = yyv3687
 	}
 
 }
@@ -43588,21 +43625,21 @@ func (x codecSelfer1234) encMapstringSliceuint8(v map[string][]uint8, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeMapStart(len(v))
-	for yyk3686, yyv3686 := range v {
-		yym3687 := z.EncBinary()
-		_ = yym3687
+	for yyk3691, yyv3691 := range v {
+		yym3692 := z.EncBinary()
+		_ = yym3692
 		if false {
 		} else {
-			r.EncodeString(codecSelferC_UTF81234, string(yyk3686))
+			r.EncodeString(codecSelferC_UTF81234, string(yyk3691))
 		}
-		if yyv3686 == nil {
+		if yyv3691 == nil {
 			r.EncodeNil()
 		} else {
-			yym3688 := z.EncBinary()
-			_ = yym3688
+			yym3693 := z.EncBinary()
+			_ = yym3693
 			if false {
 			} else {
-				r.EncodeStringBytes(codecSelferC_RAW1234, []byte(yyv3686))
+				r.EncodeStringBytes(codecSelferC_RAW1234, []byte(yyv3691))
 			}
 		}
 	}
@@ -43614,76 +43651,76 @@ func (x codecSelfer1234) decMapstringSliceuint8(v *map[string][]uint8, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3689 := *v
-	yyl3689 := r.ReadMapStart()
-	yybh3689 := z.DecBasicHandle()
-	if yyv3689 == nil {
-		yyrl3689, _ := z.DecInferLen(yyl3689, yybh3689.MaxInitLen, 40)
-		yyv3689 = make(map[string][]uint8, yyrl3689)
-		*v = yyv3689
+	yyv3694 := *v
+	yyl3694 := r.ReadMapStart()
+	yybh3694 := z.DecBasicHandle()
+	if yyv3694 == nil {
+		yyrl3694, _ := z.DecInferLen(yyl3694, yybh3694.MaxInitLen, 40)
+		yyv3694 = make(map[string][]uint8, yyrl3694)
+		*v = yyv3694
 	}
-	var yymk3689 string
-	var yymv3689 []uint8
-	var yymg3689 bool
-	if yybh3689.MapValueReset {
-		yymg3689 = true
+	var yymk3694 string
+	var yymv3694 []uint8
+	var yymg3694 bool
+	if yybh3694.MapValueReset {
+		yymg3694 = true
 	}
-	if yyl3689 > 0 {
-		for yyj3689 := 0; yyj3689 < yyl3689; yyj3689++ {
+	if yyl3694 > 0 {
+		for yyj3694 := 0; yyj3694 < yyl3694; yyj3694++ {
 			if r.TryDecodeAsNil() {
-				yymk3689 = ""
+				yymk3694 = ""
 			} else {
-				yymk3689 = string(r.DecodeString())
+				yymk3694 = string(r.DecodeString())
 			}
 
-			if yymg3689 {
-				yymv3689 = yyv3689[yymk3689]
+			if yymg3694 {
+				yymv3694 = yyv3694[yymk3694]
 			} else {
-				yymv3689 = nil
+				yymv3694 = nil
 			}
 			if r.TryDecodeAsNil() {
-				yymv3689 = nil
+				yymv3694 = nil
 			} else {
-				yyv3691 := &yymv3689
-				yym3692 := z.DecBinary()
-				_ = yym3692
+				yyv3696 := &yymv3694
+				yym3697 := z.DecBinary()
+				_ = yym3697
 				if false {
 				} else {
-					*yyv3691 = r.DecodeBytes(*(*[]byte)(yyv3691), false, false)
+					*yyv3696 = r.DecodeBytes(*(*[]byte)(yyv3696), false, false)
 				}
 			}
 
-			if yyv3689 != nil {
-				yyv3689[yymk3689] = yymv3689
+			if yyv3694 != nil {
+				yyv3694[yymk3694] = yymv3694
 			}
 		}
-	} else if yyl3689 < 0 {
-		for yyj3689 := 0; !r.CheckBreak(); yyj3689++ {
+	} else if yyl3694 < 0 {
+		for yyj3694 := 0; !r.CheckBreak(); yyj3694++ {
 			if r.TryDecodeAsNil() {
-				yymk3689 = ""
+				yymk3694 = ""
 			} else {
-				yymk3689 = string(r.DecodeString())
+				yymk3694 = string(r.DecodeString())
 			}
 
-			if yymg3689 {
-				yymv3689 = yyv3689[yymk3689]
+			if yymg3694 {
+				yymv3694 = yyv3694[yymk3694]
 			} else {
-				yymv3689 = nil
+				yymv3694 = nil
 			}
 			if r.TryDecodeAsNil() {
-				yymv3689 = nil
+				yymv3694 = nil
 			} else {
-				yyv3694 := &yymv3689
-				yym3695 := z.DecBinary()
-				_ = yym3695
+				yyv3699 := &yymv3694
+				yym3700 := z.DecBinary()
+				_ = yym3700
 				if false {
 				} else {
-					*yyv3694 = r.DecodeBytes(*(*[]byte)(yyv3694), false, false)
+					*yyv3699 = r.DecodeBytes(*(*[]byte)(yyv3699), false, false)
 				}
 			}
 
-			if yyv3689 != nil {
-				yyv3689[yymk3689] = yymv3689
+			if yyv3694 != nil {
+				yyv3694[yymk3694] = yymv3694
 			}
 		}
 		r.ReadEnd()
@@ -43695,9 +43732,9 @@ func (x codecSelfer1234) encSliceSecret(v []Secret, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3696 := range v {
-		yy3697 := &yyv3696
-		yy3697.CodecEncodeSelf(e)
+	for _, yyv3701 := range v {
+		yy3702 := &yyv3701
+		yy3702.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -43707,75 +43744,75 @@ func (x codecSelfer1234) decSliceSecret(v *[]Secret, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3698 := *v
-	yyh3698, yyl3698 := z.DecSliceHelperStart()
+	yyv3703 := *v
+	yyh3703, yyl3703 := z.DecSliceHelperStart()
 
-	var yyrr3698, yyrl3698 int
-	var yyc3698, yyrt3698 bool
-	_, _, _ = yyc3698, yyrt3698, yyrl3698
-	yyrr3698 = yyl3698
+	var yyrr3703, yyrl3703 int
+	var yyc3703, yyrt3703 bool
+	_, _, _ = yyc3703, yyrt3703, yyrl3703
+	yyrr3703 = yyl3703
 
-	if yyv3698 == nil {
-		if yyrl3698, yyrt3698 = z.DecInferLen(yyl3698, z.DecBasicHandle().MaxInitLen, 216); yyrt3698 {
-			yyrr3698 = yyrl3698
+	if yyv3703 == nil {
+		if yyrl3703, yyrt3703 = z.DecInferLen(yyl3703, z.DecBasicHandle().MaxInitLen, 216); yyrt3703 {
+			yyrr3703 = yyrl3703
 		}
-		yyv3698 = make([]Secret, yyrl3698)
-		yyc3698 = true
+		yyv3703 = make([]Secret, yyrl3703)
+		yyc3703 = true
 	}
 
-	if yyl3698 == 0 {
-		if len(yyv3698) != 0 {
-			yyv3698 = yyv3698[:0]
-			yyc3698 = true
+	if yyl3703 == 0 {
+		if len(yyv3703) != 0 {
+			yyv3703 = yyv3703[:0]
+			yyc3703 = true
 		}
-	} else if yyl3698 > 0 {
+	} else if yyl3703 > 0 {
 
-		if yyl3698 > cap(yyv3698) {
-			yyrl3698, yyrt3698 = z.DecInferLen(yyl3698, z.DecBasicHandle().MaxInitLen, 216)
-			yyv3698 = make([]Secret, yyrl3698)
-			yyc3698 = true
+		if yyl3703 > cap(yyv3703) {
+			yyrl3703, yyrt3703 = z.DecInferLen(yyl3703, z.DecBasicHandle().MaxInitLen, 216)
+			yyv3703 = make([]Secret, yyrl3703)
+			yyc3703 = true
 
-			yyrr3698 = len(yyv3698)
-		} else if yyl3698 != len(yyv3698) {
-			yyv3698 = yyv3698[:yyl3698]
-			yyc3698 = true
+			yyrr3703 = len(yyv3703)
+		} else if yyl3703 != len(yyv3703) {
+			yyv3703 = yyv3703[:yyl3703]
+			yyc3703 = true
 		}
-		yyj3698 := 0
-		for ; yyj3698 < yyrr3698; yyj3698++ {
+		yyj3703 := 0
+		for ; yyj3703 < yyrr3703; yyj3703++ {
 			if r.TryDecodeAsNil() {
-				yyv3698[yyj3698] = Secret{}
+				yyv3703[yyj3703] = Secret{}
 			} else {
-				yyv3699 := &yyv3698[yyj3698]
-				yyv3699.CodecDecodeSelf(d)
+				yyv3704 := &yyv3703[yyj3703]
+				yyv3704.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3698 {
-			for ; yyj3698 < yyl3698; yyj3698++ {
-				yyv3698 = append(yyv3698, Secret{})
+		if yyrt3703 {
+			for ; yyj3703 < yyl3703; yyj3703++ {
+				yyv3703 = append(yyv3703, Secret{})
 				if r.TryDecodeAsNil() {
-					yyv3698[yyj3698] = Secret{}
+					yyv3703[yyj3703] = Secret{}
 				} else {
-					yyv3700 := &yyv3698[yyj3698]
-					yyv3700.CodecDecodeSelf(d)
+					yyv3705 := &yyv3703[yyj3703]
+					yyv3705.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3698 := 0; !r.CheckBreak(); yyj3698++ {
-			if yyj3698 >= len(yyv3698) {
-				yyv3698 = append(yyv3698, Secret{}) // var yyz3698 Secret
-				yyc3698 = true
+		for yyj3703 := 0; !r.CheckBreak(); yyj3703++ {
+			if yyj3703 >= len(yyv3703) {
+				yyv3703 = append(yyv3703, Secret{}) // var yyz3703 Secret
+				yyc3703 = true
 			}
 
-			if yyj3698 < len(yyv3698) {
+			if yyj3703 < len(yyv3703) {
 				if r.TryDecodeAsNil() {
-					yyv3698[yyj3698] = Secret{}
+					yyv3703[yyj3703] = Secret{}
 				} else {
-					yyv3701 := &yyv3698[yyj3698]
-					yyv3701.CodecDecodeSelf(d)
+					yyv3706 := &yyv3703[yyj3703]
+					yyv3706.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -43783,10 +43820,10 @@ func (x codecSelfer1234) decSliceSecret(v *[]Secret, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3698.End()
+		yyh3703.End()
 	}
-	if yyc3698 {
-		*v = yyv3698
+	if yyc3703 {
+		*v = yyv3703
 	}
 
 }
@@ -43796,9 +43833,9 @@ func (x codecSelfer1234) encSliceComponentCondition(v []ComponentCondition, e *c
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3702 := range v {
-		yy3703 := &yyv3702
-		yy3703.CodecEncodeSelf(e)
+	for _, yyv3707 := range v {
+		yy3708 := &yyv3707
+		yy3708.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -43808,75 +43845,75 @@ func (x codecSelfer1234) decSliceComponentCondition(v *[]ComponentCondition, d *
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3704 := *v
-	yyh3704, yyl3704 := z.DecSliceHelperStart()
+	yyv3709 := *v
+	yyh3709, yyl3709 := z.DecSliceHelperStart()
 
-	var yyrr3704, yyrl3704 int
-	var yyc3704, yyrt3704 bool
-	_, _, _ = yyc3704, yyrt3704, yyrl3704
-	yyrr3704 = yyl3704
+	var yyrr3709, yyrl3709 int
+	var yyc3709, yyrt3709 bool
+	_, _, _ = yyc3709, yyrt3709, yyrl3709
+	yyrr3709 = yyl3709
 
-	if yyv3704 == nil {
-		if yyrl3704, yyrt3704 = z.DecInferLen(yyl3704, z.DecBasicHandle().MaxInitLen, 64); yyrt3704 {
-			yyrr3704 = yyrl3704
+	if yyv3709 == nil {
+		if yyrl3709, yyrt3709 = z.DecInferLen(yyl3709, z.DecBasicHandle().MaxInitLen, 64); yyrt3709 {
+			yyrr3709 = yyrl3709
 		}
-		yyv3704 = make([]ComponentCondition, yyrl3704)
-		yyc3704 = true
+		yyv3709 = make([]ComponentCondition, yyrl3709)
+		yyc3709 = true
 	}
 
-	if yyl3704 == 0 {
-		if len(yyv3704) != 0 {
-			yyv3704 = yyv3704[:0]
-			yyc3704 = true
+	if yyl3709 == 0 {
+		if len(yyv3709) != 0 {
+			yyv3709 = yyv3709[:0]
+			yyc3709 = true
 		}
-	} else if yyl3704 > 0 {
+	} else if yyl3709 > 0 {
 
-		if yyl3704 > cap(yyv3704) {
-			yyrl3704, yyrt3704 = z.DecInferLen(yyl3704, z.DecBasicHandle().MaxInitLen, 64)
-			yyv3704 = make([]ComponentCondition, yyrl3704)
-			yyc3704 = true
+		if yyl3709 > cap(yyv3709) {
+			yyrl3709, yyrt3709 = z.DecInferLen(yyl3709, z.DecBasicHandle().MaxInitLen, 64)
+			yyv3709 = make([]ComponentCondition, yyrl3709)
+			yyc3709 = true
 
-			yyrr3704 = len(yyv3704)
-		} else if yyl3704 != len(yyv3704) {
-			yyv3704 = yyv3704[:yyl3704]
-			yyc3704 = true
+			yyrr3709 = len(yyv3709)
+		} else if yyl3709 != len(yyv3709) {
+			yyv3709 = yyv3709[:yyl3709]
+			yyc3709 = true
 		}
-		yyj3704 := 0
-		for ; yyj3704 < yyrr3704; yyj3704++ {
+		yyj3709 := 0
+		for ; yyj3709 < yyrr3709; yyj3709++ {
 			if r.TryDecodeAsNil() {
-				yyv3704[yyj3704] = ComponentCondition{}
+				yyv3709[yyj3709] = ComponentCondition{}
 			} else {
-				yyv3705 := &yyv3704[yyj3704]
-				yyv3705.CodecDecodeSelf(d)
+				yyv3710 := &yyv3709[yyj3709]
+				yyv3710.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3704 {
-			for ; yyj3704 < yyl3704; yyj3704++ {
-				yyv3704 = append(yyv3704, ComponentCondition{})
+		if yyrt3709 {
+			for ; yyj3709 < yyl3709; yyj3709++ {
+				yyv3709 = append(yyv3709, ComponentCondition{})
 				if r.TryDecodeAsNil() {
-					yyv3704[yyj3704] = ComponentCondition{}
+					yyv3709[yyj3709] = ComponentCondition{}
 				} else {
-					yyv3706 := &yyv3704[yyj3704]
-					yyv3706.CodecDecodeSelf(d)
+					yyv3711 := &yyv3709[yyj3709]
+					yyv3711.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3704 := 0; !r.CheckBreak(); yyj3704++ {
-			if yyj3704 >= len(yyv3704) {
-				yyv3704 = append(yyv3704, ComponentCondition{}) // var yyz3704 ComponentCondition
-				yyc3704 = true
+		for yyj3709 := 0; !r.CheckBreak(); yyj3709++ {
+			if yyj3709 >= len(yyv3709) {
+				yyv3709 = append(yyv3709, ComponentCondition{}) // var yyz3709 ComponentCondition
+				yyc3709 = true
 			}
 
-			if yyj3704 < len(yyv3704) {
+			if yyj3709 < len(yyv3709) {
 				if r.TryDecodeAsNil() {
-					yyv3704[yyj3704] = ComponentCondition{}
+					yyv3709[yyj3709] = ComponentCondition{}
 				} else {
-					yyv3707 := &yyv3704[yyj3704]
-					yyv3707.CodecDecodeSelf(d)
+					yyv3712 := &yyv3709[yyj3709]
+					yyv3712.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -43884,10 +43921,10 @@ func (x codecSelfer1234) decSliceComponentCondition(v *[]ComponentCondition, d *
 			}
 
 		}
-		yyh3704.End()
+		yyh3709.End()
 	}
-	if yyc3704 {
-		*v = yyv3704
+	if yyc3709 {
+		*v = yyv3709
 	}
 
 }
@@ -43897,9 +43934,9 @@ func (x codecSelfer1234) encSliceComponentStatus(v []ComponentStatus, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3708 := range v {
-		yy3709 := &yyv3708
-		yy3709.CodecEncodeSelf(e)
+	for _, yyv3713 := range v {
+		yy3714 := &yyv3713
+		yy3714.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -43909,75 +43946,75 @@ func (x codecSelfer1234) decSliceComponentStatus(v *[]ComponentStatus, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3710 := *v
-	yyh3710, yyl3710 := z.DecSliceHelperStart()
+	yyv3715 := *v
+	yyh3715, yyl3715 := z.DecSliceHelperStart()
 
-	var yyrr3710, yyrl3710 int
-	var yyc3710, yyrt3710 bool
-	_, _, _ = yyc3710, yyrt3710, yyrl3710
-	yyrr3710 = yyl3710
+	var yyrr3715, yyrl3715 int
+	var yyc3715, yyrt3715 bool
+	_, _, _ = yyc3715, yyrt3715, yyrl3715
+	yyrr3715 = yyl3715
 
-	if yyv3710 == nil {
-		if yyrl3710, yyrt3710 = z.DecInferLen(yyl3710, z.DecBasicHandle().MaxInitLen, 216); yyrt3710 {
-			yyrr3710 = yyrl3710
+	if yyv3715 == nil {
+		if yyrl3715, yyrt3715 = z.DecInferLen(yyl3715, z.DecBasicHandle().MaxInitLen, 216); yyrt3715 {
+			yyrr3715 = yyrl3715
 		}
-		yyv3710 = make([]ComponentStatus, yyrl3710)
-		yyc3710 = true
+		yyv3715 = make([]ComponentStatus, yyrl3715)
+		yyc3715 = true
 	}
 
-	if yyl3710 == 0 {
-		if len(yyv3710) != 0 {
-			yyv3710 = yyv3710[:0]
-			yyc3710 = true
+	if yyl3715 == 0 {
+		if len(yyv3715) != 0 {
+			yyv3715 = yyv3715[:0]
+			yyc3715 = true
 		}
-	} else if yyl3710 > 0 {
+	} else if yyl3715 > 0 {
 
-		if yyl3710 > cap(yyv3710) {
-			yyrl3710, yyrt3710 = z.DecInferLen(yyl3710, z.DecBasicHandle().MaxInitLen, 216)
-			yyv3710 = make([]ComponentStatus, yyrl3710)
-			yyc3710 = true
+		if yyl3715 > cap(yyv3715) {
+			yyrl3715, yyrt3715 = z.DecInferLen(yyl3715, z.DecBasicHandle().MaxInitLen, 216)
+			yyv3715 = make([]ComponentStatus, yyrl3715)
+			yyc3715 = true
 
-			yyrr3710 = len(yyv3710)
-		} else if yyl3710 != len(yyv3710) {
-			yyv3710 = yyv3710[:yyl3710]
-			yyc3710 = true
+			yyrr3715 = len(yyv3715)
+		} else if yyl3715 != len(yyv3715) {
+			yyv3715 = yyv3715[:yyl3715]
+			yyc3715 = true
 		}
-		yyj3710 := 0
-		for ; yyj3710 < yyrr3710; yyj3710++ {
+		yyj3715 := 0
+		for ; yyj3715 < yyrr3715; yyj3715++ {
 			if r.TryDecodeAsNil() {
-				yyv3710[yyj3710] = ComponentStatus{}
+				yyv3715[yyj3715] = ComponentStatus{}
 			} else {
-				yyv3711 := &yyv3710[yyj3710]
-				yyv3711.CodecDecodeSelf(d)
+				yyv3716 := &yyv3715[yyj3715]
+				yyv3716.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3710 {
-			for ; yyj3710 < yyl3710; yyj3710++ {
-				yyv3710 = append(yyv3710, ComponentStatus{})
+		if yyrt3715 {
+			for ; yyj3715 < yyl3715; yyj3715++ {
+				yyv3715 = append(yyv3715, ComponentStatus{})
 				if r.TryDecodeAsNil() {
-					yyv3710[yyj3710] = ComponentStatus{}
+					yyv3715[yyj3715] = ComponentStatus{}
 				} else {
-					yyv3712 := &yyv3710[yyj3710]
-					yyv3712.CodecDecodeSelf(d)
+					yyv3717 := &yyv3715[yyj3715]
+					yyv3717.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3710 := 0; !r.CheckBreak(); yyj3710++ {
-			if yyj3710 >= len(yyv3710) {
-				yyv3710 = append(yyv3710, ComponentStatus{}) // var yyz3710 ComponentStatus
-				yyc3710 = true
+		for yyj3715 := 0; !r.CheckBreak(); yyj3715++ {
+			if yyj3715 >= len(yyv3715) {
+				yyv3715 = append(yyv3715, ComponentStatus{}) // var yyz3715 ComponentStatus
+				yyc3715 = true
 			}
 
-			if yyj3710 < len(yyv3710) {
+			if yyj3715 < len(yyv3715) {
 				if r.TryDecodeAsNil() {
-					yyv3710[yyj3710] = ComponentStatus{}
+					yyv3715[yyj3715] = ComponentStatus{}
 				} else {
-					yyv3713 := &yyv3710[yyj3710]
-					yyv3713.CodecDecodeSelf(d)
+					yyv3718 := &yyv3715[yyj3715]
+					yyv3718.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -43985,10 +44022,10 @@ func (x codecSelfer1234) decSliceComponentStatus(v *[]ComponentStatus, d *codec1
 			}
 
 		}
-		yyh3710.End()
+		yyh3715.End()
 	}
-	if yyc3710 {
-		*v = yyv3710
+	if yyc3715 {
+		*v = yyv3715
 	}
 
 }

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1519,6 +1519,7 @@ const (
 type NodeAddress struct {
 	Type    NodeAddressType `json:"type"`
 	Address string          `json:"address"`
+	Subnet  string          `json:"subnet"`
 }
 
 // NodeResources is an object for conveying resource information about a node.

--- a/pkg/api/v1/conversion_generated.go
+++ b/pkg/api/v1/conversion_generated.go
@@ -1310,6 +1310,7 @@ func autoconvert_api_NodeAddress_To_v1_NodeAddress(in *api.NodeAddress, out *Nod
 	}
 	out.Type = NodeAddressType(in.Type)
 	out.Address = in.Address
+	out.Subnet = in.Subnet
 	return nil
 }
 
@@ -4331,6 +4332,7 @@ func autoconvert_v1_NodeAddress_To_api_NodeAddress(in *NodeAddress, out *api.Nod
 	}
 	out.Type = api.NodeAddressType(in.Type)
 	out.Address = in.Address
+	out.Subnet = in.Subnet
 	return nil
 }
 

--- a/pkg/api/v1/deep_copy_generated.go
+++ b/pkg/api/v1/deep_copy_generated.go
@@ -957,6 +957,7 @@ func deepCopy_v1_Node(in Node, out *Node, c *conversion.Cloner) error {
 func deepCopy_v1_NodeAddress(in NodeAddress, out *NodeAddress, c *conversion.Cloner) error {
 	out.Type = in.Type
 	out.Address = in.Address
+	out.Subnet = in.Subnet
 	return nil
 }
 

--- a/pkg/api/v1/types.generated.go
+++ b/pkg/api/v1/types.generated.go
@@ -27860,13 +27860,13 @@ func (x *NodeAddress) CodecEncodeSelf(e *codec1978.Encoder) {
 		} else {
 			yysep2348 := !z.EncBinary()
 			yy2arr2348 := z.EncBasicHandle().StructToArray
-			var yyq2348 [2]bool
+			var yyq2348 [3]bool
 			_, _, _ = yysep2348, yyq2348, yy2arr2348
 			const yyr2348 bool = false
 			if yyr2348 || yy2arr2348 {
-				r.EncodeArrayStart(2)
+				r.EncodeArrayStart(3)
 			} else {
-				var yynn2348 int = 2
+				var yynn2348 int = 3
 				for _, b := range yyq2348 {
 					if b {
 						yynn2348++
@@ -27896,6 +27896,22 @@ func (x *NodeAddress) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Address))
 				}
 			}
+			if yyr2348 || yy2arr2348 {
+				yym2354 := z.EncBinary()
+				_ = yym2354
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Subnet))
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("subnet"))
+				yym2355 := z.EncBinary()
+				_ = yym2355
+				if false {
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, string(x.Subnet))
+				}
+			}
 			if yysep2348 {
 				r.EncodeEnd()
 			}
@@ -27907,24 +27923,24 @@ func (x *NodeAddress) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2353 := z.DecBinary()
-	_ = yym2353
+	yym2356 := z.DecBinary()
+	_ = yym2356
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2354 := r.ReadMapStart()
-			if yyl2354 == 0 {
+			yyl2357 := r.ReadMapStart()
+			if yyl2357 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2354, d)
+				x.codecDecodeSelfFromMap(yyl2357, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2354 := r.ReadArrayStart()
-			if yyl2354 == 0 {
+			yyl2357 := r.ReadArrayStart()
+			if yyl2357 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2354, d)
+				x.codecDecodeSelfFromArray(yyl2357, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -27936,12 +27952,12 @@ func (x *NodeAddress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2355Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2355Slc
-	var yyhl2355 bool = l >= 0
-	for yyj2355 := 0; ; yyj2355++ {
-		if yyhl2355 {
-			if yyj2355 >= l {
+	var yys2358Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2358Slc
+	var yyhl2358 bool = l >= 0
+	for yyj2358 := 0; ; yyj2358++ {
+		if yyhl2358 {
+			if yyj2358 >= l {
 				break
 			}
 		} else {
@@ -27949,9 +27965,9 @@ func (x *NodeAddress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2355Slc = r.DecodeBytes(yys2355Slc, true, true)
-		yys2355 := string(yys2355Slc)
-		switch yys2355 {
+		yys2358Slc = r.DecodeBytes(yys2358Slc, true, true)
+		yys2358 := string(yys2358Slc)
+		switch yys2358 {
 		case "type":
 			if r.TryDecodeAsNil() {
 				x.Type = ""
@@ -27964,11 +27980,17 @@ func (x *NodeAddress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			} else {
 				x.Address = string(r.DecodeString())
 			}
+		case "subnet":
+			if r.TryDecodeAsNil() {
+				x.Subnet = ""
+			} else {
+				x.Subnet = string(r.DecodeString())
+			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2355)
-		} // end switch yys2355
-	} // end for yyj2355
-	if !yyhl2355 {
+			z.DecStructFieldNotFound(-1, yys2358)
+		} // end switch yys2358
+	} // end for yyj2358
+	if !yyhl2358 {
 		r.ReadEnd()
 	}
 }
@@ -27977,16 +27999,16 @@ func (x *NodeAddress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2358 int
-	var yyb2358 bool
-	var yyhl2358 bool = l >= 0
-	yyj2358++
-	if yyhl2358 {
-		yyb2358 = yyj2358 > l
+	var yyj2362 int
+	var yyb2362 bool
+	var yyhl2362 bool = l >= 0
+	yyj2362++
+	if yyhl2362 {
+		yyb2362 = yyj2362 > l
 	} else {
-		yyb2358 = r.CheckBreak()
+		yyb2362 = r.CheckBreak()
 	}
-	if yyb2358 {
+	if yyb2362 {
 		r.ReadEnd()
 		return
 	}
@@ -27995,13 +28017,13 @@ func (x *NodeAddress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Type = NodeAddressType(r.DecodeString())
 	}
-	yyj2358++
-	if yyhl2358 {
-		yyb2358 = yyj2358 > l
+	yyj2362++
+	if yyhl2362 {
+		yyb2362 = yyj2362 > l
 	} else {
-		yyb2358 = r.CheckBreak()
+		yyb2362 = r.CheckBreak()
 	}
-	if yyb2358 {
+	if yyb2362 {
 		r.ReadEnd()
 		return
 	}
@@ -28010,17 +28032,32 @@ func (x *NodeAddress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Address = string(r.DecodeString())
 	}
+	yyj2362++
+	if yyhl2362 {
+		yyb2362 = yyj2362 > l
+	} else {
+		yyb2362 = r.CheckBreak()
+	}
+	if yyb2362 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Subnet = ""
+	} else {
+		x.Subnet = string(r.DecodeString())
+	}
 	for {
-		yyj2358++
-		if yyhl2358 {
-			yyb2358 = yyj2358 > l
+		yyj2362++
+		if yyhl2362 {
+			yyb2362 = yyj2362 > l
 		} else {
-			yyb2358 = r.CheckBreak()
+			yyb2362 = r.CheckBreak()
 		}
-		if yyb2358 {
+		if yyb2362 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2358-1, "")
+		z.DecStructFieldNotFound(yyj2362-1, "")
 	}
 	r.ReadEnd()
 }
@@ -28029,8 +28066,8 @@ func (x ResourceName) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym2361 := z.EncBinary()
-	_ = yym2361
+	yym2366 := z.EncBinary()
+	_ = yym2366
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -28042,8 +28079,8 @@ func (x *ResourceName) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2362 := z.DecBinary()
-	_ = yym2362
+	yym2367 := z.DecBinary()
+	_ = yym2367
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -28058,8 +28095,8 @@ func (x ResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2363 := z.EncBinary()
-		_ = yym2363
+		yym2368 := z.EncBinary()
+		_ = yym2368
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
@@ -28072,8 +28109,8 @@ func (x *ResourceList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2364 := z.DecBinary()
-	_ = yym2364
+	yym2369 := z.DecBinary()
+	_ = yym2369
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -28088,36 +28125,36 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2365 := z.EncBinary()
-		_ = yym2365
+		yym2370 := z.EncBinary()
+		_ = yym2370
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2366 := !z.EncBinary()
-			yy2arr2366 := z.EncBasicHandle().StructToArray
-			var yyq2366 [5]bool
-			_, _, _ = yysep2366, yyq2366, yy2arr2366
-			const yyr2366 bool = false
-			yyq2366[0] = x.Kind != ""
-			yyq2366[1] = x.APIVersion != ""
-			yyq2366[2] = true
-			yyq2366[3] = true
-			yyq2366[4] = true
-			if yyr2366 || yy2arr2366 {
+			yysep2371 := !z.EncBinary()
+			yy2arr2371 := z.EncBasicHandle().StructToArray
+			var yyq2371 [5]bool
+			_, _, _ = yysep2371, yyq2371, yy2arr2371
+			const yyr2371 bool = false
+			yyq2371[0] = x.Kind != ""
+			yyq2371[1] = x.APIVersion != ""
+			yyq2371[2] = true
+			yyq2371[3] = true
+			yyq2371[4] = true
+			if yyr2371 || yy2arr2371 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn2366 int = 0
-				for _, b := range yyq2366 {
+				var yynn2371 int = 0
+				for _, b := range yyq2371 {
 					if b {
-						yynn2366++
+						yynn2371++
 					}
 				}
-				r.EncodeMapStart(yynn2366)
+				r.EncodeMapStart(yynn2371)
 			}
-			if yyr2366 || yy2arr2366 {
-				if yyq2366[0] {
-					yym2368 := z.EncBinary()
-					_ = yym2368
+			if yyr2371 || yy2arr2371 {
+				if yyq2371[0] {
+					yym2373 := z.EncBinary()
+					_ = yym2373
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -28126,20 +28163,20 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2366[0] {
+				if yyq2371[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2369 := z.EncBinary()
-					_ = yym2369
+					yym2374 := z.EncBinary()
+					_ = yym2374
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2366 || yy2arr2366 {
-				if yyq2366[1] {
-					yym2371 := z.EncBinary()
-					_ = yym2371
+			if yyr2371 || yy2arr2371 {
+				if yyq2371[1] {
+					yym2376 := z.EncBinary()
+					_ = yym2376
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -28148,59 +28185,59 @@ func (x *Node) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2366[1] {
+				if yyq2371[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2372 := z.EncBinary()
-					_ = yym2372
+					yym2377 := z.EncBinary()
+					_ = yym2377
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2366 || yy2arr2366 {
-				if yyq2366[2] {
-					yy2374 := &x.ObjectMeta
-					yy2374.CodecEncodeSelf(e)
+			if yyr2371 || yy2arr2371 {
+				if yyq2371[2] {
+					yy2379 := &x.ObjectMeta
+					yy2379.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2366[2] {
+				if yyq2371[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy2375 := &x.ObjectMeta
-					yy2375.CodecEncodeSelf(e)
-				}
-			}
-			if yyr2366 || yy2arr2366 {
-				if yyq2366[3] {
-					yy2377 := &x.Spec
-					yy2377.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2366[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy2378 := &x.Spec
-					yy2378.CodecEncodeSelf(e)
-				}
-			}
-			if yyr2366 || yy2arr2366 {
-				if yyq2366[4] {
-					yy2380 := &x.Status
+					yy2380 := &x.ObjectMeta
 					yy2380.CodecEncodeSelf(e)
+				}
+			}
+			if yyr2371 || yy2arr2371 {
+				if yyq2371[3] {
+					yy2382 := &x.Spec
+					yy2382.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2366[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy2381 := &x.Status
-					yy2381.CodecEncodeSelf(e)
+				if yyq2371[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					yy2383 := &x.Spec
+					yy2383.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2366 {
+			if yyr2371 || yy2arr2371 {
+				if yyq2371[4] {
+					yy2385 := &x.Status
+					yy2385.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq2371[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					yy2386 := &x.Status
+					yy2386.CodecEncodeSelf(e)
+				}
+			}
+			if yysep2371 {
 				r.EncodeEnd()
 			}
 		}
@@ -28211,24 +28248,24 @@ func (x *Node) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2382 := z.DecBinary()
-	_ = yym2382
+	yym2387 := z.DecBinary()
+	_ = yym2387
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2383 := r.ReadMapStart()
-			if yyl2383 == 0 {
+			yyl2388 := r.ReadMapStart()
+			if yyl2388 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2383, d)
+				x.codecDecodeSelfFromMap(yyl2388, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2383 := r.ReadArrayStart()
-			if yyl2383 == 0 {
+			yyl2388 := r.ReadArrayStart()
+			if yyl2388 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2383, d)
+				x.codecDecodeSelfFromArray(yyl2388, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -28240,12 +28277,12 @@ func (x *Node) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2384Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2384Slc
-	var yyhl2384 bool = l >= 0
-	for yyj2384 := 0; ; yyj2384++ {
-		if yyhl2384 {
-			if yyj2384 >= l {
+	var yys2389Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2389Slc
+	var yyhl2389 bool = l >= 0
+	for yyj2389 := 0; ; yyj2389++ {
+		if yyhl2389 {
+			if yyj2389 >= l {
 				break
 			}
 		} else {
@@ -28253,9 +28290,9 @@ func (x *Node) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2384Slc = r.DecodeBytes(yys2384Slc, true, true)
-		yys2384 := string(yys2384Slc)
-		switch yys2384 {
+		yys2389Slc = r.DecodeBytes(yys2389Slc, true, true)
+		yys2389 := string(yys2389Slc)
+		switch yys2389 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -28272,28 +28309,28 @@ func (x *Node) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv2387 := &x.ObjectMeta
-				yyv2387.CodecDecodeSelf(d)
+				yyv2392 := &x.ObjectMeta
+				yyv2392.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = NodeSpec{}
 			} else {
-				yyv2388 := &x.Spec
-				yyv2388.CodecDecodeSelf(d)
+				yyv2393 := &x.Spec
+				yyv2393.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = NodeStatus{}
 			} else {
-				yyv2389 := &x.Status
-				yyv2389.CodecDecodeSelf(d)
+				yyv2394 := &x.Status
+				yyv2394.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2384)
-		} // end switch yys2384
-	} // end for yyj2384
-	if !yyhl2384 {
+			z.DecStructFieldNotFound(-1, yys2389)
+		} // end switch yys2389
+	} // end for yyj2389
+	if !yyhl2389 {
 		r.ReadEnd()
 	}
 }
@@ -28302,16 +28339,16 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2390 int
-	var yyb2390 bool
-	var yyhl2390 bool = l >= 0
-	yyj2390++
-	if yyhl2390 {
-		yyb2390 = yyj2390 > l
+	var yyj2395 int
+	var yyb2395 bool
+	var yyhl2395 bool = l >= 0
+	yyj2395++
+	if yyhl2395 {
+		yyb2395 = yyj2395 > l
 	} else {
-		yyb2390 = r.CheckBreak()
+		yyb2395 = r.CheckBreak()
 	}
-	if yyb2390 {
+	if yyb2395 {
 		r.ReadEnd()
 		return
 	}
@@ -28320,13 +28357,13 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2390++
-	if yyhl2390 {
-		yyb2390 = yyj2390 > l
+	yyj2395++
+	if yyhl2395 {
+		yyb2395 = yyj2395 > l
 	} else {
-		yyb2390 = r.CheckBreak()
+		yyb2395 = r.CheckBreak()
 	}
-	if yyb2390 {
+	if yyb2395 {
 		r.ReadEnd()
 		return
 	}
@@ -28335,65 +28372,65 @@ func (x *Node) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2390++
-	if yyhl2390 {
-		yyb2390 = yyj2390 > l
+	yyj2395++
+	if yyhl2395 {
+		yyb2395 = yyj2395 > l
 	} else {
-		yyb2390 = r.CheckBreak()
+		yyb2395 = r.CheckBreak()
 	}
-	if yyb2390 {
+	if yyb2395 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv2393 := &x.ObjectMeta
-		yyv2393.CodecDecodeSelf(d)
+		yyv2398 := &x.ObjectMeta
+		yyv2398.CodecDecodeSelf(d)
 	}
-	yyj2390++
-	if yyhl2390 {
-		yyb2390 = yyj2390 > l
+	yyj2395++
+	if yyhl2395 {
+		yyb2395 = yyj2395 > l
 	} else {
-		yyb2390 = r.CheckBreak()
+		yyb2395 = r.CheckBreak()
 	}
-	if yyb2390 {
+	if yyb2395 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = NodeSpec{}
 	} else {
-		yyv2394 := &x.Spec
-		yyv2394.CodecDecodeSelf(d)
+		yyv2399 := &x.Spec
+		yyv2399.CodecDecodeSelf(d)
 	}
-	yyj2390++
-	if yyhl2390 {
-		yyb2390 = yyj2390 > l
+	yyj2395++
+	if yyhl2395 {
+		yyb2395 = yyj2395 > l
 	} else {
-		yyb2390 = r.CheckBreak()
+		yyb2395 = r.CheckBreak()
 	}
-	if yyb2390 {
+	if yyb2395 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = NodeStatus{}
 	} else {
-		yyv2395 := &x.Status
-		yyv2395.CodecDecodeSelf(d)
+		yyv2400 := &x.Status
+		yyv2400.CodecDecodeSelf(d)
 	}
 	for {
-		yyj2390++
-		if yyhl2390 {
-			yyb2390 = yyj2390 > l
+		yyj2395++
+		if yyhl2395 {
+			yyb2395 = yyj2395 > l
 		} else {
-			yyb2390 = r.CheckBreak()
+			yyb2395 = r.CheckBreak()
 		}
-		if yyb2390 {
+		if yyb2395 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2390-1, "")
+		z.DecStructFieldNotFound(yyj2395-1, "")
 	}
 	r.ReadEnd()
 }
@@ -28405,34 +28442,34 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2396 := z.EncBinary()
-		_ = yym2396
+		yym2401 := z.EncBinary()
+		_ = yym2401
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2397 := !z.EncBinary()
-			yy2arr2397 := z.EncBasicHandle().StructToArray
-			var yyq2397 [4]bool
-			_, _, _ = yysep2397, yyq2397, yy2arr2397
-			const yyr2397 bool = false
-			yyq2397[0] = x.Kind != ""
-			yyq2397[1] = x.APIVersion != ""
-			yyq2397[2] = true
-			if yyr2397 || yy2arr2397 {
+			yysep2402 := !z.EncBinary()
+			yy2arr2402 := z.EncBasicHandle().StructToArray
+			var yyq2402 [4]bool
+			_, _, _ = yysep2402, yyq2402, yy2arr2402
+			const yyr2402 bool = false
+			yyq2402[0] = x.Kind != ""
+			yyq2402[1] = x.APIVersion != ""
+			yyq2402[2] = true
+			if yyr2402 || yy2arr2402 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2397 int = 1
-				for _, b := range yyq2397 {
+				var yynn2402 int = 1
+				for _, b := range yyq2402 {
 					if b {
-						yynn2397++
+						yynn2402++
 					}
 				}
-				r.EncodeMapStart(yynn2397)
+				r.EncodeMapStart(yynn2402)
 			}
-			if yyr2397 || yy2arr2397 {
-				if yyq2397[0] {
-					yym2399 := z.EncBinary()
-					_ = yym2399
+			if yyr2402 || yy2arr2402 {
+				if yyq2402[0] {
+					yym2404 := z.EncBinary()
+					_ = yym2404
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -28441,20 +28478,20 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2397[0] {
+				if yyq2402[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2400 := z.EncBinary()
-					_ = yym2400
+					yym2405 := z.EncBinary()
+					_ = yym2405
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2397 || yy2arr2397 {
-				if yyq2397[1] {
-					yym2402 := z.EncBinary()
-					_ = yym2402
+			if yyr2402 || yy2arr2402 {
+				if yyq2402[1] {
+					yym2407 := z.EncBinary()
+					_ = yym2407
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -28463,48 +28500,48 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2397[1] {
+				if yyq2402[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2403 := z.EncBinary()
-					_ = yym2403
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2397 || yy2arr2397 {
-				if yyq2397[2] {
-					yy2405 := &x.ListMeta
-					yym2406 := z.EncBinary()
-					_ = yym2406
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2405) {
-					} else {
-						z.EncFallback(yy2405)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2397[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy2407 := &x.ListMeta
 					yym2408 := z.EncBinary()
 					_ = yym2408
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2407) {
 					} else {
-						z.EncFallback(yy2407)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2397 || yy2arr2397 {
+			if yyr2402 || yy2arr2402 {
+				if yyq2402[2] {
+					yy2410 := &x.ListMeta
+					yym2411 := z.EncBinary()
+					_ = yym2411
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2410) {
+					} else {
+						z.EncFallback(yy2410)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq2402[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy2412 := &x.ListMeta
+					yym2413 := z.EncBinary()
+					_ = yym2413
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2412) {
+					} else {
+						z.EncFallback(yy2412)
+					}
+				}
+			}
+			if yyr2402 || yy2arr2402 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2410 := z.EncBinary()
-					_ = yym2410
+					yym2415 := z.EncBinary()
+					_ = yym2415
 					if false {
 					} else {
 						h.encSliceNode(([]Node)(x.Items), e)
@@ -28515,15 +28552,15 @@ func (x *NodeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2411 := z.EncBinary()
-					_ = yym2411
+					yym2416 := z.EncBinary()
+					_ = yym2416
 					if false {
 					} else {
 						h.encSliceNode(([]Node)(x.Items), e)
 					}
 				}
 			}
-			if yysep2397 {
+			if yysep2402 {
 				r.EncodeEnd()
 			}
 		}
@@ -28534,24 +28571,24 @@ func (x *NodeList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2412 := z.DecBinary()
-	_ = yym2412
+	yym2417 := z.DecBinary()
+	_ = yym2417
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2413 := r.ReadMapStart()
-			if yyl2413 == 0 {
+			yyl2418 := r.ReadMapStart()
+			if yyl2418 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2413, d)
+				x.codecDecodeSelfFromMap(yyl2418, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2413 := r.ReadArrayStart()
-			if yyl2413 == 0 {
+			yyl2418 := r.ReadArrayStart()
+			if yyl2418 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2413, d)
+				x.codecDecodeSelfFromArray(yyl2418, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -28563,12 +28600,12 @@ func (x *NodeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2414Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2414Slc
-	var yyhl2414 bool = l >= 0
-	for yyj2414 := 0; ; yyj2414++ {
-		if yyhl2414 {
-			if yyj2414 >= l {
+	var yys2419Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2419Slc
+	var yyhl2419 bool = l >= 0
+	for yyj2419 := 0; ; yyj2419++ {
+		if yyhl2419 {
+			if yyj2419 >= l {
 				break
 			}
 		} else {
@@ -28576,9 +28613,9 @@ func (x *NodeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2414Slc = r.DecodeBytes(yys2414Slc, true, true)
-		yys2414 := string(yys2414Slc)
-		switch yys2414 {
+		yys2419Slc = r.DecodeBytes(yys2419Slc, true, true)
+		yys2419 := string(yys2419Slc)
+		switch yys2419 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -28595,32 +28632,32 @@ func (x *NodeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv2417 := &x.ListMeta
-				yym2418 := z.DecBinary()
-				_ = yym2418
+				yyv2422 := &x.ListMeta
+				yym2423 := z.DecBinary()
+				_ = yym2423
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2417) {
+				} else if z.HasExtensions() && z.DecExt(yyv2422) {
 				} else {
-					z.DecFallback(yyv2417, false)
+					z.DecFallback(yyv2422, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv2419 := &x.Items
-				yym2420 := z.DecBinary()
-				_ = yym2420
+				yyv2424 := &x.Items
+				yym2425 := z.DecBinary()
+				_ = yym2425
 				if false {
 				} else {
-					h.decSliceNode((*[]Node)(yyv2419), d)
+					h.decSliceNode((*[]Node)(yyv2424), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2414)
-		} // end switch yys2414
-	} // end for yyj2414
-	if !yyhl2414 {
+			z.DecStructFieldNotFound(-1, yys2419)
+		} // end switch yys2419
+	} // end for yyj2419
+	if !yyhl2419 {
 		r.ReadEnd()
 	}
 }
@@ -28629,16 +28666,16 @@ func (x *NodeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2421 int
-	var yyb2421 bool
-	var yyhl2421 bool = l >= 0
-	yyj2421++
-	if yyhl2421 {
-		yyb2421 = yyj2421 > l
+	var yyj2426 int
+	var yyb2426 bool
+	var yyhl2426 bool = l >= 0
+	yyj2426++
+	if yyhl2426 {
+		yyb2426 = yyj2426 > l
 	} else {
-		yyb2421 = r.CheckBreak()
+		yyb2426 = r.CheckBreak()
 	}
-	if yyb2421 {
+	if yyb2426 {
 		r.ReadEnd()
 		return
 	}
@@ -28647,13 +28684,13 @@ func (x *NodeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2421++
-	if yyhl2421 {
-		yyb2421 = yyj2421 > l
+	yyj2426++
+	if yyhl2426 {
+		yyb2426 = yyj2426 > l
 	} else {
-		yyb2421 = r.CheckBreak()
+		yyb2426 = r.CheckBreak()
 	}
-	if yyb2421 {
+	if yyb2426 {
 		r.ReadEnd()
 		return
 	}
@@ -28662,60 +28699,60 @@ func (x *NodeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2421++
-	if yyhl2421 {
-		yyb2421 = yyj2421 > l
+	yyj2426++
+	if yyhl2426 {
+		yyb2426 = yyj2426 > l
 	} else {
-		yyb2421 = r.CheckBreak()
+		yyb2426 = r.CheckBreak()
 	}
-	if yyb2421 {
+	if yyb2426 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv2424 := &x.ListMeta
-		yym2425 := z.DecBinary()
-		_ = yym2425
+		yyv2429 := &x.ListMeta
+		yym2430 := z.DecBinary()
+		_ = yym2430
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2424) {
+		} else if z.HasExtensions() && z.DecExt(yyv2429) {
 		} else {
-			z.DecFallback(yyv2424, false)
+			z.DecFallback(yyv2429, false)
 		}
 	}
-	yyj2421++
-	if yyhl2421 {
-		yyb2421 = yyj2421 > l
+	yyj2426++
+	if yyhl2426 {
+		yyb2426 = yyj2426 > l
 	} else {
-		yyb2421 = r.CheckBreak()
+		yyb2426 = r.CheckBreak()
 	}
-	if yyb2421 {
+	if yyb2426 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv2426 := &x.Items
-		yym2427 := z.DecBinary()
-		_ = yym2427
+		yyv2431 := &x.Items
+		yym2432 := z.DecBinary()
+		_ = yym2432
 		if false {
 		} else {
-			h.decSliceNode((*[]Node)(yyv2426), d)
+			h.decSliceNode((*[]Node)(yyv2431), d)
 		}
 	}
 	for {
-		yyj2421++
-		if yyhl2421 {
-			yyb2421 = yyj2421 > l
+		yyj2426++
+		if yyhl2426 {
+			yyb2426 = yyj2426 > l
 		} else {
-			yyb2421 = r.CheckBreak()
+			yyb2426 = r.CheckBreak()
 		}
-		if yyb2421 {
+		if yyb2426 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2421-1, "")
+		z.DecStructFieldNotFound(yyj2426-1, "")
 	}
 	r.ReadEnd()
 }
@@ -28724,8 +28761,8 @@ func (x FinalizerName) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym2428 := z.EncBinary()
-	_ = yym2428
+	yym2433 := z.EncBinary()
+	_ = yym2433
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -28737,8 +28774,8 @@ func (x *FinalizerName) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2429 := z.DecBinary()
-	_ = yym2429
+	yym2434 := z.DecBinary()
+	_ = yym2434
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -28753,35 +28790,35 @@ func (x *NamespaceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2430 := z.EncBinary()
-		_ = yym2430
+		yym2435 := z.EncBinary()
+		_ = yym2435
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2431 := !z.EncBinary()
-			yy2arr2431 := z.EncBasicHandle().StructToArray
-			var yyq2431 [1]bool
-			_, _, _ = yysep2431, yyq2431, yy2arr2431
-			const yyr2431 bool = false
-			yyq2431[0] = len(x.Finalizers) != 0
-			if yyr2431 || yy2arr2431 {
+			yysep2436 := !z.EncBinary()
+			yy2arr2436 := z.EncBasicHandle().StructToArray
+			var yyq2436 [1]bool
+			_, _, _ = yysep2436, yyq2436, yy2arr2436
+			const yyr2436 bool = false
+			yyq2436[0] = len(x.Finalizers) != 0
+			if yyr2436 || yy2arr2436 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn2431 int = 0
-				for _, b := range yyq2431 {
+				var yynn2436 int = 0
+				for _, b := range yyq2436 {
 					if b {
-						yynn2431++
+						yynn2436++
 					}
 				}
-				r.EncodeMapStart(yynn2431)
+				r.EncodeMapStart(yynn2436)
 			}
-			if yyr2431 || yy2arr2431 {
-				if yyq2431[0] {
+			if yyr2436 || yy2arr2436 {
+				if yyq2436[0] {
 					if x.Finalizers == nil {
 						r.EncodeNil()
 					} else {
-						yym2433 := z.EncBinary()
-						_ = yym2433
+						yym2438 := z.EncBinary()
+						_ = yym2438
 						if false {
 						} else {
 							h.encSliceFinalizerName(([]FinalizerName)(x.Finalizers), e)
@@ -28791,13 +28828,13 @@ func (x *NamespaceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2431[0] {
+				if yyq2436[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("finalizers"))
 					if x.Finalizers == nil {
 						r.EncodeNil()
 					} else {
-						yym2434 := z.EncBinary()
-						_ = yym2434
+						yym2439 := z.EncBinary()
+						_ = yym2439
 						if false {
 						} else {
 							h.encSliceFinalizerName(([]FinalizerName)(x.Finalizers), e)
@@ -28805,7 +28842,7 @@ func (x *NamespaceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2431 {
+			if yysep2436 {
 				r.EncodeEnd()
 			}
 		}
@@ -28816,24 +28853,24 @@ func (x *NamespaceSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2435 := z.DecBinary()
-	_ = yym2435
+	yym2440 := z.DecBinary()
+	_ = yym2440
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2436 := r.ReadMapStart()
-			if yyl2436 == 0 {
+			yyl2441 := r.ReadMapStart()
+			if yyl2441 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2436, d)
+				x.codecDecodeSelfFromMap(yyl2441, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2436 := r.ReadArrayStart()
-			if yyl2436 == 0 {
+			yyl2441 := r.ReadArrayStart()
+			if yyl2441 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2436, d)
+				x.codecDecodeSelfFromArray(yyl2441, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -28845,12 +28882,12 @@ func (x *NamespaceSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2437Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2437Slc
-	var yyhl2437 bool = l >= 0
-	for yyj2437 := 0; ; yyj2437++ {
-		if yyhl2437 {
-			if yyj2437 >= l {
+	var yys2442Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2442Slc
+	var yyhl2442 bool = l >= 0
+	for yyj2442 := 0; ; yyj2442++ {
+		if yyhl2442 {
+			if yyj2442 >= l {
 				break
 			}
 		} else {
@@ -28858,26 +28895,26 @@ func (x *NamespaceSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2437Slc = r.DecodeBytes(yys2437Slc, true, true)
-		yys2437 := string(yys2437Slc)
-		switch yys2437 {
+		yys2442Slc = r.DecodeBytes(yys2442Slc, true, true)
+		yys2442 := string(yys2442Slc)
+		switch yys2442 {
 		case "finalizers":
 			if r.TryDecodeAsNil() {
 				x.Finalizers = nil
 			} else {
-				yyv2438 := &x.Finalizers
-				yym2439 := z.DecBinary()
-				_ = yym2439
+				yyv2443 := &x.Finalizers
+				yym2444 := z.DecBinary()
+				_ = yym2444
 				if false {
 				} else {
-					h.decSliceFinalizerName((*[]FinalizerName)(yyv2438), d)
+					h.decSliceFinalizerName((*[]FinalizerName)(yyv2443), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2437)
-		} // end switch yys2437
-	} // end for yyj2437
-	if !yyhl2437 {
+			z.DecStructFieldNotFound(-1, yys2442)
+		} // end switch yys2442
+	} // end for yyj2442
+	if !yyhl2442 {
 		r.ReadEnd()
 	}
 }
@@ -28886,41 +28923,41 @@ func (x *NamespaceSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2440 int
-	var yyb2440 bool
-	var yyhl2440 bool = l >= 0
-	yyj2440++
-	if yyhl2440 {
-		yyb2440 = yyj2440 > l
+	var yyj2445 int
+	var yyb2445 bool
+	var yyhl2445 bool = l >= 0
+	yyj2445++
+	if yyhl2445 {
+		yyb2445 = yyj2445 > l
 	} else {
-		yyb2440 = r.CheckBreak()
+		yyb2445 = r.CheckBreak()
 	}
-	if yyb2440 {
+	if yyb2445 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Finalizers = nil
 	} else {
-		yyv2441 := &x.Finalizers
-		yym2442 := z.DecBinary()
-		_ = yym2442
+		yyv2446 := &x.Finalizers
+		yym2447 := z.DecBinary()
+		_ = yym2447
 		if false {
 		} else {
-			h.decSliceFinalizerName((*[]FinalizerName)(yyv2441), d)
+			h.decSliceFinalizerName((*[]FinalizerName)(yyv2446), d)
 		}
 	}
 	for {
-		yyj2440++
-		if yyhl2440 {
-			yyb2440 = yyj2440 > l
+		yyj2445++
+		if yyhl2445 {
+			yyb2445 = yyj2445 > l
 		} else {
-			yyb2440 = r.CheckBreak()
+			yyb2445 = r.CheckBreak()
 		}
-		if yyb2440 {
+		if yyb2445 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2440-1, "")
+		z.DecStructFieldNotFound(yyj2445-1, "")
 	}
 	r.ReadEnd()
 }
@@ -28932,41 +28969,41 @@ func (x *NamespaceStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2443 := z.EncBinary()
-		_ = yym2443
+		yym2448 := z.EncBinary()
+		_ = yym2448
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2444 := !z.EncBinary()
-			yy2arr2444 := z.EncBasicHandle().StructToArray
-			var yyq2444 [1]bool
-			_, _, _ = yysep2444, yyq2444, yy2arr2444
-			const yyr2444 bool = false
-			yyq2444[0] = x.Phase != ""
-			if yyr2444 || yy2arr2444 {
+			yysep2449 := !z.EncBinary()
+			yy2arr2449 := z.EncBasicHandle().StructToArray
+			var yyq2449 [1]bool
+			_, _, _ = yysep2449, yyq2449, yy2arr2449
+			const yyr2449 bool = false
+			yyq2449[0] = x.Phase != ""
+			if yyr2449 || yy2arr2449 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn2444 int = 0
-				for _, b := range yyq2444 {
+				var yynn2449 int = 0
+				for _, b := range yyq2449 {
 					if b {
-						yynn2444++
+						yynn2449++
 					}
 				}
-				r.EncodeMapStart(yynn2444)
+				r.EncodeMapStart(yynn2449)
 			}
-			if yyr2444 || yy2arr2444 {
-				if yyq2444[0] {
+			if yyr2449 || yy2arr2449 {
+				if yyq2449[0] {
 					x.Phase.CodecEncodeSelf(e)
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2444[0] {
+				if yyq2449[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("phase"))
 					x.Phase.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2444 {
+			if yysep2449 {
 				r.EncodeEnd()
 			}
 		}
@@ -28977,24 +29014,24 @@ func (x *NamespaceStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2446 := z.DecBinary()
-	_ = yym2446
+	yym2451 := z.DecBinary()
+	_ = yym2451
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2447 := r.ReadMapStart()
-			if yyl2447 == 0 {
+			yyl2452 := r.ReadMapStart()
+			if yyl2452 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2447, d)
+				x.codecDecodeSelfFromMap(yyl2452, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2447 := r.ReadArrayStart()
-			if yyl2447 == 0 {
+			yyl2452 := r.ReadArrayStart()
+			if yyl2452 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2447, d)
+				x.codecDecodeSelfFromArray(yyl2452, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -29006,12 +29043,12 @@ func (x *NamespaceStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2448Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2448Slc
-	var yyhl2448 bool = l >= 0
-	for yyj2448 := 0; ; yyj2448++ {
-		if yyhl2448 {
-			if yyj2448 >= l {
+	var yys2453Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2453Slc
+	var yyhl2453 bool = l >= 0
+	for yyj2453 := 0; ; yyj2453++ {
+		if yyhl2453 {
+			if yyj2453 >= l {
 				break
 			}
 		} else {
@@ -29019,9 +29056,9 @@ func (x *NamespaceStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2448Slc = r.DecodeBytes(yys2448Slc, true, true)
-		yys2448 := string(yys2448Slc)
-		switch yys2448 {
+		yys2453Slc = r.DecodeBytes(yys2453Slc, true, true)
+		yys2453 := string(yys2453Slc)
+		switch yys2453 {
 		case "phase":
 			if r.TryDecodeAsNil() {
 				x.Phase = ""
@@ -29029,10 +29066,10 @@ func (x *NamespaceStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Phase = NamespacePhase(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2448)
-		} // end switch yys2448
-	} // end for yyj2448
-	if !yyhl2448 {
+			z.DecStructFieldNotFound(-1, yys2453)
+		} // end switch yys2453
+	} // end for yyj2453
+	if !yyhl2453 {
 		r.ReadEnd()
 	}
 }
@@ -29041,16 +29078,16 @@ func (x *NamespaceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2450 int
-	var yyb2450 bool
-	var yyhl2450 bool = l >= 0
-	yyj2450++
-	if yyhl2450 {
-		yyb2450 = yyj2450 > l
+	var yyj2455 int
+	var yyb2455 bool
+	var yyhl2455 bool = l >= 0
+	yyj2455++
+	if yyhl2455 {
+		yyb2455 = yyj2455 > l
 	} else {
-		yyb2450 = r.CheckBreak()
+		yyb2455 = r.CheckBreak()
 	}
-	if yyb2450 {
+	if yyb2455 {
 		r.ReadEnd()
 		return
 	}
@@ -29060,16 +29097,16 @@ func (x *NamespaceStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.Phase = NamespacePhase(r.DecodeString())
 	}
 	for {
-		yyj2450++
-		if yyhl2450 {
-			yyb2450 = yyj2450 > l
+		yyj2455++
+		if yyhl2455 {
+			yyb2455 = yyj2455 > l
 		} else {
-			yyb2450 = r.CheckBreak()
+			yyb2455 = r.CheckBreak()
 		}
-		if yyb2450 {
+		if yyb2455 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2450-1, "")
+		z.DecStructFieldNotFound(yyj2455-1, "")
 	}
 	r.ReadEnd()
 }
@@ -29078,8 +29115,8 @@ func (x NamespacePhase) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym2452 := z.EncBinary()
-	_ = yym2452
+	yym2457 := z.EncBinary()
+	_ = yym2457
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -29091,8 +29128,8 @@ func (x *NamespacePhase) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2453 := z.DecBinary()
-	_ = yym2453
+	yym2458 := z.DecBinary()
+	_ = yym2458
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -29107,36 +29144,36 @@ func (x *Namespace) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2454 := z.EncBinary()
-		_ = yym2454
+		yym2459 := z.EncBinary()
+		_ = yym2459
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2455 := !z.EncBinary()
-			yy2arr2455 := z.EncBasicHandle().StructToArray
-			var yyq2455 [5]bool
-			_, _, _ = yysep2455, yyq2455, yy2arr2455
-			const yyr2455 bool = false
-			yyq2455[0] = x.Kind != ""
-			yyq2455[1] = x.APIVersion != ""
-			yyq2455[2] = true
-			yyq2455[3] = true
-			yyq2455[4] = true
-			if yyr2455 || yy2arr2455 {
+			yysep2460 := !z.EncBinary()
+			yy2arr2460 := z.EncBasicHandle().StructToArray
+			var yyq2460 [5]bool
+			_, _, _ = yysep2460, yyq2460, yy2arr2460
+			const yyr2460 bool = false
+			yyq2460[0] = x.Kind != ""
+			yyq2460[1] = x.APIVersion != ""
+			yyq2460[2] = true
+			yyq2460[3] = true
+			yyq2460[4] = true
+			if yyr2460 || yy2arr2460 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn2455 int = 0
-				for _, b := range yyq2455 {
+				var yynn2460 int = 0
+				for _, b := range yyq2460 {
 					if b {
-						yynn2455++
+						yynn2460++
 					}
 				}
-				r.EncodeMapStart(yynn2455)
+				r.EncodeMapStart(yynn2460)
 			}
-			if yyr2455 || yy2arr2455 {
-				if yyq2455[0] {
-					yym2457 := z.EncBinary()
-					_ = yym2457
+			if yyr2460 || yy2arr2460 {
+				if yyq2460[0] {
+					yym2462 := z.EncBinary()
+					_ = yym2462
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -29145,20 +29182,20 @@ func (x *Namespace) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2455[0] {
+				if yyq2460[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2458 := z.EncBinary()
-					_ = yym2458
+					yym2463 := z.EncBinary()
+					_ = yym2463
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2455 || yy2arr2455 {
-				if yyq2455[1] {
-					yym2460 := z.EncBinary()
-					_ = yym2460
+			if yyr2460 || yy2arr2460 {
+				if yyq2460[1] {
+					yym2465 := z.EncBinary()
+					_ = yym2465
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -29167,59 +29204,59 @@ func (x *Namespace) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2455[1] {
+				if yyq2460[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2461 := z.EncBinary()
-					_ = yym2461
+					yym2466 := z.EncBinary()
+					_ = yym2466
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2455 || yy2arr2455 {
-				if yyq2455[2] {
-					yy2463 := &x.ObjectMeta
-					yy2463.CodecEncodeSelf(e)
+			if yyr2460 || yy2arr2460 {
+				if yyq2460[2] {
+					yy2468 := &x.ObjectMeta
+					yy2468.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2455[2] {
+				if yyq2460[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy2464 := &x.ObjectMeta
-					yy2464.CodecEncodeSelf(e)
-				}
-			}
-			if yyr2455 || yy2arr2455 {
-				if yyq2455[3] {
-					yy2466 := &x.Spec
-					yy2466.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2455[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy2467 := &x.Spec
-					yy2467.CodecEncodeSelf(e)
-				}
-			}
-			if yyr2455 || yy2arr2455 {
-				if yyq2455[4] {
-					yy2469 := &x.Status
+					yy2469 := &x.ObjectMeta
 					yy2469.CodecEncodeSelf(e)
+				}
+			}
+			if yyr2460 || yy2arr2460 {
+				if yyq2460[3] {
+					yy2471 := &x.Spec
+					yy2471.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2455[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy2470 := &x.Status
-					yy2470.CodecEncodeSelf(e)
+				if yyq2460[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					yy2472 := &x.Spec
+					yy2472.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2455 {
+			if yyr2460 || yy2arr2460 {
+				if yyq2460[4] {
+					yy2474 := &x.Status
+					yy2474.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq2460[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					yy2475 := &x.Status
+					yy2475.CodecEncodeSelf(e)
+				}
+			}
+			if yysep2460 {
 				r.EncodeEnd()
 			}
 		}
@@ -29230,24 +29267,24 @@ func (x *Namespace) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2471 := z.DecBinary()
-	_ = yym2471
+	yym2476 := z.DecBinary()
+	_ = yym2476
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2472 := r.ReadMapStart()
-			if yyl2472 == 0 {
+			yyl2477 := r.ReadMapStart()
+			if yyl2477 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2472, d)
+				x.codecDecodeSelfFromMap(yyl2477, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2472 := r.ReadArrayStart()
-			if yyl2472 == 0 {
+			yyl2477 := r.ReadArrayStart()
+			if yyl2477 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2472, d)
+				x.codecDecodeSelfFromArray(yyl2477, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -29259,12 +29296,12 @@ func (x *Namespace) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2473Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2473Slc
-	var yyhl2473 bool = l >= 0
-	for yyj2473 := 0; ; yyj2473++ {
-		if yyhl2473 {
-			if yyj2473 >= l {
+	var yys2478Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2478Slc
+	var yyhl2478 bool = l >= 0
+	for yyj2478 := 0; ; yyj2478++ {
+		if yyhl2478 {
+			if yyj2478 >= l {
 				break
 			}
 		} else {
@@ -29272,9 +29309,9 @@ func (x *Namespace) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2473Slc = r.DecodeBytes(yys2473Slc, true, true)
-		yys2473 := string(yys2473Slc)
-		switch yys2473 {
+		yys2478Slc = r.DecodeBytes(yys2478Slc, true, true)
+		yys2478 := string(yys2478Slc)
+		switch yys2478 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -29291,28 +29328,28 @@ func (x *Namespace) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv2476 := &x.ObjectMeta
-				yyv2476.CodecDecodeSelf(d)
+				yyv2481 := &x.ObjectMeta
+				yyv2481.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = NamespaceSpec{}
 			} else {
-				yyv2477 := &x.Spec
-				yyv2477.CodecDecodeSelf(d)
+				yyv2482 := &x.Spec
+				yyv2482.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = NamespaceStatus{}
 			} else {
-				yyv2478 := &x.Status
-				yyv2478.CodecDecodeSelf(d)
+				yyv2483 := &x.Status
+				yyv2483.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2473)
-		} // end switch yys2473
-	} // end for yyj2473
-	if !yyhl2473 {
+			z.DecStructFieldNotFound(-1, yys2478)
+		} // end switch yys2478
+	} // end for yyj2478
+	if !yyhl2478 {
 		r.ReadEnd()
 	}
 }
@@ -29321,16 +29358,16 @@ func (x *Namespace) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2479 int
-	var yyb2479 bool
-	var yyhl2479 bool = l >= 0
-	yyj2479++
-	if yyhl2479 {
-		yyb2479 = yyj2479 > l
+	var yyj2484 int
+	var yyb2484 bool
+	var yyhl2484 bool = l >= 0
+	yyj2484++
+	if yyhl2484 {
+		yyb2484 = yyj2484 > l
 	} else {
-		yyb2479 = r.CheckBreak()
+		yyb2484 = r.CheckBreak()
 	}
-	if yyb2479 {
+	if yyb2484 {
 		r.ReadEnd()
 		return
 	}
@@ -29339,13 +29376,13 @@ func (x *Namespace) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2479++
-	if yyhl2479 {
-		yyb2479 = yyj2479 > l
+	yyj2484++
+	if yyhl2484 {
+		yyb2484 = yyj2484 > l
 	} else {
-		yyb2479 = r.CheckBreak()
+		yyb2484 = r.CheckBreak()
 	}
-	if yyb2479 {
+	if yyb2484 {
 		r.ReadEnd()
 		return
 	}
@@ -29354,65 +29391,65 @@ func (x *Namespace) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2479++
-	if yyhl2479 {
-		yyb2479 = yyj2479 > l
+	yyj2484++
+	if yyhl2484 {
+		yyb2484 = yyj2484 > l
 	} else {
-		yyb2479 = r.CheckBreak()
+		yyb2484 = r.CheckBreak()
 	}
-	if yyb2479 {
+	if yyb2484 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv2482 := &x.ObjectMeta
-		yyv2482.CodecDecodeSelf(d)
+		yyv2487 := &x.ObjectMeta
+		yyv2487.CodecDecodeSelf(d)
 	}
-	yyj2479++
-	if yyhl2479 {
-		yyb2479 = yyj2479 > l
+	yyj2484++
+	if yyhl2484 {
+		yyb2484 = yyj2484 > l
 	} else {
-		yyb2479 = r.CheckBreak()
+		yyb2484 = r.CheckBreak()
 	}
-	if yyb2479 {
+	if yyb2484 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = NamespaceSpec{}
 	} else {
-		yyv2483 := &x.Spec
-		yyv2483.CodecDecodeSelf(d)
+		yyv2488 := &x.Spec
+		yyv2488.CodecDecodeSelf(d)
 	}
-	yyj2479++
-	if yyhl2479 {
-		yyb2479 = yyj2479 > l
+	yyj2484++
+	if yyhl2484 {
+		yyb2484 = yyj2484 > l
 	} else {
-		yyb2479 = r.CheckBreak()
+		yyb2484 = r.CheckBreak()
 	}
-	if yyb2479 {
+	if yyb2484 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = NamespaceStatus{}
 	} else {
-		yyv2484 := &x.Status
-		yyv2484.CodecDecodeSelf(d)
+		yyv2489 := &x.Status
+		yyv2489.CodecDecodeSelf(d)
 	}
 	for {
-		yyj2479++
-		if yyhl2479 {
-			yyb2479 = yyj2479 > l
+		yyj2484++
+		if yyhl2484 {
+			yyb2484 = yyj2484 > l
 		} else {
-			yyb2479 = r.CheckBreak()
+			yyb2484 = r.CheckBreak()
 		}
-		if yyb2479 {
+		if yyb2484 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2479-1, "")
+		z.DecStructFieldNotFound(yyj2484-1, "")
 	}
 	r.ReadEnd()
 }
@@ -29424,34 +29461,34 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2485 := z.EncBinary()
-		_ = yym2485
+		yym2490 := z.EncBinary()
+		_ = yym2490
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2486 := !z.EncBinary()
-			yy2arr2486 := z.EncBasicHandle().StructToArray
-			var yyq2486 [4]bool
-			_, _, _ = yysep2486, yyq2486, yy2arr2486
-			const yyr2486 bool = false
-			yyq2486[0] = x.Kind != ""
-			yyq2486[1] = x.APIVersion != ""
-			yyq2486[2] = true
-			if yyr2486 || yy2arr2486 {
+			yysep2491 := !z.EncBinary()
+			yy2arr2491 := z.EncBasicHandle().StructToArray
+			var yyq2491 [4]bool
+			_, _, _ = yysep2491, yyq2491, yy2arr2491
+			const yyr2491 bool = false
+			yyq2491[0] = x.Kind != ""
+			yyq2491[1] = x.APIVersion != ""
+			yyq2491[2] = true
+			if yyr2491 || yy2arr2491 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2486 int = 1
-				for _, b := range yyq2486 {
+				var yynn2491 int = 1
+				for _, b := range yyq2491 {
 					if b {
-						yynn2486++
+						yynn2491++
 					}
 				}
-				r.EncodeMapStart(yynn2486)
+				r.EncodeMapStart(yynn2491)
 			}
-			if yyr2486 || yy2arr2486 {
-				if yyq2486[0] {
-					yym2488 := z.EncBinary()
-					_ = yym2488
+			if yyr2491 || yy2arr2491 {
+				if yyq2491[0] {
+					yym2493 := z.EncBinary()
+					_ = yym2493
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -29460,20 +29497,20 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2486[0] {
+				if yyq2491[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2489 := z.EncBinary()
-					_ = yym2489
+					yym2494 := z.EncBinary()
+					_ = yym2494
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2486 || yy2arr2486 {
-				if yyq2486[1] {
-					yym2491 := z.EncBinary()
-					_ = yym2491
+			if yyr2491 || yy2arr2491 {
+				if yyq2491[1] {
+					yym2496 := z.EncBinary()
+					_ = yym2496
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -29482,48 +29519,48 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2486[1] {
+				if yyq2491[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2492 := z.EncBinary()
-					_ = yym2492
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2486 || yy2arr2486 {
-				if yyq2486[2] {
-					yy2494 := &x.ListMeta
-					yym2495 := z.EncBinary()
-					_ = yym2495
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2494) {
-					} else {
-						z.EncFallback(yy2494)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2486[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy2496 := &x.ListMeta
 					yym2497 := z.EncBinary()
 					_ = yym2497
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2496) {
 					} else {
-						z.EncFallback(yy2496)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2486 || yy2arr2486 {
+			if yyr2491 || yy2arr2491 {
+				if yyq2491[2] {
+					yy2499 := &x.ListMeta
+					yym2500 := z.EncBinary()
+					_ = yym2500
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2499) {
+					} else {
+						z.EncFallback(yy2499)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq2491[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy2501 := &x.ListMeta
+					yym2502 := z.EncBinary()
+					_ = yym2502
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2501) {
+					} else {
+						z.EncFallback(yy2501)
+					}
+				}
+			}
+			if yyr2491 || yy2arr2491 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2499 := z.EncBinary()
-					_ = yym2499
+					yym2504 := z.EncBinary()
+					_ = yym2504
 					if false {
 					} else {
 						h.encSliceNamespace(([]Namespace)(x.Items), e)
@@ -29534,15 +29571,15 @@ func (x *NamespaceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2500 := z.EncBinary()
-					_ = yym2500
+					yym2505 := z.EncBinary()
+					_ = yym2505
 					if false {
 					} else {
 						h.encSliceNamespace(([]Namespace)(x.Items), e)
 					}
 				}
 			}
-			if yysep2486 {
+			if yysep2491 {
 				r.EncodeEnd()
 			}
 		}
@@ -29553,24 +29590,24 @@ func (x *NamespaceList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2501 := z.DecBinary()
-	_ = yym2501
+	yym2506 := z.DecBinary()
+	_ = yym2506
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2502 := r.ReadMapStart()
-			if yyl2502 == 0 {
+			yyl2507 := r.ReadMapStart()
+			if yyl2507 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2502, d)
+				x.codecDecodeSelfFromMap(yyl2507, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2502 := r.ReadArrayStart()
-			if yyl2502 == 0 {
+			yyl2507 := r.ReadArrayStart()
+			if yyl2507 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2502, d)
+				x.codecDecodeSelfFromArray(yyl2507, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -29582,12 +29619,12 @@ func (x *NamespaceList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2503Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2503Slc
-	var yyhl2503 bool = l >= 0
-	for yyj2503 := 0; ; yyj2503++ {
-		if yyhl2503 {
-			if yyj2503 >= l {
+	var yys2508Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2508Slc
+	var yyhl2508 bool = l >= 0
+	for yyj2508 := 0; ; yyj2508++ {
+		if yyhl2508 {
+			if yyj2508 >= l {
 				break
 			}
 		} else {
@@ -29595,9 +29632,9 @@ func (x *NamespaceList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2503Slc = r.DecodeBytes(yys2503Slc, true, true)
-		yys2503 := string(yys2503Slc)
-		switch yys2503 {
+		yys2508Slc = r.DecodeBytes(yys2508Slc, true, true)
+		yys2508 := string(yys2508Slc)
+		switch yys2508 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -29614,32 +29651,32 @@ func (x *NamespaceList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv2506 := &x.ListMeta
-				yym2507 := z.DecBinary()
-				_ = yym2507
+				yyv2511 := &x.ListMeta
+				yym2512 := z.DecBinary()
+				_ = yym2512
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2506) {
+				} else if z.HasExtensions() && z.DecExt(yyv2511) {
 				} else {
-					z.DecFallback(yyv2506, false)
+					z.DecFallback(yyv2511, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv2508 := &x.Items
-				yym2509 := z.DecBinary()
-				_ = yym2509
+				yyv2513 := &x.Items
+				yym2514 := z.DecBinary()
+				_ = yym2514
 				if false {
 				} else {
-					h.decSliceNamespace((*[]Namespace)(yyv2508), d)
+					h.decSliceNamespace((*[]Namespace)(yyv2513), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2503)
-		} // end switch yys2503
-	} // end for yyj2503
-	if !yyhl2503 {
+			z.DecStructFieldNotFound(-1, yys2508)
+		} // end switch yys2508
+	} // end for yyj2508
+	if !yyhl2508 {
 		r.ReadEnd()
 	}
 }
@@ -29648,16 +29685,16 @@ func (x *NamespaceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2510 int
-	var yyb2510 bool
-	var yyhl2510 bool = l >= 0
-	yyj2510++
-	if yyhl2510 {
-		yyb2510 = yyj2510 > l
+	var yyj2515 int
+	var yyb2515 bool
+	var yyhl2515 bool = l >= 0
+	yyj2515++
+	if yyhl2515 {
+		yyb2515 = yyj2515 > l
 	} else {
-		yyb2510 = r.CheckBreak()
+		yyb2515 = r.CheckBreak()
 	}
-	if yyb2510 {
+	if yyb2515 {
 		r.ReadEnd()
 		return
 	}
@@ -29666,13 +29703,13 @@ func (x *NamespaceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2510++
-	if yyhl2510 {
-		yyb2510 = yyj2510 > l
+	yyj2515++
+	if yyhl2515 {
+		yyb2515 = yyj2515 > l
 	} else {
-		yyb2510 = r.CheckBreak()
+		yyb2515 = r.CheckBreak()
 	}
-	if yyb2510 {
+	if yyb2515 {
 		r.ReadEnd()
 		return
 	}
@@ -29681,60 +29718,60 @@ func (x *NamespaceList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2510++
-	if yyhl2510 {
-		yyb2510 = yyj2510 > l
+	yyj2515++
+	if yyhl2515 {
+		yyb2515 = yyj2515 > l
 	} else {
-		yyb2510 = r.CheckBreak()
+		yyb2515 = r.CheckBreak()
 	}
-	if yyb2510 {
+	if yyb2515 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv2513 := &x.ListMeta
-		yym2514 := z.DecBinary()
-		_ = yym2514
+		yyv2518 := &x.ListMeta
+		yym2519 := z.DecBinary()
+		_ = yym2519
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2513) {
+		} else if z.HasExtensions() && z.DecExt(yyv2518) {
 		} else {
-			z.DecFallback(yyv2513, false)
+			z.DecFallback(yyv2518, false)
 		}
 	}
-	yyj2510++
-	if yyhl2510 {
-		yyb2510 = yyj2510 > l
+	yyj2515++
+	if yyhl2515 {
+		yyb2515 = yyj2515 > l
 	} else {
-		yyb2510 = r.CheckBreak()
+		yyb2515 = r.CheckBreak()
 	}
-	if yyb2510 {
+	if yyb2515 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv2515 := &x.Items
-		yym2516 := z.DecBinary()
-		_ = yym2516
+		yyv2520 := &x.Items
+		yym2521 := z.DecBinary()
+		_ = yym2521
 		if false {
 		} else {
-			h.decSliceNamespace((*[]Namespace)(yyv2515), d)
+			h.decSliceNamespace((*[]Namespace)(yyv2520), d)
 		}
 	}
 	for {
-		yyj2510++
-		if yyhl2510 {
-			yyb2510 = yyj2510 > l
+		yyj2515++
+		if yyhl2515 {
+			yyb2515 = yyj2515 > l
 		} else {
-			yyb2510 = r.CheckBreak()
+			yyb2515 = r.CheckBreak()
 		}
-		if yyb2510 {
+		if yyb2515 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2510-1, "")
+		z.DecStructFieldNotFound(yyj2515-1, "")
 	}
 	r.ReadEnd()
 }
@@ -29746,34 +29783,34 @@ func (x *Binding) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2517 := z.EncBinary()
-		_ = yym2517
+		yym2522 := z.EncBinary()
+		_ = yym2522
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2518 := !z.EncBinary()
-			yy2arr2518 := z.EncBasicHandle().StructToArray
-			var yyq2518 [4]bool
-			_, _, _ = yysep2518, yyq2518, yy2arr2518
-			const yyr2518 bool = false
-			yyq2518[0] = x.Kind != ""
-			yyq2518[1] = x.APIVersion != ""
-			yyq2518[2] = true
-			if yyr2518 || yy2arr2518 {
+			yysep2523 := !z.EncBinary()
+			yy2arr2523 := z.EncBasicHandle().StructToArray
+			var yyq2523 [4]bool
+			_, _, _ = yysep2523, yyq2523, yy2arr2523
+			const yyr2523 bool = false
+			yyq2523[0] = x.Kind != ""
+			yyq2523[1] = x.APIVersion != ""
+			yyq2523[2] = true
+			if yyr2523 || yy2arr2523 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2518 int = 1
-				for _, b := range yyq2518 {
+				var yynn2523 int = 1
+				for _, b := range yyq2523 {
 					if b {
-						yynn2518++
+						yynn2523++
 					}
 				}
-				r.EncodeMapStart(yynn2518)
+				r.EncodeMapStart(yynn2523)
 			}
-			if yyr2518 || yy2arr2518 {
-				if yyq2518[0] {
-					yym2520 := z.EncBinary()
-					_ = yym2520
+			if yyr2523 || yy2arr2523 {
+				if yyq2523[0] {
+					yym2525 := z.EncBinary()
+					_ = yym2525
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -29782,20 +29819,20 @@ func (x *Binding) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2518[0] {
+				if yyq2523[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2521 := z.EncBinary()
-					_ = yym2521
+					yym2526 := z.EncBinary()
+					_ = yym2526
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2518 || yy2arr2518 {
-				if yyq2518[1] {
-					yym2523 := z.EncBinary()
-					_ = yym2523
+			if yyr2523 || yy2arr2523 {
+				if yyq2523[1] {
+					yym2528 := z.EncBinary()
+					_ = yym2528
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -29804,39 +29841,39 @@ func (x *Binding) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2518[1] {
+				if yyq2523[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2524 := z.EncBinary()
-					_ = yym2524
+					yym2529 := z.EncBinary()
+					_ = yym2529
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2518 || yy2arr2518 {
-				if yyq2518[2] {
-					yy2526 := &x.ObjectMeta
-					yy2526.CodecEncodeSelf(e)
+			if yyr2523 || yy2arr2523 {
+				if yyq2523[2] {
+					yy2531 := &x.ObjectMeta
+					yy2531.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2518[2] {
+				if yyq2523[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy2527 := &x.ObjectMeta
-					yy2527.CodecEncodeSelf(e)
+					yy2532 := &x.ObjectMeta
+					yy2532.CodecEncodeSelf(e)
 				}
 			}
-			if yyr2518 || yy2arr2518 {
-				yy2529 := &x.Target
-				yy2529.CodecEncodeSelf(e)
+			if yyr2523 || yy2arr2523 {
+				yy2534 := &x.Target
+				yy2534.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("target"))
-				yy2530 := &x.Target
-				yy2530.CodecEncodeSelf(e)
+				yy2535 := &x.Target
+				yy2535.CodecEncodeSelf(e)
 			}
-			if yysep2518 {
+			if yysep2523 {
 				r.EncodeEnd()
 			}
 		}
@@ -29847,24 +29884,24 @@ func (x *Binding) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2531 := z.DecBinary()
-	_ = yym2531
+	yym2536 := z.DecBinary()
+	_ = yym2536
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2532 := r.ReadMapStart()
-			if yyl2532 == 0 {
+			yyl2537 := r.ReadMapStart()
+			if yyl2537 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2532, d)
+				x.codecDecodeSelfFromMap(yyl2537, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2532 := r.ReadArrayStart()
-			if yyl2532 == 0 {
+			yyl2537 := r.ReadArrayStart()
+			if yyl2537 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2532, d)
+				x.codecDecodeSelfFromArray(yyl2537, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -29876,12 +29913,12 @@ func (x *Binding) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2533Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2533Slc
-	var yyhl2533 bool = l >= 0
-	for yyj2533 := 0; ; yyj2533++ {
-		if yyhl2533 {
-			if yyj2533 >= l {
+	var yys2538Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2538Slc
+	var yyhl2538 bool = l >= 0
+	for yyj2538 := 0; ; yyj2538++ {
+		if yyhl2538 {
+			if yyj2538 >= l {
 				break
 			}
 		} else {
@@ -29889,9 +29926,9 @@ func (x *Binding) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2533Slc = r.DecodeBytes(yys2533Slc, true, true)
-		yys2533 := string(yys2533Slc)
-		switch yys2533 {
+		yys2538Slc = r.DecodeBytes(yys2538Slc, true, true)
+		yys2538 := string(yys2538Slc)
+		switch yys2538 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -29908,21 +29945,21 @@ func (x *Binding) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv2536 := &x.ObjectMeta
-				yyv2536.CodecDecodeSelf(d)
+				yyv2541 := &x.ObjectMeta
+				yyv2541.CodecDecodeSelf(d)
 			}
 		case "target":
 			if r.TryDecodeAsNil() {
 				x.Target = ObjectReference{}
 			} else {
-				yyv2537 := &x.Target
-				yyv2537.CodecDecodeSelf(d)
+				yyv2542 := &x.Target
+				yyv2542.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2533)
-		} // end switch yys2533
-	} // end for yyj2533
-	if !yyhl2533 {
+			z.DecStructFieldNotFound(-1, yys2538)
+		} // end switch yys2538
+	} // end for yyj2538
+	if !yyhl2538 {
 		r.ReadEnd()
 	}
 }
@@ -29931,16 +29968,16 @@ func (x *Binding) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2538 int
-	var yyb2538 bool
-	var yyhl2538 bool = l >= 0
-	yyj2538++
-	if yyhl2538 {
-		yyb2538 = yyj2538 > l
+	var yyj2543 int
+	var yyb2543 bool
+	var yyhl2543 bool = l >= 0
+	yyj2543++
+	if yyhl2543 {
+		yyb2543 = yyj2543 > l
 	} else {
-		yyb2538 = r.CheckBreak()
+		yyb2543 = r.CheckBreak()
 	}
-	if yyb2538 {
+	if yyb2543 {
 		r.ReadEnd()
 		return
 	}
@@ -29949,13 +29986,13 @@ func (x *Binding) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2538++
-	if yyhl2538 {
-		yyb2538 = yyj2538 > l
+	yyj2543++
+	if yyhl2543 {
+		yyb2543 = yyj2543 > l
 	} else {
-		yyb2538 = r.CheckBreak()
+		yyb2543 = r.CheckBreak()
 	}
-	if yyb2538 {
+	if yyb2543 {
 		r.ReadEnd()
 		return
 	}
@@ -29964,49 +30001,49 @@ func (x *Binding) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2538++
-	if yyhl2538 {
-		yyb2538 = yyj2538 > l
+	yyj2543++
+	if yyhl2543 {
+		yyb2543 = yyj2543 > l
 	} else {
-		yyb2538 = r.CheckBreak()
+		yyb2543 = r.CheckBreak()
 	}
-	if yyb2538 {
+	if yyb2543 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv2541 := &x.ObjectMeta
-		yyv2541.CodecDecodeSelf(d)
+		yyv2546 := &x.ObjectMeta
+		yyv2546.CodecDecodeSelf(d)
 	}
-	yyj2538++
-	if yyhl2538 {
-		yyb2538 = yyj2538 > l
+	yyj2543++
+	if yyhl2543 {
+		yyb2543 = yyj2543 > l
 	} else {
-		yyb2538 = r.CheckBreak()
+		yyb2543 = r.CheckBreak()
 	}
-	if yyb2538 {
+	if yyb2543 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Target = ObjectReference{}
 	} else {
-		yyv2542 := &x.Target
-		yyv2542.CodecDecodeSelf(d)
+		yyv2547 := &x.Target
+		yyv2547.CodecDecodeSelf(d)
 	}
 	for {
-		yyj2538++
-		if yyhl2538 {
-			yyb2538 = yyj2538 > l
+		yyj2543++
+		if yyhl2543 {
+			yyb2543 = yyj2543 > l
 		} else {
-			yyb2538 = r.CheckBreak()
+			yyb2543 = r.CheckBreak()
 		}
-		if yyb2538 {
+		if yyb2543 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2538-1, "")
+		z.DecStructFieldNotFound(yyj2543-1, "")
 	}
 	r.ReadEnd()
 }
@@ -30018,33 +30055,33 @@ func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2543 := z.EncBinary()
-		_ = yym2543
+		yym2548 := z.EncBinary()
+		_ = yym2548
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2544 := !z.EncBinary()
-			yy2arr2544 := z.EncBasicHandle().StructToArray
-			var yyq2544 [3]bool
-			_, _, _ = yysep2544, yyq2544, yy2arr2544
-			const yyr2544 bool = false
-			yyq2544[0] = x.Kind != ""
-			yyq2544[1] = x.APIVersion != ""
-			if yyr2544 || yy2arr2544 {
+			yysep2549 := !z.EncBinary()
+			yy2arr2549 := z.EncBasicHandle().StructToArray
+			var yyq2549 [3]bool
+			_, _, _ = yysep2549, yyq2549, yy2arr2549
+			const yyr2549 bool = false
+			yyq2549[0] = x.Kind != ""
+			yyq2549[1] = x.APIVersion != ""
+			if yyr2549 || yy2arr2549 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn2544 int = 1
-				for _, b := range yyq2544 {
+				var yynn2549 int = 1
+				for _, b := range yyq2549 {
 					if b {
-						yynn2544++
+						yynn2549++
 					}
 				}
-				r.EncodeMapStart(yynn2544)
+				r.EncodeMapStart(yynn2549)
 			}
-			if yyr2544 || yy2arr2544 {
-				if yyq2544[0] {
-					yym2546 := z.EncBinary()
-					_ = yym2546
+			if yyr2549 || yy2arr2549 {
+				if yyq2549[0] {
+					yym2551 := z.EncBinary()
+					_ = yym2551
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -30053,20 +30090,20 @@ func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2544[0] {
+				if yyq2549[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2547 := z.EncBinary()
-					_ = yym2547
+					yym2552 := z.EncBinary()
+					_ = yym2552
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2544 || yy2arr2544 {
-				if yyq2544[1] {
-					yym2549 := z.EncBinary()
-					_ = yym2549
+			if yyr2549 || yy2arr2549 {
+				if yyq2549[1] {
+					yym2554 := z.EncBinary()
+					_ = yym2554
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -30075,26 +30112,26 @@ func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2544[1] {
+				if yyq2549[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2550 := z.EncBinary()
-					_ = yym2550
+					yym2555 := z.EncBinary()
+					_ = yym2555
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2544 || yy2arr2544 {
+			if yyr2549 || yy2arr2549 {
 				if x.GracePeriodSeconds == nil {
 					r.EncodeNil()
 				} else {
-					yy2552 := *x.GracePeriodSeconds
-					yym2553 := z.EncBinary()
-					_ = yym2553
+					yy2557 := *x.GracePeriodSeconds
+					yym2558 := z.EncBinary()
+					_ = yym2558
 					if false {
 					} else {
-						r.EncodeInt(int64(yy2552))
+						r.EncodeInt(int64(yy2557))
 					}
 				}
 			} else {
@@ -30102,16 +30139,16 @@ func (x *DeleteOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.GracePeriodSeconds == nil {
 					r.EncodeNil()
 				} else {
-					yy2554 := *x.GracePeriodSeconds
-					yym2555 := z.EncBinary()
-					_ = yym2555
+					yy2559 := *x.GracePeriodSeconds
+					yym2560 := z.EncBinary()
+					_ = yym2560
 					if false {
 					} else {
-						r.EncodeInt(int64(yy2554))
+						r.EncodeInt(int64(yy2559))
 					}
 				}
 			}
-			if yysep2544 {
+			if yysep2549 {
 				r.EncodeEnd()
 			}
 		}
@@ -30122,24 +30159,24 @@ func (x *DeleteOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2556 := z.DecBinary()
-	_ = yym2556
+	yym2561 := z.DecBinary()
+	_ = yym2561
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2557 := r.ReadMapStart()
-			if yyl2557 == 0 {
+			yyl2562 := r.ReadMapStart()
+			if yyl2562 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2557, d)
+				x.codecDecodeSelfFromMap(yyl2562, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2557 := r.ReadArrayStart()
-			if yyl2557 == 0 {
+			yyl2562 := r.ReadArrayStart()
+			if yyl2562 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2557, d)
+				x.codecDecodeSelfFromArray(yyl2562, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -30151,12 +30188,12 @@ func (x *DeleteOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2558Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2558Slc
-	var yyhl2558 bool = l >= 0
-	for yyj2558 := 0; ; yyj2558++ {
-		if yyhl2558 {
-			if yyj2558 >= l {
+	var yys2563Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2563Slc
+	var yyhl2563 bool = l >= 0
+	for yyj2563 := 0; ; yyj2563++ {
+		if yyhl2563 {
+			if yyj2563 >= l {
 				break
 			}
 		} else {
@@ -30164,9 +30201,9 @@ func (x *DeleteOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2558Slc = r.DecodeBytes(yys2558Slc, true, true)
-		yys2558 := string(yys2558Slc)
-		switch yys2558 {
+		yys2563Slc = r.DecodeBytes(yys2563Slc, true, true)
+		yys2563 := string(yys2563Slc)
+		switch yys2563 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -30188,18 +30225,18 @@ func (x *DeleteOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.GracePeriodSeconds == nil {
 					x.GracePeriodSeconds = new(int64)
 				}
-				yym2562 := z.DecBinary()
-				_ = yym2562
+				yym2567 := z.DecBinary()
+				_ = yym2567
 				if false {
 				} else {
 					*((*int64)(x.GracePeriodSeconds)) = int64(r.DecodeInt(64))
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2558)
-		} // end switch yys2558
-	} // end for yyj2558
-	if !yyhl2558 {
+			z.DecStructFieldNotFound(-1, yys2563)
+		} // end switch yys2563
+	} // end for yyj2563
+	if !yyhl2563 {
 		r.ReadEnd()
 	}
 }
@@ -30208,16 +30245,16 @@ func (x *DeleteOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2563 int
-	var yyb2563 bool
-	var yyhl2563 bool = l >= 0
-	yyj2563++
-	if yyhl2563 {
-		yyb2563 = yyj2563 > l
+	var yyj2568 int
+	var yyb2568 bool
+	var yyhl2568 bool = l >= 0
+	yyj2568++
+	if yyhl2568 {
+		yyb2568 = yyj2568 > l
 	} else {
-		yyb2563 = r.CheckBreak()
+		yyb2568 = r.CheckBreak()
 	}
-	if yyb2563 {
+	if yyb2568 {
 		r.ReadEnd()
 		return
 	}
@@ -30226,13 +30263,13 @@ func (x *DeleteOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2563++
-	if yyhl2563 {
-		yyb2563 = yyj2563 > l
+	yyj2568++
+	if yyhl2568 {
+		yyb2568 = yyj2568 > l
 	} else {
-		yyb2563 = r.CheckBreak()
+		yyb2568 = r.CheckBreak()
 	}
-	if yyb2563 {
+	if yyb2568 {
 		r.ReadEnd()
 		return
 	}
@@ -30241,13 +30278,13 @@ func (x *DeleteOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2563++
-	if yyhl2563 {
-		yyb2563 = yyj2563 > l
+	yyj2568++
+	if yyhl2568 {
+		yyb2568 = yyj2568 > l
 	} else {
-		yyb2563 = r.CheckBreak()
+		yyb2568 = r.CheckBreak()
 	}
-	if yyb2563 {
+	if yyb2568 {
 		r.ReadEnd()
 		return
 	}
@@ -30259,24 +30296,24 @@ func (x *DeleteOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.GracePeriodSeconds == nil {
 			x.GracePeriodSeconds = new(int64)
 		}
-		yym2567 := z.DecBinary()
-		_ = yym2567
+		yym2572 := z.DecBinary()
+		_ = yym2572
 		if false {
 		} else {
 			*((*int64)(x.GracePeriodSeconds)) = int64(r.DecodeInt(64))
 		}
 	}
 	for {
-		yyj2563++
-		if yyhl2563 {
-			yyb2563 = yyj2563 > l
+		yyj2568++
+		if yyhl2568 {
+			yyb2568 = yyj2568 > l
 		} else {
-			yyb2563 = r.CheckBreak()
+			yyb2568 = r.CheckBreak()
 		}
-		if yyb2563 {
+		if yyb2568 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2563-1, "")
+		z.DecStructFieldNotFound(yyj2568-1, "")
 	}
 	r.ReadEnd()
 }
@@ -30288,38 +30325,38 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2568 := z.EncBinary()
-		_ = yym2568
+		yym2573 := z.EncBinary()
+		_ = yym2573
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2569 := !z.EncBinary()
-			yy2arr2569 := z.EncBasicHandle().StructToArray
-			var yyq2569 [7]bool
-			_, _, _ = yysep2569, yyq2569, yy2arr2569
-			const yyr2569 bool = false
-			yyq2569[0] = x.Kind != ""
-			yyq2569[1] = x.APIVersion != ""
-			yyq2569[2] = x.LabelSelector != ""
-			yyq2569[3] = x.FieldSelector != ""
-			yyq2569[4] = x.Watch != false
-			yyq2569[5] = x.ResourceVersion != ""
-			yyq2569[6] = x.TimeoutSeconds != nil
-			if yyr2569 || yy2arr2569 {
+			yysep2574 := !z.EncBinary()
+			yy2arr2574 := z.EncBasicHandle().StructToArray
+			var yyq2574 [7]bool
+			_, _, _ = yysep2574, yyq2574, yy2arr2574
+			const yyr2574 bool = false
+			yyq2574[0] = x.Kind != ""
+			yyq2574[1] = x.APIVersion != ""
+			yyq2574[2] = x.LabelSelector != ""
+			yyq2574[3] = x.FieldSelector != ""
+			yyq2574[4] = x.Watch != false
+			yyq2574[5] = x.ResourceVersion != ""
+			yyq2574[6] = x.TimeoutSeconds != nil
+			if yyr2574 || yy2arr2574 {
 				r.EncodeArrayStart(7)
 			} else {
-				var yynn2569 int = 0
-				for _, b := range yyq2569 {
+				var yynn2574 int = 0
+				for _, b := range yyq2574 {
 					if b {
-						yynn2569++
+						yynn2574++
 					}
 				}
-				r.EncodeMapStart(yynn2569)
+				r.EncodeMapStart(yynn2574)
 			}
-			if yyr2569 || yy2arr2569 {
-				if yyq2569[0] {
-					yym2571 := z.EncBinary()
-					_ = yym2571
+			if yyr2574 || yy2arr2574 {
+				if yyq2574[0] {
+					yym2576 := z.EncBinary()
+					_ = yym2576
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -30328,86 +30365,86 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2569[0] {
+				if yyq2574[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2572 := z.EncBinary()
-					_ = yym2572
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2569 || yy2arr2569 {
-				if yyq2569[1] {
-					yym2574 := z.EncBinary()
-					_ = yym2574
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2569[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2575 := z.EncBinary()
-					_ = yym2575
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2569 || yy2arr2569 {
-				if yyq2569[2] {
 					yym2577 := z.EncBinary()
 					_ = yym2577
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.LabelSelector))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2574 || yy2arr2574 {
+				if yyq2574[1] {
+					yym2579 := z.EncBinary()
+					_ = yym2579
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2569[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("labelSelector"))
-					yym2578 := z.EncBinary()
-					_ = yym2578
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.LabelSelector))
-					}
-				}
-			}
-			if yyr2569 || yy2arr2569 {
-				if yyq2569[3] {
+				if yyq2574[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					yym2580 := z.EncBinary()
 					_ = yym2580
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr2574 || yy2arr2574 {
+				if yyq2574[2] {
+					yym2582 := z.EncBinary()
+					_ = yym2582
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.LabelSelector))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2574[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("labelSelector"))
+					yym2583 := z.EncBinary()
+					_ = yym2583
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.LabelSelector))
+					}
+				}
+			}
+			if yyr2574 || yy2arr2574 {
+				if yyq2574[3] {
+					yym2585 := z.EncBinary()
+					_ = yym2585
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.FieldSelector))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2569[3] {
+				if yyq2574[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("fieldSelector"))
-					yym2581 := z.EncBinary()
-					_ = yym2581
+					yym2586 := z.EncBinary()
+					_ = yym2586
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.FieldSelector))
 					}
 				}
 			}
-			if yyr2569 || yy2arr2569 {
-				if yyq2569[4] {
-					yym2583 := z.EncBinary()
-					_ = yym2583
+			if yyr2574 || yy2arr2574 {
+				if yyq2574[4] {
+					yym2588 := z.EncBinary()
+					_ = yym2588
 					if false {
 					} else {
 						r.EncodeBool(bool(x.Watch))
@@ -30416,20 +30453,20 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq2569[4] {
+				if yyq2574[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("watch"))
-					yym2584 := z.EncBinary()
-					_ = yym2584
+					yym2589 := z.EncBinary()
+					_ = yym2589
 					if false {
 					} else {
 						r.EncodeBool(bool(x.Watch))
 					}
 				}
 			}
-			if yyr2569 || yy2arr2569 {
-				if yyq2569[5] {
-					yym2586 := z.EncBinary()
-					_ = yym2586
+			if yyr2574 || yy2arr2574 {
+				if yyq2574[5] {
+					yym2591 := z.EncBinary()
+					_ = yym2591
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
@@ -30438,49 +30475,49 @@ func (x *ListOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2569[5] {
+				if yyq2574[5] {
 					r.EncodeString(codecSelferC_UTF81234, string("resourceVersion"))
-					yym2587 := z.EncBinary()
-					_ = yym2587
+					yym2592 := z.EncBinary()
+					_ = yym2592
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
 					}
 				}
 			}
-			if yyr2569 || yy2arr2569 {
-				if yyq2569[6] {
+			if yyr2574 || yy2arr2574 {
+				if yyq2574[6] {
 					if x.TimeoutSeconds == nil {
 						r.EncodeNil()
 					} else {
-						yy2589 := *x.TimeoutSeconds
-						yym2590 := z.EncBinary()
-						_ = yym2590
+						yy2594 := *x.TimeoutSeconds
+						yym2595 := z.EncBinary()
+						_ = yym2595
 						if false {
 						} else {
-							r.EncodeInt(int64(yy2589))
+							r.EncodeInt(int64(yy2594))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2569[6] {
+				if yyq2574[6] {
 					r.EncodeString(codecSelferC_UTF81234, string("timeoutSeconds"))
 					if x.TimeoutSeconds == nil {
 						r.EncodeNil()
 					} else {
-						yy2591 := *x.TimeoutSeconds
-						yym2592 := z.EncBinary()
-						_ = yym2592
+						yy2596 := *x.TimeoutSeconds
+						yym2597 := z.EncBinary()
+						_ = yym2597
 						if false {
 						} else {
-							r.EncodeInt(int64(yy2591))
+							r.EncodeInt(int64(yy2596))
 						}
 					}
 				}
 			}
-			if yysep2569 {
+			if yysep2574 {
 				r.EncodeEnd()
 			}
 		}
@@ -30491,24 +30528,24 @@ func (x *ListOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2593 := z.DecBinary()
-	_ = yym2593
+	yym2598 := z.DecBinary()
+	_ = yym2598
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2594 := r.ReadMapStart()
-			if yyl2594 == 0 {
+			yyl2599 := r.ReadMapStart()
+			if yyl2599 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2594, d)
+				x.codecDecodeSelfFromMap(yyl2599, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2594 := r.ReadArrayStart()
-			if yyl2594 == 0 {
+			yyl2599 := r.ReadArrayStart()
+			if yyl2599 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2594, d)
+				x.codecDecodeSelfFromArray(yyl2599, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -30520,12 +30557,12 @@ func (x *ListOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2595Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2595Slc
-	var yyhl2595 bool = l >= 0
-	for yyj2595 := 0; ; yyj2595++ {
-		if yyhl2595 {
-			if yyj2595 >= l {
+	var yys2600Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2600Slc
+	var yyhl2600 bool = l >= 0
+	for yyj2600 := 0; ; yyj2600++ {
+		if yyhl2600 {
+			if yyj2600 >= l {
 				break
 			}
 		} else {
@@ -30533,9 +30570,9 @@ func (x *ListOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2595Slc = r.DecodeBytes(yys2595Slc, true, true)
-		yys2595 := string(yys2595Slc)
-		switch yys2595 {
+		yys2600Slc = r.DecodeBytes(yys2600Slc, true, true)
+		yys2600 := string(yys2600Slc)
+		switch yys2600 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -30581,18 +30618,18 @@ func (x *ListOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TimeoutSeconds == nil {
 					x.TimeoutSeconds = new(int64)
 				}
-				yym2603 := z.DecBinary()
-				_ = yym2603
+				yym2608 := z.DecBinary()
+				_ = yym2608
 				if false {
 				} else {
 					*((*int64)(x.TimeoutSeconds)) = int64(r.DecodeInt(64))
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2595)
-		} // end switch yys2595
-	} // end for yyj2595
-	if !yyhl2595 {
+			z.DecStructFieldNotFound(-1, yys2600)
+		} // end switch yys2600
+	} // end for yyj2600
+	if !yyhl2600 {
 		r.ReadEnd()
 	}
 }
@@ -30601,16 +30638,16 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2604 int
-	var yyb2604 bool
-	var yyhl2604 bool = l >= 0
-	yyj2604++
-	if yyhl2604 {
-		yyb2604 = yyj2604 > l
+	var yyj2609 int
+	var yyb2609 bool
+	var yyhl2609 bool = l >= 0
+	yyj2609++
+	if yyhl2609 {
+		yyb2609 = yyj2609 > l
 	} else {
-		yyb2604 = r.CheckBreak()
+		yyb2609 = r.CheckBreak()
 	}
-	if yyb2604 {
+	if yyb2609 {
 		r.ReadEnd()
 		return
 	}
@@ -30619,13 +30656,13 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2604++
-	if yyhl2604 {
-		yyb2604 = yyj2604 > l
+	yyj2609++
+	if yyhl2609 {
+		yyb2609 = yyj2609 > l
 	} else {
-		yyb2604 = r.CheckBreak()
+		yyb2609 = r.CheckBreak()
 	}
-	if yyb2604 {
+	if yyb2609 {
 		r.ReadEnd()
 		return
 	}
@@ -30634,13 +30671,13 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2604++
-	if yyhl2604 {
-		yyb2604 = yyj2604 > l
+	yyj2609++
+	if yyhl2609 {
+		yyb2609 = yyj2609 > l
 	} else {
-		yyb2604 = r.CheckBreak()
+		yyb2609 = r.CheckBreak()
 	}
-	if yyb2604 {
+	if yyb2609 {
 		r.ReadEnd()
 		return
 	}
@@ -30649,13 +30686,13 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.LabelSelector = string(r.DecodeString())
 	}
-	yyj2604++
-	if yyhl2604 {
-		yyb2604 = yyj2604 > l
+	yyj2609++
+	if yyhl2609 {
+		yyb2609 = yyj2609 > l
 	} else {
-		yyb2604 = r.CheckBreak()
+		yyb2609 = r.CheckBreak()
 	}
-	if yyb2604 {
+	if yyb2609 {
 		r.ReadEnd()
 		return
 	}
@@ -30664,13 +30701,13 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.FieldSelector = string(r.DecodeString())
 	}
-	yyj2604++
-	if yyhl2604 {
-		yyb2604 = yyj2604 > l
+	yyj2609++
+	if yyhl2609 {
+		yyb2609 = yyj2609 > l
 	} else {
-		yyb2604 = r.CheckBreak()
+		yyb2609 = r.CheckBreak()
 	}
-	if yyb2604 {
+	if yyb2609 {
 		r.ReadEnd()
 		return
 	}
@@ -30679,13 +30716,13 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Watch = bool(r.DecodeBool())
 	}
-	yyj2604++
-	if yyhl2604 {
-		yyb2604 = yyj2604 > l
+	yyj2609++
+	if yyhl2609 {
+		yyb2609 = yyj2609 > l
 	} else {
-		yyb2604 = r.CheckBreak()
+		yyb2609 = r.CheckBreak()
 	}
-	if yyb2604 {
+	if yyb2609 {
 		r.ReadEnd()
 		return
 	}
@@ -30694,13 +30731,13 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.ResourceVersion = string(r.DecodeString())
 	}
-	yyj2604++
-	if yyhl2604 {
-		yyb2604 = yyj2604 > l
+	yyj2609++
+	if yyhl2609 {
+		yyb2609 = yyj2609 > l
 	} else {
-		yyb2604 = r.CheckBreak()
+		yyb2609 = r.CheckBreak()
 	}
-	if yyb2604 {
+	if yyb2609 {
 		r.ReadEnd()
 		return
 	}
@@ -30712,24 +30749,24 @@ func (x *ListOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TimeoutSeconds == nil {
 			x.TimeoutSeconds = new(int64)
 		}
-		yym2612 := z.DecBinary()
-		_ = yym2612
+		yym2617 := z.DecBinary()
+		_ = yym2617
 		if false {
 		} else {
 			*((*int64)(x.TimeoutSeconds)) = int64(r.DecodeInt(64))
 		}
 	}
 	for {
-		yyj2604++
-		if yyhl2604 {
-			yyb2604 = yyj2604 > l
+		yyj2609++
+		if yyhl2609 {
+			yyb2609 = yyj2609 > l
 		} else {
-			yyb2604 = r.CheckBreak()
+			yyb2609 = r.CheckBreak()
 		}
-		if yyb2604 {
+		if yyb2609 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2604-1, "")
+		z.DecStructFieldNotFound(yyj2609-1, "")
 	}
 	r.ReadEnd()
 }
@@ -30741,41 +30778,41 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2613 := z.EncBinary()
-		_ = yym2613
+		yym2618 := z.EncBinary()
+		_ = yym2618
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2614 := !z.EncBinary()
-			yy2arr2614 := z.EncBasicHandle().StructToArray
-			var yyq2614 [10]bool
-			_, _, _ = yysep2614, yyq2614, yy2arr2614
-			const yyr2614 bool = false
-			yyq2614[0] = x.Kind != ""
-			yyq2614[1] = x.APIVersion != ""
-			yyq2614[2] = x.Container != ""
-			yyq2614[3] = x.Follow != false
-			yyq2614[4] = x.Previous != false
-			yyq2614[5] = x.SinceSeconds != nil
-			yyq2614[6] = x.SinceTime != nil
-			yyq2614[7] = x.Timestamps != false
-			yyq2614[8] = x.TailLines != nil
-			yyq2614[9] = x.LimitBytes != nil
-			if yyr2614 || yy2arr2614 {
+			yysep2619 := !z.EncBinary()
+			yy2arr2619 := z.EncBasicHandle().StructToArray
+			var yyq2619 [10]bool
+			_, _, _ = yysep2619, yyq2619, yy2arr2619
+			const yyr2619 bool = false
+			yyq2619[0] = x.Kind != ""
+			yyq2619[1] = x.APIVersion != ""
+			yyq2619[2] = x.Container != ""
+			yyq2619[3] = x.Follow != false
+			yyq2619[4] = x.Previous != false
+			yyq2619[5] = x.SinceSeconds != nil
+			yyq2619[6] = x.SinceTime != nil
+			yyq2619[7] = x.Timestamps != false
+			yyq2619[8] = x.TailLines != nil
+			yyq2619[9] = x.LimitBytes != nil
+			if yyr2619 || yy2arr2619 {
 				r.EncodeArrayStart(10)
 			} else {
-				var yynn2614 int = 0
-				for _, b := range yyq2614 {
+				var yynn2619 int = 0
+				for _, b := range yyq2619 {
 					if b {
-						yynn2614++
+						yynn2619++
 					}
 				}
-				r.EncodeMapStart(yynn2614)
+				r.EncodeMapStart(yynn2619)
 			}
-			if yyr2614 || yy2arr2614 {
-				if yyq2614[0] {
-					yym2616 := z.EncBinary()
-					_ = yym2616
+			if yyr2619 || yy2arr2619 {
+				if yyq2619[0] {
+					yym2621 := z.EncBinary()
+					_ = yym2621
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -30784,64 +30821,64 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2614[0] {
+				if yyq2619[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2617 := z.EncBinary()
-					_ = yym2617
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2614 || yy2arr2614 {
-				if yyq2614[1] {
-					yym2619 := z.EncBinary()
-					_ = yym2619
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2614[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2620 := z.EncBinary()
-					_ = yym2620
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2614 || yy2arr2614 {
-				if yyq2614[2] {
 					yym2622 := z.EncBinary()
 					_ = yym2622
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2619 || yy2arr2619 {
+				if yyq2619[1] {
+					yym2624 := z.EncBinary()
+					_ = yym2624
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2619[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym2625 := z.EncBinary()
+					_ = yym2625
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr2619 || yy2arr2619 {
+				if yyq2619[2] {
+					yym2627 := z.EncBinary()
+					_ = yym2627
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Container))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2614[2] {
+				if yyq2619[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("container"))
-					yym2623 := z.EncBinary()
-					_ = yym2623
+					yym2628 := z.EncBinary()
+					_ = yym2628
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Container))
 					}
 				}
 			}
-			if yyr2614 || yy2arr2614 {
-				if yyq2614[3] {
-					yym2625 := z.EncBinary()
-					_ = yym2625
+			if yyr2619 || yy2arr2619 {
+				if yyq2619[3] {
+					yym2630 := z.EncBinary()
+					_ = yym2630
 					if false {
 					} else {
 						r.EncodeBool(bool(x.Follow))
@@ -30850,20 +30887,20 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq2614[3] {
+				if yyq2619[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("follow"))
-					yym2626 := z.EncBinary()
-					_ = yym2626
+					yym2631 := z.EncBinary()
+					_ = yym2631
 					if false {
 					} else {
 						r.EncodeBool(bool(x.Follow))
 					}
 				}
 			}
-			if yyr2614 || yy2arr2614 {
-				if yyq2614[4] {
-					yym2628 := z.EncBinary()
-					_ = yym2628
+			if yyr2619 || yy2arr2619 {
+				if yyq2619[4] {
+					yym2633 := z.EncBinary()
+					_ = yym2633
 					if false {
 					} else {
 						r.EncodeBool(bool(x.Previous))
@@ -30872,60 +30909,60 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq2614[4] {
+				if yyq2619[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("previous"))
-					yym2629 := z.EncBinary()
-					_ = yym2629
+					yym2634 := z.EncBinary()
+					_ = yym2634
 					if false {
 					} else {
 						r.EncodeBool(bool(x.Previous))
 					}
 				}
 			}
-			if yyr2614 || yy2arr2614 {
-				if yyq2614[5] {
+			if yyr2619 || yy2arr2619 {
+				if yyq2619[5] {
 					if x.SinceSeconds == nil {
 						r.EncodeNil()
 					} else {
-						yy2631 := *x.SinceSeconds
-						yym2632 := z.EncBinary()
-						_ = yym2632
+						yy2636 := *x.SinceSeconds
+						yym2637 := z.EncBinary()
+						_ = yym2637
 						if false {
 						} else {
-							r.EncodeInt(int64(yy2631))
+							r.EncodeInt(int64(yy2636))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2614[5] {
+				if yyq2619[5] {
 					r.EncodeString(codecSelferC_UTF81234, string("sinceSeconds"))
 					if x.SinceSeconds == nil {
 						r.EncodeNil()
 					} else {
-						yy2633 := *x.SinceSeconds
-						yym2634 := z.EncBinary()
-						_ = yym2634
+						yy2638 := *x.SinceSeconds
+						yym2639 := z.EncBinary()
+						_ = yym2639
 						if false {
 						} else {
-							r.EncodeInt(int64(yy2633))
+							r.EncodeInt(int64(yy2638))
 						}
 					}
 				}
 			}
-			if yyr2614 || yy2arr2614 {
-				if yyq2614[6] {
+			if yyr2619 || yy2arr2619 {
+				if yyq2619[6] {
 					if x.SinceTime == nil {
 						r.EncodeNil()
 					} else {
-						yym2636 := z.EncBinary()
-						_ = yym2636
+						yym2641 := z.EncBinary()
+						_ = yym2641
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.SinceTime) {
-						} else if yym2636 {
+						} else if yym2641 {
 							z.EncBinaryMarshal(x.SinceTime)
-						} else if !yym2636 && z.IsJSONHandle() {
+						} else if !yym2641 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.SinceTime)
 						} else {
 							z.EncFallback(x.SinceTime)
@@ -30935,18 +30972,18 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2614[6] {
+				if yyq2619[6] {
 					r.EncodeString(codecSelferC_UTF81234, string("sinceTime"))
 					if x.SinceTime == nil {
 						r.EncodeNil()
 					} else {
-						yym2637 := z.EncBinary()
-						_ = yym2637
+						yym2642 := z.EncBinary()
+						_ = yym2642
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.SinceTime) {
-						} else if yym2637 {
+						} else if yym2642 {
 							z.EncBinaryMarshal(x.SinceTime)
-						} else if !yym2637 && z.IsJSONHandle() {
+						} else if !yym2642 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.SinceTime)
 						} else {
 							z.EncFallback(x.SinceTime)
@@ -30954,10 +30991,10 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr2614 || yy2arr2614 {
-				if yyq2614[7] {
-					yym2639 := z.EncBinary()
-					_ = yym2639
+			if yyr2619 || yy2arr2619 {
+				if yyq2619[7] {
+					yym2644 := z.EncBinary()
+					_ = yym2644
 					if false {
 					} else {
 						r.EncodeBool(bool(x.Timestamps))
@@ -30966,54 +31003,22 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq2614[7] {
+				if yyq2619[7] {
 					r.EncodeString(codecSelferC_UTF81234, string("timestamps"))
-					yym2640 := z.EncBinary()
-					_ = yym2640
+					yym2645 := z.EncBinary()
+					_ = yym2645
 					if false {
 					} else {
 						r.EncodeBool(bool(x.Timestamps))
 					}
 				}
 			}
-			if yyr2614 || yy2arr2614 {
-				if yyq2614[8] {
+			if yyr2619 || yy2arr2619 {
+				if yyq2619[8] {
 					if x.TailLines == nil {
 						r.EncodeNil()
 					} else {
-						yy2642 := *x.TailLines
-						yym2643 := z.EncBinary()
-						_ = yym2643
-						if false {
-						} else {
-							r.EncodeInt(int64(yy2642))
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2614[8] {
-					r.EncodeString(codecSelferC_UTF81234, string("tailLines"))
-					if x.TailLines == nil {
-						r.EncodeNil()
-					} else {
-						yy2644 := *x.TailLines
-						yym2645 := z.EncBinary()
-						_ = yym2645
-						if false {
-						} else {
-							r.EncodeInt(int64(yy2644))
-						}
-					}
-				}
-			}
-			if yyr2614 || yy2arr2614 {
-				if yyq2614[9] {
-					if x.LimitBytes == nil {
-						r.EncodeNil()
-					} else {
-						yy2647 := *x.LimitBytes
+						yy2647 := *x.TailLines
 						yym2648 := z.EncBinary()
 						_ = yym2648
 						if false {
@@ -31025,12 +31030,12 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2614[9] {
-					r.EncodeString(codecSelferC_UTF81234, string("limitBytes"))
-					if x.LimitBytes == nil {
+				if yyq2619[8] {
+					r.EncodeString(codecSelferC_UTF81234, string("tailLines"))
+					if x.TailLines == nil {
 						r.EncodeNil()
 					} else {
-						yy2649 := *x.LimitBytes
+						yy2649 := *x.TailLines
 						yym2650 := z.EncBinary()
 						_ = yym2650
 						if false {
@@ -31040,7 +31045,39 @@ func (x *PodLogOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep2614 {
+			if yyr2619 || yy2arr2619 {
+				if yyq2619[9] {
+					if x.LimitBytes == nil {
+						r.EncodeNil()
+					} else {
+						yy2652 := *x.LimitBytes
+						yym2653 := z.EncBinary()
+						_ = yym2653
+						if false {
+						} else {
+							r.EncodeInt(int64(yy2652))
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq2619[9] {
+					r.EncodeString(codecSelferC_UTF81234, string("limitBytes"))
+					if x.LimitBytes == nil {
+						r.EncodeNil()
+					} else {
+						yy2654 := *x.LimitBytes
+						yym2655 := z.EncBinary()
+						_ = yym2655
+						if false {
+						} else {
+							r.EncodeInt(int64(yy2654))
+						}
+					}
+				}
+			}
+			if yysep2619 {
 				r.EncodeEnd()
 			}
 		}
@@ -31051,24 +31088,24 @@ func (x *PodLogOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2651 := z.DecBinary()
-	_ = yym2651
+	yym2656 := z.DecBinary()
+	_ = yym2656
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2652 := r.ReadMapStart()
-			if yyl2652 == 0 {
+			yyl2657 := r.ReadMapStart()
+			if yyl2657 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2652, d)
+				x.codecDecodeSelfFromMap(yyl2657, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2652 := r.ReadArrayStart()
-			if yyl2652 == 0 {
+			yyl2657 := r.ReadArrayStart()
+			if yyl2657 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2652, d)
+				x.codecDecodeSelfFromArray(yyl2657, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -31080,12 +31117,12 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2653Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2653Slc
-	var yyhl2653 bool = l >= 0
-	for yyj2653 := 0; ; yyj2653++ {
-		if yyhl2653 {
-			if yyj2653 >= l {
+	var yys2658Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2658Slc
+	var yyhl2658 bool = l >= 0
+	for yyj2658 := 0; ; yyj2658++ {
+		if yyhl2658 {
+			if yyj2658 >= l {
 				break
 			}
 		} else {
@@ -31093,9 +31130,9 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2653Slc = r.DecodeBytes(yys2653Slc, true, true)
-		yys2653 := string(yys2653Slc)
-		switch yys2653 {
+		yys2658Slc = r.DecodeBytes(yys2658Slc, true, true)
+		yys2658 := string(yys2658Slc)
+		switch yys2658 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -31135,8 +31172,8 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.SinceSeconds == nil {
 					x.SinceSeconds = new(int64)
 				}
-				yym2660 := z.DecBinary()
-				_ = yym2660
+				yym2665 := z.DecBinary()
+				_ = yym2665
 				if false {
 				} else {
 					*((*int64)(x.SinceSeconds)) = int64(r.DecodeInt(64))
@@ -31151,13 +31188,13 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.SinceTime == nil {
 					x.SinceTime = new(pkg2_unversioned.Time)
 				}
-				yym2662 := z.DecBinary()
-				_ = yym2662
+				yym2667 := z.DecBinary()
+				_ = yym2667
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.SinceTime) {
-				} else if yym2662 {
+				} else if yym2667 {
 					z.DecBinaryUnmarshal(x.SinceTime)
-				} else if !yym2662 && z.IsJSONHandle() {
+				} else if !yym2667 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.SinceTime)
 				} else {
 					z.DecFallback(x.SinceTime, false)
@@ -31178,8 +31215,8 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.TailLines == nil {
 					x.TailLines = new(int64)
 				}
-				yym2665 := z.DecBinary()
-				_ = yym2665
+				yym2670 := z.DecBinary()
+				_ = yym2670
 				if false {
 				} else {
 					*((*int64)(x.TailLines)) = int64(r.DecodeInt(64))
@@ -31194,18 +31231,18 @@ func (x *PodLogOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.LimitBytes == nil {
 					x.LimitBytes = new(int64)
 				}
-				yym2667 := z.DecBinary()
-				_ = yym2667
+				yym2672 := z.DecBinary()
+				_ = yym2672
 				if false {
 				} else {
 					*((*int64)(x.LimitBytes)) = int64(r.DecodeInt(64))
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2653)
-		} // end switch yys2653
-	} // end for yyj2653
-	if !yyhl2653 {
+			z.DecStructFieldNotFound(-1, yys2658)
+		} // end switch yys2658
+	} // end for yyj2658
+	if !yyhl2658 {
 		r.ReadEnd()
 	}
 }
@@ -31214,16 +31251,16 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2668 int
-	var yyb2668 bool
-	var yyhl2668 bool = l >= 0
-	yyj2668++
-	if yyhl2668 {
-		yyb2668 = yyj2668 > l
+	var yyj2673 int
+	var yyb2673 bool
+	var yyhl2673 bool = l >= 0
+	yyj2673++
+	if yyhl2673 {
+		yyb2673 = yyj2673 > l
 	} else {
-		yyb2668 = r.CheckBreak()
+		yyb2673 = r.CheckBreak()
 	}
-	if yyb2668 {
+	if yyb2673 {
 		r.ReadEnd()
 		return
 	}
@@ -31232,13 +31269,13 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2668++
-	if yyhl2668 {
-		yyb2668 = yyj2668 > l
+	yyj2673++
+	if yyhl2673 {
+		yyb2673 = yyj2673 > l
 	} else {
-		yyb2668 = r.CheckBreak()
+		yyb2673 = r.CheckBreak()
 	}
-	if yyb2668 {
+	if yyb2673 {
 		r.ReadEnd()
 		return
 	}
@@ -31247,13 +31284,13 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2668++
-	if yyhl2668 {
-		yyb2668 = yyj2668 > l
+	yyj2673++
+	if yyhl2673 {
+		yyb2673 = yyj2673 > l
 	} else {
-		yyb2668 = r.CheckBreak()
+		yyb2673 = r.CheckBreak()
 	}
-	if yyb2668 {
+	if yyb2673 {
 		r.ReadEnd()
 		return
 	}
@@ -31262,13 +31299,13 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Container = string(r.DecodeString())
 	}
-	yyj2668++
-	if yyhl2668 {
-		yyb2668 = yyj2668 > l
+	yyj2673++
+	if yyhl2673 {
+		yyb2673 = yyj2673 > l
 	} else {
-		yyb2668 = r.CheckBreak()
+		yyb2673 = r.CheckBreak()
 	}
-	if yyb2668 {
+	if yyb2673 {
 		r.ReadEnd()
 		return
 	}
@@ -31277,13 +31314,13 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Follow = bool(r.DecodeBool())
 	}
-	yyj2668++
-	if yyhl2668 {
-		yyb2668 = yyj2668 > l
+	yyj2673++
+	if yyhl2673 {
+		yyb2673 = yyj2673 > l
 	} else {
-		yyb2668 = r.CheckBreak()
+		yyb2673 = r.CheckBreak()
 	}
-	if yyb2668 {
+	if yyb2673 {
 		r.ReadEnd()
 		return
 	}
@@ -31292,13 +31329,13 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Previous = bool(r.DecodeBool())
 	}
-	yyj2668++
-	if yyhl2668 {
-		yyb2668 = yyj2668 > l
+	yyj2673++
+	if yyhl2673 {
+		yyb2673 = yyj2673 > l
 	} else {
-		yyb2668 = r.CheckBreak()
+		yyb2673 = r.CheckBreak()
 	}
-	if yyb2668 {
+	if yyb2673 {
 		r.ReadEnd()
 		return
 	}
@@ -31310,20 +31347,20 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.SinceSeconds == nil {
 			x.SinceSeconds = new(int64)
 		}
-		yym2675 := z.DecBinary()
-		_ = yym2675
+		yym2680 := z.DecBinary()
+		_ = yym2680
 		if false {
 		} else {
 			*((*int64)(x.SinceSeconds)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj2668++
-	if yyhl2668 {
-		yyb2668 = yyj2668 > l
+	yyj2673++
+	if yyhl2673 {
+		yyb2673 = yyj2673 > l
 	} else {
-		yyb2668 = r.CheckBreak()
+		yyb2673 = r.CheckBreak()
 	}
-	if yyb2668 {
+	if yyb2673 {
 		r.ReadEnd()
 		return
 	}
@@ -31335,25 +31372,25 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.SinceTime == nil {
 			x.SinceTime = new(pkg2_unversioned.Time)
 		}
-		yym2677 := z.DecBinary()
-		_ = yym2677
+		yym2682 := z.DecBinary()
+		_ = yym2682
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.SinceTime) {
-		} else if yym2677 {
+		} else if yym2682 {
 			z.DecBinaryUnmarshal(x.SinceTime)
-		} else if !yym2677 && z.IsJSONHandle() {
+		} else if !yym2682 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.SinceTime)
 		} else {
 			z.DecFallback(x.SinceTime, false)
 		}
 	}
-	yyj2668++
-	if yyhl2668 {
-		yyb2668 = yyj2668 > l
+	yyj2673++
+	if yyhl2673 {
+		yyb2673 = yyj2673 > l
 	} else {
-		yyb2668 = r.CheckBreak()
+		yyb2673 = r.CheckBreak()
 	}
-	if yyb2668 {
+	if yyb2673 {
 		r.ReadEnd()
 		return
 	}
@@ -31362,13 +31399,13 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Timestamps = bool(r.DecodeBool())
 	}
-	yyj2668++
-	if yyhl2668 {
-		yyb2668 = yyj2668 > l
+	yyj2673++
+	if yyhl2673 {
+		yyb2673 = yyj2673 > l
 	} else {
-		yyb2668 = r.CheckBreak()
+		yyb2673 = r.CheckBreak()
 	}
-	if yyb2668 {
+	if yyb2673 {
 		r.ReadEnd()
 		return
 	}
@@ -31380,20 +31417,20 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.TailLines == nil {
 			x.TailLines = new(int64)
 		}
-		yym2680 := z.DecBinary()
-		_ = yym2680
+		yym2685 := z.DecBinary()
+		_ = yym2685
 		if false {
 		} else {
 			*((*int64)(x.TailLines)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj2668++
-	if yyhl2668 {
-		yyb2668 = yyj2668 > l
+	yyj2673++
+	if yyhl2673 {
+		yyb2673 = yyj2673 > l
 	} else {
-		yyb2668 = r.CheckBreak()
+		yyb2673 = r.CheckBreak()
 	}
-	if yyb2668 {
+	if yyb2673 {
 		r.ReadEnd()
 		return
 	}
@@ -31405,24 +31442,24 @@ func (x *PodLogOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.LimitBytes == nil {
 			x.LimitBytes = new(int64)
 		}
-		yym2682 := z.DecBinary()
-		_ = yym2682
+		yym2687 := z.DecBinary()
+		_ = yym2687
 		if false {
 		} else {
 			*((*int64)(x.LimitBytes)) = int64(r.DecodeInt(64))
 		}
 	}
 	for {
-		yyj2668++
-		if yyhl2668 {
-			yyb2668 = yyj2668 > l
+		yyj2673++
+		if yyhl2673 {
+			yyb2673 = yyj2673 > l
 		} else {
-			yyb2668 = r.CheckBreak()
+			yyb2673 = r.CheckBreak()
 		}
-		if yyb2668 {
+		if yyb2673 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2668-1, "")
+		z.DecStructFieldNotFound(yyj2673-1, "")
 	}
 	r.ReadEnd()
 }
@@ -31434,38 +31471,38 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2683 := z.EncBinary()
-		_ = yym2683
+		yym2688 := z.EncBinary()
+		_ = yym2688
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2684 := !z.EncBinary()
-			yy2arr2684 := z.EncBasicHandle().StructToArray
-			var yyq2684 [7]bool
-			_, _, _ = yysep2684, yyq2684, yy2arr2684
-			const yyr2684 bool = false
-			yyq2684[0] = x.Kind != ""
-			yyq2684[1] = x.APIVersion != ""
-			yyq2684[2] = x.Stdin != false
-			yyq2684[3] = x.Stdout != false
-			yyq2684[4] = x.Stderr != false
-			yyq2684[5] = x.TTY != false
-			yyq2684[6] = x.Container != ""
-			if yyr2684 || yy2arr2684 {
+			yysep2689 := !z.EncBinary()
+			yy2arr2689 := z.EncBasicHandle().StructToArray
+			var yyq2689 [7]bool
+			_, _, _ = yysep2689, yyq2689, yy2arr2689
+			const yyr2689 bool = false
+			yyq2689[0] = x.Kind != ""
+			yyq2689[1] = x.APIVersion != ""
+			yyq2689[2] = x.Stdin != false
+			yyq2689[3] = x.Stdout != false
+			yyq2689[4] = x.Stderr != false
+			yyq2689[5] = x.TTY != false
+			yyq2689[6] = x.Container != ""
+			if yyr2689 || yy2arr2689 {
 				r.EncodeArrayStart(7)
 			} else {
-				var yynn2684 int = 0
-				for _, b := range yyq2684 {
+				var yynn2689 int = 0
+				for _, b := range yyq2689 {
 					if b {
-						yynn2684++
+						yynn2689++
 					}
 				}
-				r.EncodeMapStart(yynn2684)
+				r.EncodeMapStart(yynn2689)
 			}
-			if yyr2684 || yy2arr2684 {
-				if yyq2684[0] {
-					yym2686 := z.EncBinary()
-					_ = yym2686
+			if yyr2689 || yy2arr2689 {
+				if yyq2689[0] {
+					yym2691 := z.EncBinary()
+					_ = yym2691
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -31474,130 +31511,130 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2684[0] {
+				if yyq2689[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2687 := z.EncBinary()
-					_ = yym2687
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2684 || yy2arr2684 {
-				if yyq2684[1] {
-					yym2689 := z.EncBinary()
-					_ = yym2689
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2684[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2690 := z.EncBinary()
-					_ = yym2690
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2684 || yy2arr2684 {
-				if yyq2684[2] {
 					yym2692 := z.EncBinary()
 					_ = yym2692
 					if false {
 					} else {
-						r.EncodeBool(bool(x.Stdin))
-					}
-				} else {
-					r.EncodeBool(false)
-				}
-			} else {
-				if yyq2684[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("stdin"))
-					yym2693 := z.EncBinary()
-					_ = yym2693
-					if false {
-					} else {
-						r.EncodeBool(bool(x.Stdin))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2684 || yy2arr2684 {
-				if yyq2684[3] {
+			if yyr2689 || yy2arr2689 {
+				if yyq2689[1] {
+					yym2694 := z.EncBinary()
+					_ = yym2694
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2689[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					yym2695 := z.EncBinary()
 					_ = yym2695
 					if false {
 					} else {
-						r.EncodeBool(bool(x.Stdout))
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr2689 || yy2arr2689 {
+				if yyq2689[2] {
+					yym2697 := z.EncBinary()
+					_ = yym2697
+					if false {
+					} else {
+						r.EncodeBool(bool(x.Stdin))
 					}
 				} else {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq2684[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("stdout"))
-					yym2696 := z.EncBinary()
-					_ = yym2696
-					if false {
-					} else {
-						r.EncodeBool(bool(x.Stdout))
-					}
-				}
-			}
-			if yyr2684 || yy2arr2684 {
-				if yyq2684[4] {
+				if yyq2689[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("stdin"))
 					yym2698 := z.EncBinary()
 					_ = yym2698
 					if false {
 					} else {
-						r.EncodeBool(bool(x.Stderr))
+						r.EncodeBool(bool(x.Stdin))
+					}
+				}
+			}
+			if yyr2689 || yy2arr2689 {
+				if yyq2689[3] {
+					yym2700 := z.EncBinary()
+					_ = yym2700
+					if false {
+					} else {
+						r.EncodeBool(bool(x.Stdout))
 					}
 				} else {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq2684[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("stderr"))
-					yym2699 := z.EncBinary()
-					_ = yym2699
-					if false {
-					} else {
-						r.EncodeBool(bool(x.Stderr))
-					}
-				}
-			}
-			if yyr2684 || yy2arr2684 {
-				if yyq2684[5] {
+				if yyq2689[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("stdout"))
 					yym2701 := z.EncBinary()
 					_ = yym2701
 					if false {
 					} else {
+						r.EncodeBool(bool(x.Stdout))
+					}
+				}
+			}
+			if yyr2689 || yy2arr2689 {
+				if yyq2689[4] {
+					yym2703 := z.EncBinary()
+					_ = yym2703
+					if false {
+					} else {
+						r.EncodeBool(bool(x.Stderr))
+					}
+				} else {
+					r.EncodeBool(false)
+				}
+			} else {
+				if yyq2689[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("stderr"))
+					yym2704 := z.EncBinary()
+					_ = yym2704
+					if false {
+					} else {
+						r.EncodeBool(bool(x.Stderr))
+					}
+				}
+			}
+			if yyr2689 || yy2arr2689 {
+				if yyq2689[5] {
+					yym2706 := z.EncBinary()
+					_ = yym2706
+					if false {
+					} else {
 						r.EncodeBool(bool(x.TTY))
 					}
 				} else {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq2684[5] {
+				if yyq2689[5] {
 					r.EncodeString(codecSelferC_UTF81234, string("tty"))
-					yym2702 := z.EncBinary()
-					_ = yym2702
+					yym2707 := z.EncBinary()
+					_ = yym2707
 					if false {
 					} else {
 						r.EncodeBool(bool(x.TTY))
 					}
 				}
 			}
-			if yyr2684 || yy2arr2684 {
-				if yyq2684[6] {
-					yym2704 := z.EncBinary()
-					_ = yym2704
+			if yyr2689 || yy2arr2689 {
+				if yyq2689[6] {
+					yym2709 := z.EncBinary()
+					_ = yym2709
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Container))
@@ -31606,17 +31643,17 @@ func (x *PodAttachOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2684[6] {
+				if yyq2689[6] {
 					r.EncodeString(codecSelferC_UTF81234, string("container"))
-					yym2705 := z.EncBinary()
-					_ = yym2705
+					yym2710 := z.EncBinary()
+					_ = yym2710
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Container))
 					}
 				}
 			}
-			if yysep2684 {
+			if yysep2689 {
 				r.EncodeEnd()
 			}
 		}
@@ -31627,24 +31664,24 @@ func (x *PodAttachOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2706 := z.DecBinary()
-	_ = yym2706
+	yym2711 := z.DecBinary()
+	_ = yym2711
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2707 := r.ReadMapStart()
-			if yyl2707 == 0 {
+			yyl2712 := r.ReadMapStart()
+			if yyl2712 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2707, d)
+				x.codecDecodeSelfFromMap(yyl2712, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2707 := r.ReadArrayStart()
-			if yyl2707 == 0 {
+			yyl2712 := r.ReadArrayStart()
+			if yyl2712 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2707, d)
+				x.codecDecodeSelfFromArray(yyl2712, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -31656,12 +31693,12 @@ func (x *PodAttachOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2708Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2708Slc
-	var yyhl2708 bool = l >= 0
-	for yyj2708 := 0; ; yyj2708++ {
-		if yyhl2708 {
-			if yyj2708 >= l {
+	var yys2713Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2713Slc
+	var yyhl2713 bool = l >= 0
+	for yyj2713 := 0; ; yyj2713++ {
+		if yyhl2713 {
+			if yyj2713 >= l {
 				break
 			}
 		} else {
@@ -31669,9 +31706,9 @@ func (x *PodAttachOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2708Slc = r.DecodeBytes(yys2708Slc, true, true)
-		yys2708 := string(yys2708Slc)
-		switch yys2708 {
+		yys2713Slc = r.DecodeBytes(yys2713Slc, true, true)
+		yys2713 := string(yys2713Slc)
+		switch yys2713 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -31715,10 +31752,10 @@ func (x *PodAttachOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Container = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2708)
-		} // end switch yys2708
-	} // end for yyj2708
-	if !yyhl2708 {
+			z.DecStructFieldNotFound(-1, yys2713)
+		} // end switch yys2713
+	} // end for yyj2713
+	if !yyhl2713 {
 		r.ReadEnd()
 	}
 }
@@ -31727,16 +31764,16 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2716 int
-	var yyb2716 bool
-	var yyhl2716 bool = l >= 0
-	yyj2716++
-	if yyhl2716 {
-		yyb2716 = yyj2716 > l
+	var yyj2721 int
+	var yyb2721 bool
+	var yyhl2721 bool = l >= 0
+	yyj2721++
+	if yyhl2721 {
+		yyb2721 = yyj2721 > l
 	} else {
-		yyb2716 = r.CheckBreak()
+		yyb2721 = r.CheckBreak()
 	}
-	if yyb2716 {
+	if yyb2721 {
 		r.ReadEnd()
 		return
 	}
@@ -31745,13 +31782,13 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2716++
-	if yyhl2716 {
-		yyb2716 = yyj2716 > l
+	yyj2721++
+	if yyhl2721 {
+		yyb2721 = yyj2721 > l
 	} else {
-		yyb2716 = r.CheckBreak()
+		yyb2721 = r.CheckBreak()
 	}
-	if yyb2716 {
+	if yyb2721 {
 		r.ReadEnd()
 		return
 	}
@@ -31760,13 +31797,13 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2716++
-	if yyhl2716 {
-		yyb2716 = yyj2716 > l
+	yyj2721++
+	if yyhl2721 {
+		yyb2721 = yyj2721 > l
 	} else {
-		yyb2716 = r.CheckBreak()
+		yyb2721 = r.CheckBreak()
 	}
-	if yyb2716 {
+	if yyb2721 {
 		r.ReadEnd()
 		return
 	}
@@ -31775,13 +31812,13 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.Stdin = bool(r.DecodeBool())
 	}
-	yyj2716++
-	if yyhl2716 {
-		yyb2716 = yyj2716 > l
+	yyj2721++
+	if yyhl2721 {
+		yyb2721 = yyj2721 > l
 	} else {
-		yyb2716 = r.CheckBreak()
+		yyb2721 = r.CheckBreak()
 	}
-	if yyb2716 {
+	if yyb2721 {
 		r.ReadEnd()
 		return
 	}
@@ -31790,13 +31827,13 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.Stdout = bool(r.DecodeBool())
 	}
-	yyj2716++
-	if yyhl2716 {
-		yyb2716 = yyj2716 > l
+	yyj2721++
+	if yyhl2721 {
+		yyb2721 = yyj2721 > l
 	} else {
-		yyb2716 = r.CheckBreak()
+		yyb2721 = r.CheckBreak()
 	}
-	if yyb2716 {
+	if yyb2721 {
 		r.ReadEnd()
 		return
 	}
@@ -31805,13 +31842,13 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.Stderr = bool(r.DecodeBool())
 	}
-	yyj2716++
-	if yyhl2716 {
-		yyb2716 = yyj2716 > l
+	yyj2721++
+	if yyhl2721 {
+		yyb2721 = yyj2721 > l
 	} else {
-		yyb2716 = r.CheckBreak()
+		yyb2721 = r.CheckBreak()
 	}
-	if yyb2716 {
+	if yyb2721 {
 		r.ReadEnd()
 		return
 	}
@@ -31820,13 +31857,13 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.TTY = bool(r.DecodeBool())
 	}
-	yyj2716++
-	if yyhl2716 {
-		yyb2716 = yyj2716 > l
+	yyj2721++
+	if yyhl2721 {
+		yyb2721 = yyj2721 > l
 	} else {
-		yyb2716 = r.CheckBreak()
+		yyb2721 = r.CheckBreak()
 	}
-	if yyb2716 {
+	if yyb2721 {
 		r.ReadEnd()
 		return
 	}
@@ -31836,16 +31873,16 @@ func (x *PodAttachOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		x.Container = string(r.DecodeString())
 	}
 	for {
-		yyj2716++
-		if yyhl2716 {
-			yyb2716 = yyj2716 > l
+		yyj2721++
+		if yyhl2721 {
+			yyb2721 = yyj2721 > l
 		} else {
-			yyb2716 = r.CheckBreak()
+			yyb2721 = r.CheckBreak()
 		}
-		if yyb2716 {
+		if yyb2721 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2716-1, "")
+		z.DecStructFieldNotFound(yyj2721-1, "")
 	}
 	r.ReadEnd()
 }
@@ -31857,38 +31894,38 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2724 := z.EncBinary()
-		_ = yym2724
+		yym2729 := z.EncBinary()
+		_ = yym2729
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2725 := !z.EncBinary()
-			yy2arr2725 := z.EncBasicHandle().StructToArray
-			var yyq2725 [8]bool
-			_, _, _ = yysep2725, yyq2725, yy2arr2725
-			const yyr2725 bool = false
-			yyq2725[0] = x.Kind != ""
-			yyq2725[1] = x.APIVersion != ""
-			yyq2725[2] = x.Stdin != false
-			yyq2725[3] = x.Stdout != false
-			yyq2725[4] = x.Stderr != false
-			yyq2725[5] = x.TTY != false
-			yyq2725[6] = x.Container != ""
-			if yyr2725 || yy2arr2725 {
+			yysep2730 := !z.EncBinary()
+			yy2arr2730 := z.EncBasicHandle().StructToArray
+			var yyq2730 [8]bool
+			_, _, _ = yysep2730, yyq2730, yy2arr2730
+			const yyr2730 bool = false
+			yyq2730[0] = x.Kind != ""
+			yyq2730[1] = x.APIVersion != ""
+			yyq2730[2] = x.Stdin != false
+			yyq2730[3] = x.Stdout != false
+			yyq2730[4] = x.Stderr != false
+			yyq2730[5] = x.TTY != false
+			yyq2730[6] = x.Container != ""
+			if yyr2730 || yy2arr2730 {
 				r.EncodeArrayStart(8)
 			} else {
-				var yynn2725 int = 1
-				for _, b := range yyq2725 {
+				var yynn2730 int = 1
+				for _, b := range yyq2730 {
 					if b {
-						yynn2725++
+						yynn2730++
 					}
 				}
-				r.EncodeMapStart(yynn2725)
+				r.EncodeMapStart(yynn2730)
 			}
-			if yyr2725 || yy2arr2725 {
-				if yyq2725[0] {
-					yym2727 := z.EncBinary()
-					_ = yym2727
+			if yyr2730 || yy2arr2730 {
+				if yyq2730[0] {
+					yym2732 := z.EncBinary()
+					_ = yym2732
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -31897,130 +31934,130 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2725[0] {
+				if yyq2730[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2728 := z.EncBinary()
-					_ = yym2728
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2725 || yy2arr2725 {
-				if yyq2725[1] {
-					yym2730 := z.EncBinary()
-					_ = yym2730
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2725[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2731 := z.EncBinary()
-					_ = yym2731
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2725 || yy2arr2725 {
-				if yyq2725[2] {
 					yym2733 := z.EncBinary()
 					_ = yym2733
 					if false {
 					} else {
-						r.EncodeBool(bool(x.Stdin))
-					}
-				} else {
-					r.EncodeBool(false)
-				}
-			} else {
-				if yyq2725[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("stdin"))
-					yym2734 := z.EncBinary()
-					_ = yym2734
-					if false {
-					} else {
-						r.EncodeBool(bool(x.Stdin))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2725 || yy2arr2725 {
-				if yyq2725[3] {
+			if yyr2730 || yy2arr2730 {
+				if yyq2730[1] {
+					yym2735 := z.EncBinary()
+					_ = yym2735
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2730[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					yym2736 := z.EncBinary()
 					_ = yym2736
 					if false {
 					} else {
-						r.EncodeBool(bool(x.Stdout))
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr2730 || yy2arr2730 {
+				if yyq2730[2] {
+					yym2738 := z.EncBinary()
+					_ = yym2738
+					if false {
+					} else {
+						r.EncodeBool(bool(x.Stdin))
 					}
 				} else {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq2725[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("stdout"))
-					yym2737 := z.EncBinary()
-					_ = yym2737
-					if false {
-					} else {
-						r.EncodeBool(bool(x.Stdout))
-					}
-				}
-			}
-			if yyr2725 || yy2arr2725 {
-				if yyq2725[4] {
+				if yyq2730[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("stdin"))
 					yym2739 := z.EncBinary()
 					_ = yym2739
 					if false {
 					} else {
-						r.EncodeBool(bool(x.Stderr))
+						r.EncodeBool(bool(x.Stdin))
+					}
+				}
+			}
+			if yyr2730 || yy2arr2730 {
+				if yyq2730[3] {
+					yym2741 := z.EncBinary()
+					_ = yym2741
+					if false {
+					} else {
+						r.EncodeBool(bool(x.Stdout))
 					}
 				} else {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq2725[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("stderr"))
-					yym2740 := z.EncBinary()
-					_ = yym2740
-					if false {
-					} else {
-						r.EncodeBool(bool(x.Stderr))
-					}
-				}
-			}
-			if yyr2725 || yy2arr2725 {
-				if yyq2725[5] {
+				if yyq2730[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("stdout"))
 					yym2742 := z.EncBinary()
 					_ = yym2742
 					if false {
 					} else {
+						r.EncodeBool(bool(x.Stdout))
+					}
+				}
+			}
+			if yyr2730 || yy2arr2730 {
+				if yyq2730[4] {
+					yym2744 := z.EncBinary()
+					_ = yym2744
+					if false {
+					} else {
+						r.EncodeBool(bool(x.Stderr))
+					}
+				} else {
+					r.EncodeBool(false)
+				}
+			} else {
+				if yyq2730[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("stderr"))
+					yym2745 := z.EncBinary()
+					_ = yym2745
+					if false {
+					} else {
+						r.EncodeBool(bool(x.Stderr))
+					}
+				}
+			}
+			if yyr2730 || yy2arr2730 {
+				if yyq2730[5] {
+					yym2747 := z.EncBinary()
+					_ = yym2747
+					if false {
+					} else {
 						r.EncodeBool(bool(x.TTY))
 					}
 				} else {
 					r.EncodeBool(false)
 				}
 			} else {
-				if yyq2725[5] {
+				if yyq2730[5] {
 					r.EncodeString(codecSelferC_UTF81234, string("tty"))
-					yym2743 := z.EncBinary()
-					_ = yym2743
+					yym2748 := z.EncBinary()
+					_ = yym2748
 					if false {
 					} else {
 						r.EncodeBool(bool(x.TTY))
 					}
 				}
 			}
-			if yyr2725 || yy2arr2725 {
-				if yyq2725[6] {
-					yym2745 := z.EncBinary()
-					_ = yym2745
+			if yyr2730 || yy2arr2730 {
+				if yyq2730[6] {
+					yym2750 := z.EncBinary()
+					_ = yym2750
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Container))
@@ -32029,22 +32066,22 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2725[6] {
+				if yyq2730[6] {
 					r.EncodeString(codecSelferC_UTF81234, string("container"))
-					yym2746 := z.EncBinary()
-					_ = yym2746
+					yym2751 := z.EncBinary()
+					_ = yym2751
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Container))
 					}
 				}
 			}
-			if yyr2725 || yy2arr2725 {
+			if yyr2730 || yy2arr2730 {
 				if x.Command == nil {
 					r.EncodeNil()
 				} else {
-					yym2748 := z.EncBinary()
-					_ = yym2748
+					yym2753 := z.EncBinary()
+					_ = yym2753
 					if false {
 					} else {
 						z.F.EncSliceStringV(x.Command, false, e)
@@ -32055,15 +32092,15 @@ func (x *PodExecOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Command == nil {
 					r.EncodeNil()
 				} else {
-					yym2749 := z.EncBinary()
-					_ = yym2749
+					yym2754 := z.EncBinary()
+					_ = yym2754
 					if false {
 					} else {
 						z.F.EncSliceStringV(x.Command, false, e)
 					}
 				}
 			}
-			if yysep2725 {
+			if yysep2730 {
 				r.EncodeEnd()
 			}
 		}
@@ -32074,24 +32111,24 @@ func (x *PodExecOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2750 := z.DecBinary()
-	_ = yym2750
+	yym2755 := z.DecBinary()
+	_ = yym2755
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2751 := r.ReadMapStart()
-			if yyl2751 == 0 {
+			yyl2756 := r.ReadMapStart()
+			if yyl2756 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2751, d)
+				x.codecDecodeSelfFromMap(yyl2756, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2751 := r.ReadArrayStart()
-			if yyl2751 == 0 {
+			yyl2756 := r.ReadArrayStart()
+			if yyl2756 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2751, d)
+				x.codecDecodeSelfFromArray(yyl2756, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -32103,12 +32140,12 @@ func (x *PodExecOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2752Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2752Slc
-	var yyhl2752 bool = l >= 0
-	for yyj2752 := 0; ; yyj2752++ {
-		if yyhl2752 {
-			if yyj2752 >= l {
+	var yys2757Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2757Slc
+	var yyhl2757 bool = l >= 0
+	for yyj2757 := 0; ; yyj2757++ {
+		if yyhl2757 {
+			if yyj2757 >= l {
 				break
 			}
 		} else {
@@ -32116,9 +32153,9 @@ func (x *PodExecOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2752Slc = r.DecodeBytes(yys2752Slc, true, true)
-		yys2752 := string(yys2752Slc)
-		switch yys2752 {
+		yys2757Slc = r.DecodeBytes(yys2757Slc, true, true)
+		yys2757 := string(yys2757Slc)
+		switch yys2757 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -32165,19 +32202,19 @@ func (x *PodExecOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Command = nil
 			} else {
-				yyv2760 := &x.Command
-				yym2761 := z.DecBinary()
-				_ = yym2761
+				yyv2765 := &x.Command
+				yym2766 := z.DecBinary()
+				_ = yym2766
 				if false {
 				} else {
-					z.F.DecSliceStringX(yyv2760, false, d)
+					z.F.DecSliceStringX(yyv2765, false, d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2752)
-		} // end switch yys2752
-	} // end for yyj2752
-	if !yyhl2752 {
+			z.DecStructFieldNotFound(-1, yys2757)
+		} // end switch yys2757
+	} // end for yyj2757
+	if !yyhl2757 {
 		r.ReadEnd()
 	}
 }
@@ -32186,16 +32223,16 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2762 int
-	var yyb2762 bool
-	var yyhl2762 bool = l >= 0
-	yyj2762++
-	if yyhl2762 {
-		yyb2762 = yyj2762 > l
+	var yyj2767 int
+	var yyb2767 bool
+	var yyhl2767 bool = l >= 0
+	yyj2767++
+	if yyhl2767 {
+		yyb2767 = yyj2767 > l
 	} else {
-		yyb2762 = r.CheckBreak()
+		yyb2767 = r.CheckBreak()
 	}
-	if yyb2762 {
+	if yyb2767 {
 		r.ReadEnd()
 		return
 	}
@@ -32204,13 +32241,13 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2762++
-	if yyhl2762 {
-		yyb2762 = yyj2762 > l
+	yyj2767++
+	if yyhl2767 {
+		yyb2767 = yyj2767 > l
 	} else {
-		yyb2762 = r.CheckBreak()
+		yyb2767 = r.CheckBreak()
 	}
-	if yyb2762 {
+	if yyb2767 {
 		r.ReadEnd()
 		return
 	}
@@ -32219,13 +32256,13 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2762++
-	if yyhl2762 {
-		yyb2762 = yyj2762 > l
+	yyj2767++
+	if yyhl2767 {
+		yyb2767 = yyj2767 > l
 	} else {
-		yyb2762 = r.CheckBreak()
+		yyb2767 = r.CheckBreak()
 	}
-	if yyb2762 {
+	if yyb2767 {
 		r.ReadEnd()
 		return
 	}
@@ -32234,13 +32271,13 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Stdin = bool(r.DecodeBool())
 	}
-	yyj2762++
-	if yyhl2762 {
-		yyb2762 = yyj2762 > l
+	yyj2767++
+	if yyhl2767 {
+		yyb2767 = yyj2767 > l
 	} else {
-		yyb2762 = r.CheckBreak()
+		yyb2767 = r.CheckBreak()
 	}
-	if yyb2762 {
+	if yyb2767 {
 		r.ReadEnd()
 		return
 	}
@@ -32249,13 +32286,13 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Stdout = bool(r.DecodeBool())
 	}
-	yyj2762++
-	if yyhl2762 {
-		yyb2762 = yyj2762 > l
+	yyj2767++
+	if yyhl2767 {
+		yyb2767 = yyj2767 > l
 	} else {
-		yyb2762 = r.CheckBreak()
+		yyb2767 = r.CheckBreak()
 	}
-	if yyb2762 {
+	if yyb2767 {
 		r.ReadEnd()
 		return
 	}
@@ -32264,13 +32301,13 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Stderr = bool(r.DecodeBool())
 	}
-	yyj2762++
-	if yyhl2762 {
-		yyb2762 = yyj2762 > l
+	yyj2767++
+	if yyhl2767 {
+		yyb2767 = yyj2767 > l
 	} else {
-		yyb2762 = r.CheckBreak()
+		yyb2767 = r.CheckBreak()
 	}
-	if yyb2762 {
+	if yyb2767 {
 		r.ReadEnd()
 		return
 	}
@@ -32279,13 +32316,13 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.TTY = bool(r.DecodeBool())
 	}
-	yyj2762++
-	if yyhl2762 {
-		yyb2762 = yyj2762 > l
+	yyj2767++
+	if yyhl2767 {
+		yyb2767 = yyj2767 > l
 	} else {
-		yyb2762 = r.CheckBreak()
+		yyb2767 = r.CheckBreak()
 	}
-	if yyb2762 {
+	if yyb2767 {
 		r.ReadEnd()
 		return
 	}
@@ -32294,38 +32331,38 @@ func (x *PodExecOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Container = string(r.DecodeString())
 	}
-	yyj2762++
-	if yyhl2762 {
-		yyb2762 = yyj2762 > l
+	yyj2767++
+	if yyhl2767 {
+		yyb2767 = yyj2767 > l
 	} else {
-		yyb2762 = r.CheckBreak()
+		yyb2767 = r.CheckBreak()
 	}
-	if yyb2762 {
+	if yyb2767 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Command = nil
 	} else {
-		yyv2770 := &x.Command
-		yym2771 := z.DecBinary()
-		_ = yym2771
+		yyv2775 := &x.Command
+		yym2776 := z.DecBinary()
+		_ = yym2776
 		if false {
 		} else {
-			z.F.DecSliceStringX(yyv2770, false, d)
+			z.F.DecSliceStringX(yyv2775, false, d)
 		}
 	}
 	for {
-		yyj2762++
-		if yyhl2762 {
-			yyb2762 = yyj2762 > l
+		yyj2767++
+		if yyhl2767 {
+			yyb2767 = yyj2767 > l
 		} else {
-			yyb2762 = r.CheckBreak()
+			yyb2767 = r.CheckBreak()
 		}
-		if yyb2762 {
+		if yyb2767 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2762-1, "")
+		z.DecStructFieldNotFound(yyj2767-1, "")
 	}
 	r.ReadEnd()
 }
@@ -32337,34 +32374,34 @@ func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2772 := z.EncBinary()
-		_ = yym2772
+		yym2777 := z.EncBinary()
+		_ = yym2777
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2773 := !z.EncBinary()
-			yy2arr2773 := z.EncBasicHandle().StructToArray
-			var yyq2773 [3]bool
-			_, _, _ = yysep2773, yyq2773, yy2arr2773
-			const yyr2773 bool = false
-			yyq2773[0] = x.Kind != ""
-			yyq2773[1] = x.APIVersion != ""
-			yyq2773[2] = x.Path != ""
-			if yyr2773 || yy2arr2773 {
+			yysep2778 := !z.EncBinary()
+			yy2arr2778 := z.EncBasicHandle().StructToArray
+			var yyq2778 [3]bool
+			_, _, _ = yysep2778, yyq2778, yy2arr2778
+			const yyr2778 bool = false
+			yyq2778[0] = x.Kind != ""
+			yyq2778[1] = x.APIVersion != ""
+			yyq2778[2] = x.Path != ""
+			if yyr2778 || yy2arr2778 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn2773 int = 0
-				for _, b := range yyq2773 {
+				var yynn2778 int = 0
+				for _, b := range yyq2778 {
 					if b {
-						yynn2773++
+						yynn2778++
 					}
 				}
-				r.EncodeMapStart(yynn2773)
+				r.EncodeMapStart(yynn2778)
 			}
-			if yyr2773 || yy2arr2773 {
-				if yyq2773[0] {
-					yym2775 := z.EncBinary()
-					_ = yym2775
+			if yyr2778 || yy2arr2778 {
+				if yyq2778[0] {
+					yym2780 := z.EncBinary()
+					_ = yym2780
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -32373,61 +32410,61 @@ func (x *PodProxyOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2773[0] {
+				if yyq2778[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2776 := z.EncBinary()
-					_ = yym2776
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2773 || yy2arr2773 {
-				if yyq2773[1] {
-					yym2778 := z.EncBinary()
-					_ = yym2778
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2773[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2779 := z.EncBinary()
-					_ = yym2779
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2773 || yy2arr2773 {
-				if yyq2773[2] {
 					yym2781 := z.EncBinary()
 					_ = yym2781
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2778 || yy2arr2778 {
+				if yyq2778[1] {
+					yym2783 := z.EncBinary()
+					_ = yym2783
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2778[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym2784 := z.EncBinary()
+					_ = yym2784
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr2778 || yy2arr2778 {
+				if yyq2778[2] {
+					yym2786 := z.EncBinary()
+					_ = yym2786
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2773[2] {
+				if yyq2778[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("path"))
-					yym2782 := z.EncBinary()
-					_ = yym2782
+					yym2787 := z.EncBinary()
+					_ = yym2787
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 					}
 				}
 			}
-			if yysep2773 {
+			if yysep2778 {
 				r.EncodeEnd()
 			}
 		}
@@ -32438,24 +32475,24 @@ func (x *PodProxyOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2783 := z.DecBinary()
-	_ = yym2783
+	yym2788 := z.DecBinary()
+	_ = yym2788
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2784 := r.ReadMapStart()
-			if yyl2784 == 0 {
+			yyl2789 := r.ReadMapStart()
+			if yyl2789 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2784, d)
+				x.codecDecodeSelfFromMap(yyl2789, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2784 := r.ReadArrayStart()
-			if yyl2784 == 0 {
+			yyl2789 := r.ReadArrayStart()
+			if yyl2789 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2784, d)
+				x.codecDecodeSelfFromArray(yyl2789, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -32467,12 +32504,12 @@ func (x *PodProxyOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2785Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2785Slc
-	var yyhl2785 bool = l >= 0
-	for yyj2785 := 0; ; yyj2785++ {
-		if yyhl2785 {
-			if yyj2785 >= l {
+	var yys2790Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2790Slc
+	var yyhl2790 bool = l >= 0
+	for yyj2790 := 0; ; yyj2790++ {
+		if yyhl2790 {
+			if yyj2790 >= l {
 				break
 			}
 		} else {
@@ -32480,9 +32517,9 @@ func (x *PodProxyOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2785Slc = r.DecodeBytes(yys2785Slc, true, true)
-		yys2785 := string(yys2785Slc)
-		switch yys2785 {
+		yys2790Slc = r.DecodeBytes(yys2790Slc, true, true)
+		yys2790 := string(yys2790Slc)
+		switch yys2790 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -32502,10 +32539,10 @@ func (x *PodProxyOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Path = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2785)
-		} // end switch yys2785
-	} // end for yyj2785
-	if !yyhl2785 {
+			z.DecStructFieldNotFound(-1, yys2790)
+		} // end switch yys2790
+	} // end for yyj2790
+	if !yyhl2790 {
 		r.ReadEnd()
 	}
 }
@@ -32514,16 +32551,16 @@ func (x *PodProxyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2789 int
-	var yyb2789 bool
-	var yyhl2789 bool = l >= 0
-	yyj2789++
-	if yyhl2789 {
-		yyb2789 = yyj2789 > l
+	var yyj2794 int
+	var yyb2794 bool
+	var yyhl2794 bool = l >= 0
+	yyj2794++
+	if yyhl2794 {
+		yyb2794 = yyj2794 > l
 	} else {
-		yyb2789 = r.CheckBreak()
+		yyb2794 = r.CheckBreak()
 	}
-	if yyb2789 {
+	if yyb2794 {
 		r.ReadEnd()
 		return
 	}
@@ -32532,13 +32569,13 @@ func (x *PodProxyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2789++
-	if yyhl2789 {
-		yyb2789 = yyj2789 > l
+	yyj2794++
+	if yyhl2794 {
+		yyb2794 = yyj2794 > l
 	} else {
-		yyb2789 = r.CheckBreak()
+		yyb2794 = r.CheckBreak()
 	}
-	if yyb2789 {
+	if yyb2794 {
 		r.ReadEnd()
 		return
 	}
@@ -32547,13 +32584,13 @@ func (x *PodProxyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2789++
-	if yyhl2789 {
-		yyb2789 = yyj2789 > l
+	yyj2794++
+	if yyhl2794 {
+		yyb2794 = yyj2794 > l
 	} else {
-		yyb2789 = r.CheckBreak()
+		yyb2794 = r.CheckBreak()
 	}
-	if yyb2789 {
+	if yyb2794 {
 		r.ReadEnd()
 		return
 	}
@@ -32563,16 +32600,16 @@ func (x *PodProxyOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.Path = string(r.DecodeString())
 	}
 	for {
-		yyj2789++
-		if yyhl2789 {
-			yyb2789 = yyj2789 > l
+		yyj2794++
+		if yyhl2794 {
+			yyb2794 = yyj2794 > l
 		} else {
-			yyb2789 = r.CheckBreak()
+			yyb2794 = r.CheckBreak()
 		}
-		if yyb2789 {
+		if yyb2794 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2789-1, "")
+		z.DecStructFieldNotFound(yyj2794-1, "")
 	}
 	r.ReadEnd()
 }
@@ -32584,38 +32621,38 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2793 := z.EncBinary()
-		_ = yym2793
+		yym2798 := z.EncBinary()
+		_ = yym2798
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2794 := !z.EncBinary()
-			yy2arr2794 := z.EncBasicHandle().StructToArray
-			var yyq2794 [7]bool
-			_, _, _ = yysep2794, yyq2794, yy2arr2794
-			const yyr2794 bool = false
-			yyq2794[0] = x.Kind != ""
-			yyq2794[1] = x.Namespace != ""
-			yyq2794[2] = x.Name != ""
-			yyq2794[3] = x.UID != ""
-			yyq2794[4] = x.APIVersion != ""
-			yyq2794[5] = x.ResourceVersion != ""
-			yyq2794[6] = x.FieldPath != ""
-			if yyr2794 || yy2arr2794 {
+			yysep2799 := !z.EncBinary()
+			yy2arr2799 := z.EncBasicHandle().StructToArray
+			var yyq2799 [7]bool
+			_, _, _ = yysep2799, yyq2799, yy2arr2799
+			const yyr2799 bool = false
+			yyq2799[0] = x.Kind != ""
+			yyq2799[1] = x.Namespace != ""
+			yyq2799[2] = x.Name != ""
+			yyq2799[3] = x.UID != ""
+			yyq2799[4] = x.APIVersion != ""
+			yyq2799[5] = x.ResourceVersion != ""
+			yyq2799[6] = x.FieldPath != ""
+			if yyr2799 || yy2arr2799 {
 				r.EncodeArrayStart(7)
 			} else {
-				var yynn2794 int = 0
-				for _, b := range yyq2794 {
+				var yynn2799 int = 0
+				for _, b := range yyq2799 {
 					if b {
-						yynn2794++
+						yynn2799++
 					}
 				}
-				r.EncodeMapStart(yynn2794)
+				r.EncodeMapStart(yynn2799)
 			}
-			if yyr2794 || yy2arr2794 {
-				if yyq2794[0] {
-					yym2796 := z.EncBinary()
-					_ = yym2796
+			if yyr2799 || yy2arr2799 {
+				if yyq2799[0] {
+					yym2801 := z.EncBinary()
+					_ = yym2801
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -32624,151 +32661,151 @@ func (x *ObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2794[0] {
+				if yyq2799[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2797 := z.EncBinary()
-					_ = yym2797
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr2794 || yy2arr2794 {
-				if yyq2794[1] {
-					yym2799 := z.EncBinary()
-					_ = yym2799
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Namespace))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq2794[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("namespace"))
-					yym2800 := z.EncBinary()
-					_ = yym2800
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Namespace))
-					}
-				}
-			}
-			if yyr2794 || yy2arr2794 {
-				if yyq2794[2] {
 					yym2802 := z.EncBinary()
 					_ = yym2802
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr2799 || yy2arr2799 {
+				if yyq2799[1] {
+					yym2804 := z.EncBinary()
+					_ = yym2804
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Namespace))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2794[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("name"))
-					yym2803 := z.EncBinary()
-					_ = yym2803
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
-					}
-				}
-			}
-			if yyr2794 || yy2arr2794 {
-				if yyq2794[3] {
+				if yyq2799[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("namespace"))
 					yym2805 := z.EncBinary()
 					_ = yym2805
 					if false {
-					} else if z.HasExtensions() && z.EncExt(x.UID) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.UID))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Namespace))
+					}
+				}
+			}
+			if yyr2799 || yy2arr2799 {
+				if yyq2799[2] {
+					yym2807 := z.EncBinary()
+					_ = yym2807
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2794[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("uid"))
-					yym2806 := z.EncBinary()
-					_ = yym2806
-					if false {
-					} else if z.HasExtensions() && z.EncExt(x.UID) {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.UID))
-					}
-				}
-			}
-			if yyr2794 || yy2arr2794 {
-				if yyq2794[4] {
+				if yyq2799[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("name"))
 					yym2808 := z.EncBinary()
 					_ = yym2808
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+					}
+				}
+			}
+			if yyr2799 || yy2arr2799 {
+				if yyq2799[3] {
+					yym2810 := z.EncBinary()
+					_ = yym2810
+					if false {
+					} else if z.HasExtensions() && z.EncExt(x.UID) {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.UID))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2794[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2809 := z.EncBinary()
-					_ = yym2809
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2794 || yy2arr2794 {
-				if yyq2794[5] {
+				if yyq2799[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("uid"))
 					yym2811 := z.EncBinary()
 					_ = yym2811
 					if false {
+					} else if z.HasExtensions() && z.EncExt(x.UID) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
+						r.EncodeString(codecSelferC_UTF81234, string(x.UID))
+					}
+				}
+			}
+			if yyr2799 || yy2arr2799 {
+				if yyq2799[4] {
+					yym2813 := z.EncBinary()
+					_ = yym2813
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2794[5] {
-					r.EncodeString(codecSelferC_UTF81234, string("resourceVersion"))
-					yym2812 := z.EncBinary()
-					_ = yym2812
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
-					}
-				}
-			}
-			if yyr2794 || yy2arr2794 {
-				if yyq2794[6] {
+				if yyq2799[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					yym2814 := z.EncBinary()
 					_ = yym2814
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr2799 || yy2arr2799 {
+				if yyq2799[5] {
+					yym2816 := z.EncBinary()
+					_ = yym2816
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq2799[5] {
+					r.EncodeString(codecSelferC_UTF81234, string("resourceVersion"))
+					yym2817 := z.EncBinary()
+					_ = yym2817
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.ResourceVersion))
+					}
+				}
+			}
+			if yyr2799 || yy2arr2799 {
+				if yyq2799[6] {
+					yym2819 := z.EncBinary()
+					_ = yym2819
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.FieldPath))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2794[6] {
+				if yyq2799[6] {
 					r.EncodeString(codecSelferC_UTF81234, string("fieldPath"))
-					yym2815 := z.EncBinary()
-					_ = yym2815
+					yym2820 := z.EncBinary()
+					_ = yym2820
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.FieldPath))
 					}
 				}
 			}
-			if yysep2794 {
+			if yysep2799 {
 				r.EncodeEnd()
 			}
 		}
@@ -32779,24 +32816,24 @@ func (x *ObjectReference) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2816 := z.DecBinary()
-	_ = yym2816
+	yym2821 := z.DecBinary()
+	_ = yym2821
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2817 := r.ReadMapStart()
-			if yyl2817 == 0 {
+			yyl2822 := r.ReadMapStart()
+			if yyl2822 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2817, d)
+				x.codecDecodeSelfFromMap(yyl2822, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2817 := r.ReadArrayStart()
-			if yyl2817 == 0 {
+			yyl2822 := r.ReadArrayStart()
+			if yyl2822 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2817, d)
+				x.codecDecodeSelfFromArray(yyl2822, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -32808,12 +32845,12 @@ func (x *ObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2818Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2818Slc
-	var yyhl2818 bool = l >= 0
-	for yyj2818 := 0; ; yyj2818++ {
-		if yyhl2818 {
-			if yyj2818 >= l {
+	var yys2823Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2823Slc
+	var yyhl2823 bool = l >= 0
+	for yyj2823 := 0; ; yyj2823++ {
+		if yyhl2823 {
+			if yyj2823 >= l {
 				break
 			}
 		} else {
@@ -32821,9 +32858,9 @@ func (x *ObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2818Slc = r.DecodeBytes(yys2818Slc, true, true)
-		yys2818 := string(yys2818Slc)
-		switch yys2818 {
+		yys2823Slc = r.DecodeBytes(yys2823Slc, true, true)
+		yys2823 := string(yys2823Slc)
+		switch yys2823 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -32867,10 +32904,10 @@ func (x *ObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.FieldPath = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2818)
-		} // end switch yys2818
-	} // end for yyj2818
-	if !yyhl2818 {
+			z.DecStructFieldNotFound(-1, yys2823)
+		} // end switch yys2823
+	} // end for yyj2823
+	if !yyhl2823 {
 		r.ReadEnd()
 	}
 }
@@ -32879,16 +32916,16 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2826 int
-	var yyb2826 bool
-	var yyhl2826 bool = l >= 0
-	yyj2826++
-	if yyhl2826 {
-		yyb2826 = yyj2826 > l
+	var yyj2831 int
+	var yyb2831 bool
+	var yyhl2831 bool = l >= 0
+	yyj2831++
+	if yyhl2831 {
+		yyb2831 = yyj2831 > l
 	} else {
-		yyb2826 = r.CheckBreak()
+		yyb2831 = r.CheckBreak()
 	}
-	if yyb2826 {
+	if yyb2831 {
 		r.ReadEnd()
 		return
 	}
@@ -32897,13 +32934,13 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2826++
-	if yyhl2826 {
-		yyb2826 = yyj2826 > l
+	yyj2831++
+	if yyhl2831 {
+		yyb2831 = yyj2831 > l
 	} else {
-		yyb2826 = r.CheckBreak()
+		yyb2831 = r.CheckBreak()
 	}
-	if yyb2826 {
+	if yyb2831 {
 		r.ReadEnd()
 		return
 	}
@@ -32912,13 +32949,13 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Namespace = string(r.DecodeString())
 	}
-	yyj2826++
-	if yyhl2826 {
-		yyb2826 = yyj2826 > l
+	yyj2831++
+	if yyhl2831 {
+		yyb2831 = yyj2831 > l
 	} else {
-		yyb2826 = r.CheckBreak()
+		yyb2831 = r.CheckBreak()
 	}
-	if yyb2826 {
+	if yyb2831 {
 		r.ReadEnd()
 		return
 	}
@@ -32927,13 +32964,13 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Name = string(r.DecodeString())
 	}
-	yyj2826++
-	if yyhl2826 {
-		yyb2826 = yyj2826 > l
+	yyj2831++
+	if yyhl2831 {
+		yyb2831 = yyj2831 > l
 	} else {
-		yyb2826 = r.CheckBreak()
+		yyb2831 = r.CheckBreak()
 	}
-	if yyb2826 {
+	if yyb2831 {
 		r.ReadEnd()
 		return
 	}
@@ -32942,13 +32979,13 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.UID = pkg1_types.UID(r.DecodeString())
 	}
-	yyj2826++
-	if yyhl2826 {
-		yyb2826 = yyj2826 > l
+	yyj2831++
+	if yyhl2831 {
+		yyb2831 = yyj2831 > l
 	} else {
-		yyb2826 = r.CheckBreak()
+		yyb2831 = r.CheckBreak()
 	}
-	if yyb2826 {
+	if yyb2831 {
 		r.ReadEnd()
 		return
 	}
@@ -32957,13 +32994,13 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2826++
-	if yyhl2826 {
-		yyb2826 = yyj2826 > l
+	yyj2831++
+	if yyhl2831 {
+		yyb2831 = yyj2831 > l
 	} else {
-		yyb2826 = r.CheckBreak()
+		yyb2831 = r.CheckBreak()
 	}
-	if yyb2826 {
+	if yyb2831 {
 		r.ReadEnd()
 		return
 	}
@@ -32972,13 +33009,13 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.ResourceVersion = string(r.DecodeString())
 	}
-	yyj2826++
-	if yyhl2826 {
-		yyb2826 = yyj2826 > l
+	yyj2831++
+	if yyhl2831 {
+		yyb2831 = yyj2831 > l
 	} else {
-		yyb2826 = r.CheckBreak()
+		yyb2831 = r.CheckBreak()
 	}
-	if yyb2826 {
+	if yyb2831 {
 		r.ReadEnd()
 		return
 	}
@@ -32988,16 +33025,16 @@ func (x *ObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.FieldPath = string(r.DecodeString())
 	}
 	for {
-		yyj2826++
-		if yyhl2826 {
-			yyb2826 = yyj2826 > l
+		yyj2831++
+		if yyhl2831 {
+			yyb2831 = yyj2831 > l
 		} else {
-			yyb2826 = r.CheckBreak()
+			yyb2831 = r.CheckBreak()
 		}
-		if yyb2826 {
+		if yyb2831 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2826-1, "")
+		z.DecStructFieldNotFound(yyj2831-1, "")
 	}
 	r.ReadEnd()
 }
@@ -33009,32 +33046,32 @@ func (x *LocalObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2834 := z.EncBinary()
-		_ = yym2834
+		yym2839 := z.EncBinary()
+		_ = yym2839
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2835 := !z.EncBinary()
-			yy2arr2835 := z.EncBasicHandle().StructToArray
-			var yyq2835 [1]bool
-			_, _, _ = yysep2835, yyq2835, yy2arr2835
-			const yyr2835 bool = false
-			yyq2835[0] = x.Name != ""
-			if yyr2835 || yy2arr2835 {
+			yysep2840 := !z.EncBinary()
+			yy2arr2840 := z.EncBasicHandle().StructToArray
+			var yyq2840 [1]bool
+			_, _, _ = yysep2840, yyq2840, yy2arr2840
+			const yyr2840 bool = false
+			yyq2840[0] = x.Name != ""
+			if yyr2840 || yy2arr2840 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn2835 int = 0
-				for _, b := range yyq2835 {
+				var yynn2840 int = 0
+				for _, b := range yyq2840 {
 					if b {
-						yynn2835++
+						yynn2840++
 					}
 				}
-				r.EncodeMapStart(yynn2835)
+				r.EncodeMapStart(yynn2840)
 			}
-			if yyr2835 || yy2arr2835 {
-				if yyq2835[0] {
-					yym2837 := z.EncBinary()
-					_ = yym2837
+			if yyr2840 || yy2arr2840 {
+				if yyq2840[0] {
+					yym2842 := z.EncBinary()
+					_ = yym2842
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
@@ -33043,17 +33080,17 @@ func (x *LocalObjectReference) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2835[0] {
+				if yyq2840[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("name"))
-					yym2838 := z.EncBinary()
-					_ = yym2838
+					yym2843 := z.EncBinary()
+					_ = yym2843
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 					}
 				}
 			}
-			if yysep2835 {
+			if yysep2840 {
 				r.EncodeEnd()
 			}
 		}
@@ -33064,24 +33101,24 @@ func (x *LocalObjectReference) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2839 := z.DecBinary()
-	_ = yym2839
+	yym2844 := z.DecBinary()
+	_ = yym2844
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2840 := r.ReadMapStart()
-			if yyl2840 == 0 {
+			yyl2845 := r.ReadMapStart()
+			if yyl2845 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2840, d)
+				x.codecDecodeSelfFromMap(yyl2845, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2840 := r.ReadArrayStart()
-			if yyl2840 == 0 {
+			yyl2845 := r.ReadArrayStart()
+			if yyl2845 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2840, d)
+				x.codecDecodeSelfFromArray(yyl2845, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -33093,12 +33130,12 @@ func (x *LocalObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2841Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2841Slc
-	var yyhl2841 bool = l >= 0
-	for yyj2841 := 0; ; yyj2841++ {
-		if yyhl2841 {
-			if yyj2841 >= l {
+	var yys2846Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2846Slc
+	var yyhl2846 bool = l >= 0
+	for yyj2846 := 0; ; yyj2846++ {
+		if yyhl2846 {
+			if yyj2846 >= l {
 				break
 			}
 		} else {
@@ -33106,9 +33143,9 @@ func (x *LocalObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
-		yys2841Slc = r.DecodeBytes(yys2841Slc, true, true)
-		yys2841 := string(yys2841Slc)
-		switch yys2841 {
+		yys2846Slc = r.DecodeBytes(yys2846Slc, true, true)
+		yys2846 := string(yys2846Slc)
+		switch yys2846 {
 		case "name":
 			if r.TryDecodeAsNil() {
 				x.Name = ""
@@ -33116,10 +33153,10 @@ func (x *LocalObjectReference) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				x.Name = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2841)
-		} // end switch yys2841
-	} // end for yyj2841
-	if !yyhl2841 {
+			z.DecStructFieldNotFound(-1, yys2846)
+		} // end switch yys2846
+	} // end for yyj2846
+	if !yyhl2846 {
 		r.ReadEnd()
 	}
 }
@@ -33128,16 +33165,16 @@ func (x *LocalObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2843 int
-	var yyb2843 bool
-	var yyhl2843 bool = l >= 0
-	yyj2843++
-	if yyhl2843 {
-		yyb2843 = yyj2843 > l
+	var yyj2848 int
+	var yyb2848 bool
+	var yyhl2848 bool = l >= 0
+	yyj2848++
+	if yyhl2848 {
+		yyb2848 = yyj2848 > l
 	} else {
-		yyb2843 = r.CheckBreak()
+		yyb2848 = r.CheckBreak()
 	}
-	if yyb2843 {
+	if yyb2848 {
 		r.ReadEnd()
 		return
 	}
@@ -33147,16 +33184,16 @@ func (x *LocalObjectReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		x.Name = string(r.DecodeString())
 	}
 	for {
-		yyj2843++
-		if yyhl2843 {
-			yyb2843 = yyj2843 > l
+		yyj2848++
+		if yyhl2848 {
+			yyb2848 = yyj2848 > l
 		} else {
-			yyb2843 = r.CheckBreak()
+			yyb2848 = r.CheckBreak()
 		}
-		if yyb2843 {
+		if yyb2848 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2843-1, "")
+		z.DecStructFieldNotFound(yyj2848-1, "")
 	}
 	r.ReadEnd()
 }
@@ -33168,34 +33205,34 @@ func (x *SerializedReference) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2845 := z.EncBinary()
-		_ = yym2845
+		yym2850 := z.EncBinary()
+		_ = yym2850
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2846 := !z.EncBinary()
-			yy2arr2846 := z.EncBasicHandle().StructToArray
-			var yyq2846 [3]bool
-			_, _, _ = yysep2846, yyq2846, yy2arr2846
-			const yyr2846 bool = false
-			yyq2846[0] = x.Kind != ""
-			yyq2846[1] = x.APIVersion != ""
-			yyq2846[2] = true
-			if yyr2846 || yy2arr2846 {
+			yysep2851 := !z.EncBinary()
+			yy2arr2851 := z.EncBasicHandle().StructToArray
+			var yyq2851 [3]bool
+			_, _, _ = yysep2851, yyq2851, yy2arr2851
+			const yyr2851 bool = false
+			yyq2851[0] = x.Kind != ""
+			yyq2851[1] = x.APIVersion != ""
+			yyq2851[2] = true
+			if yyr2851 || yy2arr2851 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn2846 int = 0
-				for _, b := range yyq2846 {
+				var yynn2851 int = 0
+				for _, b := range yyq2851 {
 					if b {
-						yynn2846++
+						yynn2851++
 					}
 				}
-				r.EncodeMapStart(yynn2846)
+				r.EncodeMapStart(yynn2851)
 			}
-			if yyr2846 || yy2arr2846 {
-				if yyq2846[0] {
-					yym2848 := z.EncBinary()
-					_ = yym2848
+			if yyr2851 || yy2arr2851 {
+				if yyq2851[0] {
+					yym2853 := z.EncBinary()
+					_ = yym2853
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -33204,20 +33241,20 @@ func (x *SerializedReference) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2846[0] {
+				if yyq2851[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2849 := z.EncBinary()
-					_ = yym2849
+					yym2854 := z.EncBinary()
+					_ = yym2854
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2846 || yy2arr2846 {
-				if yyq2846[1] {
-					yym2851 := z.EncBinary()
-					_ = yym2851
+			if yyr2851 || yy2arr2851 {
+				if yyq2851[1] {
+					yym2856 := z.EncBinary()
+					_ = yym2856
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -33226,31 +33263,31 @@ func (x *SerializedReference) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2846[1] {
+				if yyq2851[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2852 := z.EncBinary()
-					_ = yym2852
+					yym2857 := z.EncBinary()
+					_ = yym2857
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2846 || yy2arr2846 {
-				if yyq2846[2] {
-					yy2854 := &x.Reference
-					yy2854.CodecEncodeSelf(e)
+			if yyr2851 || yy2arr2851 {
+				if yyq2851[2] {
+					yy2859 := &x.Reference
+					yy2859.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2846[2] {
+				if yyq2851[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("reference"))
-					yy2855 := &x.Reference
-					yy2855.CodecEncodeSelf(e)
+					yy2860 := &x.Reference
+					yy2860.CodecEncodeSelf(e)
 				}
 			}
-			if yysep2846 {
+			if yysep2851 {
 				r.EncodeEnd()
 			}
 		}
@@ -33261,24 +33298,24 @@ func (x *SerializedReference) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2856 := z.DecBinary()
-	_ = yym2856
+	yym2861 := z.DecBinary()
+	_ = yym2861
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2857 := r.ReadMapStart()
-			if yyl2857 == 0 {
+			yyl2862 := r.ReadMapStart()
+			if yyl2862 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2857, d)
+				x.codecDecodeSelfFromMap(yyl2862, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2857 := r.ReadArrayStart()
-			if yyl2857 == 0 {
+			yyl2862 := r.ReadArrayStart()
+			if yyl2862 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2857, d)
+				x.codecDecodeSelfFromArray(yyl2862, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -33290,12 +33327,12 @@ func (x *SerializedReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2858Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2858Slc
-	var yyhl2858 bool = l >= 0
-	for yyj2858 := 0; ; yyj2858++ {
-		if yyhl2858 {
-			if yyj2858 >= l {
+	var yys2863Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2863Slc
+	var yyhl2863 bool = l >= 0
+	for yyj2863 := 0; ; yyj2863++ {
+		if yyhl2863 {
+			if yyj2863 >= l {
 				break
 			}
 		} else {
@@ -33303,9 +33340,9 @@ func (x *SerializedReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				break
 			}
 		}
-		yys2858Slc = r.DecodeBytes(yys2858Slc, true, true)
-		yys2858 := string(yys2858Slc)
-		switch yys2858 {
+		yys2863Slc = r.DecodeBytes(yys2863Slc, true, true)
+		yys2863 := string(yys2863Slc)
+		switch yys2863 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -33322,14 +33359,14 @@ func (x *SerializedReference) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 			if r.TryDecodeAsNil() {
 				x.Reference = ObjectReference{}
 			} else {
-				yyv2861 := &x.Reference
-				yyv2861.CodecDecodeSelf(d)
+				yyv2866 := &x.Reference
+				yyv2866.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2858)
-		} // end switch yys2858
-	} // end for yyj2858
-	if !yyhl2858 {
+			z.DecStructFieldNotFound(-1, yys2863)
+		} // end switch yys2863
+	} // end for yyj2863
+	if !yyhl2863 {
 		r.ReadEnd()
 	}
 }
@@ -33338,16 +33375,16 @@ func (x *SerializedReference) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2862 int
-	var yyb2862 bool
-	var yyhl2862 bool = l >= 0
-	yyj2862++
-	if yyhl2862 {
-		yyb2862 = yyj2862 > l
+	var yyj2867 int
+	var yyb2867 bool
+	var yyhl2867 bool = l >= 0
+	yyj2867++
+	if yyhl2867 {
+		yyb2867 = yyj2867 > l
 	} else {
-		yyb2862 = r.CheckBreak()
+		yyb2867 = r.CheckBreak()
 	}
-	if yyb2862 {
+	if yyb2867 {
 		r.ReadEnd()
 		return
 	}
@@ -33356,13 +33393,13 @@ func (x *SerializedReference) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2862++
-	if yyhl2862 {
-		yyb2862 = yyj2862 > l
+	yyj2867++
+	if yyhl2867 {
+		yyb2867 = yyj2867 > l
 	} else {
-		yyb2862 = r.CheckBreak()
+		yyb2867 = r.CheckBreak()
 	}
-	if yyb2862 {
+	if yyb2867 {
 		r.ReadEnd()
 		return
 	}
@@ -33371,33 +33408,33 @@ func (x *SerializedReference) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2862++
-	if yyhl2862 {
-		yyb2862 = yyj2862 > l
+	yyj2867++
+	if yyhl2867 {
+		yyb2867 = yyj2867 > l
 	} else {
-		yyb2862 = r.CheckBreak()
+		yyb2867 = r.CheckBreak()
 	}
-	if yyb2862 {
+	if yyb2867 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Reference = ObjectReference{}
 	} else {
-		yyv2865 := &x.Reference
-		yyv2865.CodecDecodeSelf(d)
+		yyv2870 := &x.Reference
+		yyv2870.CodecDecodeSelf(d)
 	}
 	for {
-		yyj2862++
-		if yyhl2862 {
-			yyb2862 = yyj2862 > l
+		yyj2867++
+		if yyhl2867 {
+			yyb2867 = yyj2867 > l
 		} else {
-			yyb2862 = r.CheckBreak()
+			yyb2867 = r.CheckBreak()
 		}
-		if yyb2862 {
+		if yyb2867 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2862-1, "")
+		z.DecStructFieldNotFound(yyj2867-1, "")
 	}
 	r.ReadEnd()
 }
@@ -33409,33 +33446,33 @@ func (x *EventSource) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2866 := z.EncBinary()
-		_ = yym2866
+		yym2871 := z.EncBinary()
+		_ = yym2871
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2867 := !z.EncBinary()
-			yy2arr2867 := z.EncBasicHandle().StructToArray
-			var yyq2867 [2]bool
-			_, _, _ = yysep2867, yyq2867, yy2arr2867
-			const yyr2867 bool = false
-			yyq2867[0] = x.Component != ""
-			yyq2867[1] = x.Host != ""
-			if yyr2867 || yy2arr2867 {
+			yysep2872 := !z.EncBinary()
+			yy2arr2872 := z.EncBasicHandle().StructToArray
+			var yyq2872 [2]bool
+			_, _, _ = yysep2872, yyq2872, yy2arr2872
+			const yyr2872 bool = false
+			yyq2872[0] = x.Component != ""
+			yyq2872[1] = x.Host != ""
+			if yyr2872 || yy2arr2872 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn2867 int = 0
-				for _, b := range yyq2867 {
+				var yynn2872 int = 0
+				for _, b := range yyq2872 {
 					if b {
-						yynn2867++
+						yynn2872++
 					}
 				}
-				r.EncodeMapStart(yynn2867)
+				r.EncodeMapStart(yynn2872)
 			}
-			if yyr2867 || yy2arr2867 {
-				if yyq2867[0] {
-					yym2869 := z.EncBinary()
-					_ = yym2869
+			if yyr2872 || yy2arr2872 {
+				if yyq2872[0] {
+					yym2874 := z.EncBinary()
+					_ = yym2874
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Component))
@@ -33444,20 +33481,20 @@ func (x *EventSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2867[0] {
+				if yyq2872[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("component"))
-					yym2870 := z.EncBinary()
-					_ = yym2870
+					yym2875 := z.EncBinary()
+					_ = yym2875
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Component))
 					}
 				}
 			}
-			if yyr2867 || yy2arr2867 {
-				if yyq2867[1] {
-					yym2872 := z.EncBinary()
-					_ = yym2872
+			if yyr2872 || yy2arr2872 {
+				if yyq2872[1] {
+					yym2877 := z.EncBinary()
+					_ = yym2877
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Host))
@@ -33466,17 +33503,17 @@ func (x *EventSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2867[1] {
+				if yyq2872[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("host"))
-					yym2873 := z.EncBinary()
-					_ = yym2873
+					yym2878 := z.EncBinary()
+					_ = yym2878
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Host))
 					}
 				}
 			}
-			if yysep2867 {
+			if yysep2872 {
 				r.EncodeEnd()
 			}
 		}
@@ -33487,24 +33524,24 @@ func (x *EventSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2874 := z.DecBinary()
-	_ = yym2874
+	yym2879 := z.DecBinary()
+	_ = yym2879
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2875 := r.ReadMapStart()
-			if yyl2875 == 0 {
+			yyl2880 := r.ReadMapStart()
+			if yyl2880 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2875, d)
+				x.codecDecodeSelfFromMap(yyl2880, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2875 := r.ReadArrayStart()
-			if yyl2875 == 0 {
+			yyl2880 := r.ReadArrayStart()
+			if yyl2880 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2875, d)
+				x.codecDecodeSelfFromArray(yyl2880, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -33516,12 +33553,12 @@ func (x *EventSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2876Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2876Slc
-	var yyhl2876 bool = l >= 0
-	for yyj2876 := 0; ; yyj2876++ {
-		if yyhl2876 {
-			if yyj2876 >= l {
+	var yys2881Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2881Slc
+	var yyhl2881 bool = l >= 0
+	for yyj2881 := 0; ; yyj2881++ {
+		if yyhl2881 {
+			if yyj2881 >= l {
 				break
 			}
 		} else {
@@ -33529,9 +33566,9 @@ func (x *EventSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2876Slc = r.DecodeBytes(yys2876Slc, true, true)
-		yys2876 := string(yys2876Slc)
-		switch yys2876 {
+		yys2881Slc = r.DecodeBytes(yys2881Slc, true, true)
+		yys2881 := string(yys2881Slc)
+		switch yys2881 {
 		case "component":
 			if r.TryDecodeAsNil() {
 				x.Component = ""
@@ -33545,10 +33582,10 @@ func (x *EventSource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Host = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2876)
-		} // end switch yys2876
-	} // end for yyj2876
-	if !yyhl2876 {
+			z.DecStructFieldNotFound(-1, yys2881)
+		} // end switch yys2881
+	} // end for yyj2881
+	if !yyhl2881 {
 		r.ReadEnd()
 	}
 }
@@ -33557,16 +33594,16 @@ func (x *EventSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2879 int
-	var yyb2879 bool
-	var yyhl2879 bool = l >= 0
-	yyj2879++
-	if yyhl2879 {
-		yyb2879 = yyj2879 > l
+	var yyj2884 int
+	var yyb2884 bool
+	var yyhl2884 bool = l >= 0
+	yyj2884++
+	if yyhl2884 {
+		yyb2884 = yyj2884 > l
 	} else {
-		yyb2879 = r.CheckBreak()
+		yyb2884 = r.CheckBreak()
 	}
-	if yyb2879 {
+	if yyb2884 {
 		r.ReadEnd()
 		return
 	}
@@ -33575,13 +33612,13 @@ func (x *EventSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Component = string(r.DecodeString())
 	}
-	yyj2879++
-	if yyhl2879 {
-		yyb2879 = yyj2879 > l
+	yyj2884++
+	if yyhl2884 {
+		yyb2884 = yyj2884 > l
 	} else {
-		yyb2879 = r.CheckBreak()
+		yyb2884 = r.CheckBreak()
 	}
-	if yyb2879 {
+	if yyb2884 {
 		r.ReadEnd()
 		return
 	}
@@ -33591,16 +33628,16 @@ func (x *EventSource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Host = string(r.DecodeString())
 	}
 	for {
-		yyj2879++
-		if yyhl2879 {
-			yyb2879 = yyj2879 > l
+		yyj2884++
+		if yyhl2884 {
+			yyb2884 = yyj2884 > l
 		} else {
-			yyb2879 = r.CheckBreak()
+			yyb2884 = r.CheckBreak()
 		}
-		if yyb2879 {
+		if yyb2884 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2879-1, "")
+		z.DecStructFieldNotFound(yyj2884-1, "")
 	}
 	r.ReadEnd()
 }
@@ -33612,39 +33649,39 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2882 := z.EncBinary()
-		_ = yym2882
+		yym2887 := z.EncBinary()
+		_ = yym2887
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2883 := !z.EncBinary()
-			yy2arr2883 := z.EncBasicHandle().StructToArray
-			var yyq2883 [10]bool
-			_, _, _ = yysep2883, yyq2883, yy2arr2883
-			const yyr2883 bool = false
-			yyq2883[0] = x.Kind != ""
-			yyq2883[1] = x.APIVersion != ""
-			yyq2883[4] = x.Reason != ""
-			yyq2883[5] = x.Message != ""
-			yyq2883[6] = true
-			yyq2883[7] = true
-			yyq2883[8] = true
-			yyq2883[9] = x.Count != 0
-			if yyr2883 || yy2arr2883 {
+			yysep2888 := !z.EncBinary()
+			yy2arr2888 := z.EncBasicHandle().StructToArray
+			var yyq2888 [10]bool
+			_, _, _ = yysep2888, yyq2888, yy2arr2888
+			const yyr2888 bool = false
+			yyq2888[0] = x.Kind != ""
+			yyq2888[1] = x.APIVersion != ""
+			yyq2888[4] = x.Reason != ""
+			yyq2888[5] = x.Message != ""
+			yyq2888[6] = true
+			yyq2888[7] = true
+			yyq2888[8] = true
+			yyq2888[9] = x.Count != 0
+			if yyr2888 || yy2arr2888 {
 				r.EncodeArrayStart(10)
 			} else {
-				var yynn2883 int = 2
-				for _, b := range yyq2883 {
+				var yynn2888 int = 2
+				for _, b := range yyq2888 {
 					if b {
-						yynn2883++
+						yynn2888++
 					}
 				}
-				r.EncodeMapStart(yynn2883)
+				r.EncodeMapStart(yynn2888)
 			}
-			if yyr2883 || yy2arr2883 {
-				if yyq2883[0] {
-					yym2885 := z.EncBinary()
-					_ = yym2885
+			if yyr2888 || yy2arr2888 {
+				if yyq2888[0] {
+					yym2890 := z.EncBinary()
+					_ = yym2890
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -33653,20 +33690,20 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2883[0] {
+				if yyq2888[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2886 := z.EncBinary()
-					_ = yym2886
+					yym2891 := z.EncBinary()
+					_ = yym2891
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2883 || yy2arr2883 {
-				if yyq2883[1] {
-					yym2888 := z.EncBinary()
-					_ = yym2888
+			if yyr2888 || yy2arr2888 {
+				if yyq2888[1] {
+					yym2893 := z.EncBinary()
+					_ = yym2893
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -33675,36 +33712,36 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2883[1] {
+				if yyq2888[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2889 := z.EncBinary()
-					_ = yym2889
+					yym2894 := z.EncBinary()
+					_ = yym2894
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2883 || yy2arr2883 {
-				yy2891 := &x.ObjectMeta
-				yy2891.CodecEncodeSelf(e)
+			if yyr2888 || yy2arr2888 {
+				yy2896 := &x.ObjectMeta
+				yy2896.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-				yy2892 := &x.ObjectMeta
-				yy2892.CodecEncodeSelf(e)
+				yy2897 := &x.ObjectMeta
+				yy2897.CodecEncodeSelf(e)
 			}
-			if yyr2883 || yy2arr2883 {
-				yy2894 := &x.InvolvedObject
-				yy2894.CodecEncodeSelf(e)
+			if yyr2888 || yy2arr2888 {
+				yy2899 := &x.InvolvedObject
+				yy2899.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("involvedObject"))
-				yy2895 := &x.InvolvedObject
-				yy2895.CodecEncodeSelf(e)
+				yy2900 := &x.InvolvedObject
+				yy2900.CodecEncodeSelf(e)
 			}
-			if yyr2883 || yy2arr2883 {
-				if yyq2883[4] {
-					yym2897 := z.EncBinary()
-					_ = yym2897
+			if yyr2888 || yy2arr2888 {
+				if yyq2888[4] {
+					yym2902 := z.EncBinary()
+					_ = yym2902
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
@@ -33713,20 +33750,20 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2883[4] {
+				if yyq2888[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("reason"))
-					yym2898 := z.EncBinary()
-					_ = yym2898
+					yym2903 := z.EncBinary()
+					_ = yym2903
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
 					}
 				}
 			}
-			if yyr2883 || yy2arr2883 {
-				if yyq2883[5] {
-					yym2900 := z.EncBinary()
-					_ = yym2900
+			if yyr2888 || yy2arr2888 {
+				if yyq2888[5] {
+					yym2905 := z.EncBinary()
+					_ = yym2905
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
@@ -33735,67 +33772,33 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2883[5] {
+				if yyq2888[5] {
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
-					yym2901 := z.EncBinary()
-					_ = yym2901
+					yym2906 := z.EncBinary()
+					_ = yym2906
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
 					}
 				}
 			}
-			if yyr2883 || yy2arr2883 {
-				if yyq2883[6] {
-					yy2903 := &x.Source
-					yy2903.CodecEncodeSelf(e)
+			if yyr2888 || yy2arr2888 {
+				if yyq2888[6] {
+					yy2908 := &x.Source
+					yy2908.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2883[6] {
+				if yyq2888[6] {
 					r.EncodeString(codecSelferC_UTF81234, string("source"))
-					yy2904 := &x.Source
-					yy2904.CodecEncodeSelf(e)
+					yy2909 := &x.Source
+					yy2909.CodecEncodeSelf(e)
 				}
 			}
-			if yyr2883 || yy2arr2883 {
-				if yyq2883[7] {
-					yy2906 := &x.FirstTimestamp
-					yym2907 := z.EncBinary()
-					_ = yym2907
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2906) {
-					} else if yym2907 {
-						z.EncBinaryMarshal(yy2906)
-					} else if !yym2907 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy2906)
-					} else {
-						z.EncFallback(yy2906)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2883[7] {
-					r.EncodeString(codecSelferC_UTF81234, string("firstTimestamp"))
-					yy2908 := &x.FirstTimestamp
-					yym2909 := z.EncBinary()
-					_ = yym2909
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2908) {
-					} else if yym2909 {
-						z.EncBinaryMarshal(yy2908)
-					} else if !yym2909 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy2908)
-					} else {
-						z.EncFallback(yy2908)
-					}
-				}
-			}
-			if yyr2883 || yy2arr2883 {
-				if yyq2883[8] {
-					yy2911 := &x.LastTimestamp
+			if yyr2888 || yy2arr2888 {
+				if yyq2888[7] {
+					yy2911 := &x.FirstTimestamp
 					yym2912 := z.EncBinary()
 					_ = yym2912
 					if false {
@@ -33811,9 +33814,9 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq2883[8] {
-					r.EncodeString(codecSelferC_UTF81234, string("lastTimestamp"))
-					yy2913 := &x.LastTimestamp
+				if yyq2888[7] {
+					r.EncodeString(codecSelferC_UTF81234, string("firstTimestamp"))
+					yy2913 := &x.FirstTimestamp
 					yym2914 := z.EncBinary()
 					_ = yym2914
 					if false {
@@ -33827,10 +33830,44 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr2883 || yy2arr2883 {
-				if yyq2883[9] {
-					yym2916 := z.EncBinary()
-					_ = yym2916
+			if yyr2888 || yy2arr2888 {
+				if yyq2888[8] {
+					yy2916 := &x.LastTimestamp
+					yym2917 := z.EncBinary()
+					_ = yym2917
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2916) {
+					} else if yym2917 {
+						z.EncBinaryMarshal(yy2916)
+					} else if !yym2917 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy2916)
+					} else {
+						z.EncFallback(yy2916)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq2888[8] {
+					r.EncodeString(codecSelferC_UTF81234, string("lastTimestamp"))
+					yy2918 := &x.LastTimestamp
+					yym2919 := z.EncBinary()
+					_ = yym2919
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2918) {
+					} else if yym2919 {
+						z.EncBinaryMarshal(yy2918)
+					} else if !yym2919 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy2918)
+					} else {
+						z.EncFallback(yy2918)
+					}
+				}
+			}
+			if yyr2888 || yy2arr2888 {
+				if yyq2888[9] {
+					yym2921 := z.EncBinary()
+					_ = yym2921
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Count))
@@ -33839,17 +33876,17 @@ func (x *Event) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq2883[9] {
+				if yyq2888[9] {
 					r.EncodeString(codecSelferC_UTF81234, string("count"))
-					yym2917 := z.EncBinary()
-					_ = yym2917
+					yym2922 := z.EncBinary()
+					_ = yym2922
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Count))
 					}
 				}
 			}
-			if yysep2883 {
+			if yysep2888 {
 				r.EncodeEnd()
 			}
 		}
@@ -33860,24 +33897,24 @@ func (x *Event) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2918 := z.DecBinary()
-	_ = yym2918
+	yym2923 := z.DecBinary()
+	_ = yym2923
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2919 := r.ReadMapStart()
-			if yyl2919 == 0 {
+			yyl2924 := r.ReadMapStart()
+			if yyl2924 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2919, d)
+				x.codecDecodeSelfFromMap(yyl2924, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2919 := r.ReadArrayStart()
-			if yyl2919 == 0 {
+			yyl2924 := r.ReadArrayStart()
+			if yyl2924 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2919, d)
+				x.codecDecodeSelfFromArray(yyl2924, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -33889,12 +33926,12 @@ func (x *Event) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2920Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2920Slc
-	var yyhl2920 bool = l >= 0
-	for yyj2920 := 0; ; yyj2920++ {
-		if yyhl2920 {
-			if yyj2920 >= l {
+	var yys2925Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2925Slc
+	var yyhl2925 bool = l >= 0
+	for yyj2925 := 0; ; yyj2925++ {
+		if yyhl2925 {
+			if yyj2925 >= l {
 				break
 			}
 		} else {
@@ -33902,9 +33939,9 @@ func (x *Event) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2920Slc = r.DecodeBytes(yys2920Slc, true, true)
-		yys2920 := string(yys2920Slc)
-		switch yys2920 {
+		yys2925Slc = r.DecodeBytes(yys2925Slc, true, true)
+		yys2925 := string(yys2925Slc)
+		switch yys2925 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -33921,15 +33958,15 @@ func (x *Event) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv2923 := &x.ObjectMeta
-				yyv2923.CodecDecodeSelf(d)
+				yyv2928 := &x.ObjectMeta
+				yyv2928.CodecDecodeSelf(d)
 			}
 		case "involvedObject":
 			if r.TryDecodeAsNil() {
 				x.InvolvedObject = ObjectReference{}
 			} else {
-				yyv2924 := &x.InvolvedObject
-				yyv2924.CodecDecodeSelf(d)
+				yyv2929 := &x.InvolvedObject
+				yyv2929.CodecDecodeSelf(d)
 			}
 		case "reason":
 			if r.TryDecodeAsNil() {
@@ -33947,41 +33984,41 @@ func (x *Event) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Source = EventSource{}
 			} else {
-				yyv2927 := &x.Source
-				yyv2927.CodecDecodeSelf(d)
+				yyv2932 := &x.Source
+				yyv2932.CodecDecodeSelf(d)
 			}
 		case "firstTimestamp":
 			if r.TryDecodeAsNil() {
 				x.FirstTimestamp = pkg2_unversioned.Time{}
 			} else {
-				yyv2928 := &x.FirstTimestamp
-				yym2929 := z.DecBinary()
-				_ = yym2929
+				yyv2933 := &x.FirstTimestamp
+				yym2934 := z.DecBinary()
+				_ = yym2934
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2928) {
-				} else if yym2929 {
-					z.DecBinaryUnmarshal(yyv2928)
-				} else if !yym2929 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv2928)
+				} else if z.HasExtensions() && z.DecExt(yyv2933) {
+				} else if yym2934 {
+					z.DecBinaryUnmarshal(yyv2933)
+				} else if !yym2934 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv2933)
 				} else {
-					z.DecFallback(yyv2928, false)
+					z.DecFallback(yyv2933, false)
 				}
 			}
 		case "lastTimestamp":
 			if r.TryDecodeAsNil() {
 				x.LastTimestamp = pkg2_unversioned.Time{}
 			} else {
-				yyv2930 := &x.LastTimestamp
-				yym2931 := z.DecBinary()
-				_ = yym2931
+				yyv2935 := &x.LastTimestamp
+				yym2936 := z.DecBinary()
+				_ = yym2936
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2930) {
-				} else if yym2931 {
-					z.DecBinaryUnmarshal(yyv2930)
-				} else if !yym2931 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv2930)
+				} else if z.HasExtensions() && z.DecExt(yyv2935) {
+				} else if yym2936 {
+					z.DecBinaryUnmarshal(yyv2935)
+				} else if !yym2936 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv2935)
 				} else {
-					z.DecFallback(yyv2930, false)
+					z.DecFallback(yyv2935, false)
 				}
 			}
 		case "count":
@@ -33991,10 +34028,10 @@ func (x *Event) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Count = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2920)
-		} // end switch yys2920
-	} // end for yyj2920
-	if !yyhl2920 {
+			z.DecStructFieldNotFound(-1, yys2925)
+		} // end switch yys2925
+	} // end for yyj2925
+	if !yyhl2925 {
 		r.ReadEnd()
 	}
 }
@@ -34003,16 +34040,16 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2933 int
-	var yyb2933 bool
-	var yyhl2933 bool = l >= 0
-	yyj2933++
-	if yyhl2933 {
-		yyb2933 = yyj2933 > l
+	var yyj2938 int
+	var yyb2938 bool
+	var yyhl2938 bool = l >= 0
+	yyj2938++
+	if yyhl2938 {
+		yyb2938 = yyj2938 > l
 	} else {
-		yyb2933 = r.CheckBreak()
+		yyb2938 = r.CheckBreak()
 	}
-	if yyb2933 {
+	if yyb2938 {
 		r.ReadEnd()
 		return
 	}
@@ -34021,13 +34058,13 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2933++
-	if yyhl2933 {
-		yyb2933 = yyj2933 > l
+	yyj2938++
+	if yyhl2938 {
+		yyb2938 = yyj2938 > l
 	} else {
-		yyb2933 = r.CheckBreak()
+		yyb2938 = r.CheckBreak()
 	}
-	if yyb2933 {
+	if yyb2938 {
 		r.ReadEnd()
 		return
 	}
@@ -34036,45 +34073,45 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2933++
-	if yyhl2933 {
-		yyb2933 = yyj2933 > l
+	yyj2938++
+	if yyhl2938 {
+		yyb2938 = yyj2938 > l
 	} else {
-		yyb2933 = r.CheckBreak()
+		yyb2938 = r.CheckBreak()
 	}
-	if yyb2933 {
+	if yyb2938 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv2936 := &x.ObjectMeta
-		yyv2936.CodecDecodeSelf(d)
+		yyv2941 := &x.ObjectMeta
+		yyv2941.CodecDecodeSelf(d)
 	}
-	yyj2933++
-	if yyhl2933 {
-		yyb2933 = yyj2933 > l
+	yyj2938++
+	if yyhl2938 {
+		yyb2938 = yyj2938 > l
 	} else {
-		yyb2933 = r.CheckBreak()
+		yyb2938 = r.CheckBreak()
 	}
-	if yyb2933 {
+	if yyb2938 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.InvolvedObject = ObjectReference{}
 	} else {
-		yyv2937 := &x.InvolvedObject
-		yyv2937.CodecDecodeSelf(d)
+		yyv2942 := &x.InvolvedObject
+		yyv2942.CodecDecodeSelf(d)
 	}
-	yyj2933++
-	if yyhl2933 {
-		yyb2933 = yyj2933 > l
+	yyj2938++
+	if yyhl2938 {
+		yyb2938 = yyj2938 > l
 	} else {
-		yyb2933 = r.CheckBreak()
+		yyb2938 = r.CheckBreak()
 	}
-	if yyb2933 {
+	if yyb2938 {
 		r.ReadEnd()
 		return
 	}
@@ -34083,13 +34120,13 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Reason = string(r.DecodeString())
 	}
-	yyj2933++
-	if yyhl2933 {
-		yyb2933 = yyj2933 > l
+	yyj2938++
+	if yyhl2938 {
+		yyb2938 = yyj2938 > l
 	} else {
-		yyb2933 = r.CheckBreak()
+		yyb2938 = r.CheckBreak()
 	}
-	if yyb2933 {
+	if yyb2938 {
 		r.ReadEnd()
 		return
 	}
@@ -34098,81 +34135,81 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Message = string(r.DecodeString())
 	}
-	yyj2933++
-	if yyhl2933 {
-		yyb2933 = yyj2933 > l
+	yyj2938++
+	if yyhl2938 {
+		yyb2938 = yyj2938 > l
 	} else {
-		yyb2933 = r.CheckBreak()
+		yyb2938 = r.CheckBreak()
 	}
-	if yyb2933 {
+	if yyb2938 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Source = EventSource{}
 	} else {
-		yyv2940 := &x.Source
-		yyv2940.CodecDecodeSelf(d)
+		yyv2945 := &x.Source
+		yyv2945.CodecDecodeSelf(d)
 	}
-	yyj2933++
-	if yyhl2933 {
-		yyb2933 = yyj2933 > l
+	yyj2938++
+	if yyhl2938 {
+		yyb2938 = yyj2938 > l
 	} else {
-		yyb2933 = r.CheckBreak()
+		yyb2938 = r.CheckBreak()
 	}
-	if yyb2933 {
+	if yyb2938 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.FirstTimestamp = pkg2_unversioned.Time{}
 	} else {
-		yyv2941 := &x.FirstTimestamp
-		yym2942 := z.DecBinary()
-		_ = yym2942
+		yyv2946 := &x.FirstTimestamp
+		yym2947 := z.DecBinary()
+		_ = yym2947
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2941) {
-		} else if yym2942 {
-			z.DecBinaryUnmarshal(yyv2941)
-		} else if !yym2942 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv2941)
+		} else if z.HasExtensions() && z.DecExt(yyv2946) {
+		} else if yym2947 {
+			z.DecBinaryUnmarshal(yyv2946)
+		} else if !yym2947 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv2946)
 		} else {
-			z.DecFallback(yyv2941, false)
+			z.DecFallback(yyv2946, false)
 		}
 	}
-	yyj2933++
-	if yyhl2933 {
-		yyb2933 = yyj2933 > l
+	yyj2938++
+	if yyhl2938 {
+		yyb2938 = yyj2938 > l
 	} else {
-		yyb2933 = r.CheckBreak()
+		yyb2938 = r.CheckBreak()
 	}
-	if yyb2933 {
+	if yyb2938 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.LastTimestamp = pkg2_unversioned.Time{}
 	} else {
-		yyv2943 := &x.LastTimestamp
-		yym2944 := z.DecBinary()
-		_ = yym2944
+		yyv2948 := &x.LastTimestamp
+		yym2949 := z.DecBinary()
+		_ = yym2949
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2943) {
-		} else if yym2944 {
-			z.DecBinaryUnmarshal(yyv2943)
-		} else if !yym2944 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv2943)
+		} else if z.HasExtensions() && z.DecExt(yyv2948) {
+		} else if yym2949 {
+			z.DecBinaryUnmarshal(yyv2948)
+		} else if !yym2949 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv2948)
 		} else {
-			z.DecFallback(yyv2943, false)
+			z.DecFallback(yyv2948, false)
 		}
 	}
-	yyj2933++
-	if yyhl2933 {
-		yyb2933 = yyj2933 > l
+	yyj2938++
+	if yyhl2938 {
+		yyb2938 = yyj2938 > l
 	} else {
-		yyb2933 = r.CheckBreak()
+		yyb2938 = r.CheckBreak()
 	}
-	if yyb2933 {
+	if yyb2938 {
 		r.ReadEnd()
 		return
 	}
@@ -34182,16 +34219,16 @@ func (x *Event) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Count = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj2933++
-		if yyhl2933 {
-			yyb2933 = yyj2933 > l
+		yyj2938++
+		if yyhl2938 {
+			yyb2938 = yyj2938 > l
 		} else {
-			yyb2933 = r.CheckBreak()
+			yyb2938 = r.CheckBreak()
 		}
-		if yyb2933 {
+		if yyb2938 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2933-1, "")
+		z.DecStructFieldNotFound(yyj2938-1, "")
 	}
 	r.ReadEnd()
 }
@@ -34203,34 +34240,34 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2946 := z.EncBinary()
-		_ = yym2946
+		yym2951 := z.EncBinary()
+		_ = yym2951
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2947 := !z.EncBinary()
-			yy2arr2947 := z.EncBasicHandle().StructToArray
-			var yyq2947 [4]bool
-			_, _, _ = yysep2947, yyq2947, yy2arr2947
-			const yyr2947 bool = false
-			yyq2947[0] = x.Kind != ""
-			yyq2947[1] = x.APIVersion != ""
-			yyq2947[2] = true
-			if yyr2947 || yy2arr2947 {
+			yysep2952 := !z.EncBinary()
+			yy2arr2952 := z.EncBasicHandle().StructToArray
+			var yyq2952 [4]bool
+			_, _, _ = yysep2952, yyq2952, yy2arr2952
+			const yyr2952 bool = false
+			yyq2952[0] = x.Kind != ""
+			yyq2952[1] = x.APIVersion != ""
+			yyq2952[2] = true
+			if yyr2952 || yy2arr2952 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2947 int = 1
-				for _, b := range yyq2947 {
+				var yynn2952 int = 1
+				for _, b := range yyq2952 {
 					if b {
-						yynn2947++
+						yynn2952++
 					}
 				}
-				r.EncodeMapStart(yynn2947)
+				r.EncodeMapStart(yynn2952)
 			}
-			if yyr2947 || yy2arr2947 {
-				if yyq2947[0] {
-					yym2949 := z.EncBinary()
-					_ = yym2949
+			if yyr2952 || yy2arr2952 {
+				if yyq2952[0] {
+					yym2954 := z.EncBinary()
+					_ = yym2954
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -34239,20 +34276,20 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2947[0] {
+				if yyq2952[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2950 := z.EncBinary()
-					_ = yym2950
+					yym2955 := z.EncBinary()
+					_ = yym2955
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2947 || yy2arr2947 {
-				if yyq2947[1] {
-					yym2952 := z.EncBinary()
-					_ = yym2952
+			if yyr2952 || yy2arr2952 {
+				if yyq2952[1] {
+					yym2957 := z.EncBinary()
+					_ = yym2957
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -34261,48 +34298,48 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2947[1] {
+				if yyq2952[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2953 := z.EncBinary()
-					_ = yym2953
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2947 || yy2arr2947 {
-				if yyq2947[2] {
-					yy2955 := &x.ListMeta
-					yym2956 := z.EncBinary()
-					_ = yym2956
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2955) {
-					} else {
-						z.EncFallback(yy2955)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2947[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy2957 := &x.ListMeta
 					yym2958 := z.EncBinary()
 					_ = yym2958
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2957) {
 					} else {
-						z.EncFallback(yy2957)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2947 || yy2arr2947 {
+			if yyr2952 || yy2arr2952 {
+				if yyq2952[2] {
+					yy2960 := &x.ListMeta
+					yym2961 := z.EncBinary()
+					_ = yym2961
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2960) {
+					} else {
+						z.EncFallback(yy2960)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq2952[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy2962 := &x.ListMeta
+					yym2963 := z.EncBinary()
+					_ = yym2963
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2962) {
+					} else {
+						z.EncFallback(yy2962)
+					}
+				}
+			}
+			if yyr2952 || yy2arr2952 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2960 := z.EncBinary()
-					_ = yym2960
+					yym2965 := z.EncBinary()
+					_ = yym2965
 					if false {
 					} else {
 						h.encSliceEvent(([]Event)(x.Items), e)
@@ -34313,15 +34350,15 @@ func (x *EventList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2961 := z.EncBinary()
-					_ = yym2961
+					yym2966 := z.EncBinary()
+					_ = yym2966
 					if false {
 					} else {
 						h.encSliceEvent(([]Event)(x.Items), e)
 					}
 				}
 			}
-			if yysep2947 {
+			if yysep2952 {
 				r.EncodeEnd()
 			}
 		}
@@ -34332,24 +34369,24 @@ func (x *EventList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2962 := z.DecBinary()
-	_ = yym2962
+	yym2967 := z.DecBinary()
+	_ = yym2967
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2963 := r.ReadMapStart()
-			if yyl2963 == 0 {
+			yyl2968 := r.ReadMapStart()
+			if yyl2968 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2963, d)
+				x.codecDecodeSelfFromMap(yyl2968, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2963 := r.ReadArrayStart()
-			if yyl2963 == 0 {
+			yyl2968 := r.ReadArrayStart()
+			if yyl2968 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2963, d)
+				x.codecDecodeSelfFromArray(yyl2968, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -34361,12 +34398,12 @@ func (x *EventList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2964Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2964Slc
-	var yyhl2964 bool = l >= 0
-	for yyj2964 := 0; ; yyj2964++ {
-		if yyhl2964 {
-			if yyj2964 >= l {
+	var yys2969Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys2969Slc
+	var yyhl2969 bool = l >= 0
+	for yyj2969 := 0; ; yyj2969++ {
+		if yyhl2969 {
+			if yyj2969 >= l {
 				break
 			}
 		} else {
@@ -34374,9 +34411,9 @@ func (x *EventList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2964Slc = r.DecodeBytes(yys2964Slc, true, true)
-		yys2964 := string(yys2964Slc)
-		switch yys2964 {
+		yys2969Slc = r.DecodeBytes(yys2969Slc, true, true)
+		yys2969 := string(yys2969Slc)
+		switch yys2969 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -34393,32 +34430,32 @@ func (x *EventList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv2967 := &x.ListMeta
-				yym2968 := z.DecBinary()
-				_ = yym2968
+				yyv2972 := &x.ListMeta
+				yym2973 := z.DecBinary()
+				_ = yym2973
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2967) {
+				} else if z.HasExtensions() && z.DecExt(yyv2972) {
 				} else {
-					z.DecFallback(yyv2967, false)
+					z.DecFallback(yyv2972, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv2969 := &x.Items
-				yym2970 := z.DecBinary()
-				_ = yym2970
+				yyv2974 := &x.Items
+				yym2975 := z.DecBinary()
+				_ = yym2975
 				if false {
 				} else {
-					h.decSliceEvent((*[]Event)(yyv2969), d)
+					h.decSliceEvent((*[]Event)(yyv2974), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2964)
-		} // end switch yys2964
-	} // end for yyj2964
-	if !yyhl2964 {
+			z.DecStructFieldNotFound(-1, yys2969)
+		} // end switch yys2969
+	} // end for yyj2969
+	if !yyhl2969 {
 		r.ReadEnd()
 	}
 }
@@ -34427,16 +34464,16 @@ func (x *EventList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj2971 int
-	var yyb2971 bool
-	var yyhl2971 bool = l >= 0
-	yyj2971++
-	if yyhl2971 {
-		yyb2971 = yyj2971 > l
+	var yyj2976 int
+	var yyb2976 bool
+	var yyhl2976 bool = l >= 0
+	yyj2976++
+	if yyhl2976 {
+		yyb2976 = yyj2976 > l
 	} else {
-		yyb2971 = r.CheckBreak()
+		yyb2976 = r.CheckBreak()
 	}
-	if yyb2971 {
+	if yyb2976 {
 		r.ReadEnd()
 		return
 	}
@@ -34445,13 +34482,13 @@ func (x *EventList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj2971++
-	if yyhl2971 {
-		yyb2971 = yyj2971 > l
+	yyj2976++
+	if yyhl2976 {
+		yyb2976 = yyj2976 > l
 	} else {
-		yyb2971 = r.CheckBreak()
+		yyb2976 = r.CheckBreak()
 	}
-	if yyb2971 {
+	if yyb2976 {
 		r.ReadEnd()
 		return
 	}
@@ -34460,60 +34497,60 @@ func (x *EventList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj2971++
-	if yyhl2971 {
-		yyb2971 = yyj2971 > l
+	yyj2976++
+	if yyhl2976 {
+		yyb2976 = yyj2976 > l
 	} else {
-		yyb2971 = r.CheckBreak()
+		yyb2976 = r.CheckBreak()
 	}
-	if yyb2971 {
+	if yyb2976 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv2974 := &x.ListMeta
-		yym2975 := z.DecBinary()
-		_ = yym2975
+		yyv2979 := &x.ListMeta
+		yym2980 := z.DecBinary()
+		_ = yym2980
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv2974) {
+		} else if z.HasExtensions() && z.DecExt(yyv2979) {
 		} else {
-			z.DecFallback(yyv2974, false)
+			z.DecFallback(yyv2979, false)
 		}
 	}
-	yyj2971++
-	if yyhl2971 {
-		yyb2971 = yyj2971 > l
+	yyj2976++
+	if yyhl2976 {
+		yyb2976 = yyj2976 > l
 	} else {
-		yyb2971 = r.CheckBreak()
+		yyb2976 = r.CheckBreak()
 	}
-	if yyb2971 {
+	if yyb2976 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv2976 := &x.Items
-		yym2977 := z.DecBinary()
-		_ = yym2977
+		yyv2981 := &x.Items
+		yym2982 := z.DecBinary()
+		_ = yym2982
 		if false {
 		} else {
-			h.decSliceEvent((*[]Event)(yyv2976), d)
+			h.decSliceEvent((*[]Event)(yyv2981), d)
 		}
 	}
 	for {
-		yyj2971++
-		if yyhl2971 {
-			yyb2971 = yyj2971 > l
+		yyj2976++
+		if yyhl2976 {
+			yyb2976 = yyj2976 > l
 		} else {
-			yyb2971 = r.CheckBreak()
+			yyb2976 = r.CheckBreak()
 		}
-		if yyb2971 {
+		if yyb2976 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj2971-1, "")
+		z.DecStructFieldNotFound(yyj2976-1, "")
 	}
 	r.ReadEnd()
 }
@@ -34525,34 +34562,34 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym2978 := z.EncBinary()
-		_ = yym2978
+		yym2983 := z.EncBinary()
+		_ = yym2983
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep2979 := !z.EncBinary()
-			yy2arr2979 := z.EncBasicHandle().StructToArray
-			var yyq2979 [4]bool
-			_, _, _ = yysep2979, yyq2979, yy2arr2979
-			const yyr2979 bool = false
-			yyq2979[0] = x.Kind != ""
-			yyq2979[1] = x.APIVersion != ""
-			yyq2979[2] = true
-			if yyr2979 || yy2arr2979 {
+			yysep2984 := !z.EncBinary()
+			yy2arr2984 := z.EncBasicHandle().StructToArray
+			var yyq2984 [4]bool
+			_, _, _ = yysep2984, yyq2984, yy2arr2984
+			const yyr2984 bool = false
+			yyq2984[0] = x.Kind != ""
+			yyq2984[1] = x.APIVersion != ""
+			yyq2984[2] = true
+			if yyr2984 || yy2arr2984 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn2979 int = 1
-				for _, b := range yyq2979 {
+				var yynn2984 int = 1
+				for _, b := range yyq2984 {
 					if b {
-						yynn2979++
+						yynn2984++
 					}
 				}
-				r.EncodeMapStart(yynn2979)
+				r.EncodeMapStart(yynn2984)
 			}
-			if yyr2979 || yy2arr2979 {
-				if yyq2979[0] {
-					yym2981 := z.EncBinary()
-					_ = yym2981
+			if yyr2984 || yy2arr2984 {
+				if yyq2984[0] {
+					yym2986 := z.EncBinary()
+					_ = yym2986
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -34561,20 +34598,20 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2979[0] {
+				if yyq2984[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym2982 := z.EncBinary()
-					_ = yym2982
+					yym2987 := z.EncBinary()
+					_ = yym2987
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr2979 || yy2arr2979 {
-				if yyq2979[1] {
-					yym2984 := z.EncBinary()
-					_ = yym2984
+			if yyr2984 || yy2arr2984 {
+				if yyq2984[1] {
+					yym2989 := z.EncBinary()
+					_ = yym2989
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -34583,48 +34620,48 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq2979[1] {
+				if yyq2984[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym2985 := z.EncBinary()
-					_ = yym2985
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr2979 || yy2arr2979 {
-				if yyq2979[2] {
-					yy2987 := &x.ListMeta
-					yym2988 := z.EncBinary()
-					_ = yym2988
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2987) {
-					} else {
-						z.EncFallback(yy2987)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq2979[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy2989 := &x.ListMeta
 					yym2990 := z.EncBinary()
 					_ = yym2990
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy2989) {
 					} else {
-						z.EncFallback(yy2989)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr2979 || yy2arr2979 {
+			if yyr2984 || yy2arr2984 {
+				if yyq2984[2] {
+					yy2992 := &x.ListMeta
+					yym2993 := z.EncBinary()
+					_ = yym2993
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2992) {
+					} else {
+						z.EncFallback(yy2992)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq2984[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy2994 := &x.ListMeta
+					yym2995 := z.EncBinary()
+					_ = yym2995
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy2994) {
+					} else {
+						z.EncFallback(yy2994)
+					}
+				}
+			}
+			if yyr2984 || yy2arr2984 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2992 := z.EncBinary()
-					_ = yym2992
+					yym2997 := z.EncBinary()
+					_ = yym2997
 					if false {
 					} else {
 						h.encSliceruntime_RawExtension(([]pkg6_runtime.RawExtension)(x.Items), e)
@@ -34635,15 +34672,15 @@ func (x *List) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym2993 := z.EncBinary()
-					_ = yym2993
+					yym2998 := z.EncBinary()
+					_ = yym2998
 					if false {
 					} else {
 						h.encSliceruntime_RawExtension(([]pkg6_runtime.RawExtension)(x.Items), e)
 					}
 				}
 			}
-			if yysep2979 {
+			if yysep2984 {
 				r.EncodeEnd()
 			}
 		}
@@ -34654,24 +34691,24 @@ func (x *List) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym2994 := z.DecBinary()
-	_ = yym2994
+	yym2999 := z.DecBinary()
+	_ = yym2999
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl2995 := r.ReadMapStart()
-			if yyl2995 == 0 {
+			yyl3000 := r.ReadMapStart()
+			if yyl3000 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl2995, d)
+				x.codecDecodeSelfFromMap(yyl3000, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl2995 := r.ReadArrayStart()
-			if yyl2995 == 0 {
+			yyl3000 := r.ReadArrayStart()
+			if yyl3000 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl2995, d)
+				x.codecDecodeSelfFromArray(yyl3000, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -34683,12 +34720,12 @@ func (x *List) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys2996Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys2996Slc
-	var yyhl2996 bool = l >= 0
-	for yyj2996 := 0; ; yyj2996++ {
-		if yyhl2996 {
-			if yyj2996 >= l {
+	var yys3001Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3001Slc
+	var yyhl3001 bool = l >= 0
+	for yyj3001 := 0; ; yyj3001++ {
+		if yyhl3001 {
+			if yyj3001 >= l {
 				break
 			}
 		} else {
@@ -34696,9 +34733,9 @@ func (x *List) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys2996Slc = r.DecodeBytes(yys2996Slc, true, true)
-		yys2996 := string(yys2996Slc)
-		switch yys2996 {
+		yys3001Slc = r.DecodeBytes(yys3001Slc, true, true)
+		yys3001 := string(yys3001Slc)
+		switch yys3001 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -34715,32 +34752,32 @@ func (x *List) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv2999 := &x.ListMeta
-				yym3000 := z.DecBinary()
-				_ = yym3000
+				yyv3004 := &x.ListMeta
+				yym3005 := z.DecBinary()
+				_ = yym3005
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv2999) {
+				} else if z.HasExtensions() && z.DecExt(yyv3004) {
 				} else {
-					z.DecFallback(yyv2999, false)
+					z.DecFallback(yyv3004, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv3001 := &x.Items
-				yym3002 := z.DecBinary()
-				_ = yym3002
+				yyv3006 := &x.Items
+				yym3007 := z.DecBinary()
+				_ = yym3007
 				if false {
 				} else {
-					h.decSliceruntime_RawExtension((*[]pkg6_runtime.RawExtension)(yyv3001), d)
+					h.decSliceruntime_RawExtension((*[]pkg6_runtime.RawExtension)(yyv3006), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys2996)
-		} // end switch yys2996
-	} // end for yyj2996
-	if !yyhl2996 {
+			z.DecStructFieldNotFound(-1, yys3001)
+		} // end switch yys3001
+	} // end for yyj3001
+	if !yyhl3001 {
 		r.ReadEnd()
 	}
 }
@@ -34749,16 +34786,16 @@ func (x *List) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3003 int
-	var yyb3003 bool
-	var yyhl3003 bool = l >= 0
-	yyj3003++
-	if yyhl3003 {
-		yyb3003 = yyj3003 > l
+	var yyj3008 int
+	var yyb3008 bool
+	var yyhl3008 bool = l >= 0
+	yyj3008++
+	if yyhl3008 {
+		yyb3008 = yyj3008 > l
 	} else {
-		yyb3003 = r.CheckBreak()
+		yyb3008 = r.CheckBreak()
 	}
-	if yyb3003 {
+	if yyb3008 {
 		r.ReadEnd()
 		return
 	}
@@ -34767,13 +34804,13 @@ func (x *List) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3003++
-	if yyhl3003 {
-		yyb3003 = yyj3003 > l
+	yyj3008++
+	if yyhl3008 {
+		yyb3008 = yyj3008 > l
 	} else {
-		yyb3003 = r.CheckBreak()
+		yyb3008 = r.CheckBreak()
 	}
-	if yyb3003 {
+	if yyb3008 {
 		r.ReadEnd()
 		return
 	}
@@ -34782,60 +34819,60 @@ func (x *List) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3003++
-	if yyhl3003 {
-		yyb3003 = yyj3003 > l
+	yyj3008++
+	if yyhl3008 {
+		yyb3008 = yyj3008 > l
 	} else {
-		yyb3003 = r.CheckBreak()
+		yyb3008 = r.CheckBreak()
 	}
-	if yyb3003 {
+	if yyb3008 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv3006 := &x.ListMeta
-		yym3007 := z.DecBinary()
-		_ = yym3007
+		yyv3011 := &x.ListMeta
+		yym3012 := z.DecBinary()
+		_ = yym3012
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3006) {
+		} else if z.HasExtensions() && z.DecExt(yyv3011) {
 		} else {
-			z.DecFallback(yyv3006, false)
+			z.DecFallback(yyv3011, false)
 		}
 	}
-	yyj3003++
-	if yyhl3003 {
-		yyb3003 = yyj3003 > l
+	yyj3008++
+	if yyhl3008 {
+		yyb3008 = yyj3008 > l
 	} else {
-		yyb3003 = r.CheckBreak()
+		yyb3008 = r.CheckBreak()
 	}
-	if yyb3003 {
+	if yyb3008 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv3008 := &x.Items
-		yym3009 := z.DecBinary()
-		_ = yym3009
+		yyv3013 := &x.Items
+		yym3014 := z.DecBinary()
+		_ = yym3014
 		if false {
 		} else {
-			h.decSliceruntime_RawExtension((*[]pkg6_runtime.RawExtension)(yyv3008), d)
+			h.decSliceruntime_RawExtension((*[]pkg6_runtime.RawExtension)(yyv3013), d)
 		}
 	}
 	for {
-		yyj3003++
-		if yyhl3003 {
-			yyb3003 = yyj3003 > l
+		yyj3008++
+		if yyhl3008 {
+			yyb3008 = yyj3008 > l
 		} else {
-			yyb3003 = r.CheckBreak()
+			yyb3008 = r.CheckBreak()
 		}
-		if yyb3003 {
+		if yyb3008 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3003-1, "")
+		z.DecStructFieldNotFound(yyj3008-1, "")
 	}
 	r.ReadEnd()
 }
@@ -34844,8 +34881,8 @@ func (x LimitType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym3010 := z.EncBinary()
-	_ = yym3010
+	yym3015 := z.EncBinary()
+	_ = yym3015
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -34857,8 +34894,8 @@ func (x *LimitType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3011 := z.DecBinary()
-	_ = yym3011
+	yym3016 := z.DecBinary()
+	_ = yym3016
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -34873,47 +34910,47 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3012 := z.EncBinary()
-		_ = yym3012
+		yym3017 := z.EncBinary()
+		_ = yym3017
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3013 := !z.EncBinary()
-			yy2arr3013 := z.EncBasicHandle().StructToArray
-			var yyq3013 [6]bool
-			_, _, _ = yysep3013, yyq3013, yy2arr3013
-			const yyr3013 bool = false
-			yyq3013[0] = x.Type != ""
-			yyq3013[1] = len(x.Max) != 0
-			yyq3013[2] = len(x.Min) != 0
-			yyq3013[3] = len(x.Default) != 0
-			yyq3013[4] = len(x.DefaultRequest) != 0
-			yyq3013[5] = len(x.MaxLimitRequestRatio) != 0
-			if yyr3013 || yy2arr3013 {
+			yysep3018 := !z.EncBinary()
+			yy2arr3018 := z.EncBasicHandle().StructToArray
+			var yyq3018 [6]bool
+			_, _, _ = yysep3018, yyq3018, yy2arr3018
+			const yyr3018 bool = false
+			yyq3018[0] = x.Type != ""
+			yyq3018[1] = len(x.Max) != 0
+			yyq3018[2] = len(x.Min) != 0
+			yyq3018[3] = len(x.Default) != 0
+			yyq3018[4] = len(x.DefaultRequest) != 0
+			yyq3018[5] = len(x.MaxLimitRequestRatio) != 0
+			if yyr3018 || yy2arr3018 {
 				r.EncodeArrayStart(6)
 			} else {
-				var yynn3013 int = 0
-				for _, b := range yyq3013 {
+				var yynn3018 int = 0
+				for _, b := range yyq3018 {
 					if b {
-						yynn3013++
+						yynn3018++
 					}
 				}
-				r.EncodeMapStart(yynn3013)
+				r.EncodeMapStart(yynn3018)
 			}
-			if yyr3013 || yy2arr3013 {
-				if yyq3013[0] {
+			if yyr3018 || yy2arr3018 {
+				if yyq3018[0] {
 					x.Type.CodecEncodeSelf(e)
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3013[0] {
+				if yyq3018[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("type"))
 					x.Type.CodecEncodeSelf(e)
 				}
 			}
-			if yyr3013 || yy2arr3013 {
-				if yyq3013[1] {
+			if yyr3018 || yy2arr3018 {
+				if yyq3018[1] {
 					if x.Max == nil {
 						r.EncodeNil()
 					} else {
@@ -34923,7 +34960,7 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3013[1] {
+				if yyq3018[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("max"))
 					if x.Max == nil {
 						r.EncodeNil()
@@ -34932,8 +34969,8 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr3013 || yy2arr3013 {
-				if yyq3013[2] {
+			if yyr3018 || yy2arr3018 {
+				if yyq3018[2] {
 					if x.Min == nil {
 						r.EncodeNil()
 					} else {
@@ -34943,7 +34980,7 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3013[2] {
+				if yyq3018[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("min"))
 					if x.Min == nil {
 						r.EncodeNil()
@@ -34952,8 +34989,8 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr3013 || yy2arr3013 {
-				if yyq3013[3] {
+			if yyr3018 || yy2arr3018 {
+				if yyq3018[3] {
 					if x.Default == nil {
 						r.EncodeNil()
 					} else {
@@ -34963,7 +35000,7 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3013[3] {
+				if yyq3018[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("default"))
 					if x.Default == nil {
 						r.EncodeNil()
@@ -34972,8 +35009,8 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr3013 || yy2arr3013 {
-				if yyq3013[4] {
+			if yyr3018 || yy2arr3018 {
+				if yyq3018[4] {
 					if x.DefaultRequest == nil {
 						r.EncodeNil()
 					} else {
@@ -34983,7 +35020,7 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3013[4] {
+				if yyq3018[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("defaultRequest"))
 					if x.DefaultRequest == nil {
 						r.EncodeNil()
@@ -34992,8 +35029,8 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr3013 || yy2arr3013 {
-				if yyq3013[5] {
+			if yyr3018 || yy2arr3018 {
+				if yyq3018[5] {
 					if x.MaxLimitRequestRatio == nil {
 						r.EncodeNil()
 					} else {
@@ -35003,7 +35040,7 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3013[5] {
+				if yyq3018[5] {
 					r.EncodeString(codecSelferC_UTF81234, string("maxLimitRequestRatio"))
 					if x.MaxLimitRequestRatio == nil {
 						r.EncodeNil()
@@ -35012,7 +35049,7 @@ func (x *LimitRangeItem) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3013 {
+			if yysep3018 {
 				r.EncodeEnd()
 			}
 		}
@@ -35023,24 +35060,24 @@ func (x *LimitRangeItem) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3020 := z.DecBinary()
-	_ = yym3020
+	yym3025 := z.DecBinary()
+	_ = yym3025
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3021 := r.ReadMapStart()
-			if yyl3021 == 0 {
+			yyl3026 := r.ReadMapStart()
+			if yyl3026 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3021, d)
+				x.codecDecodeSelfFromMap(yyl3026, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3021 := r.ReadArrayStart()
-			if yyl3021 == 0 {
+			yyl3026 := r.ReadArrayStart()
+			if yyl3026 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3021, d)
+				x.codecDecodeSelfFromArray(yyl3026, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -35052,12 +35089,12 @@ func (x *LimitRangeItem) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3022Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3022Slc
-	var yyhl3022 bool = l >= 0
-	for yyj3022 := 0; ; yyj3022++ {
-		if yyhl3022 {
-			if yyj3022 >= l {
+	var yys3027Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3027Slc
+	var yyhl3027 bool = l >= 0
+	for yyj3027 := 0; ; yyj3027++ {
+		if yyhl3027 {
+			if yyj3027 >= l {
 				break
 			}
 		} else {
@@ -35065,9 +35102,9 @@ func (x *LimitRangeItem) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3022Slc = r.DecodeBytes(yys3022Slc, true, true)
-		yys3022 := string(yys3022Slc)
-		switch yys3022 {
+		yys3027Slc = r.DecodeBytes(yys3027Slc, true, true)
+		yys3027 := string(yys3027Slc)
+		switch yys3027 {
 		case "type":
 			if r.TryDecodeAsNil() {
 				x.Type = ""
@@ -35078,42 +35115,42 @@ func (x *LimitRangeItem) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Max = nil
 			} else {
-				yyv3024 := &x.Max
-				yyv3024.CodecDecodeSelf(d)
+				yyv3029 := &x.Max
+				yyv3029.CodecDecodeSelf(d)
 			}
 		case "min":
 			if r.TryDecodeAsNil() {
 				x.Min = nil
 			} else {
-				yyv3025 := &x.Min
-				yyv3025.CodecDecodeSelf(d)
+				yyv3030 := &x.Min
+				yyv3030.CodecDecodeSelf(d)
 			}
 		case "default":
 			if r.TryDecodeAsNil() {
 				x.Default = nil
 			} else {
-				yyv3026 := &x.Default
-				yyv3026.CodecDecodeSelf(d)
+				yyv3031 := &x.Default
+				yyv3031.CodecDecodeSelf(d)
 			}
 		case "defaultRequest":
 			if r.TryDecodeAsNil() {
 				x.DefaultRequest = nil
 			} else {
-				yyv3027 := &x.DefaultRequest
-				yyv3027.CodecDecodeSelf(d)
+				yyv3032 := &x.DefaultRequest
+				yyv3032.CodecDecodeSelf(d)
 			}
 		case "maxLimitRequestRatio":
 			if r.TryDecodeAsNil() {
 				x.MaxLimitRequestRatio = nil
 			} else {
-				yyv3028 := &x.MaxLimitRequestRatio
-				yyv3028.CodecDecodeSelf(d)
+				yyv3033 := &x.MaxLimitRequestRatio
+				yyv3033.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3022)
-		} // end switch yys3022
-	} // end for yyj3022
-	if !yyhl3022 {
+			z.DecStructFieldNotFound(-1, yys3027)
+		} // end switch yys3027
+	} // end for yyj3027
+	if !yyhl3027 {
 		r.ReadEnd()
 	}
 }
@@ -35122,16 +35159,16 @@ func (x *LimitRangeItem) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3029 int
-	var yyb3029 bool
-	var yyhl3029 bool = l >= 0
-	yyj3029++
-	if yyhl3029 {
-		yyb3029 = yyj3029 > l
+	var yyj3034 int
+	var yyb3034 bool
+	var yyhl3034 bool = l >= 0
+	yyj3034++
+	if yyhl3034 {
+		yyb3034 = yyj3034 > l
 	} else {
-		yyb3029 = r.CheckBreak()
+		yyb3034 = r.CheckBreak()
 	}
-	if yyb3029 {
+	if yyb3034 {
 		r.ReadEnd()
 		return
 	}
@@ -35140,97 +35177,97 @@ func (x *LimitRangeItem) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Type = LimitType(r.DecodeString())
 	}
-	yyj3029++
-	if yyhl3029 {
-		yyb3029 = yyj3029 > l
+	yyj3034++
+	if yyhl3034 {
+		yyb3034 = yyj3034 > l
 	} else {
-		yyb3029 = r.CheckBreak()
+		yyb3034 = r.CheckBreak()
 	}
-	if yyb3029 {
+	if yyb3034 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Max = nil
 	} else {
-		yyv3031 := &x.Max
-		yyv3031.CodecDecodeSelf(d)
+		yyv3036 := &x.Max
+		yyv3036.CodecDecodeSelf(d)
 	}
-	yyj3029++
-	if yyhl3029 {
-		yyb3029 = yyj3029 > l
+	yyj3034++
+	if yyhl3034 {
+		yyb3034 = yyj3034 > l
 	} else {
-		yyb3029 = r.CheckBreak()
+		yyb3034 = r.CheckBreak()
 	}
-	if yyb3029 {
+	if yyb3034 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Min = nil
 	} else {
-		yyv3032 := &x.Min
-		yyv3032.CodecDecodeSelf(d)
+		yyv3037 := &x.Min
+		yyv3037.CodecDecodeSelf(d)
 	}
-	yyj3029++
-	if yyhl3029 {
-		yyb3029 = yyj3029 > l
+	yyj3034++
+	if yyhl3034 {
+		yyb3034 = yyj3034 > l
 	} else {
-		yyb3029 = r.CheckBreak()
+		yyb3034 = r.CheckBreak()
 	}
-	if yyb3029 {
+	if yyb3034 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Default = nil
 	} else {
-		yyv3033 := &x.Default
-		yyv3033.CodecDecodeSelf(d)
+		yyv3038 := &x.Default
+		yyv3038.CodecDecodeSelf(d)
 	}
-	yyj3029++
-	if yyhl3029 {
-		yyb3029 = yyj3029 > l
+	yyj3034++
+	if yyhl3034 {
+		yyb3034 = yyj3034 > l
 	} else {
-		yyb3029 = r.CheckBreak()
+		yyb3034 = r.CheckBreak()
 	}
-	if yyb3029 {
+	if yyb3034 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.DefaultRequest = nil
 	} else {
-		yyv3034 := &x.DefaultRequest
-		yyv3034.CodecDecodeSelf(d)
+		yyv3039 := &x.DefaultRequest
+		yyv3039.CodecDecodeSelf(d)
 	}
-	yyj3029++
-	if yyhl3029 {
-		yyb3029 = yyj3029 > l
+	yyj3034++
+	if yyhl3034 {
+		yyb3034 = yyj3034 > l
 	} else {
-		yyb3029 = r.CheckBreak()
+		yyb3034 = r.CheckBreak()
 	}
-	if yyb3029 {
+	if yyb3034 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.MaxLimitRequestRatio = nil
 	} else {
-		yyv3035 := &x.MaxLimitRequestRatio
-		yyv3035.CodecDecodeSelf(d)
+		yyv3040 := &x.MaxLimitRequestRatio
+		yyv3040.CodecDecodeSelf(d)
 	}
 	for {
-		yyj3029++
-		if yyhl3029 {
-			yyb3029 = yyj3029 > l
+		yyj3034++
+		if yyhl3034 {
+			yyb3034 = yyj3034 > l
 		} else {
-			yyb3029 = r.CheckBreak()
+			yyb3034 = r.CheckBreak()
 		}
-		if yyb3029 {
+		if yyb3034 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3029-1, "")
+		z.DecStructFieldNotFound(yyj3034-1, "")
 	}
 	r.ReadEnd()
 }
@@ -35242,33 +35279,33 @@ func (x *LimitRangeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3036 := z.EncBinary()
-		_ = yym3036
+		yym3041 := z.EncBinary()
+		_ = yym3041
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3037 := !z.EncBinary()
-			yy2arr3037 := z.EncBasicHandle().StructToArray
-			var yyq3037 [1]bool
-			_, _, _ = yysep3037, yyq3037, yy2arr3037
-			const yyr3037 bool = false
-			if yyr3037 || yy2arr3037 {
+			yysep3042 := !z.EncBinary()
+			yy2arr3042 := z.EncBasicHandle().StructToArray
+			var yyq3042 [1]bool
+			_, _, _ = yysep3042, yyq3042, yy2arr3042
+			const yyr3042 bool = false
+			if yyr3042 || yy2arr3042 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn3037 int = 1
-				for _, b := range yyq3037 {
+				var yynn3042 int = 1
+				for _, b := range yyq3042 {
 					if b {
-						yynn3037++
+						yynn3042++
 					}
 				}
-				r.EncodeMapStart(yynn3037)
+				r.EncodeMapStart(yynn3042)
 			}
-			if yyr3037 || yy2arr3037 {
+			if yyr3042 || yy2arr3042 {
 				if x.Limits == nil {
 					r.EncodeNil()
 				} else {
-					yym3039 := z.EncBinary()
-					_ = yym3039
+					yym3044 := z.EncBinary()
+					_ = yym3044
 					if false {
 					} else {
 						h.encSliceLimitRangeItem(([]LimitRangeItem)(x.Limits), e)
@@ -35279,15 +35316,15 @@ func (x *LimitRangeSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Limits == nil {
 					r.EncodeNil()
 				} else {
-					yym3040 := z.EncBinary()
-					_ = yym3040
+					yym3045 := z.EncBinary()
+					_ = yym3045
 					if false {
 					} else {
 						h.encSliceLimitRangeItem(([]LimitRangeItem)(x.Limits), e)
 					}
 				}
 			}
-			if yysep3037 {
+			if yysep3042 {
 				r.EncodeEnd()
 			}
 		}
@@ -35298,24 +35335,24 @@ func (x *LimitRangeSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3041 := z.DecBinary()
-	_ = yym3041
+	yym3046 := z.DecBinary()
+	_ = yym3046
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3042 := r.ReadMapStart()
-			if yyl3042 == 0 {
+			yyl3047 := r.ReadMapStart()
+			if yyl3047 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3042, d)
+				x.codecDecodeSelfFromMap(yyl3047, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3042 := r.ReadArrayStart()
-			if yyl3042 == 0 {
+			yyl3047 := r.ReadArrayStart()
+			if yyl3047 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3042, d)
+				x.codecDecodeSelfFromArray(yyl3047, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -35327,12 +35364,12 @@ func (x *LimitRangeSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3043Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3043Slc
-	var yyhl3043 bool = l >= 0
-	for yyj3043 := 0; ; yyj3043++ {
-		if yyhl3043 {
-			if yyj3043 >= l {
+	var yys3048Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3048Slc
+	var yyhl3048 bool = l >= 0
+	for yyj3048 := 0; ; yyj3048++ {
+		if yyhl3048 {
+			if yyj3048 >= l {
 				break
 			}
 		} else {
@@ -35340,26 +35377,26 @@ func (x *LimitRangeSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3043Slc = r.DecodeBytes(yys3043Slc, true, true)
-		yys3043 := string(yys3043Slc)
-		switch yys3043 {
+		yys3048Slc = r.DecodeBytes(yys3048Slc, true, true)
+		yys3048 := string(yys3048Slc)
+		switch yys3048 {
 		case "limits":
 			if r.TryDecodeAsNil() {
 				x.Limits = nil
 			} else {
-				yyv3044 := &x.Limits
-				yym3045 := z.DecBinary()
-				_ = yym3045
+				yyv3049 := &x.Limits
+				yym3050 := z.DecBinary()
+				_ = yym3050
 				if false {
 				} else {
-					h.decSliceLimitRangeItem((*[]LimitRangeItem)(yyv3044), d)
+					h.decSliceLimitRangeItem((*[]LimitRangeItem)(yyv3049), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3043)
-		} // end switch yys3043
-	} // end for yyj3043
-	if !yyhl3043 {
+			z.DecStructFieldNotFound(-1, yys3048)
+		} // end switch yys3048
+	} // end for yyj3048
+	if !yyhl3048 {
 		r.ReadEnd()
 	}
 }
@@ -35368,41 +35405,41 @@ func (x *LimitRangeSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3046 int
-	var yyb3046 bool
-	var yyhl3046 bool = l >= 0
-	yyj3046++
-	if yyhl3046 {
-		yyb3046 = yyj3046 > l
+	var yyj3051 int
+	var yyb3051 bool
+	var yyhl3051 bool = l >= 0
+	yyj3051++
+	if yyhl3051 {
+		yyb3051 = yyj3051 > l
 	} else {
-		yyb3046 = r.CheckBreak()
+		yyb3051 = r.CheckBreak()
 	}
-	if yyb3046 {
+	if yyb3051 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Limits = nil
 	} else {
-		yyv3047 := &x.Limits
-		yym3048 := z.DecBinary()
-		_ = yym3048
+		yyv3052 := &x.Limits
+		yym3053 := z.DecBinary()
+		_ = yym3053
 		if false {
 		} else {
-			h.decSliceLimitRangeItem((*[]LimitRangeItem)(yyv3047), d)
+			h.decSliceLimitRangeItem((*[]LimitRangeItem)(yyv3052), d)
 		}
 	}
 	for {
-		yyj3046++
-		if yyhl3046 {
-			yyb3046 = yyj3046 > l
+		yyj3051++
+		if yyhl3051 {
+			yyb3051 = yyj3051 > l
 		} else {
-			yyb3046 = r.CheckBreak()
+			yyb3051 = r.CheckBreak()
 		}
-		if yyb3046 {
+		if yyb3051 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3046-1, "")
+		z.DecStructFieldNotFound(yyj3051-1, "")
 	}
 	r.ReadEnd()
 }
@@ -35414,35 +35451,35 @@ func (x *LimitRange) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3049 := z.EncBinary()
-		_ = yym3049
+		yym3054 := z.EncBinary()
+		_ = yym3054
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3050 := !z.EncBinary()
-			yy2arr3050 := z.EncBasicHandle().StructToArray
-			var yyq3050 [4]bool
-			_, _, _ = yysep3050, yyq3050, yy2arr3050
-			const yyr3050 bool = false
-			yyq3050[0] = x.Kind != ""
-			yyq3050[1] = x.APIVersion != ""
-			yyq3050[2] = true
-			yyq3050[3] = true
-			if yyr3050 || yy2arr3050 {
+			yysep3055 := !z.EncBinary()
+			yy2arr3055 := z.EncBasicHandle().StructToArray
+			var yyq3055 [4]bool
+			_, _, _ = yysep3055, yyq3055, yy2arr3055
+			const yyr3055 bool = false
+			yyq3055[0] = x.Kind != ""
+			yyq3055[1] = x.APIVersion != ""
+			yyq3055[2] = true
+			yyq3055[3] = true
+			if yyr3055 || yy2arr3055 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3050 int = 0
-				for _, b := range yyq3050 {
+				var yynn3055 int = 0
+				for _, b := range yyq3055 {
 					if b {
-						yynn3050++
+						yynn3055++
 					}
 				}
-				r.EncodeMapStart(yynn3050)
+				r.EncodeMapStart(yynn3055)
 			}
-			if yyr3050 || yy2arr3050 {
-				if yyq3050[0] {
-					yym3052 := z.EncBinary()
-					_ = yym3052
+			if yyr3055 || yy2arr3055 {
+				if yyq3055[0] {
+					yym3057 := z.EncBinary()
+					_ = yym3057
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -35451,20 +35488,20 @@ func (x *LimitRange) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3050[0] {
+				if yyq3055[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3053 := z.EncBinary()
-					_ = yym3053
+					yym3058 := z.EncBinary()
+					_ = yym3058
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr3050 || yy2arr3050 {
-				if yyq3050[1] {
-					yym3055 := z.EncBinary()
-					_ = yym3055
+			if yyr3055 || yy2arr3055 {
+				if yyq3055[1] {
+					yym3060 := z.EncBinary()
+					_ = yym3060
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -35473,45 +35510,45 @@ func (x *LimitRange) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3050[1] {
+				if yyq3055[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym3056 := z.EncBinary()
-					_ = yym3056
+					yym3061 := z.EncBinary()
+					_ = yym3061
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr3050 || yy2arr3050 {
-				if yyq3050[2] {
-					yy3058 := &x.ObjectMeta
-					yy3058.CodecEncodeSelf(e)
+			if yyr3055 || yy2arr3055 {
+				if yyq3055[2] {
+					yy3063 := &x.ObjectMeta
+					yy3063.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3050[2] {
+				if yyq3055[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3059 := &x.ObjectMeta
-					yy3059.CodecEncodeSelf(e)
+					yy3064 := &x.ObjectMeta
+					yy3064.CodecEncodeSelf(e)
 				}
 			}
-			if yyr3050 || yy2arr3050 {
-				if yyq3050[3] {
-					yy3061 := &x.Spec
-					yy3061.CodecEncodeSelf(e)
+			if yyr3055 || yy2arr3055 {
+				if yyq3055[3] {
+					yy3066 := &x.Spec
+					yy3066.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3050[3] {
+				if yyq3055[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy3062 := &x.Spec
-					yy3062.CodecEncodeSelf(e)
+					yy3067 := &x.Spec
+					yy3067.CodecEncodeSelf(e)
 				}
 			}
-			if yysep3050 {
+			if yysep3055 {
 				r.EncodeEnd()
 			}
 		}
@@ -35522,24 +35559,24 @@ func (x *LimitRange) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3063 := z.DecBinary()
-	_ = yym3063
+	yym3068 := z.DecBinary()
+	_ = yym3068
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3064 := r.ReadMapStart()
-			if yyl3064 == 0 {
+			yyl3069 := r.ReadMapStart()
+			if yyl3069 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3064, d)
+				x.codecDecodeSelfFromMap(yyl3069, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3064 := r.ReadArrayStart()
-			if yyl3064 == 0 {
+			yyl3069 := r.ReadArrayStart()
+			if yyl3069 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3064, d)
+				x.codecDecodeSelfFromArray(yyl3069, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -35551,12 +35588,12 @@ func (x *LimitRange) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3065Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3065Slc
-	var yyhl3065 bool = l >= 0
-	for yyj3065 := 0; ; yyj3065++ {
-		if yyhl3065 {
-			if yyj3065 >= l {
+	var yys3070Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3070Slc
+	var yyhl3070 bool = l >= 0
+	for yyj3070 := 0; ; yyj3070++ {
+		if yyhl3070 {
+			if yyj3070 >= l {
 				break
 			}
 		} else {
@@ -35564,9 +35601,9 @@ func (x *LimitRange) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3065Slc = r.DecodeBytes(yys3065Slc, true, true)
-		yys3065 := string(yys3065Slc)
-		switch yys3065 {
+		yys3070Slc = r.DecodeBytes(yys3070Slc, true, true)
+		yys3070 := string(yys3070Slc)
+		switch yys3070 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -35583,21 +35620,21 @@ func (x *LimitRange) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv3068 := &x.ObjectMeta
-				yyv3068.CodecDecodeSelf(d)
+				yyv3073 := &x.ObjectMeta
+				yyv3073.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = LimitRangeSpec{}
 			} else {
-				yyv3069 := &x.Spec
-				yyv3069.CodecDecodeSelf(d)
+				yyv3074 := &x.Spec
+				yyv3074.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3065)
-		} // end switch yys3065
-	} // end for yyj3065
-	if !yyhl3065 {
+			z.DecStructFieldNotFound(-1, yys3070)
+		} // end switch yys3070
+	} // end for yyj3070
+	if !yyhl3070 {
 		r.ReadEnd()
 	}
 }
@@ -35606,16 +35643,16 @@ func (x *LimitRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3070 int
-	var yyb3070 bool
-	var yyhl3070 bool = l >= 0
-	yyj3070++
-	if yyhl3070 {
-		yyb3070 = yyj3070 > l
+	var yyj3075 int
+	var yyb3075 bool
+	var yyhl3075 bool = l >= 0
+	yyj3075++
+	if yyhl3075 {
+		yyb3075 = yyj3075 > l
 	} else {
-		yyb3070 = r.CheckBreak()
+		yyb3075 = r.CheckBreak()
 	}
-	if yyb3070 {
+	if yyb3075 {
 		r.ReadEnd()
 		return
 	}
@@ -35624,13 +35661,13 @@ func (x *LimitRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3070++
-	if yyhl3070 {
-		yyb3070 = yyj3070 > l
+	yyj3075++
+	if yyhl3075 {
+		yyb3075 = yyj3075 > l
 	} else {
-		yyb3070 = r.CheckBreak()
+		yyb3075 = r.CheckBreak()
 	}
-	if yyb3070 {
+	if yyb3075 {
 		r.ReadEnd()
 		return
 	}
@@ -35639,49 +35676,49 @@ func (x *LimitRange) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3070++
-	if yyhl3070 {
-		yyb3070 = yyj3070 > l
+	yyj3075++
+	if yyhl3075 {
+		yyb3075 = yyj3075 > l
 	} else {
-		yyb3070 = r.CheckBreak()
+		yyb3075 = r.CheckBreak()
 	}
-	if yyb3070 {
+	if yyb3075 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv3073 := &x.ObjectMeta
-		yyv3073.CodecDecodeSelf(d)
+		yyv3078 := &x.ObjectMeta
+		yyv3078.CodecDecodeSelf(d)
 	}
-	yyj3070++
-	if yyhl3070 {
-		yyb3070 = yyj3070 > l
+	yyj3075++
+	if yyhl3075 {
+		yyb3075 = yyj3075 > l
 	} else {
-		yyb3070 = r.CheckBreak()
+		yyb3075 = r.CheckBreak()
 	}
-	if yyb3070 {
+	if yyb3075 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = LimitRangeSpec{}
 	} else {
-		yyv3074 := &x.Spec
-		yyv3074.CodecDecodeSelf(d)
+		yyv3079 := &x.Spec
+		yyv3079.CodecDecodeSelf(d)
 	}
 	for {
-		yyj3070++
-		if yyhl3070 {
-			yyb3070 = yyj3070 > l
+		yyj3075++
+		if yyhl3075 {
+			yyb3075 = yyj3075 > l
 		} else {
-			yyb3070 = r.CheckBreak()
+			yyb3075 = r.CheckBreak()
 		}
-		if yyb3070 {
+		if yyb3075 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3070-1, "")
+		z.DecStructFieldNotFound(yyj3075-1, "")
 	}
 	r.ReadEnd()
 }
@@ -35693,34 +35730,34 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3075 := z.EncBinary()
-		_ = yym3075
+		yym3080 := z.EncBinary()
+		_ = yym3080
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3076 := !z.EncBinary()
-			yy2arr3076 := z.EncBasicHandle().StructToArray
-			var yyq3076 [4]bool
-			_, _, _ = yysep3076, yyq3076, yy2arr3076
-			const yyr3076 bool = false
-			yyq3076[0] = x.Kind != ""
-			yyq3076[1] = x.APIVersion != ""
-			yyq3076[2] = true
-			if yyr3076 || yy2arr3076 {
+			yysep3081 := !z.EncBinary()
+			yy2arr3081 := z.EncBasicHandle().StructToArray
+			var yyq3081 [4]bool
+			_, _, _ = yysep3081, yyq3081, yy2arr3081
+			const yyr3081 bool = false
+			yyq3081[0] = x.Kind != ""
+			yyq3081[1] = x.APIVersion != ""
+			yyq3081[2] = true
+			if yyr3081 || yy2arr3081 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3076 int = 1
-				for _, b := range yyq3076 {
+				var yynn3081 int = 1
+				for _, b := range yyq3081 {
 					if b {
-						yynn3076++
+						yynn3081++
 					}
 				}
-				r.EncodeMapStart(yynn3076)
+				r.EncodeMapStart(yynn3081)
 			}
-			if yyr3076 || yy2arr3076 {
-				if yyq3076[0] {
-					yym3078 := z.EncBinary()
-					_ = yym3078
+			if yyr3081 || yy2arr3081 {
+				if yyq3081[0] {
+					yym3083 := z.EncBinary()
+					_ = yym3083
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -35729,20 +35766,20 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3076[0] {
+				if yyq3081[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3079 := z.EncBinary()
-					_ = yym3079
+					yym3084 := z.EncBinary()
+					_ = yym3084
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr3076 || yy2arr3076 {
-				if yyq3076[1] {
-					yym3081 := z.EncBinary()
-					_ = yym3081
+			if yyr3081 || yy2arr3081 {
+				if yyq3081[1] {
+					yym3086 := z.EncBinary()
+					_ = yym3086
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -35751,48 +35788,48 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3076[1] {
+				if yyq3081[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym3082 := z.EncBinary()
-					_ = yym3082
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3076 || yy2arr3076 {
-				if yyq3076[2] {
-					yy3084 := &x.ListMeta
-					yym3085 := z.EncBinary()
-					_ = yym3085
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3084) {
-					} else {
-						z.EncFallback(yy3084)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq3076[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3086 := &x.ListMeta
 					yym3087 := z.EncBinary()
 					_ = yym3087
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3086) {
 					} else {
-						z.EncFallback(yy3086)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr3076 || yy2arr3076 {
+			if yyr3081 || yy2arr3081 {
+				if yyq3081[2] {
+					yy3089 := &x.ListMeta
+					yym3090 := z.EncBinary()
+					_ = yym3090
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3089) {
+					} else {
+						z.EncFallback(yy3089)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq3081[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy3091 := &x.ListMeta
+					yym3092 := z.EncBinary()
+					_ = yym3092
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3091) {
+					} else {
+						z.EncFallback(yy3091)
+					}
+				}
+			}
+			if yyr3081 || yy2arr3081 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3089 := z.EncBinary()
-					_ = yym3089
+					yym3094 := z.EncBinary()
+					_ = yym3094
 					if false {
 					} else {
 						h.encSliceLimitRange(([]LimitRange)(x.Items), e)
@@ -35803,15 +35840,15 @@ func (x *LimitRangeList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3090 := z.EncBinary()
-					_ = yym3090
+					yym3095 := z.EncBinary()
+					_ = yym3095
 					if false {
 					} else {
 						h.encSliceLimitRange(([]LimitRange)(x.Items), e)
 					}
 				}
 			}
-			if yysep3076 {
+			if yysep3081 {
 				r.EncodeEnd()
 			}
 		}
@@ -35822,24 +35859,24 @@ func (x *LimitRangeList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3091 := z.DecBinary()
-	_ = yym3091
+	yym3096 := z.DecBinary()
+	_ = yym3096
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3092 := r.ReadMapStart()
-			if yyl3092 == 0 {
+			yyl3097 := r.ReadMapStart()
+			if yyl3097 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3092, d)
+				x.codecDecodeSelfFromMap(yyl3097, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3092 := r.ReadArrayStart()
-			if yyl3092 == 0 {
+			yyl3097 := r.ReadArrayStart()
+			if yyl3097 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3092, d)
+				x.codecDecodeSelfFromArray(yyl3097, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -35851,12 +35888,12 @@ func (x *LimitRangeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3093Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3093Slc
-	var yyhl3093 bool = l >= 0
-	for yyj3093 := 0; ; yyj3093++ {
-		if yyhl3093 {
-			if yyj3093 >= l {
+	var yys3098Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3098Slc
+	var yyhl3098 bool = l >= 0
+	for yyj3098 := 0; ; yyj3098++ {
+		if yyhl3098 {
+			if yyj3098 >= l {
 				break
 			}
 		} else {
@@ -35864,9 +35901,9 @@ func (x *LimitRangeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3093Slc = r.DecodeBytes(yys3093Slc, true, true)
-		yys3093 := string(yys3093Slc)
-		switch yys3093 {
+		yys3098Slc = r.DecodeBytes(yys3098Slc, true, true)
+		yys3098 := string(yys3098Slc)
+		switch yys3098 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -35883,32 +35920,32 @@ func (x *LimitRangeList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv3096 := &x.ListMeta
-				yym3097 := z.DecBinary()
-				_ = yym3097
+				yyv3101 := &x.ListMeta
+				yym3102 := z.DecBinary()
+				_ = yym3102
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3096) {
+				} else if z.HasExtensions() && z.DecExt(yyv3101) {
 				} else {
-					z.DecFallback(yyv3096, false)
+					z.DecFallback(yyv3101, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv3098 := &x.Items
-				yym3099 := z.DecBinary()
-				_ = yym3099
+				yyv3103 := &x.Items
+				yym3104 := z.DecBinary()
+				_ = yym3104
 				if false {
 				} else {
-					h.decSliceLimitRange((*[]LimitRange)(yyv3098), d)
+					h.decSliceLimitRange((*[]LimitRange)(yyv3103), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3093)
-		} // end switch yys3093
-	} // end for yyj3093
-	if !yyhl3093 {
+			z.DecStructFieldNotFound(-1, yys3098)
+		} // end switch yys3098
+	} // end for yyj3098
+	if !yyhl3098 {
 		r.ReadEnd()
 	}
 }
@@ -35917,16 +35954,16 @@ func (x *LimitRangeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3100 int
-	var yyb3100 bool
-	var yyhl3100 bool = l >= 0
-	yyj3100++
-	if yyhl3100 {
-		yyb3100 = yyj3100 > l
+	var yyj3105 int
+	var yyb3105 bool
+	var yyhl3105 bool = l >= 0
+	yyj3105++
+	if yyhl3105 {
+		yyb3105 = yyj3105 > l
 	} else {
-		yyb3100 = r.CheckBreak()
+		yyb3105 = r.CheckBreak()
 	}
-	if yyb3100 {
+	if yyb3105 {
 		r.ReadEnd()
 		return
 	}
@@ -35935,13 +35972,13 @@ func (x *LimitRangeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3100++
-	if yyhl3100 {
-		yyb3100 = yyj3100 > l
+	yyj3105++
+	if yyhl3105 {
+		yyb3105 = yyj3105 > l
 	} else {
-		yyb3100 = r.CheckBreak()
+		yyb3105 = r.CheckBreak()
 	}
-	if yyb3100 {
+	if yyb3105 {
 		r.ReadEnd()
 		return
 	}
@@ -35950,60 +35987,60 @@ func (x *LimitRangeList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3100++
-	if yyhl3100 {
-		yyb3100 = yyj3100 > l
+	yyj3105++
+	if yyhl3105 {
+		yyb3105 = yyj3105 > l
 	} else {
-		yyb3100 = r.CheckBreak()
+		yyb3105 = r.CheckBreak()
 	}
-	if yyb3100 {
+	if yyb3105 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv3103 := &x.ListMeta
-		yym3104 := z.DecBinary()
-		_ = yym3104
+		yyv3108 := &x.ListMeta
+		yym3109 := z.DecBinary()
+		_ = yym3109
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3103) {
+		} else if z.HasExtensions() && z.DecExt(yyv3108) {
 		} else {
-			z.DecFallback(yyv3103, false)
+			z.DecFallback(yyv3108, false)
 		}
 	}
-	yyj3100++
-	if yyhl3100 {
-		yyb3100 = yyj3100 > l
+	yyj3105++
+	if yyhl3105 {
+		yyb3105 = yyj3105 > l
 	} else {
-		yyb3100 = r.CheckBreak()
+		yyb3105 = r.CheckBreak()
 	}
-	if yyb3100 {
+	if yyb3105 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv3105 := &x.Items
-		yym3106 := z.DecBinary()
-		_ = yym3106
+		yyv3110 := &x.Items
+		yym3111 := z.DecBinary()
+		_ = yym3111
 		if false {
 		} else {
-			h.decSliceLimitRange((*[]LimitRange)(yyv3105), d)
+			h.decSliceLimitRange((*[]LimitRange)(yyv3110), d)
 		}
 	}
 	for {
-		yyj3100++
-		if yyhl3100 {
-			yyb3100 = yyj3100 > l
+		yyj3105++
+		if yyhl3105 {
+			yyb3105 = yyj3105 > l
 		} else {
-			yyb3100 = r.CheckBreak()
+			yyb3105 = r.CheckBreak()
 		}
-		if yyb3100 {
+		if yyb3105 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3100-1, "")
+		z.DecStructFieldNotFound(yyj3105-1, "")
 	}
 	r.ReadEnd()
 }
@@ -36015,30 +36052,30 @@ func (x *ResourceQuotaSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3107 := z.EncBinary()
-		_ = yym3107
+		yym3112 := z.EncBinary()
+		_ = yym3112
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3108 := !z.EncBinary()
-			yy2arr3108 := z.EncBasicHandle().StructToArray
-			var yyq3108 [1]bool
-			_, _, _ = yysep3108, yyq3108, yy2arr3108
-			const yyr3108 bool = false
-			yyq3108[0] = len(x.Hard) != 0
-			if yyr3108 || yy2arr3108 {
+			yysep3113 := !z.EncBinary()
+			yy2arr3113 := z.EncBasicHandle().StructToArray
+			var yyq3113 [1]bool
+			_, _, _ = yysep3113, yyq3113, yy2arr3113
+			const yyr3113 bool = false
+			yyq3113[0] = len(x.Hard) != 0
+			if yyr3113 || yy2arr3113 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn3108 int = 0
-				for _, b := range yyq3108 {
+				var yynn3113 int = 0
+				for _, b := range yyq3113 {
 					if b {
-						yynn3108++
+						yynn3113++
 					}
 				}
-				r.EncodeMapStart(yynn3108)
+				r.EncodeMapStart(yynn3113)
 			}
-			if yyr3108 || yy2arr3108 {
-				if yyq3108[0] {
+			if yyr3113 || yy2arr3113 {
+				if yyq3113[0] {
 					if x.Hard == nil {
 						r.EncodeNil()
 					} else {
@@ -36048,7 +36085,7 @@ func (x *ResourceQuotaSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3108[0] {
+				if yyq3113[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("hard"))
 					if x.Hard == nil {
 						r.EncodeNil()
@@ -36057,7 +36094,7 @@ func (x *ResourceQuotaSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3108 {
+			if yysep3113 {
 				r.EncodeEnd()
 			}
 		}
@@ -36068,24 +36105,24 @@ func (x *ResourceQuotaSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3110 := z.DecBinary()
-	_ = yym3110
+	yym3115 := z.DecBinary()
+	_ = yym3115
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3111 := r.ReadMapStart()
-			if yyl3111 == 0 {
+			yyl3116 := r.ReadMapStart()
+			if yyl3116 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3111, d)
+				x.codecDecodeSelfFromMap(yyl3116, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3111 := r.ReadArrayStart()
-			if yyl3111 == 0 {
+			yyl3116 := r.ReadArrayStart()
+			if yyl3116 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3111, d)
+				x.codecDecodeSelfFromArray(yyl3116, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -36097,12 +36134,12 @@ func (x *ResourceQuotaSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3112Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3112Slc
-	var yyhl3112 bool = l >= 0
-	for yyj3112 := 0; ; yyj3112++ {
-		if yyhl3112 {
-			if yyj3112 >= l {
+	var yys3117Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3117Slc
+	var yyhl3117 bool = l >= 0
+	for yyj3117 := 0; ; yyj3117++ {
+		if yyhl3117 {
+			if yyj3117 >= l {
 				break
 			}
 		} else {
@@ -36110,21 +36147,21 @@ func (x *ResourceQuotaSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				break
 			}
 		}
-		yys3112Slc = r.DecodeBytes(yys3112Slc, true, true)
-		yys3112 := string(yys3112Slc)
-		switch yys3112 {
+		yys3117Slc = r.DecodeBytes(yys3117Slc, true, true)
+		yys3117 := string(yys3117Slc)
+		switch yys3117 {
 		case "hard":
 			if r.TryDecodeAsNil() {
 				x.Hard = nil
 			} else {
-				yyv3113 := &x.Hard
-				yyv3113.CodecDecodeSelf(d)
+				yyv3118 := &x.Hard
+				yyv3118.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3112)
-		} // end switch yys3112
-	} // end for yyj3112
-	if !yyhl3112 {
+			z.DecStructFieldNotFound(-1, yys3117)
+		} // end switch yys3117
+	} // end for yyj3117
+	if !yyhl3117 {
 		r.ReadEnd()
 	}
 }
@@ -36133,36 +36170,36 @@ func (x *ResourceQuotaSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3114 int
-	var yyb3114 bool
-	var yyhl3114 bool = l >= 0
-	yyj3114++
-	if yyhl3114 {
-		yyb3114 = yyj3114 > l
+	var yyj3119 int
+	var yyb3119 bool
+	var yyhl3119 bool = l >= 0
+	yyj3119++
+	if yyhl3119 {
+		yyb3119 = yyj3119 > l
 	} else {
-		yyb3114 = r.CheckBreak()
+		yyb3119 = r.CheckBreak()
 	}
-	if yyb3114 {
+	if yyb3119 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Hard = nil
 	} else {
-		yyv3115 := &x.Hard
-		yyv3115.CodecDecodeSelf(d)
+		yyv3120 := &x.Hard
+		yyv3120.CodecDecodeSelf(d)
 	}
 	for {
-		yyj3114++
-		if yyhl3114 {
-			yyb3114 = yyj3114 > l
+		yyj3119++
+		if yyhl3119 {
+			yyb3119 = yyj3119 > l
 		} else {
-			yyb3114 = r.CheckBreak()
+			yyb3119 = r.CheckBreak()
 		}
-		if yyb3114 {
+		if yyb3119 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3114-1, "")
+		z.DecStructFieldNotFound(yyj3119-1, "")
 	}
 	r.ReadEnd()
 }
@@ -36174,31 +36211,31 @@ func (x *ResourceQuotaStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3116 := z.EncBinary()
-		_ = yym3116
+		yym3121 := z.EncBinary()
+		_ = yym3121
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3117 := !z.EncBinary()
-			yy2arr3117 := z.EncBasicHandle().StructToArray
-			var yyq3117 [2]bool
-			_, _, _ = yysep3117, yyq3117, yy2arr3117
-			const yyr3117 bool = false
-			yyq3117[0] = len(x.Hard) != 0
-			yyq3117[1] = len(x.Used) != 0
-			if yyr3117 || yy2arr3117 {
+			yysep3122 := !z.EncBinary()
+			yy2arr3122 := z.EncBasicHandle().StructToArray
+			var yyq3122 [2]bool
+			_, _, _ = yysep3122, yyq3122, yy2arr3122
+			const yyr3122 bool = false
+			yyq3122[0] = len(x.Hard) != 0
+			yyq3122[1] = len(x.Used) != 0
+			if yyr3122 || yy2arr3122 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn3117 int = 0
-				for _, b := range yyq3117 {
+				var yynn3122 int = 0
+				for _, b := range yyq3122 {
 					if b {
-						yynn3117++
+						yynn3122++
 					}
 				}
-				r.EncodeMapStart(yynn3117)
+				r.EncodeMapStart(yynn3122)
 			}
-			if yyr3117 || yy2arr3117 {
-				if yyq3117[0] {
+			if yyr3122 || yy2arr3122 {
+				if yyq3122[0] {
 					if x.Hard == nil {
 						r.EncodeNil()
 					} else {
@@ -36208,7 +36245,7 @@ func (x *ResourceQuotaStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3117[0] {
+				if yyq3122[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("hard"))
 					if x.Hard == nil {
 						r.EncodeNil()
@@ -36217,8 +36254,8 @@ func (x *ResourceQuotaStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr3117 || yy2arr3117 {
-				if yyq3117[1] {
+			if yyr3122 || yy2arr3122 {
+				if yyq3122[1] {
 					if x.Used == nil {
 						r.EncodeNil()
 					} else {
@@ -36228,7 +36265,7 @@ func (x *ResourceQuotaStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3117[1] {
+				if yyq3122[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("used"))
 					if x.Used == nil {
 						r.EncodeNil()
@@ -36237,7 +36274,7 @@ func (x *ResourceQuotaStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3117 {
+			if yysep3122 {
 				r.EncodeEnd()
 			}
 		}
@@ -36248,24 +36285,24 @@ func (x *ResourceQuotaStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3120 := z.DecBinary()
-	_ = yym3120
+	yym3125 := z.DecBinary()
+	_ = yym3125
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3121 := r.ReadMapStart()
-			if yyl3121 == 0 {
+			yyl3126 := r.ReadMapStart()
+			if yyl3126 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3121, d)
+				x.codecDecodeSelfFromMap(yyl3126, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3121 := r.ReadArrayStart()
-			if yyl3121 == 0 {
+			yyl3126 := r.ReadArrayStart()
+			if yyl3126 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3121, d)
+				x.codecDecodeSelfFromArray(yyl3126, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -36277,12 +36314,12 @@ func (x *ResourceQuotaStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3122Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3122Slc
-	var yyhl3122 bool = l >= 0
-	for yyj3122 := 0; ; yyj3122++ {
-		if yyhl3122 {
-			if yyj3122 >= l {
+	var yys3127Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3127Slc
+	var yyhl3127 bool = l >= 0
+	for yyj3127 := 0; ; yyj3127++ {
+		if yyhl3127 {
+			if yyj3127 >= l {
 				break
 			}
 		} else {
@@ -36290,28 +36327,28 @@ func (x *ResourceQuotaStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				break
 			}
 		}
-		yys3122Slc = r.DecodeBytes(yys3122Slc, true, true)
-		yys3122 := string(yys3122Slc)
-		switch yys3122 {
+		yys3127Slc = r.DecodeBytes(yys3127Slc, true, true)
+		yys3127 := string(yys3127Slc)
+		switch yys3127 {
 		case "hard":
 			if r.TryDecodeAsNil() {
 				x.Hard = nil
 			} else {
-				yyv3123 := &x.Hard
-				yyv3123.CodecDecodeSelf(d)
+				yyv3128 := &x.Hard
+				yyv3128.CodecDecodeSelf(d)
 			}
 		case "used":
 			if r.TryDecodeAsNil() {
 				x.Used = nil
 			} else {
-				yyv3124 := &x.Used
-				yyv3124.CodecDecodeSelf(d)
+				yyv3129 := &x.Used
+				yyv3129.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3122)
-		} // end switch yys3122
-	} // end for yyj3122
-	if !yyhl3122 {
+			z.DecStructFieldNotFound(-1, yys3127)
+		} // end switch yys3127
+	} // end for yyj3127
+	if !yyhl3127 {
 		r.ReadEnd()
 	}
 }
@@ -36320,52 +36357,52 @@ func (x *ResourceQuotaStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3125 int
-	var yyb3125 bool
-	var yyhl3125 bool = l >= 0
-	yyj3125++
-	if yyhl3125 {
-		yyb3125 = yyj3125 > l
+	var yyj3130 int
+	var yyb3130 bool
+	var yyhl3130 bool = l >= 0
+	yyj3130++
+	if yyhl3130 {
+		yyb3130 = yyj3130 > l
 	} else {
-		yyb3125 = r.CheckBreak()
+		yyb3130 = r.CheckBreak()
 	}
-	if yyb3125 {
+	if yyb3130 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Hard = nil
 	} else {
-		yyv3126 := &x.Hard
-		yyv3126.CodecDecodeSelf(d)
+		yyv3131 := &x.Hard
+		yyv3131.CodecDecodeSelf(d)
 	}
-	yyj3125++
-	if yyhl3125 {
-		yyb3125 = yyj3125 > l
+	yyj3130++
+	if yyhl3130 {
+		yyb3130 = yyj3130 > l
 	} else {
-		yyb3125 = r.CheckBreak()
+		yyb3130 = r.CheckBreak()
 	}
-	if yyb3125 {
+	if yyb3130 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Used = nil
 	} else {
-		yyv3127 := &x.Used
-		yyv3127.CodecDecodeSelf(d)
+		yyv3132 := &x.Used
+		yyv3132.CodecDecodeSelf(d)
 	}
 	for {
-		yyj3125++
-		if yyhl3125 {
-			yyb3125 = yyj3125 > l
+		yyj3130++
+		if yyhl3130 {
+			yyb3130 = yyj3130 > l
 		} else {
-			yyb3125 = r.CheckBreak()
+			yyb3130 = r.CheckBreak()
 		}
-		if yyb3125 {
+		if yyb3130 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3125-1, "")
+		z.DecStructFieldNotFound(yyj3130-1, "")
 	}
 	r.ReadEnd()
 }
@@ -36377,36 +36414,36 @@ func (x *ResourceQuota) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3128 := z.EncBinary()
-		_ = yym3128
+		yym3133 := z.EncBinary()
+		_ = yym3133
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3129 := !z.EncBinary()
-			yy2arr3129 := z.EncBasicHandle().StructToArray
-			var yyq3129 [5]bool
-			_, _, _ = yysep3129, yyq3129, yy2arr3129
-			const yyr3129 bool = false
-			yyq3129[0] = x.Kind != ""
-			yyq3129[1] = x.APIVersion != ""
-			yyq3129[2] = true
-			yyq3129[3] = true
-			yyq3129[4] = true
-			if yyr3129 || yy2arr3129 {
+			yysep3134 := !z.EncBinary()
+			yy2arr3134 := z.EncBasicHandle().StructToArray
+			var yyq3134 [5]bool
+			_, _, _ = yysep3134, yyq3134, yy2arr3134
+			const yyr3134 bool = false
+			yyq3134[0] = x.Kind != ""
+			yyq3134[1] = x.APIVersion != ""
+			yyq3134[2] = true
+			yyq3134[3] = true
+			yyq3134[4] = true
+			if yyr3134 || yy2arr3134 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn3129 int = 0
-				for _, b := range yyq3129 {
+				var yynn3134 int = 0
+				for _, b := range yyq3134 {
 					if b {
-						yynn3129++
+						yynn3134++
 					}
 				}
-				r.EncodeMapStart(yynn3129)
+				r.EncodeMapStart(yynn3134)
 			}
-			if yyr3129 || yy2arr3129 {
-				if yyq3129[0] {
-					yym3131 := z.EncBinary()
-					_ = yym3131
+			if yyr3134 || yy2arr3134 {
+				if yyq3134[0] {
+					yym3136 := z.EncBinary()
+					_ = yym3136
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -36415,20 +36452,20 @@ func (x *ResourceQuota) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3129[0] {
+				if yyq3134[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3132 := z.EncBinary()
-					_ = yym3132
+					yym3137 := z.EncBinary()
+					_ = yym3137
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr3129 || yy2arr3129 {
-				if yyq3129[1] {
-					yym3134 := z.EncBinary()
-					_ = yym3134
+			if yyr3134 || yy2arr3134 {
+				if yyq3134[1] {
+					yym3139 := z.EncBinary()
+					_ = yym3139
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -36437,59 +36474,59 @@ func (x *ResourceQuota) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3129[1] {
+				if yyq3134[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym3135 := z.EncBinary()
-					_ = yym3135
+					yym3140 := z.EncBinary()
+					_ = yym3140
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr3129 || yy2arr3129 {
-				if yyq3129[2] {
-					yy3137 := &x.ObjectMeta
-					yy3137.CodecEncodeSelf(e)
+			if yyr3134 || yy2arr3134 {
+				if yyq3134[2] {
+					yy3142 := &x.ObjectMeta
+					yy3142.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3129[2] {
+				if yyq3134[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3138 := &x.ObjectMeta
-					yy3138.CodecEncodeSelf(e)
-				}
-			}
-			if yyr3129 || yy2arr3129 {
-				if yyq3129[3] {
-					yy3140 := &x.Spec
-					yy3140.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq3129[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy3141 := &x.Spec
-					yy3141.CodecEncodeSelf(e)
-				}
-			}
-			if yyr3129 || yy2arr3129 {
-				if yyq3129[4] {
-					yy3143 := &x.Status
+					yy3143 := &x.ObjectMeta
 					yy3143.CodecEncodeSelf(e)
+				}
+			}
+			if yyr3134 || yy2arr3134 {
+				if yyq3134[3] {
+					yy3145 := &x.Spec
+					yy3145.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3129[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy3144 := &x.Status
-					yy3144.CodecEncodeSelf(e)
+				if yyq3134[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					yy3146 := &x.Spec
+					yy3146.CodecEncodeSelf(e)
 				}
 			}
-			if yysep3129 {
+			if yyr3134 || yy2arr3134 {
+				if yyq3134[4] {
+					yy3148 := &x.Status
+					yy3148.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq3134[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					yy3149 := &x.Status
+					yy3149.CodecEncodeSelf(e)
+				}
+			}
+			if yysep3134 {
 				r.EncodeEnd()
 			}
 		}
@@ -36500,24 +36537,24 @@ func (x *ResourceQuota) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3145 := z.DecBinary()
-	_ = yym3145
+	yym3150 := z.DecBinary()
+	_ = yym3150
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3146 := r.ReadMapStart()
-			if yyl3146 == 0 {
+			yyl3151 := r.ReadMapStart()
+			if yyl3151 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3146, d)
+				x.codecDecodeSelfFromMap(yyl3151, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3146 := r.ReadArrayStart()
-			if yyl3146 == 0 {
+			yyl3151 := r.ReadArrayStart()
+			if yyl3151 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3146, d)
+				x.codecDecodeSelfFromArray(yyl3151, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -36529,12 +36566,12 @@ func (x *ResourceQuota) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3147Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3147Slc
-	var yyhl3147 bool = l >= 0
-	for yyj3147 := 0; ; yyj3147++ {
-		if yyhl3147 {
-			if yyj3147 >= l {
+	var yys3152Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3152Slc
+	var yyhl3152 bool = l >= 0
+	for yyj3152 := 0; ; yyj3152++ {
+		if yyhl3152 {
+			if yyj3152 >= l {
 				break
 			}
 		} else {
@@ -36542,9 +36579,9 @@ func (x *ResourceQuota) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3147Slc = r.DecodeBytes(yys3147Slc, true, true)
-		yys3147 := string(yys3147Slc)
-		switch yys3147 {
+		yys3152Slc = r.DecodeBytes(yys3152Slc, true, true)
+		yys3152 := string(yys3152Slc)
+		switch yys3152 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -36561,28 +36598,28 @@ func (x *ResourceQuota) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv3150 := &x.ObjectMeta
-				yyv3150.CodecDecodeSelf(d)
+				yyv3155 := &x.ObjectMeta
+				yyv3155.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = ResourceQuotaSpec{}
 			} else {
-				yyv3151 := &x.Spec
-				yyv3151.CodecDecodeSelf(d)
+				yyv3156 := &x.Spec
+				yyv3156.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = ResourceQuotaStatus{}
 			} else {
-				yyv3152 := &x.Status
-				yyv3152.CodecDecodeSelf(d)
+				yyv3157 := &x.Status
+				yyv3157.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3147)
-		} // end switch yys3147
-	} // end for yyj3147
-	if !yyhl3147 {
+			z.DecStructFieldNotFound(-1, yys3152)
+		} // end switch yys3152
+	} // end for yyj3152
+	if !yyhl3152 {
 		r.ReadEnd()
 	}
 }
@@ -36591,16 +36628,16 @@ func (x *ResourceQuota) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3153 int
-	var yyb3153 bool
-	var yyhl3153 bool = l >= 0
-	yyj3153++
-	if yyhl3153 {
-		yyb3153 = yyj3153 > l
+	var yyj3158 int
+	var yyb3158 bool
+	var yyhl3158 bool = l >= 0
+	yyj3158++
+	if yyhl3158 {
+		yyb3158 = yyj3158 > l
 	} else {
-		yyb3153 = r.CheckBreak()
+		yyb3158 = r.CheckBreak()
 	}
-	if yyb3153 {
+	if yyb3158 {
 		r.ReadEnd()
 		return
 	}
@@ -36609,13 +36646,13 @@ func (x *ResourceQuota) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3153++
-	if yyhl3153 {
-		yyb3153 = yyj3153 > l
+	yyj3158++
+	if yyhl3158 {
+		yyb3158 = yyj3158 > l
 	} else {
-		yyb3153 = r.CheckBreak()
+		yyb3158 = r.CheckBreak()
 	}
-	if yyb3153 {
+	if yyb3158 {
 		r.ReadEnd()
 		return
 	}
@@ -36624,65 +36661,65 @@ func (x *ResourceQuota) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3153++
-	if yyhl3153 {
-		yyb3153 = yyj3153 > l
+	yyj3158++
+	if yyhl3158 {
+		yyb3158 = yyj3158 > l
 	} else {
-		yyb3153 = r.CheckBreak()
+		yyb3158 = r.CheckBreak()
 	}
-	if yyb3153 {
+	if yyb3158 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv3156 := &x.ObjectMeta
-		yyv3156.CodecDecodeSelf(d)
+		yyv3161 := &x.ObjectMeta
+		yyv3161.CodecDecodeSelf(d)
 	}
-	yyj3153++
-	if yyhl3153 {
-		yyb3153 = yyj3153 > l
+	yyj3158++
+	if yyhl3158 {
+		yyb3158 = yyj3158 > l
 	} else {
-		yyb3153 = r.CheckBreak()
+		yyb3158 = r.CheckBreak()
 	}
-	if yyb3153 {
+	if yyb3158 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = ResourceQuotaSpec{}
 	} else {
-		yyv3157 := &x.Spec
-		yyv3157.CodecDecodeSelf(d)
+		yyv3162 := &x.Spec
+		yyv3162.CodecDecodeSelf(d)
 	}
-	yyj3153++
-	if yyhl3153 {
-		yyb3153 = yyj3153 > l
+	yyj3158++
+	if yyhl3158 {
+		yyb3158 = yyj3158 > l
 	} else {
-		yyb3153 = r.CheckBreak()
+		yyb3158 = r.CheckBreak()
 	}
-	if yyb3153 {
+	if yyb3158 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = ResourceQuotaStatus{}
 	} else {
-		yyv3158 := &x.Status
-		yyv3158.CodecDecodeSelf(d)
+		yyv3163 := &x.Status
+		yyv3163.CodecDecodeSelf(d)
 	}
 	for {
-		yyj3153++
-		if yyhl3153 {
-			yyb3153 = yyj3153 > l
+		yyj3158++
+		if yyhl3158 {
+			yyb3158 = yyj3158 > l
 		} else {
-			yyb3153 = r.CheckBreak()
+			yyb3158 = r.CheckBreak()
 		}
-		if yyb3153 {
+		if yyb3158 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3153-1, "")
+		z.DecStructFieldNotFound(yyj3158-1, "")
 	}
 	r.ReadEnd()
 }
@@ -36694,34 +36731,34 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3159 := z.EncBinary()
-		_ = yym3159
+		yym3164 := z.EncBinary()
+		_ = yym3164
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3160 := !z.EncBinary()
-			yy2arr3160 := z.EncBasicHandle().StructToArray
-			var yyq3160 [4]bool
-			_, _, _ = yysep3160, yyq3160, yy2arr3160
-			const yyr3160 bool = false
-			yyq3160[0] = x.Kind != ""
-			yyq3160[1] = x.APIVersion != ""
-			yyq3160[2] = true
-			if yyr3160 || yy2arr3160 {
+			yysep3165 := !z.EncBinary()
+			yy2arr3165 := z.EncBasicHandle().StructToArray
+			var yyq3165 [4]bool
+			_, _, _ = yysep3165, yyq3165, yy2arr3165
+			const yyr3165 bool = false
+			yyq3165[0] = x.Kind != ""
+			yyq3165[1] = x.APIVersion != ""
+			yyq3165[2] = true
+			if yyr3165 || yy2arr3165 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3160 int = 1
-				for _, b := range yyq3160 {
+				var yynn3165 int = 1
+				for _, b := range yyq3165 {
 					if b {
-						yynn3160++
+						yynn3165++
 					}
 				}
-				r.EncodeMapStart(yynn3160)
+				r.EncodeMapStart(yynn3165)
 			}
-			if yyr3160 || yy2arr3160 {
-				if yyq3160[0] {
-					yym3162 := z.EncBinary()
-					_ = yym3162
+			if yyr3165 || yy2arr3165 {
+				if yyq3165[0] {
+					yym3167 := z.EncBinary()
+					_ = yym3167
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -36730,20 +36767,20 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3160[0] {
+				if yyq3165[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3163 := z.EncBinary()
-					_ = yym3163
+					yym3168 := z.EncBinary()
+					_ = yym3168
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr3160 || yy2arr3160 {
-				if yyq3160[1] {
-					yym3165 := z.EncBinary()
-					_ = yym3165
+			if yyr3165 || yy2arr3165 {
+				if yyq3165[1] {
+					yym3170 := z.EncBinary()
+					_ = yym3170
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -36752,48 +36789,48 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3160[1] {
+				if yyq3165[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym3166 := z.EncBinary()
-					_ = yym3166
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3160 || yy2arr3160 {
-				if yyq3160[2] {
-					yy3168 := &x.ListMeta
-					yym3169 := z.EncBinary()
-					_ = yym3169
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3168) {
-					} else {
-						z.EncFallback(yy3168)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq3160[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3170 := &x.ListMeta
 					yym3171 := z.EncBinary()
 					_ = yym3171
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3170) {
 					} else {
-						z.EncFallback(yy3170)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr3160 || yy2arr3160 {
+			if yyr3165 || yy2arr3165 {
+				if yyq3165[2] {
+					yy3173 := &x.ListMeta
+					yym3174 := z.EncBinary()
+					_ = yym3174
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3173) {
+					} else {
+						z.EncFallback(yy3173)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq3165[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy3175 := &x.ListMeta
+					yym3176 := z.EncBinary()
+					_ = yym3176
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3175) {
+					} else {
+						z.EncFallback(yy3175)
+					}
+				}
+			}
+			if yyr3165 || yy2arr3165 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3173 := z.EncBinary()
-					_ = yym3173
+					yym3178 := z.EncBinary()
+					_ = yym3178
 					if false {
 					} else {
 						h.encSliceResourceQuota(([]ResourceQuota)(x.Items), e)
@@ -36804,15 +36841,15 @@ func (x *ResourceQuotaList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3174 := z.EncBinary()
-					_ = yym3174
+					yym3179 := z.EncBinary()
+					_ = yym3179
 					if false {
 					} else {
 						h.encSliceResourceQuota(([]ResourceQuota)(x.Items), e)
 					}
 				}
 			}
-			if yysep3160 {
+			if yysep3165 {
 				r.EncodeEnd()
 			}
 		}
@@ -36823,24 +36860,24 @@ func (x *ResourceQuotaList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3175 := z.DecBinary()
-	_ = yym3175
+	yym3180 := z.DecBinary()
+	_ = yym3180
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3176 := r.ReadMapStart()
-			if yyl3176 == 0 {
+			yyl3181 := r.ReadMapStart()
+			if yyl3181 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3176, d)
+				x.codecDecodeSelfFromMap(yyl3181, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3176 := r.ReadArrayStart()
-			if yyl3176 == 0 {
+			yyl3181 := r.ReadArrayStart()
+			if yyl3181 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3176, d)
+				x.codecDecodeSelfFromArray(yyl3181, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -36852,12 +36889,12 @@ func (x *ResourceQuotaList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3177Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3177Slc
-	var yyhl3177 bool = l >= 0
-	for yyj3177 := 0; ; yyj3177++ {
-		if yyhl3177 {
-			if yyj3177 >= l {
+	var yys3182Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3182Slc
+	var yyhl3182 bool = l >= 0
+	for yyj3182 := 0; ; yyj3182++ {
+		if yyhl3182 {
+			if yyj3182 >= l {
 				break
 			}
 		} else {
@@ -36865,9 +36902,9 @@ func (x *ResourceQuotaList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				break
 			}
 		}
-		yys3177Slc = r.DecodeBytes(yys3177Slc, true, true)
-		yys3177 := string(yys3177Slc)
-		switch yys3177 {
+		yys3182Slc = r.DecodeBytes(yys3182Slc, true, true)
+		yys3182 := string(yys3182Slc)
+		switch yys3182 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -36884,32 +36921,32 @@ func (x *ResourceQuotaList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv3180 := &x.ListMeta
-				yym3181 := z.DecBinary()
-				_ = yym3181
+				yyv3185 := &x.ListMeta
+				yym3186 := z.DecBinary()
+				_ = yym3186
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3180) {
+				} else if z.HasExtensions() && z.DecExt(yyv3185) {
 				} else {
-					z.DecFallback(yyv3180, false)
+					z.DecFallback(yyv3185, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv3182 := &x.Items
-				yym3183 := z.DecBinary()
-				_ = yym3183
+				yyv3187 := &x.Items
+				yym3188 := z.DecBinary()
+				_ = yym3188
 				if false {
 				} else {
-					h.decSliceResourceQuota((*[]ResourceQuota)(yyv3182), d)
+					h.decSliceResourceQuota((*[]ResourceQuota)(yyv3187), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3177)
-		} // end switch yys3177
-	} // end for yyj3177
-	if !yyhl3177 {
+			z.DecStructFieldNotFound(-1, yys3182)
+		} // end switch yys3182
+	} // end for yyj3182
+	if !yyhl3182 {
 		r.ReadEnd()
 	}
 }
@@ -36918,16 +36955,16 @@ func (x *ResourceQuotaList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3184 int
-	var yyb3184 bool
-	var yyhl3184 bool = l >= 0
-	yyj3184++
-	if yyhl3184 {
-		yyb3184 = yyj3184 > l
+	var yyj3189 int
+	var yyb3189 bool
+	var yyhl3189 bool = l >= 0
+	yyj3189++
+	if yyhl3189 {
+		yyb3189 = yyj3189 > l
 	} else {
-		yyb3184 = r.CheckBreak()
+		yyb3189 = r.CheckBreak()
 	}
-	if yyb3184 {
+	if yyb3189 {
 		r.ReadEnd()
 		return
 	}
@@ -36936,13 +36973,13 @@ func (x *ResourceQuotaList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3184++
-	if yyhl3184 {
-		yyb3184 = yyj3184 > l
+	yyj3189++
+	if yyhl3189 {
+		yyb3189 = yyj3189 > l
 	} else {
-		yyb3184 = r.CheckBreak()
+		yyb3189 = r.CheckBreak()
 	}
-	if yyb3184 {
+	if yyb3189 {
 		r.ReadEnd()
 		return
 	}
@@ -36951,60 +36988,60 @@ func (x *ResourceQuotaList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3184++
-	if yyhl3184 {
-		yyb3184 = yyj3184 > l
+	yyj3189++
+	if yyhl3189 {
+		yyb3189 = yyj3189 > l
 	} else {
-		yyb3184 = r.CheckBreak()
+		yyb3189 = r.CheckBreak()
 	}
-	if yyb3184 {
+	if yyb3189 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv3187 := &x.ListMeta
-		yym3188 := z.DecBinary()
-		_ = yym3188
+		yyv3192 := &x.ListMeta
+		yym3193 := z.DecBinary()
+		_ = yym3193
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3187) {
+		} else if z.HasExtensions() && z.DecExt(yyv3192) {
 		} else {
-			z.DecFallback(yyv3187, false)
+			z.DecFallback(yyv3192, false)
 		}
 	}
-	yyj3184++
-	if yyhl3184 {
-		yyb3184 = yyj3184 > l
+	yyj3189++
+	if yyhl3189 {
+		yyb3189 = yyj3189 > l
 	} else {
-		yyb3184 = r.CheckBreak()
+		yyb3189 = r.CheckBreak()
 	}
-	if yyb3184 {
+	if yyb3189 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv3189 := &x.Items
-		yym3190 := z.DecBinary()
-		_ = yym3190
+		yyv3194 := &x.Items
+		yym3195 := z.DecBinary()
+		_ = yym3195
 		if false {
 		} else {
-			h.decSliceResourceQuota((*[]ResourceQuota)(yyv3189), d)
+			h.decSliceResourceQuota((*[]ResourceQuota)(yyv3194), d)
 		}
 	}
 	for {
-		yyj3184++
-		if yyhl3184 {
-			yyb3184 = yyj3184 > l
+		yyj3189++
+		if yyhl3189 {
+			yyb3189 = yyj3189 > l
 		} else {
-			yyb3184 = r.CheckBreak()
+			yyb3189 = r.CheckBreak()
 		}
-		if yyb3184 {
+		if yyb3189 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3184-1, "")
+		z.DecStructFieldNotFound(yyj3189-1, "")
 	}
 	r.ReadEnd()
 }
@@ -37016,36 +37053,36 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3191 := z.EncBinary()
-		_ = yym3191
+		yym3196 := z.EncBinary()
+		_ = yym3196
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3192 := !z.EncBinary()
-			yy2arr3192 := z.EncBasicHandle().StructToArray
-			var yyq3192 [5]bool
-			_, _, _ = yysep3192, yyq3192, yy2arr3192
-			const yyr3192 bool = false
-			yyq3192[0] = x.Kind != ""
-			yyq3192[1] = x.APIVersion != ""
-			yyq3192[2] = true
-			yyq3192[3] = len(x.Data) != 0
-			yyq3192[4] = x.Type != ""
-			if yyr3192 || yy2arr3192 {
+			yysep3197 := !z.EncBinary()
+			yy2arr3197 := z.EncBasicHandle().StructToArray
+			var yyq3197 [5]bool
+			_, _, _ = yysep3197, yyq3197, yy2arr3197
+			const yyr3197 bool = false
+			yyq3197[0] = x.Kind != ""
+			yyq3197[1] = x.APIVersion != ""
+			yyq3197[2] = true
+			yyq3197[3] = len(x.Data) != 0
+			yyq3197[4] = x.Type != ""
+			if yyr3197 || yy2arr3197 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn3192 int = 0
-				for _, b := range yyq3192 {
+				var yynn3197 int = 0
+				for _, b := range yyq3197 {
 					if b {
-						yynn3192++
+						yynn3197++
 					}
 				}
-				r.EncodeMapStart(yynn3192)
+				r.EncodeMapStart(yynn3197)
 			}
-			if yyr3192 || yy2arr3192 {
-				if yyq3192[0] {
-					yym3194 := z.EncBinary()
-					_ = yym3194
+			if yyr3197 || yy2arr3197 {
+				if yyq3197[0] {
+					yym3199 := z.EncBinary()
+					_ = yym3199
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -37054,20 +37091,20 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3192[0] {
+				if yyq3197[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3195 := z.EncBinary()
-					_ = yym3195
+					yym3200 := z.EncBinary()
+					_ = yym3200
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr3192 || yy2arr3192 {
-				if yyq3192[1] {
-					yym3197 := z.EncBinary()
-					_ = yym3197
+			if yyr3197 || yy2arr3197 {
+				if yyq3197[1] {
+					yym3202 := z.EncBinary()
+					_ = yym3202
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -37076,37 +37113,37 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3192[1] {
+				if yyq3197[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym3198 := z.EncBinary()
-					_ = yym3198
+					yym3203 := z.EncBinary()
+					_ = yym3203
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr3192 || yy2arr3192 {
-				if yyq3192[2] {
-					yy3200 := &x.ObjectMeta
-					yy3200.CodecEncodeSelf(e)
+			if yyr3197 || yy2arr3197 {
+				if yyq3197[2] {
+					yy3205 := &x.ObjectMeta
+					yy3205.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3192[2] {
+				if yyq3197[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3201 := &x.ObjectMeta
-					yy3201.CodecEncodeSelf(e)
+					yy3206 := &x.ObjectMeta
+					yy3206.CodecEncodeSelf(e)
 				}
 			}
-			if yyr3192 || yy2arr3192 {
-				if yyq3192[3] {
+			if yyr3197 || yy2arr3197 {
+				if yyq3197[3] {
 					if x.Data == nil {
 						r.EncodeNil()
 					} else {
-						yym3203 := z.EncBinary()
-						_ = yym3203
+						yym3208 := z.EncBinary()
+						_ = yym3208
 						if false {
 						} else {
 							h.encMapstringSliceuint8((map[string][]uint8)(x.Data), e)
@@ -37116,13 +37153,13 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3192[3] {
+				if yyq3197[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("data"))
 					if x.Data == nil {
 						r.EncodeNil()
 					} else {
-						yym3204 := z.EncBinary()
-						_ = yym3204
+						yym3209 := z.EncBinary()
+						_ = yym3209
 						if false {
 						} else {
 							h.encMapstringSliceuint8((map[string][]uint8)(x.Data), e)
@@ -37130,19 +37167,19 @@ func (x *Secret) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr3192 || yy2arr3192 {
-				if yyq3192[4] {
+			if yyr3197 || yy2arr3197 {
+				if yyq3197[4] {
 					x.Type.CodecEncodeSelf(e)
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3192[4] {
+				if yyq3197[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("type"))
 					x.Type.CodecEncodeSelf(e)
 				}
 			}
-			if yysep3192 {
+			if yysep3197 {
 				r.EncodeEnd()
 			}
 		}
@@ -37153,24 +37190,24 @@ func (x *Secret) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3206 := z.DecBinary()
-	_ = yym3206
+	yym3211 := z.DecBinary()
+	_ = yym3211
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3207 := r.ReadMapStart()
-			if yyl3207 == 0 {
+			yyl3212 := r.ReadMapStart()
+			if yyl3212 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3207, d)
+				x.codecDecodeSelfFromMap(yyl3212, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3207 := r.ReadArrayStart()
-			if yyl3207 == 0 {
+			yyl3212 := r.ReadArrayStart()
+			if yyl3212 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3207, d)
+				x.codecDecodeSelfFromArray(yyl3212, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -37182,12 +37219,12 @@ func (x *Secret) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3208Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3208Slc
-	var yyhl3208 bool = l >= 0
-	for yyj3208 := 0; ; yyj3208++ {
-		if yyhl3208 {
-			if yyj3208 >= l {
+	var yys3213Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3213Slc
+	var yyhl3213 bool = l >= 0
+	for yyj3213 := 0; ; yyj3213++ {
+		if yyhl3213 {
+			if yyj3213 >= l {
 				break
 			}
 		} else {
@@ -37195,9 +37232,9 @@ func (x *Secret) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3208Slc = r.DecodeBytes(yys3208Slc, true, true)
-		yys3208 := string(yys3208Slc)
-		switch yys3208 {
+		yys3213Slc = r.DecodeBytes(yys3213Slc, true, true)
+		yys3213 := string(yys3213Slc)
+		switch yys3213 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -37214,19 +37251,19 @@ func (x *Secret) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv3211 := &x.ObjectMeta
-				yyv3211.CodecDecodeSelf(d)
+				yyv3216 := &x.ObjectMeta
+				yyv3216.CodecDecodeSelf(d)
 			}
 		case "data":
 			if r.TryDecodeAsNil() {
 				x.Data = nil
 			} else {
-				yyv3212 := &x.Data
-				yym3213 := z.DecBinary()
-				_ = yym3213
+				yyv3217 := &x.Data
+				yym3218 := z.DecBinary()
+				_ = yym3218
 				if false {
 				} else {
-					h.decMapstringSliceuint8((*map[string][]uint8)(yyv3212), d)
+					h.decMapstringSliceuint8((*map[string][]uint8)(yyv3217), d)
 				}
 			}
 		case "type":
@@ -37236,10 +37273,10 @@ func (x *Secret) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Type = SecretType(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3208)
-		} // end switch yys3208
-	} // end for yyj3208
-	if !yyhl3208 {
+			z.DecStructFieldNotFound(-1, yys3213)
+		} // end switch yys3213
+	} // end for yyj3213
+	if !yyhl3213 {
 		r.ReadEnd()
 	}
 }
@@ -37248,16 +37285,16 @@ func (x *Secret) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3215 int
-	var yyb3215 bool
-	var yyhl3215 bool = l >= 0
-	yyj3215++
-	if yyhl3215 {
-		yyb3215 = yyj3215 > l
+	var yyj3220 int
+	var yyb3220 bool
+	var yyhl3220 bool = l >= 0
+	yyj3220++
+	if yyhl3220 {
+		yyb3220 = yyj3220 > l
 	} else {
-		yyb3215 = r.CheckBreak()
+		yyb3220 = r.CheckBreak()
 	}
-	if yyb3215 {
+	if yyb3220 {
 		r.ReadEnd()
 		return
 	}
@@ -37266,13 +37303,13 @@ func (x *Secret) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3215++
-	if yyhl3215 {
-		yyb3215 = yyj3215 > l
+	yyj3220++
+	if yyhl3220 {
+		yyb3220 = yyj3220 > l
 	} else {
-		yyb3215 = r.CheckBreak()
+		yyb3220 = r.CheckBreak()
 	}
-	if yyb3215 {
+	if yyb3220 {
 		r.ReadEnd()
 		return
 	}
@@ -37281,50 +37318,50 @@ func (x *Secret) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3215++
-	if yyhl3215 {
-		yyb3215 = yyj3215 > l
+	yyj3220++
+	if yyhl3220 {
+		yyb3220 = yyj3220 > l
 	} else {
-		yyb3215 = r.CheckBreak()
+		yyb3220 = r.CheckBreak()
 	}
-	if yyb3215 {
+	if yyb3220 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv3218 := &x.ObjectMeta
-		yyv3218.CodecDecodeSelf(d)
+		yyv3223 := &x.ObjectMeta
+		yyv3223.CodecDecodeSelf(d)
 	}
-	yyj3215++
-	if yyhl3215 {
-		yyb3215 = yyj3215 > l
+	yyj3220++
+	if yyhl3220 {
+		yyb3220 = yyj3220 > l
 	} else {
-		yyb3215 = r.CheckBreak()
+		yyb3220 = r.CheckBreak()
 	}
-	if yyb3215 {
+	if yyb3220 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Data = nil
 	} else {
-		yyv3219 := &x.Data
-		yym3220 := z.DecBinary()
-		_ = yym3220
+		yyv3224 := &x.Data
+		yym3225 := z.DecBinary()
+		_ = yym3225
 		if false {
 		} else {
-			h.decMapstringSliceuint8((*map[string][]uint8)(yyv3219), d)
+			h.decMapstringSliceuint8((*map[string][]uint8)(yyv3224), d)
 		}
 	}
-	yyj3215++
-	if yyhl3215 {
-		yyb3215 = yyj3215 > l
+	yyj3220++
+	if yyhl3220 {
+		yyb3220 = yyj3220 > l
 	} else {
-		yyb3215 = r.CheckBreak()
+		yyb3220 = r.CheckBreak()
 	}
-	if yyb3215 {
+	if yyb3220 {
 		r.ReadEnd()
 		return
 	}
@@ -37334,16 +37371,16 @@ func (x *Secret) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Type = SecretType(r.DecodeString())
 	}
 	for {
-		yyj3215++
-		if yyhl3215 {
-			yyb3215 = yyj3215 > l
+		yyj3220++
+		if yyhl3220 {
+			yyb3220 = yyj3220 > l
 		} else {
-			yyb3215 = r.CheckBreak()
+			yyb3220 = r.CheckBreak()
 		}
-		if yyb3215 {
+		if yyb3220 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3215-1, "")
+		z.DecStructFieldNotFound(yyj3220-1, "")
 	}
 	r.ReadEnd()
 }
@@ -37352,8 +37389,8 @@ func (x SecretType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym3222 := z.EncBinary()
-	_ = yym3222
+	yym3227 := z.EncBinary()
+	_ = yym3227
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -37365,8 +37402,8 @@ func (x *SecretType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3223 := z.DecBinary()
-	_ = yym3223
+	yym3228 := z.DecBinary()
+	_ = yym3228
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -37381,34 +37418,34 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3224 := z.EncBinary()
-		_ = yym3224
+		yym3229 := z.EncBinary()
+		_ = yym3229
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3225 := !z.EncBinary()
-			yy2arr3225 := z.EncBasicHandle().StructToArray
-			var yyq3225 [4]bool
-			_, _, _ = yysep3225, yyq3225, yy2arr3225
-			const yyr3225 bool = false
-			yyq3225[0] = x.Kind != ""
-			yyq3225[1] = x.APIVersion != ""
-			yyq3225[2] = true
-			if yyr3225 || yy2arr3225 {
+			yysep3230 := !z.EncBinary()
+			yy2arr3230 := z.EncBasicHandle().StructToArray
+			var yyq3230 [4]bool
+			_, _, _ = yysep3230, yyq3230, yy2arr3230
+			const yyr3230 bool = false
+			yyq3230[0] = x.Kind != ""
+			yyq3230[1] = x.APIVersion != ""
+			yyq3230[2] = true
+			if yyr3230 || yy2arr3230 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3225 int = 1
-				for _, b := range yyq3225 {
+				var yynn3230 int = 1
+				for _, b := range yyq3230 {
 					if b {
-						yynn3225++
+						yynn3230++
 					}
 				}
-				r.EncodeMapStart(yynn3225)
+				r.EncodeMapStart(yynn3230)
 			}
-			if yyr3225 || yy2arr3225 {
-				if yyq3225[0] {
-					yym3227 := z.EncBinary()
-					_ = yym3227
+			if yyr3230 || yy2arr3230 {
+				if yyq3230[0] {
+					yym3232 := z.EncBinary()
+					_ = yym3232
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -37417,20 +37454,20 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3225[0] {
+				if yyq3230[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3228 := z.EncBinary()
-					_ = yym3228
+					yym3233 := z.EncBinary()
+					_ = yym3233
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr3225 || yy2arr3225 {
-				if yyq3225[1] {
-					yym3230 := z.EncBinary()
-					_ = yym3230
+			if yyr3230 || yy2arr3230 {
+				if yyq3230[1] {
+					yym3235 := z.EncBinary()
+					_ = yym3235
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -37439,48 +37476,48 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3225[1] {
+				if yyq3230[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym3231 := z.EncBinary()
-					_ = yym3231
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3225 || yy2arr3225 {
-				if yyq3225[2] {
-					yy3233 := &x.ListMeta
-					yym3234 := z.EncBinary()
-					_ = yym3234
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3233) {
-					} else {
-						z.EncFallback(yy3233)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq3225[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3235 := &x.ListMeta
 					yym3236 := z.EncBinary()
 					_ = yym3236
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3235) {
 					} else {
-						z.EncFallback(yy3235)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr3225 || yy2arr3225 {
+			if yyr3230 || yy2arr3230 {
+				if yyq3230[2] {
+					yy3238 := &x.ListMeta
+					yym3239 := z.EncBinary()
+					_ = yym3239
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3238) {
+					} else {
+						z.EncFallback(yy3238)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq3230[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy3240 := &x.ListMeta
+					yym3241 := z.EncBinary()
+					_ = yym3241
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3240) {
+					} else {
+						z.EncFallback(yy3240)
+					}
+				}
+			}
+			if yyr3230 || yy2arr3230 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3238 := z.EncBinary()
-					_ = yym3238
+					yym3243 := z.EncBinary()
+					_ = yym3243
 					if false {
 					} else {
 						h.encSliceSecret(([]Secret)(x.Items), e)
@@ -37491,15 +37528,15 @@ func (x *SecretList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3239 := z.EncBinary()
-					_ = yym3239
+					yym3244 := z.EncBinary()
+					_ = yym3244
 					if false {
 					} else {
 						h.encSliceSecret(([]Secret)(x.Items), e)
 					}
 				}
 			}
-			if yysep3225 {
+			if yysep3230 {
 				r.EncodeEnd()
 			}
 		}
@@ -37510,24 +37547,24 @@ func (x *SecretList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3240 := z.DecBinary()
-	_ = yym3240
+	yym3245 := z.DecBinary()
+	_ = yym3245
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3241 := r.ReadMapStart()
-			if yyl3241 == 0 {
+			yyl3246 := r.ReadMapStart()
+			if yyl3246 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3241, d)
+				x.codecDecodeSelfFromMap(yyl3246, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3241 := r.ReadArrayStart()
-			if yyl3241 == 0 {
+			yyl3246 := r.ReadArrayStart()
+			if yyl3246 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3241, d)
+				x.codecDecodeSelfFromArray(yyl3246, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -37539,12 +37576,12 @@ func (x *SecretList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3242Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3242Slc
-	var yyhl3242 bool = l >= 0
-	for yyj3242 := 0; ; yyj3242++ {
-		if yyhl3242 {
-			if yyj3242 >= l {
+	var yys3247Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3247Slc
+	var yyhl3247 bool = l >= 0
+	for yyj3247 := 0; ; yyj3247++ {
+		if yyhl3247 {
+			if yyj3247 >= l {
 				break
 			}
 		} else {
@@ -37552,9 +37589,9 @@ func (x *SecretList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3242Slc = r.DecodeBytes(yys3242Slc, true, true)
-		yys3242 := string(yys3242Slc)
-		switch yys3242 {
+		yys3247Slc = r.DecodeBytes(yys3247Slc, true, true)
+		yys3247 := string(yys3247Slc)
+		switch yys3247 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -37571,32 +37608,32 @@ func (x *SecretList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv3245 := &x.ListMeta
-				yym3246 := z.DecBinary()
-				_ = yym3246
+				yyv3250 := &x.ListMeta
+				yym3251 := z.DecBinary()
+				_ = yym3251
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3245) {
+				} else if z.HasExtensions() && z.DecExt(yyv3250) {
 				} else {
-					z.DecFallback(yyv3245, false)
+					z.DecFallback(yyv3250, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv3247 := &x.Items
-				yym3248 := z.DecBinary()
-				_ = yym3248
+				yyv3252 := &x.Items
+				yym3253 := z.DecBinary()
+				_ = yym3253
 				if false {
 				} else {
-					h.decSliceSecret((*[]Secret)(yyv3247), d)
+					h.decSliceSecret((*[]Secret)(yyv3252), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3242)
-		} // end switch yys3242
-	} // end for yyj3242
-	if !yyhl3242 {
+			z.DecStructFieldNotFound(-1, yys3247)
+		} // end switch yys3247
+	} // end for yyj3247
+	if !yyhl3247 {
 		r.ReadEnd()
 	}
 }
@@ -37605,16 +37642,16 @@ func (x *SecretList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3249 int
-	var yyb3249 bool
-	var yyhl3249 bool = l >= 0
-	yyj3249++
-	if yyhl3249 {
-		yyb3249 = yyj3249 > l
+	var yyj3254 int
+	var yyb3254 bool
+	var yyhl3254 bool = l >= 0
+	yyj3254++
+	if yyhl3254 {
+		yyb3254 = yyj3254 > l
 	} else {
-		yyb3249 = r.CheckBreak()
+		yyb3254 = r.CheckBreak()
 	}
-	if yyb3249 {
+	if yyb3254 {
 		r.ReadEnd()
 		return
 	}
@@ -37623,13 +37660,13 @@ func (x *SecretList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3249++
-	if yyhl3249 {
-		yyb3249 = yyj3249 > l
+	yyj3254++
+	if yyhl3254 {
+		yyb3254 = yyj3254 > l
 	} else {
-		yyb3249 = r.CheckBreak()
+		yyb3254 = r.CheckBreak()
 	}
-	if yyb3249 {
+	if yyb3254 {
 		r.ReadEnd()
 		return
 	}
@@ -37638,60 +37675,60 @@ func (x *SecretList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3249++
-	if yyhl3249 {
-		yyb3249 = yyj3249 > l
+	yyj3254++
+	if yyhl3254 {
+		yyb3254 = yyj3254 > l
 	} else {
-		yyb3249 = r.CheckBreak()
+		yyb3254 = r.CheckBreak()
 	}
-	if yyb3249 {
+	if yyb3254 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv3252 := &x.ListMeta
-		yym3253 := z.DecBinary()
-		_ = yym3253
+		yyv3257 := &x.ListMeta
+		yym3258 := z.DecBinary()
+		_ = yym3258
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3252) {
+		} else if z.HasExtensions() && z.DecExt(yyv3257) {
 		} else {
-			z.DecFallback(yyv3252, false)
+			z.DecFallback(yyv3257, false)
 		}
 	}
-	yyj3249++
-	if yyhl3249 {
-		yyb3249 = yyj3249 > l
+	yyj3254++
+	if yyhl3254 {
+		yyb3254 = yyj3254 > l
 	} else {
-		yyb3249 = r.CheckBreak()
+		yyb3254 = r.CheckBreak()
 	}
-	if yyb3249 {
+	if yyb3254 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv3254 := &x.Items
-		yym3255 := z.DecBinary()
-		_ = yym3255
+		yyv3259 := &x.Items
+		yym3260 := z.DecBinary()
+		_ = yym3260
 		if false {
 		} else {
-			h.decSliceSecret((*[]Secret)(yyv3254), d)
+			h.decSliceSecret((*[]Secret)(yyv3259), d)
 		}
 	}
 	for {
-		yyj3249++
-		if yyhl3249 {
-			yyb3249 = yyj3249 > l
+		yyj3254++
+		if yyhl3254 {
+			yyb3254 = yyj3254 > l
 		} else {
-			yyb3249 = r.CheckBreak()
+			yyb3254 = r.CheckBreak()
 		}
-		if yyb3249 {
+		if yyb3254 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3249-1, "")
+		z.DecStructFieldNotFound(yyj3254-1, "")
 	}
 	r.ReadEnd()
 }
@@ -37700,8 +37737,8 @@ func (x ComponentConditionType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym3256 := z.EncBinary()
-	_ = yym3256
+	yym3261 := z.EncBinary()
+	_ = yym3261
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -37713,8 +37750,8 @@ func (x *ComponentConditionType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3257 := z.DecBinary()
-	_ = yym3257
+	yym3262 := z.DecBinary()
+	_ = yym3262
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -37729,45 +37766,45 @@ func (x *ComponentCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3258 := z.EncBinary()
-		_ = yym3258
+		yym3263 := z.EncBinary()
+		_ = yym3263
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3259 := !z.EncBinary()
-			yy2arr3259 := z.EncBasicHandle().StructToArray
-			var yyq3259 [4]bool
-			_, _, _ = yysep3259, yyq3259, yy2arr3259
-			const yyr3259 bool = false
-			yyq3259[2] = x.Message != ""
-			yyq3259[3] = x.Error != ""
-			if yyr3259 || yy2arr3259 {
+			yysep3264 := !z.EncBinary()
+			yy2arr3264 := z.EncBasicHandle().StructToArray
+			var yyq3264 [4]bool
+			_, _, _ = yysep3264, yyq3264, yy2arr3264
+			const yyr3264 bool = false
+			yyq3264[2] = x.Message != ""
+			yyq3264[3] = x.Error != ""
+			if yyr3264 || yy2arr3264 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3259 int = 2
-				for _, b := range yyq3259 {
+				var yynn3264 int = 2
+				for _, b := range yyq3264 {
 					if b {
-						yynn3259++
+						yynn3264++
 					}
 				}
-				r.EncodeMapStart(yynn3259)
+				r.EncodeMapStart(yynn3264)
 			}
-			if yyr3259 || yy2arr3259 {
+			if yyr3264 || yy2arr3264 {
 				x.Type.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("type"))
 				x.Type.CodecEncodeSelf(e)
 			}
-			if yyr3259 || yy2arr3259 {
+			if yyr3264 || yy2arr3264 {
 				x.Status.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("status"))
 				x.Status.CodecEncodeSelf(e)
 			}
-			if yyr3259 || yy2arr3259 {
-				if yyq3259[2] {
-					yym3263 := z.EncBinary()
-					_ = yym3263
+			if yyr3264 || yy2arr3264 {
+				if yyq3264[2] {
+					yym3268 := z.EncBinary()
+					_ = yym3268
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
@@ -37776,20 +37813,20 @@ func (x *ComponentCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3259[2] {
+				if yyq3264[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
-					yym3264 := z.EncBinary()
-					_ = yym3264
+					yym3269 := z.EncBinary()
+					_ = yym3269
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
 					}
 				}
 			}
-			if yyr3259 || yy2arr3259 {
-				if yyq3259[3] {
-					yym3266 := z.EncBinary()
-					_ = yym3266
+			if yyr3264 || yy2arr3264 {
+				if yyq3264[3] {
+					yym3271 := z.EncBinary()
+					_ = yym3271
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Error))
@@ -37798,17 +37835,17 @@ func (x *ComponentCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3259[3] {
+				if yyq3264[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("error"))
-					yym3267 := z.EncBinary()
-					_ = yym3267
+					yym3272 := z.EncBinary()
+					_ = yym3272
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Error))
 					}
 				}
 			}
-			if yysep3259 {
+			if yysep3264 {
 				r.EncodeEnd()
 			}
 		}
@@ -37819,24 +37856,24 @@ func (x *ComponentCondition) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3268 := z.DecBinary()
-	_ = yym3268
+	yym3273 := z.DecBinary()
+	_ = yym3273
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3269 := r.ReadMapStart()
-			if yyl3269 == 0 {
+			yyl3274 := r.ReadMapStart()
+			if yyl3274 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3269, d)
+				x.codecDecodeSelfFromMap(yyl3274, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3269 := r.ReadArrayStart()
-			if yyl3269 == 0 {
+			yyl3274 := r.ReadArrayStart()
+			if yyl3274 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3269, d)
+				x.codecDecodeSelfFromArray(yyl3274, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -37848,12 +37885,12 @@ func (x *ComponentCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3270Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3270Slc
-	var yyhl3270 bool = l >= 0
-	for yyj3270 := 0; ; yyj3270++ {
-		if yyhl3270 {
-			if yyj3270 >= l {
+	var yys3275Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3275Slc
+	var yyhl3275 bool = l >= 0
+	for yyj3275 := 0; ; yyj3275++ {
+		if yyhl3275 {
+			if yyj3275 >= l {
 				break
 			}
 		} else {
@@ -37861,9 +37898,9 @@ func (x *ComponentCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
-		yys3270Slc = r.DecodeBytes(yys3270Slc, true, true)
-		yys3270 := string(yys3270Slc)
-		switch yys3270 {
+		yys3275Slc = r.DecodeBytes(yys3275Slc, true, true)
+		yys3275 := string(yys3275Slc)
+		switch yys3275 {
 		case "type":
 			if r.TryDecodeAsNil() {
 				x.Type = ""
@@ -37889,10 +37926,10 @@ func (x *ComponentCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				x.Error = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3270)
-		} // end switch yys3270
-	} // end for yyj3270
-	if !yyhl3270 {
+			z.DecStructFieldNotFound(-1, yys3275)
+		} // end switch yys3275
+	} // end for yyj3275
+	if !yyhl3275 {
 		r.ReadEnd()
 	}
 }
@@ -37901,16 +37938,16 @@ func (x *ComponentCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3275 int
-	var yyb3275 bool
-	var yyhl3275 bool = l >= 0
-	yyj3275++
-	if yyhl3275 {
-		yyb3275 = yyj3275 > l
+	var yyj3280 int
+	var yyb3280 bool
+	var yyhl3280 bool = l >= 0
+	yyj3280++
+	if yyhl3280 {
+		yyb3280 = yyj3280 > l
 	} else {
-		yyb3275 = r.CheckBreak()
+		yyb3280 = r.CheckBreak()
 	}
-	if yyb3275 {
+	if yyb3280 {
 		r.ReadEnd()
 		return
 	}
@@ -37919,13 +37956,13 @@ func (x *ComponentCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.Type = ComponentConditionType(r.DecodeString())
 	}
-	yyj3275++
-	if yyhl3275 {
-		yyb3275 = yyj3275 > l
+	yyj3280++
+	if yyhl3280 {
+		yyb3280 = yyj3280 > l
 	} else {
-		yyb3275 = r.CheckBreak()
+		yyb3280 = r.CheckBreak()
 	}
-	if yyb3275 {
+	if yyb3280 {
 		r.ReadEnd()
 		return
 	}
@@ -37934,13 +37971,13 @@ func (x *ComponentCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.Status = ConditionStatus(r.DecodeString())
 	}
-	yyj3275++
-	if yyhl3275 {
-		yyb3275 = yyj3275 > l
+	yyj3280++
+	if yyhl3280 {
+		yyb3280 = yyj3280 > l
 	} else {
-		yyb3275 = r.CheckBreak()
+		yyb3280 = r.CheckBreak()
 	}
-	if yyb3275 {
+	if yyb3280 {
 		r.ReadEnd()
 		return
 	}
@@ -37949,13 +37986,13 @@ func (x *ComponentCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.Message = string(r.DecodeString())
 	}
-	yyj3275++
-	if yyhl3275 {
-		yyb3275 = yyj3275 > l
+	yyj3280++
+	if yyhl3280 {
+		yyb3280 = yyj3280 > l
 	} else {
-		yyb3275 = r.CheckBreak()
+		yyb3280 = r.CheckBreak()
 	}
-	if yyb3275 {
+	if yyb3280 {
 		r.ReadEnd()
 		return
 	}
@@ -37965,16 +38002,16 @@ func (x *ComponentCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		x.Error = string(r.DecodeString())
 	}
 	for {
-		yyj3275++
-		if yyhl3275 {
-			yyb3275 = yyj3275 > l
+		yyj3280++
+		if yyhl3280 {
+			yyb3280 = yyj3280 > l
 		} else {
-			yyb3275 = r.CheckBreak()
+			yyb3280 = r.CheckBreak()
 		}
-		if yyb3275 {
+		if yyb3280 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3275-1, "")
+		z.DecStructFieldNotFound(yyj3280-1, "")
 	}
 	r.ReadEnd()
 }
@@ -37986,35 +38023,35 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3280 := z.EncBinary()
-		_ = yym3280
+		yym3285 := z.EncBinary()
+		_ = yym3285
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3281 := !z.EncBinary()
-			yy2arr3281 := z.EncBasicHandle().StructToArray
-			var yyq3281 [4]bool
-			_, _, _ = yysep3281, yyq3281, yy2arr3281
-			const yyr3281 bool = false
-			yyq3281[0] = x.Kind != ""
-			yyq3281[1] = x.APIVersion != ""
-			yyq3281[2] = true
-			yyq3281[3] = len(x.Conditions) != 0
-			if yyr3281 || yy2arr3281 {
+			yysep3286 := !z.EncBinary()
+			yy2arr3286 := z.EncBasicHandle().StructToArray
+			var yyq3286 [4]bool
+			_, _, _ = yysep3286, yyq3286, yy2arr3286
+			const yyr3286 bool = false
+			yyq3286[0] = x.Kind != ""
+			yyq3286[1] = x.APIVersion != ""
+			yyq3286[2] = true
+			yyq3286[3] = len(x.Conditions) != 0
+			if yyr3286 || yy2arr3286 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3281 int = 0
-				for _, b := range yyq3281 {
+				var yynn3286 int = 0
+				for _, b := range yyq3286 {
 					if b {
-						yynn3281++
+						yynn3286++
 					}
 				}
-				r.EncodeMapStart(yynn3281)
+				r.EncodeMapStart(yynn3286)
 			}
-			if yyr3281 || yy2arr3281 {
-				if yyq3281[0] {
-					yym3283 := z.EncBinary()
-					_ = yym3283
+			if yyr3286 || yy2arr3286 {
+				if yyq3286[0] {
+					yym3288 := z.EncBinary()
+					_ = yym3288
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -38023,20 +38060,20 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3281[0] {
+				if yyq3286[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3284 := z.EncBinary()
-					_ = yym3284
+					yym3289 := z.EncBinary()
+					_ = yym3289
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr3281 || yy2arr3281 {
-				if yyq3281[1] {
-					yym3286 := z.EncBinary()
-					_ = yym3286
+			if yyr3286 || yy2arr3286 {
+				if yyq3286[1] {
+					yym3291 := z.EncBinary()
+					_ = yym3291
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -38045,37 +38082,37 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3281[1] {
+				if yyq3286[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym3287 := z.EncBinary()
-					_ = yym3287
+					yym3292 := z.EncBinary()
+					_ = yym3292
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr3281 || yy2arr3281 {
-				if yyq3281[2] {
-					yy3289 := &x.ObjectMeta
-					yy3289.CodecEncodeSelf(e)
+			if yyr3286 || yy2arr3286 {
+				if yyq3286[2] {
+					yy3294 := &x.ObjectMeta
+					yy3294.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3281[2] {
+				if yyq3286[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3290 := &x.ObjectMeta
-					yy3290.CodecEncodeSelf(e)
+					yy3295 := &x.ObjectMeta
+					yy3295.CodecEncodeSelf(e)
 				}
 			}
-			if yyr3281 || yy2arr3281 {
-				if yyq3281[3] {
+			if yyr3286 || yy2arr3286 {
+				if yyq3286[3] {
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
-						yym3292 := z.EncBinary()
-						_ = yym3292
+						yym3297 := z.EncBinary()
+						_ = yym3297
 						if false {
 						} else {
 							h.encSliceComponentCondition(([]ComponentCondition)(x.Conditions), e)
@@ -38085,13 +38122,13 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3281[3] {
+				if yyq3286[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("conditions"))
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
-						yym3293 := z.EncBinary()
-						_ = yym3293
+						yym3298 := z.EncBinary()
+						_ = yym3298
 						if false {
 						} else {
 							h.encSliceComponentCondition(([]ComponentCondition)(x.Conditions), e)
@@ -38099,7 +38136,7 @@ func (x *ComponentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3281 {
+			if yysep3286 {
 				r.EncodeEnd()
 			}
 		}
@@ -38110,24 +38147,24 @@ func (x *ComponentStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3294 := z.DecBinary()
-	_ = yym3294
+	yym3299 := z.DecBinary()
+	_ = yym3299
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3295 := r.ReadMapStart()
-			if yyl3295 == 0 {
+			yyl3300 := r.ReadMapStart()
+			if yyl3300 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3295, d)
+				x.codecDecodeSelfFromMap(yyl3300, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3295 := r.ReadArrayStart()
-			if yyl3295 == 0 {
+			yyl3300 := r.ReadArrayStart()
+			if yyl3300 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3295, d)
+				x.codecDecodeSelfFromArray(yyl3300, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -38139,12 +38176,12 @@ func (x *ComponentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3296Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3296Slc
-	var yyhl3296 bool = l >= 0
-	for yyj3296 := 0; ; yyj3296++ {
-		if yyhl3296 {
-			if yyj3296 >= l {
+	var yys3301Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3301Slc
+	var yyhl3301 bool = l >= 0
+	for yyj3301 := 0; ; yyj3301++ {
+		if yyhl3301 {
+			if yyj3301 >= l {
 				break
 			}
 		} else {
@@ -38152,9 +38189,9 @@ func (x *ComponentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3296Slc = r.DecodeBytes(yys3296Slc, true, true)
-		yys3296 := string(yys3296Slc)
-		switch yys3296 {
+		yys3301Slc = r.DecodeBytes(yys3301Slc, true, true)
+		yys3301 := string(yys3301Slc)
+		switch yys3301 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -38171,26 +38208,26 @@ func (x *ComponentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv3299 := &x.ObjectMeta
-				yyv3299.CodecDecodeSelf(d)
+				yyv3304 := &x.ObjectMeta
+				yyv3304.CodecDecodeSelf(d)
 			}
 		case "conditions":
 			if r.TryDecodeAsNil() {
 				x.Conditions = nil
 			} else {
-				yyv3300 := &x.Conditions
-				yym3301 := z.DecBinary()
-				_ = yym3301
+				yyv3305 := &x.Conditions
+				yym3306 := z.DecBinary()
+				_ = yym3306
 				if false {
 				} else {
-					h.decSliceComponentCondition((*[]ComponentCondition)(yyv3300), d)
+					h.decSliceComponentCondition((*[]ComponentCondition)(yyv3305), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3296)
-		} // end switch yys3296
-	} // end for yyj3296
-	if !yyhl3296 {
+			z.DecStructFieldNotFound(-1, yys3301)
+		} // end switch yys3301
+	} // end for yyj3301
+	if !yyhl3301 {
 		r.ReadEnd()
 	}
 }
@@ -38199,16 +38236,16 @@ func (x *ComponentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3302 int
-	var yyb3302 bool
-	var yyhl3302 bool = l >= 0
-	yyj3302++
-	if yyhl3302 {
-		yyb3302 = yyj3302 > l
+	var yyj3307 int
+	var yyb3307 bool
+	var yyhl3307 bool = l >= 0
+	yyj3307++
+	if yyhl3307 {
+		yyb3307 = yyj3307 > l
 	} else {
-		yyb3302 = r.CheckBreak()
+		yyb3307 = r.CheckBreak()
 	}
-	if yyb3302 {
+	if yyb3307 {
 		r.ReadEnd()
 		return
 	}
@@ -38217,13 +38254,13 @@ func (x *ComponentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3302++
-	if yyhl3302 {
-		yyb3302 = yyj3302 > l
+	yyj3307++
+	if yyhl3307 {
+		yyb3307 = yyj3307 > l
 	} else {
-		yyb3302 = r.CheckBreak()
+		yyb3307 = r.CheckBreak()
 	}
-	if yyb3302 {
+	if yyb3307 {
 		r.ReadEnd()
 		return
 	}
@@ -38232,54 +38269,54 @@ func (x *ComponentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3302++
-	if yyhl3302 {
-		yyb3302 = yyj3302 > l
+	yyj3307++
+	if yyhl3307 {
+		yyb3307 = yyj3307 > l
 	} else {
-		yyb3302 = r.CheckBreak()
+		yyb3307 = r.CheckBreak()
 	}
-	if yyb3302 {
+	if yyb3307 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv3305 := &x.ObjectMeta
-		yyv3305.CodecDecodeSelf(d)
+		yyv3310 := &x.ObjectMeta
+		yyv3310.CodecDecodeSelf(d)
 	}
-	yyj3302++
-	if yyhl3302 {
-		yyb3302 = yyj3302 > l
+	yyj3307++
+	if yyhl3307 {
+		yyb3307 = yyj3307 > l
 	} else {
-		yyb3302 = r.CheckBreak()
+		yyb3307 = r.CheckBreak()
 	}
-	if yyb3302 {
+	if yyb3307 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Conditions = nil
 	} else {
-		yyv3306 := &x.Conditions
-		yym3307 := z.DecBinary()
-		_ = yym3307
+		yyv3311 := &x.Conditions
+		yym3312 := z.DecBinary()
+		_ = yym3312
 		if false {
 		} else {
-			h.decSliceComponentCondition((*[]ComponentCondition)(yyv3306), d)
+			h.decSliceComponentCondition((*[]ComponentCondition)(yyv3311), d)
 		}
 	}
 	for {
-		yyj3302++
-		if yyhl3302 {
-			yyb3302 = yyj3302 > l
+		yyj3307++
+		if yyhl3307 {
+			yyb3307 = yyj3307 > l
 		} else {
-			yyb3302 = r.CheckBreak()
+			yyb3307 = r.CheckBreak()
 		}
-		if yyb3302 {
+		if yyb3307 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3302-1, "")
+		z.DecStructFieldNotFound(yyj3307-1, "")
 	}
 	r.ReadEnd()
 }
@@ -38291,34 +38328,34 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3308 := z.EncBinary()
-		_ = yym3308
+		yym3313 := z.EncBinary()
+		_ = yym3313
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3309 := !z.EncBinary()
-			yy2arr3309 := z.EncBasicHandle().StructToArray
-			var yyq3309 [4]bool
-			_, _, _ = yysep3309, yyq3309, yy2arr3309
-			const yyr3309 bool = false
-			yyq3309[0] = x.Kind != ""
-			yyq3309[1] = x.APIVersion != ""
-			yyq3309[2] = true
-			if yyr3309 || yy2arr3309 {
+			yysep3314 := !z.EncBinary()
+			yy2arr3314 := z.EncBasicHandle().StructToArray
+			var yyq3314 [4]bool
+			_, _, _ = yysep3314, yyq3314, yy2arr3314
+			const yyr3314 bool = false
+			yyq3314[0] = x.Kind != ""
+			yyq3314[1] = x.APIVersion != ""
+			yyq3314[2] = true
+			if yyr3314 || yy2arr3314 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3309 int = 1
-				for _, b := range yyq3309 {
+				var yynn3314 int = 1
+				for _, b := range yyq3314 {
 					if b {
-						yynn3309++
+						yynn3314++
 					}
 				}
-				r.EncodeMapStart(yynn3309)
+				r.EncodeMapStart(yynn3314)
 			}
-			if yyr3309 || yy2arr3309 {
-				if yyq3309[0] {
-					yym3311 := z.EncBinary()
-					_ = yym3311
+			if yyr3314 || yy2arr3314 {
+				if yyq3314[0] {
+					yym3316 := z.EncBinary()
+					_ = yym3316
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -38327,20 +38364,20 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3309[0] {
+				if yyq3314[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3312 := z.EncBinary()
-					_ = yym3312
+					yym3317 := z.EncBinary()
+					_ = yym3317
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr3309 || yy2arr3309 {
-				if yyq3309[1] {
-					yym3314 := z.EncBinary()
-					_ = yym3314
+			if yyr3314 || yy2arr3314 {
+				if yyq3314[1] {
+					yym3319 := z.EncBinary()
+					_ = yym3319
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -38349,48 +38386,48 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3309[1] {
+				if yyq3314[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym3315 := z.EncBinary()
-					_ = yym3315
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr3309 || yy2arr3309 {
-				if yyq3309[2] {
-					yy3317 := &x.ListMeta
-					yym3318 := z.EncBinary()
-					_ = yym3318
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3317) {
-					} else {
-						z.EncFallback(yy3317)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq3309[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3319 := &x.ListMeta
 					yym3320 := z.EncBinary()
 					_ = yym3320
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy3319) {
 					} else {
-						z.EncFallback(yy3319)
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr3309 || yy2arr3309 {
+			if yyr3314 || yy2arr3314 {
+				if yyq3314[2] {
+					yy3322 := &x.ListMeta
+					yym3323 := z.EncBinary()
+					_ = yym3323
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3322) {
+					} else {
+						z.EncFallback(yy3322)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq3314[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy3324 := &x.ListMeta
+					yym3325 := z.EncBinary()
+					_ = yym3325
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy3324) {
+					} else {
+						z.EncFallback(yy3324)
+					}
+				}
+			}
+			if yyr3314 || yy2arr3314 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3322 := z.EncBinary()
-					_ = yym3322
+					yym3327 := z.EncBinary()
+					_ = yym3327
 					if false {
 					} else {
 						h.encSliceComponentStatus(([]ComponentStatus)(x.Items), e)
@@ -38401,15 +38438,15 @@ func (x *ComponentStatusList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym3323 := z.EncBinary()
-					_ = yym3323
+					yym3328 := z.EncBinary()
+					_ = yym3328
 					if false {
 					} else {
 						h.encSliceComponentStatus(([]ComponentStatus)(x.Items), e)
 					}
 				}
 			}
-			if yysep3309 {
+			if yysep3314 {
 				r.EncodeEnd()
 			}
 		}
@@ -38420,24 +38457,24 @@ func (x *ComponentStatusList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3324 := z.DecBinary()
-	_ = yym3324
+	yym3329 := z.DecBinary()
+	_ = yym3329
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3325 := r.ReadMapStart()
-			if yyl3325 == 0 {
+			yyl3330 := r.ReadMapStart()
+			if yyl3330 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3325, d)
+				x.codecDecodeSelfFromMap(yyl3330, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3325 := r.ReadArrayStart()
-			if yyl3325 == 0 {
+			yyl3330 := r.ReadArrayStart()
+			if yyl3330 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3325, d)
+				x.codecDecodeSelfFromArray(yyl3330, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -38449,12 +38486,12 @@ func (x *ComponentStatusList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3326Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3326Slc
-	var yyhl3326 bool = l >= 0
-	for yyj3326 := 0; ; yyj3326++ {
-		if yyhl3326 {
-			if yyj3326 >= l {
+	var yys3331Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3331Slc
+	var yyhl3331 bool = l >= 0
+	for yyj3331 := 0; ; yyj3331++ {
+		if yyhl3331 {
+			if yyj3331 >= l {
 				break
 			}
 		} else {
@@ -38462,9 +38499,9 @@ func (x *ComponentStatusList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 				break
 			}
 		}
-		yys3326Slc = r.DecodeBytes(yys3326Slc, true, true)
-		yys3326 := string(yys3326Slc)
-		switch yys3326 {
+		yys3331Slc = r.DecodeBytes(yys3331Slc, true, true)
+		yys3331 := string(yys3331Slc)
+		switch yys3331 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -38481,32 +38518,32 @@ func (x *ComponentStatusList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg2_unversioned.ListMeta{}
 			} else {
-				yyv3329 := &x.ListMeta
-				yym3330 := z.DecBinary()
-				_ = yym3330
+				yyv3334 := &x.ListMeta
+				yym3335 := z.DecBinary()
+				_ = yym3335
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3329) {
+				} else if z.HasExtensions() && z.DecExt(yyv3334) {
 				} else {
-					z.DecFallback(yyv3329, false)
+					z.DecFallback(yyv3334, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv3331 := &x.Items
-				yym3332 := z.DecBinary()
-				_ = yym3332
+				yyv3336 := &x.Items
+				yym3337 := z.DecBinary()
+				_ = yym3337
 				if false {
 				} else {
-					h.decSliceComponentStatus((*[]ComponentStatus)(yyv3331), d)
+					h.decSliceComponentStatus((*[]ComponentStatus)(yyv3336), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3326)
-		} // end switch yys3326
-	} // end for yyj3326
-	if !yyhl3326 {
+			z.DecStructFieldNotFound(-1, yys3331)
+		} // end switch yys3331
+	} // end for yyj3331
+	if !yyhl3331 {
 		r.ReadEnd()
 	}
 }
@@ -38515,16 +38552,16 @@ func (x *ComponentStatusList) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3333 int
-	var yyb3333 bool
-	var yyhl3333 bool = l >= 0
-	yyj3333++
-	if yyhl3333 {
-		yyb3333 = yyj3333 > l
+	var yyj3338 int
+	var yyb3338 bool
+	var yyhl3338 bool = l >= 0
+	yyj3338++
+	if yyhl3338 {
+		yyb3338 = yyj3338 > l
 	} else {
-		yyb3333 = r.CheckBreak()
+		yyb3338 = r.CheckBreak()
 	}
-	if yyb3333 {
+	if yyb3338 {
 		r.ReadEnd()
 		return
 	}
@@ -38533,13 +38570,13 @@ func (x *ComponentStatusList) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3333++
-	if yyhl3333 {
-		yyb3333 = yyj3333 > l
+	yyj3338++
+	if yyhl3338 {
+		yyb3338 = yyj3338 > l
 	} else {
-		yyb3333 = r.CheckBreak()
+		yyb3338 = r.CheckBreak()
 	}
-	if yyb3333 {
+	if yyb3338 {
 		r.ReadEnd()
 		return
 	}
@@ -38548,60 +38585,60 @@ func (x *ComponentStatusList) codecDecodeSelfFromArray(l int, d *codec1978.Decod
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3333++
-	if yyhl3333 {
-		yyb3333 = yyj3333 > l
+	yyj3338++
+	if yyhl3338 {
+		yyb3338 = yyj3338 > l
 	} else {
-		yyb3333 = r.CheckBreak()
+		yyb3338 = r.CheckBreak()
 	}
-	if yyb3333 {
+	if yyb3338 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
-		yyv3336 := &x.ListMeta
-		yym3337 := z.DecBinary()
-		_ = yym3337
+		yyv3341 := &x.ListMeta
+		yym3342 := z.DecBinary()
+		_ = yym3342
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv3336) {
+		} else if z.HasExtensions() && z.DecExt(yyv3341) {
 		} else {
-			z.DecFallback(yyv3336, false)
+			z.DecFallback(yyv3341, false)
 		}
 	}
-	yyj3333++
-	if yyhl3333 {
-		yyb3333 = yyj3333 > l
+	yyj3338++
+	if yyhl3338 {
+		yyb3338 = yyj3338 > l
 	} else {
-		yyb3333 = r.CheckBreak()
+		yyb3338 = r.CheckBreak()
 	}
-	if yyb3333 {
+	if yyb3338 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv3338 := &x.Items
-		yym3339 := z.DecBinary()
-		_ = yym3339
+		yyv3343 := &x.Items
+		yym3344 := z.DecBinary()
+		_ = yym3344
 		if false {
 		} else {
-			h.decSliceComponentStatus((*[]ComponentStatus)(yyv3338), d)
+			h.decSliceComponentStatus((*[]ComponentStatus)(yyv3343), d)
 		}
 	}
 	for {
-		yyj3333++
-		if yyhl3333 {
-			yyb3333 = yyj3333 > l
+		yyj3338++
+		if yyhl3338 {
+			yyb3338 = yyj3338 > l
 		} else {
-			yyb3333 = r.CheckBreak()
+			yyb3338 = r.CheckBreak()
 		}
-		if yyb3333 {
+		if yyb3338 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3333-1, "")
+		z.DecStructFieldNotFound(yyj3338-1, "")
 	}
 	r.ReadEnd()
 }
@@ -38613,35 +38650,35 @@ func (x *DownwardAPIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3340 := z.EncBinary()
-		_ = yym3340
+		yym3345 := z.EncBinary()
+		_ = yym3345
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3341 := !z.EncBinary()
-			yy2arr3341 := z.EncBasicHandle().StructToArray
-			var yyq3341 [1]bool
-			_, _, _ = yysep3341, yyq3341, yy2arr3341
-			const yyr3341 bool = false
-			yyq3341[0] = len(x.Items) != 0
-			if yyr3341 || yy2arr3341 {
+			yysep3346 := !z.EncBinary()
+			yy2arr3346 := z.EncBasicHandle().StructToArray
+			var yyq3346 [1]bool
+			_, _, _ = yysep3346, yyq3346, yy2arr3346
+			const yyr3346 bool = false
+			yyq3346[0] = len(x.Items) != 0
+			if yyr3346 || yy2arr3346 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn3341 int = 0
-				for _, b := range yyq3341 {
+				var yynn3346 int = 0
+				for _, b := range yyq3346 {
 					if b {
-						yynn3341++
+						yynn3346++
 					}
 				}
-				r.EncodeMapStart(yynn3341)
+				r.EncodeMapStart(yynn3346)
 			}
-			if yyr3341 || yy2arr3341 {
-				if yyq3341[0] {
+			if yyr3346 || yy2arr3346 {
+				if yyq3346[0] {
 					if x.Items == nil {
 						r.EncodeNil()
 					} else {
-						yym3343 := z.EncBinary()
-						_ = yym3343
+						yym3348 := z.EncBinary()
+						_ = yym3348
 						if false {
 						} else {
 							h.encSliceDownwardAPIVolumeFile(([]DownwardAPIVolumeFile)(x.Items), e)
@@ -38651,13 +38688,13 @@ func (x *DownwardAPIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3341[0] {
+				if yyq3346[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("items"))
 					if x.Items == nil {
 						r.EncodeNil()
 					} else {
-						yym3344 := z.EncBinary()
-						_ = yym3344
+						yym3349 := z.EncBinary()
+						_ = yym3349
 						if false {
 						} else {
 							h.encSliceDownwardAPIVolumeFile(([]DownwardAPIVolumeFile)(x.Items), e)
@@ -38665,7 +38702,7 @@ func (x *DownwardAPIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep3341 {
+			if yysep3346 {
 				r.EncodeEnd()
 			}
 		}
@@ -38676,24 +38713,24 @@ func (x *DownwardAPIVolumeSource) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3345 := z.DecBinary()
-	_ = yym3345
+	yym3350 := z.DecBinary()
+	_ = yym3350
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3346 := r.ReadMapStart()
-			if yyl3346 == 0 {
+			yyl3351 := r.ReadMapStart()
+			if yyl3351 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3346, d)
+				x.codecDecodeSelfFromMap(yyl3351, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3346 := r.ReadArrayStart()
-			if yyl3346 == 0 {
+			yyl3351 := r.ReadArrayStart()
+			if yyl3351 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3346, d)
+				x.codecDecodeSelfFromArray(yyl3351, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -38705,12 +38742,12 @@ func (x *DownwardAPIVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3347Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3347Slc
-	var yyhl3347 bool = l >= 0
-	for yyj3347 := 0; ; yyj3347++ {
-		if yyhl3347 {
-			if yyj3347 >= l {
+	var yys3352Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3352Slc
+	var yyhl3352 bool = l >= 0
+	for yyj3352 := 0; ; yyj3352++ {
+		if yyhl3352 {
+			if yyj3352 >= l {
 				break
 			}
 		} else {
@@ -38718,26 +38755,26 @@ func (x *DownwardAPIVolumeSource) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				break
 			}
 		}
-		yys3347Slc = r.DecodeBytes(yys3347Slc, true, true)
-		yys3347 := string(yys3347Slc)
-		switch yys3347 {
+		yys3352Slc = r.DecodeBytes(yys3352Slc, true, true)
+		yys3352 := string(yys3352Slc)
+		switch yys3352 {
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv3348 := &x.Items
-				yym3349 := z.DecBinary()
-				_ = yym3349
+				yyv3353 := &x.Items
+				yym3354 := z.DecBinary()
+				_ = yym3354
 				if false {
 				} else {
-					h.decSliceDownwardAPIVolumeFile((*[]DownwardAPIVolumeFile)(yyv3348), d)
+					h.decSliceDownwardAPIVolumeFile((*[]DownwardAPIVolumeFile)(yyv3353), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3347)
-		} // end switch yys3347
-	} // end for yyj3347
-	if !yyhl3347 {
+			z.DecStructFieldNotFound(-1, yys3352)
+		} // end switch yys3352
+	} // end for yyj3352
+	if !yyhl3352 {
 		r.ReadEnd()
 	}
 }
@@ -38746,41 +38783,41 @@ func (x *DownwardAPIVolumeSource) codecDecodeSelfFromArray(l int, d *codec1978.D
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3350 int
-	var yyb3350 bool
-	var yyhl3350 bool = l >= 0
-	yyj3350++
-	if yyhl3350 {
-		yyb3350 = yyj3350 > l
+	var yyj3355 int
+	var yyb3355 bool
+	var yyhl3355 bool = l >= 0
+	yyj3355++
+	if yyhl3355 {
+		yyb3355 = yyj3355 > l
 	} else {
-		yyb3350 = r.CheckBreak()
+		yyb3355 = r.CheckBreak()
 	}
-	if yyb3350 {
+	if yyb3355 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv3351 := &x.Items
-		yym3352 := z.DecBinary()
-		_ = yym3352
+		yyv3356 := &x.Items
+		yym3357 := z.DecBinary()
+		_ = yym3357
 		if false {
 		} else {
-			h.decSliceDownwardAPIVolumeFile((*[]DownwardAPIVolumeFile)(yyv3351), d)
+			h.decSliceDownwardAPIVolumeFile((*[]DownwardAPIVolumeFile)(yyv3356), d)
 		}
 	}
 	for {
-		yyj3350++
-		if yyhl3350 {
-			yyb3350 = yyj3350 > l
+		yyj3355++
+		if yyhl3355 {
+			yyb3355 = yyj3355 > l
 		} else {
-			yyb3350 = r.CheckBreak()
+			yyb3355 = r.CheckBreak()
 		}
-		if yyb3350 {
+		if yyb3355 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3350-1, "")
+		z.DecStructFieldNotFound(yyj3355-1, "")
 	}
 	r.ReadEnd()
 }
@@ -38792,52 +38829,52 @@ func (x *DownwardAPIVolumeFile) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3353 := z.EncBinary()
-		_ = yym3353
+		yym3358 := z.EncBinary()
+		_ = yym3358
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3354 := !z.EncBinary()
-			yy2arr3354 := z.EncBasicHandle().StructToArray
-			var yyq3354 [2]bool
-			_, _, _ = yysep3354, yyq3354, yy2arr3354
-			const yyr3354 bool = false
-			if yyr3354 || yy2arr3354 {
+			yysep3359 := !z.EncBinary()
+			yy2arr3359 := z.EncBasicHandle().StructToArray
+			var yyq3359 [2]bool
+			_, _, _ = yysep3359, yyq3359, yy2arr3359
+			const yyr3359 bool = false
+			if yyr3359 || yy2arr3359 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn3354 int = 2
-				for _, b := range yyq3354 {
+				var yynn3359 int = 2
+				for _, b := range yyq3359 {
 					if b {
-						yynn3354++
+						yynn3359++
 					}
 				}
-				r.EncodeMapStart(yynn3354)
+				r.EncodeMapStart(yynn3359)
 			}
-			if yyr3354 || yy2arr3354 {
-				yym3356 := z.EncBinary()
-				_ = yym3356
+			if yyr3359 || yy2arr3359 {
+				yym3361 := z.EncBinary()
+				_ = yym3361
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("path"))
-				yym3357 := z.EncBinary()
-				_ = yym3357
+				yym3362 := z.EncBinary()
+				_ = yym3362
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 				}
 			}
-			if yyr3354 || yy2arr3354 {
-				yy3359 := &x.FieldRef
-				yy3359.CodecEncodeSelf(e)
+			if yyr3359 || yy2arr3359 {
+				yy3364 := &x.FieldRef
+				yy3364.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("fieldRef"))
-				yy3360 := &x.FieldRef
-				yy3360.CodecEncodeSelf(e)
+				yy3365 := &x.FieldRef
+				yy3365.CodecEncodeSelf(e)
 			}
-			if yysep3354 {
+			if yysep3359 {
 				r.EncodeEnd()
 			}
 		}
@@ -38848,24 +38885,24 @@ func (x *DownwardAPIVolumeFile) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3361 := z.DecBinary()
-	_ = yym3361
+	yym3366 := z.DecBinary()
+	_ = yym3366
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3362 := r.ReadMapStart()
-			if yyl3362 == 0 {
+			yyl3367 := r.ReadMapStart()
+			if yyl3367 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3362, d)
+				x.codecDecodeSelfFromMap(yyl3367, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3362 := r.ReadArrayStart()
-			if yyl3362 == 0 {
+			yyl3367 := r.ReadArrayStart()
+			if yyl3367 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3362, d)
+				x.codecDecodeSelfFromArray(yyl3367, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -38877,12 +38914,12 @@ func (x *DownwardAPIVolumeFile) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3363Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3363Slc
-	var yyhl3363 bool = l >= 0
-	for yyj3363 := 0; ; yyj3363++ {
-		if yyhl3363 {
-			if yyj3363 >= l {
+	var yys3368Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3368Slc
+	var yyhl3368 bool = l >= 0
+	for yyj3368 := 0; ; yyj3368++ {
+		if yyhl3368 {
+			if yyj3368 >= l {
 				break
 			}
 		} else {
@@ -38890,9 +38927,9 @@ func (x *DownwardAPIVolumeFile) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				break
 			}
 		}
-		yys3363Slc = r.DecodeBytes(yys3363Slc, true, true)
-		yys3363 := string(yys3363Slc)
-		switch yys3363 {
+		yys3368Slc = r.DecodeBytes(yys3368Slc, true, true)
+		yys3368 := string(yys3368Slc)
+		switch yys3368 {
 		case "path":
 			if r.TryDecodeAsNil() {
 				x.Path = ""
@@ -38903,14 +38940,14 @@ func (x *DownwardAPIVolumeFile) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			if r.TryDecodeAsNil() {
 				x.FieldRef = ObjectFieldSelector{}
 			} else {
-				yyv3365 := &x.FieldRef
-				yyv3365.CodecDecodeSelf(d)
+				yyv3370 := &x.FieldRef
+				yyv3370.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3363)
-		} // end switch yys3363
-	} // end for yyj3363
-	if !yyhl3363 {
+			z.DecStructFieldNotFound(-1, yys3368)
+		} // end switch yys3368
+	} // end for yyj3368
+	if !yyhl3368 {
 		r.ReadEnd()
 	}
 }
@@ -38919,16 +38956,16 @@ func (x *DownwardAPIVolumeFile) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3366 int
-	var yyb3366 bool
-	var yyhl3366 bool = l >= 0
-	yyj3366++
-	if yyhl3366 {
-		yyb3366 = yyj3366 > l
+	var yyj3371 int
+	var yyb3371 bool
+	var yyhl3371 bool = l >= 0
+	yyj3371++
+	if yyhl3371 {
+		yyb3371 = yyj3371 > l
 	} else {
-		yyb3366 = r.CheckBreak()
+		yyb3371 = r.CheckBreak()
 	}
-	if yyb3366 {
+	if yyb3371 {
 		r.ReadEnd()
 		return
 	}
@@ -38937,33 +38974,33 @@ func (x *DownwardAPIVolumeFile) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.Path = string(r.DecodeString())
 	}
-	yyj3366++
-	if yyhl3366 {
-		yyb3366 = yyj3366 > l
+	yyj3371++
+	if yyhl3371 {
+		yyb3371 = yyj3371 > l
 	} else {
-		yyb3366 = r.CheckBreak()
+		yyb3371 = r.CheckBreak()
 	}
-	if yyb3366 {
+	if yyb3371 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.FieldRef = ObjectFieldSelector{}
 	} else {
-		yyv3368 := &x.FieldRef
-		yyv3368.CodecDecodeSelf(d)
+		yyv3373 := &x.FieldRef
+		yyv3373.CodecDecodeSelf(d)
 	}
 	for {
-		yyj3366++
-		if yyhl3366 {
-			yyb3366 = yyj3366 > l
+		yyj3371++
+		if yyhl3371 {
+			yyb3371 = yyj3371 > l
 		} else {
-			yyb3366 = r.CheckBreak()
+			yyb3371 = r.CheckBreak()
 		}
-		if yyb3366 {
+		if yyb3371 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3366-1, "")
+		z.DecStructFieldNotFound(yyj3371-1, "")
 	}
 	r.ReadEnd()
 }
@@ -38975,34 +39012,34 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3369 := z.EncBinary()
-		_ = yym3369
+		yym3374 := z.EncBinary()
+		_ = yym3374
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3370 := !z.EncBinary()
-			yy2arr3370 := z.EncBasicHandle().StructToArray
-			var yyq3370 [5]bool
-			_, _, _ = yysep3370, yyq3370, yy2arr3370
-			const yyr3370 bool = false
-			yyq3370[0] = x.Capabilities != nil
-			yyq3370[1] = x.Privileged != nil
-			yyq3370[2] = x.SELinuxOptions != nil
-			yyq3370[3] = x.RunAsUser != nil
-			yyq3370[4] = x.RunAsNonRoot != nil
-			if yyr3370 || yy2arr3370 {
+			yysep3375 := !z.EncBinary()
+			yy2arr3375 := z.EncBasicHandle().StructToArray
+			var yyq3375 [5]bool
+			_, _, _ = yysep3375, yyq3375, yy2arr3375
+			const yyr3375 bool = false
+			yyq3375[0] = x.Capabilities != nil
+			yyq3375[1] = x.Privileged != nil
+			yyq3375[2] = x.SELinuxOptions != nil
+			yyq3375[3] = x.RunAsUser != nil
+			yyq3375[4] = x.RunAsNonRoot != nil
+			if yyr3375 || yy2arr3375 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn3370 int = 0
-				for _, b := range yyq3370 {
+				var yynn3375 int = 0
+				for _, b := range yyq3375 {
 					if b {
-						yynn3370++
+						yynn3375++
 					}
 				}
-				r.EncodeMapStart(yynn3370)
+				r.EncodeMapStart(yynn3375)
 			}
-			if yyr3370 || yy2arr3370 {
-				if yyq3370[0] {
+			if yyr3375 || yy2arr3375 {
+				if yyq3375[0] {
 					if x.Capabilities == nil {
 						r.EncodeNil()
 					} else {
@@ -39012,7 +39049,7 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3370[0] {
+				if yyq3375[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("capabilities"))
 					if x.Capabilities == nil {
 						r.EncodeNil()
@@ -39021,40 +39058,40 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr3370 || yy2arr3370 {
-				if yyq3370[1] {
+			if yyr3375 || yy2arr3375 {
+				if yyq3375[1] {
 					if x.Privileged == nil {
 						r.EncodeNil()
 					} else {
-						yy3373 := *x.Privileged
-						yym3374 := z.EncBinary()
-						_ = yym3374
+						yy3378 := *x.Privileged
+						yym3379 := z.EncBinary()
+						_ = yym3379
 						if false {
 						} else {
-							r.EncodeBool(bool(yy3373))
+							r.EncodeBool(bool(yy3378))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3370[1] {
+				if yyq3375[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("privileged"))
 					if x.Privileged == nil {
 						r.EncodeNil()
 					} else {
-						yy3375 := *x.Privileged
-						yym3376 := z.EncBinary()
-						_ = yym3376
+						yy3380 := *x.Privileged
+						yym3381 := z.EncBinary()
+						_ = yym3381
 						if false {
 						} else {
-							r.EncodeBool(bool(yy3375))
+							r.EncodeBool(bool(yy3380))
 						}
 					}
 				}
 			}
-			if yyr3370 || yy2arr3370 {
-				if yyq3370[2] {
+			if yyr3375 || yy2arr3375 {
+				if yyq3375[2] {
 					if x.SELinuxOptions == nil {
 						r.EncodeNil()
 					} else {
@@ -39064,7 +39101,7 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3370[2] {
+				if yyq3375[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("seLinuxOptions"))
 					if x.SELinuxOptions == nil {
 						r.EncodeNil()
@@ -39073,71 +39110,71 @@ func (x *SecurityContext) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr3370 || yy2arr3370 {
-				if yyq3370[3] {
+			if yyr3375 || yy2arr3375 {
+				if yyq3375[3] {
 					if x.RunAsUser == nil {
 						r.EncodeNil()
 					} else {
-						yy3379 := *x.RunAsUser
-						yym3380 := z.EncBinary()
-						_ = yym3380
-						if false {
-						} else {
-							r.EncodeInt(int64(yy3379))
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq3370[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("runAsUser"))
-					if x.RunAsUser == nil {
-						r.EncodeNil()
-					} else {
-						yy3381 := *x.RunAsUser
-						yym3382 := z.EncBinary()
-						_ = yym3382
-						if false {
-						} else {
-							r.EncodeInt(int64(yy3381))
-						}
-					}
-				}
-			}
-			if yyr3370 || yy2arr3370 {
-				if yyq3370[4] {
-					if x.RunAsNonRoot == nil {
-						r.EncodeNil()
-					} else {
-						yy3384 := *x.RunAsNonRoot
+						yy3384 := *x.RunAsUser
 						yym3385 := z.EncBinary()
 						_ = yym3385
 						if false {
 						} else {
-							r.EncodeBool(bool(yy3384))
+							r.EncodeInt(int64(yy3384))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3370[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("runAsNonRoot"))
-					if x.RunAsNonRoot == nil {
+				if yyq3375[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("runAsUser"))
+					if x.RunAsUser == nil {
 						r.EncodeNil()
 					} else {
-						yy3386 := *x.RunAsNonRoot
+						yy3386 := *x.RunAsUser
 						yym3387 := z.EncBinary()
 						_ = yym3387
 						if false {
 						} else {
-							r.EncodeBool(bool(yy3386))
+							r.EncodeInt(int64(yy3386))
 						}
 					}
 				}
 			}
-			if yysep3370 {
+			if yyr3375 || yy2arr3375 {
+				if yyq3375[4] {
+					if x.RunAsNonRoot == nil {
+						r.EncodeNil()
+					} else {
+						yy3389 := *x.RunAsNonRoot
+						yym3390 := z.EncBinary()
+						_ = yym3390
+						if false {
+						} else {
+							r.EncodeBool(bool(yy3389))
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq3375[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("runAsNonRoot"))
+					if x.RunAsNonRoot == nil {
+						r.EncodeNil()
+					} else {
+						yy3391 := *x.RunAsNonRoot
+						yym3392 := z.EncBinary()
+						_ = yym3392
+						if false {
+						} else {
+							r.EncodeBool(bool(yy3391))
+						}
+					}
+				}
+			}
+			if yysep3375 {
 				r.EncodeEnd()
 			}
 		}
@@ -39148,24 +39185,24 @@ func (x *SecurityContext) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3388 := z.DecBinary()
-	_ = yym3388
+	yym3393 := z.DecBinary()
+	_ = yym3393
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3389 := r.ReadMapStart()
-			if yyl3389 == 0 {
+			yyl3394 := r.ReadMapStart()
+			if yyl3394 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3389, d)
+				x.codecDecodeSelfFromMap(yyl3394, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3389 := r.ReadArrayStart()
-			if yyl3389 == 0 {
+			yyl3394 := r.ReadArrayStart()
+			if yyl3394 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3389, d)
+				x.codecDecodeSelfFromArray(yyl3394, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -39177,12 +39214,12 @@ func (x *SecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3390Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3390Slc
-	var yyhl3390 bool = l >= 0
-	for yyj3390 := 0; ; yyj3390++ {
-		if yyhl3390 {
-			if yyj3390 >= l {
+	var yys3395Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3395Slc
+	var yyhl3395 bool = l >= 0
+	for yyj3395 := 0; ; yyj3395++ {
+		if yyhl3395 {
+			if yyj3395 >= l {
 				break
 			}
 		} else {
@@ -39190,9 +39227,9 @@ func (x *SecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3390Slc = r.DecodeBytes(yys3390Slc, true, true)
-		yys3390 := string(yys3390Slc)
-		switch yys3390 {
+		yys3395Slc = r.DecodeBytes(yys3395Slc, true, true)
+		yys3395 := string(yys3395Slc)
+		switch yys3395 {
 		case "capabilities":
 			if r.TryDecodeAsNil() {
 				if x.Capabilities != nil {
@@ -39213,8 +39250,8 @@ func (x *SecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.Privileged == nil {
 					x.Privileged = new(bool)
 				}
-				yym3393 := z.DecBinary()
-				_ = yym3393
+				yym3398 := z.DecBinary()
+				_ = yym3398
 				if false {
 				} else {
 					*((*bool)(x.Privileged)) = r.DecodeBool()
@@ -39240,8 +39277,8 @@ func (x *SecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.RunAsUser == nil {
 					x.RunAsUser = new(int64)
 				}
-				yym3396 := z.DecBinary()
-				_ = yym3396
+				yym3401 := z.DecBinary()
+				_ = yym3401
 				if false {
 				} else {
 					*((*int64)(x.RunAsUser)) = int64(r.DecodeInt(64))
@@ -39256,18 +39293,18 @@ func (x *SecurityContext) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.RunAsNonRoot == nil {
 					x.RunAsNonRoot = new(bool)
 				}
-				yym3398 := z.DecBinary()
-				_ = yym3398
+				yym3403 := z.DecBinary()
+				_ = yym3403
 				if false {
 				} else {
 					*((*bool)(x.RunAsNonRoot)) = r.DecodeBool()
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3390)
-		} // end switch yys3390
-	} // end for yyj3390
-	if !yyhl3390 {
+			z.DecStructFieldNotFound(-1, yys3395)
+		} // end switch yys3395
+	} // end for yyj3395
+	if !yyhl3395 {
 		r.ReadEnd()
 	}
 }
@@ -39276,16 +39313,16 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3399 int
-	var yyb3399 bool
-	var yyhl3399 bool = l >= 0
-	yyj3399++
-	if yyhl3399 {
-		yyb3399 = yyj3399 > l
+	var yyj3404 int
+	var yyb3404 bool
+	var yyhl3404 bool = l >= 0
+	yyj3404++
+	if yyhl3404 {
+		yyb3404 = yyj3404 > l
 	} else {
-		yyb3399 = r.CheckBreak()
+		yyb3404 = r.CheckBreak()
 	}
-	if yyb3399 {
+	if yyb3404 {
 		r.ReadEnd()
 		return
 	}
@@ -39299,13 +39336,13 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		}
 		x.Capabilities.CodecDecodeSelf(d)
 	}
-	yyj3399++
-	if yyhl3399 {
-		yyb3399 = yyj3399 > l
+	yyj3404++
+	if yyhl3404 {
+		yyb3404 = yyj3404 > l
 	} else {
-		yyb3399 = r.CheckBreak()
+		yyb3404 = r.CheckBreak()
 	}
-	if yyb3399 {
+	if yyb3404 {
 		r.ReadEnd()
 		return
 	}
@@ -39317,20 +39354,20 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if x.Privileged == nil {
 			x.Privileged = new(bool)
 		}
-		yym3402 := z.DecBinary()
-		_ = yym3402
+		yym3407 := z.DecBinary()
+		_ = yym3407
 		if false {
 		} else {
 			*((*bool)(x.Privileged)) = r.DecodeBool()
 		}
 	}
-	yyj3399++
-	if yyhl3399 {
-		yyb3399 = yyj3399 > l
+	yyj3404++
+	if yyhl3404 {
+		yyb3404 = yyj3404 > l
 	} else {
-		yyb3399 = r.CheckBreak()
+		yyb3404 = r.CheckBreak()
 	}
-	if yyb3399 {
+	if yyb3404 {
 		r.ReadEnd()
 		return
 	}
@@ -39344,13 +39381,13 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		}
 		x.SELinuxOptions.CodecDecodeSelf(d)
 	}
-	yyj3399++
-	if yyhl3399 {
-		yyb3399 = yyj3399 > l
+	yyj3404++
+	if yyhl3404 {
+		yyb3404 = yyj3404 > l
 	} else {
-		yyb3399 = r.CheckBreak()
+		yyb3404 = r.CheckBreak()
 	}
-	if yyb3399 {
+	if yyb3404 {
 		r.ReadEnd()
 		return
 	}
@@ -39362,20 +39399,20 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if x.RunAsUser == nil {
 			x.RunAsUser = new(int64)
 		}
-		yym3405 := z.DecBinary()
-		_ = yym3405
+		yym3410 := z.DecBinary()
+		_ = yym3410
 		if false {
 		} else {
 			*((*int64)(x.RunAsUser)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj3399++
-	if yyhl3399 {
-		yyb3399 = yyj3399 > l
+	yyj3404++
+	if yyhl3404 {
+		yyb3404 = yyj3404 > l
 	} else {
-		yyb3399 = r.CheckBreak()
+		yyb3404 = r.CheckBreak()
 	}
-	if yyb3399 {
+	if yyb3404 {
 		r.ReadEnd()
 		return
 	}
@@ -39387,24 +39424,24 @@ func (x *SecurityContext) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if x.RunAsNonRoot == nil {
 			x.RunAsNonRoot = new(bool)
 		}
-		yym3407 := z.DecBinary()
-		_ = yym3407
+		yym3412 := z.DecBinary()
+		_ = yym3412
 		if false {
 		} else {
 			*((*bool)(x.RunAsNonRoot)) = r.DecodeBool()
 		}
 	}
 	for {
-		yyj3399++
-		if yyhl3399 {
-			yyb3399 = yyj3399 > l
+		yyj3404++
+		if yyhl3404 {
+			yyb3404 = yyj3404 > l
 		} else {
-			yyb3399 = r.CheckBreak()
+			yyb3404 = r.CheckBreak()
 		}
-		if yyb3399 {
+		if yyb3404 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3399-1, "")
+		z.DecStructFieldNotFound(yyj3404-1, "")
 	}
 	r.ReadEnd()
 }
@@ -39416,35 +39453,35 @@ func (x *SELinuxOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3408 := z.EncBinary()
-		_ = yym3408
+		yym3413 := z.EncBinary()
+		_ = yym3413
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3409 := !z.EncBinary()
-			yy2arr3409 := z.EncBasicHandle().StructToArray
-			var yyq3409 [4]bool
-			_, _, _ = yysep3409, yyq3409, yy2arr3409
-			const yyr3409 bool = false
-			yyq3409[0] = x.User != ""
-			yyq3409[1] = x.Role != ""
-			yyq3409[2] = x.Type != ""
-			yyq3409[3] = x.Level != ""
-			if yyr3409 || yy2arr3409 {
+			yysep3414 := !z.EncBinary()
+			yy2arr3414 := z.EncBasicHandle().StructToArray
+			var yyq3414 [4]bool
+			_, _, _ = yysep3414, yyq3414, yy2arr3414
+			const yyr3414 bool = false
+			yyq3414[0] = x.User != ""
+			yyq3414[1] = x.Role != ""
+			yyq3414[2] = x.Type != ""
+			yyq3414[3] = x.Level != ""
+			if yyr3414 || yy2arr3414 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn3409 int = 0
-				for _, b := range yyq3409 {
+				var yynn3414 int = 0
+				for _, b := range yyq3414 {
 					if b {
-						yynn3409++
+						yynn3414++
 					}
 				}
-				r.EncodeMapStart(yynn3409)
+				r.EncodeMapStart(yynn3414)
 			}
-			if yyr3409 || yy2arr3409 {
-				if yyq3409[0] {
-					yym3411 := z.EncBinary()
-					_ = yym3411
+			if yyr3414 || yy2arr3414 {
+				if yyq3414[0] {
+					yym3416 := z.EncBinary()
+					_ = yym3416
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.User))
@@ -39453,83 +39490,83 @@ func (x *SELinuxOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3409[0] {
+				if yyq3414[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("user"))
-					yym3412 := z.EncBinary()
-					_ = yym3412
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.User))
-					}
-				}
-			}
-			if yyr3409 || yy2arr3409 {
-				if yyq3409[1] {
-					yym3414 := z.EncBinary()
-					_ = yym3414
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Role))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq3409[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("role"))
-					yym3415 := z.EncBinary()
-					_ = yym3415
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Role))
-					}
-				}
-			}
-			if yyr3409 || yy2arr3409 {
-				if yyq3409[2] {
 					yym3417 := z.EncBinary()
 					_ = yym3417
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Type))
+						r.EncodeString(codecSelferC_UTF81234, string(x.User))
+					}
+				}
+			}
+			if yyr3414 || yy2arr3414 {
+				if yyq3414[1] {
+					yym3419 := z.EncBinary()
+					_ = yym3419
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Role))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3409[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("type"))
-					yym3418 := z.EncBinary()
-					_ = yym3418
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Type))
-					}
-				}
-			}
-			if yyr3409 || yy2arr3409 {
-				if yyq3409[3] {
+				if yyq3414[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("role"))
 					yym3420 := z.EncBinary()
 					_ = yym3420
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Role))
+					}
+				}
+			}
+			if yyr3414 || yy2arr3414 {
+				if yyq3414[2] {
+					yym3422 := z.EncBinary()
+					_ = yym3422
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Type))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq3414[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("type"))
+					yym3423 := z.EncBinary()
+					_ = yym3423
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Type))
+					}
+				}
+			}
+			if yyr3414 || yy2arr3414 {
+				if yyq3414[3] {
+					yym3425 := z.EncBinary()
+					_ = yym3425
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Level))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3409[3] {
+				if yyq3414[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("level"))
-					yym3421 := z.EncBinary()
-					_ = yym3421
+					yym3426 := z.EncBinary()
+					_ = yym3426
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Level))
 					}
 				}
 			}
-			if yysep3409 {
+			if yysep3414 {
 				r.EncodeEnd()
 			}
 		}
@@ -39540,24 +39577,24 @@ func (x *SELinuxOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3422 := z.DecBinary()
-	_ = yym3422
+	yym3427 := z.DecBinary()
+	_ = yym3427
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3423 := r.ReadMapStart()
-			if yyl3423 == 0 {
+			yyl3428 := r.ReadMapStart()
+			if yyl3428 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3423, d)
+				x.codecDecodeSelfFromMap(yyl3428, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3423 := r.ReadArrayStart()
-			if yyl3423 == 0 {
+			yyl3428 := r.ReadArrayStart()
+			if yyl3428 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3423, d)
+				x.codecDecodeSelfFromArray(yyl3428, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -39569,12 +39606,12 @@ func (x *SELinuxOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3424Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3424Slc
-	var yyhl3424 bool = l >= 0
-	for yyj3424 := 0; ; yyj3424++ {
-		if yyhl3424 {
-			if yyj3424 >= l {
+	var yys3429Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3429Slc
+	var yyhl3429 bool = l >= 0
+	for yyj3429 := 0; ; yyj3429++ {
+		if yyhl3429 {
+			if yyj3429 >= l {
 				break
 			}
 		} else {
@@ -39582,9 +39619,9 @@ func (x *SELinuxOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3424Slc = r.DecodeBytes(yys3424Slc, true, true)
-		yys3424 := string(yys3424Slc)
-		switch yys3424 {
+		yys3429Slc = r.DecodeBytes(yys3429Slc, true, true)
+		yys3429 := string(yys3429Slc)
+		switch yys3429 {
 		case "user":
 			if r.TryDecodeAsNil() {
 				x.User = ""
@@ -39610,10 +39647,10 @@ func (x *SELinuxOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Level = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3424)
-		} // end switch yys3424
-	} // end for yyj3424
-	if !yyhl3424 {
+			z.DecStructFieldNotFound(-1, yys3429)
+		} // end switch yys3429
+	} // end for yyj3429
+	if !yyhl3429 {
 		r.ReadEnd()
 	}
 }
@@ -39622,16 +39659,16 @@ func (x *SELinuxOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3429 int
-	var yyb3429 bool
-	var yyhl3429 bool = l >= 0
-	yyj3429++
-	if yyhl3429 {
-		yyb3429 = yyj3429 > l
+	var yyj3434 int
+	var yyb3434 bool
+	var yyhl3434 bool = l >= 0
+	yyj3434++
+	if yyhl3434 {
+		yyb3434 = yyj3434 > l
 	} else {
-		yyb3429 = r.CheckBreak()
+		yyb3434 = r.CheckBreak()
 	}
-	if yyb3429 {
+	if yyb3434 {
 		r.ReadEnd()
 		return
 	}
@@ -39640,13 +39677,13 @@ func (x *SELinuxOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.User = string(r.DecodeString())
 	}
-	yyj3429++
-	if yyhl3429 {
-		yyb3429 = yyj3429 > l
+	yyj3434++
+	if yyhl3434 {
+		yyb3434 = yyj3434 > l
 	} else {
-		yyb3429 = r.CheckBreak()
+		yyb3434 = r.CheckBreak()
 	}
-	if yyb3429 {
+	if yyb3434 {
 		r.ReadEnd()
 		return
 	}
@@ -39655,13 +39692,13 @@ func (x *SELinuxOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Role = string(r.DecodeString())
 	}
-	yyj3429++
-	if yyhl3429 {
-		yyb3429 = yyj3429 > l
+	yyj3434++
+	if yyhl3434 {
+		yyb3434 = yyj3434 > l
 	} else {
-		yyb3429 = r.CheckBreak()
+		yyb3434 = r.CheckBreak()
 	}
-	if yyb3429 {
+	if yyb3434 {
 		r.ReadEnd()
 		return
 	}
@@ -39670,13 +39707,13 @@ func (x *SELinuxOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Type = string(r.DecodeString())
 	}
-	yyj3429++
-	if yyhl3429 {
-		yyb3429 = yyj3429 > l
+	yyj3434++
+	if yyhl3434 {
+		yyb3434 = yyj3434 > l
 	} else {
-		yyb3429 = r.CheckBreak()
+		yyb3434 = r.CheckBreak()
 	}
-	if yyb3429 {
+	if yyb3434 {
 		r.ReadEnd()
 		return
 	}
@@ -39686,16 +39723,16 @@ func (x *SELinuxOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Level = string(r.DecodeString())
 	}
 	for {
-		yyj3429++
-		if yyhl3429 {
-			yyb3429 = yyj3429 > l
+		yyj3434++
+		if yyhl3434 {
+			yyb3434 = yyj3434 > l
 		} else {
-			yyb3429 = r.CheckBreak()
+			yyb3434 = r.CheckBreak()
 		}
-		if yyb3429 {
+		if yyb3434 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3429-1, "")
+		z.DecStructFieldNotFound(yyj3434-1, "")
 	}
 	r.ReadEnd()
 }
@@ -39707,34 +39744,34 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym3434 := z.EncBinary()
-		_ = yym3434
+		yym3439 := z.EncBinary()
+		_ = yym3439
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep3435 := !z.EncBinary()
-			yy2arr3435 := z.EncBasicHandle().StructToArray
-			var yyq3435 [5]bool
-			_, _, _ = yysep3435, yyq3435, yy2arr3435
-			const yyr3435 bool = false
-			yyq3435[0] = x.Kind != ""
-			yyq3435[1] = x.APIVersion != ""
-			yyq3435[2] = true
-			if yyr3435 || yy2arr3435 {
+			yysep3440 := !z.EncBinary()
+			yy2arr3440 := z.EncBasicHandle().StructToArray
+			var yyq3440 [5]bool
+			_, _, _ = yysep3440, yyq3440, yy2arr3440
+			const yyr3440 bool = false
+			yyq3440[0] = x.Kind != ""
+			yyq3440[1] = x.APIVersion != ""
+			yyq3440[2] = true
+			if yyr3440 || yy2arr3440 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn3435 int = 2
-				for _, b := range yyq3435 {
+				var yynn3440 int = 2
+				for _, b := range yyq3440 {
 					if b {
-						yynn3435++
+						yynn3440++
 					}
 				}
-				r.EncodeMapStart(yynn3435)
+				r.EncodeMapStart(yynn3440)
 			}
-			if yyr3435 || yy2arr3435 {
-				if yyq3435[0] {
-					yym3437 := z.EncBinary()
-					_ = yym3437
+			if yyr3440 || yy2arr3440 {
+				if yyq3440[0] {
+					yym3442 := z.EncBinary()
+					_ = yym3442
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -39743,20 +39780,20 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3435[0] {
+				if yyq3440[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym3438 := z.EncBinary()
-					_ = yym3438
+					yym3443 := z.EncBinary()
+					_ = yym3443
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr3435 || yy2arr3435 {
-				if yyq3435[1] {
-					yym3440 := z.EncBinary()
-					_ = yym3440
+			if yyr3440 || yy2arr3440 {
+				if yyq3440[1] {
+					yym3445 := z.EncBinary()
+					_ = yym3445
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -39765,52 +39802,52 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq3435[1] {
+				if yyq3440[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym3441 := z.EncBinary()
-					_ = yym3441
+					yym3446 := z.EncBinary()
+					_ = yym3446
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr3435 || yy2arr3435 {
-				if yyq3435[2] {
-					yy3443 := &x.ObjectMeta
-					yy3443.CodecEncodeSelf(e)
+			if yyr3440 || yy2arr3440 {
+				if yyq3440[2] {
+					yy3448 := &x.ObjectMeta
+					yy3448.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq3435[2] {
+				if yyq3440[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy3444 := &x.ObjectMeta
-					yy3444.CodecEncodeSelf(e)
+					yy3449 := &x.ObjectMeta
+					yy3449.CodecEncodeSelf(e)
 				}
 			}
-			if yyr3435 || yy2arr3435 {
-				yym3446 := z.EncBinary()
-				_ = yym3446
+			if yyr3440 || yy2arr3440 {
+				yym3451 := z.EncBinary()
+				_ = yym3451
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Range))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("range"))
-				yym3447 := z.EncBinary()
-				_ = yym3447
+				yym3452 := z.EncBinary()
+				_ = yym3452
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Range))
 				}
 			}
-			if yyr3435 || yy2arr3435 {
+			if yyr3440 || yy2arr3440 {
 				if x.Data == nil {
 					r.EncodeNil()
 				} else {
-					yym3449 := z.EncBinary()
-					_ = yym3449
+					yym3454 := z.EncBinary()
+					_ = yym3454
 					if false {
 					} else {
 						r.EncodeStringBytes(codecSelferC_RAW1234, []byte(x.Data))
@@ -39821,15 +39858,15 @@ func (x *RangeAllocation) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Data == nil {
 					r.EncodeNil()
 				} else {
-					yym3450 := z.EncBinary()
-					_ = yym3450
+					yym3455 := z.EncBinary()
+					_ = yym3455
 					if false {
 					} else {
 						r.EncodeStringBytes(codecSelferC_RAW1234, []byte(x.Data))
 					}
 				}
 			}
-			if yysep3435 {
+			if yysep3440 {
 				r.EncodeEnd()
 			}
 		}
@@ -39840,24 +39877,24 @@ func (x *RangeAllocation) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym3451 := z.DecBinary()
-	_ = yym3451
+	yym3456 := z.DecBinary()
+	_ = yym3456
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl3452 := r.ReadMapStart()
-			if yyl3452 == 0 {
+			yyl3457 := r.ReadMapStart()
+			if yyl3457 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl3452, d)
+				x.codecDecodeSelfFromMap(yyl3457, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl3452 := r.ReadArrayStart()
-			if yyl3452 == 0 {
+			yyl3457 := r.ReadArrayStart()
+			if yyl3457 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl3452, d)
+				x.codecDecodeSelfFromArray(yyl3457, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -39869,12 +39906,12 @@ func (x *RangeAllocation) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys3453Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys3453Slc
-	var yyhl3453 bool = l >= 0
-	for yyj3453 := 0; ; yyj3453++ {
-		if yyhl3453 {
-			if yyj3453 >= l {
+	var yys3458Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys3458Slc
+	var yyhl3458 bool = l >= 0
+	for yyj3458 := 0; ; yyj3458++ {
+		if yyhl3458 {
+			if yyj3458 >= l {
 				break
 			}
 		} else {
@@ -39882,9 +39919,9 @@ func (x *RangeAllocation) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys3453Slc = r.DecodeBytes(yys3453Slc, true, true)
-		yys3453 := string(yys3453Slc)
-		switch yys3453 {
+		yys3458Slc = r.DecodeBytes(yys3458Slc, true, true)
+		yys3458 := string(yys3458Slc)
+		switch yys3458 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -39901,8 +39938,8 @@ func (x *RangeAllocation) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = ObjectMeta{}
 			} else {
-				yyv3456 := &x.ObjectMeta
-				yyv3456.CodecDecodeSelf(d)
+				yyv3461 := &x.ObjectMeta
+				yyv3461.CodecDecodeSelf(d)
 			}
 		case "range":
 			if r.TryDecodeAsNil() {
@@ -39914,19 +39951,19 @@ func (x *RangeAllocation) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Data = nil
 			} else {
-				yyv3458 := &x.Data
-				yym3459 := z.DecBinary()
-				_ = yym3459
+				yyv3463 := &x.Data
+				yym3464 := z.DecBinary()
+				_ = yym3464
 				if false {
 				} else {
-					*yyv3458 = r.DecodeBytes(*(*[]byte)(yyv3458), false, false)
+					*yyv3463 = r.DecodeBytes(*(*[]byte)(yyv3463), false, false)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys3453)
-		} // end switch yys3453
-	} // end for yyj3453
-	if !yyhl3453 {
+			z.DecStructFieldNotFound(-1, yys3458)
+		} // end switch yys3458
+	} // end for yyj3458
+	if !yyhl3458 {
 		r.ReadEnd()
 	}
 }
@@ -39935,16 +39972,16 @@ func (x *RangeAllocation) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj3460 int
-	var yyb3460 bool
-	var yyhl3460 bool = l >= 0
-	yyj3460++
-	if yyhl3460 {
-		yyb3460 = yyj3460 > l
+	var yyj3465 int
+	var yyb3465 bool
+	var yyhl3465 bool = l >= 0
+	yyj3465++
+	if yyhl3465 {
+		yyb3465 = yyj3465 > l
 	} else {
-		yyb3460 = r.CheckBreak()
+		yyb3465 = r.CheckBreak()
 	}
-	if yyb3460 {
+	if yyb3465 {
 		r.ReadEnd()
 		return
 	}
@@ -39953,13 +39990,13 @@ func (x *RangeAllocation) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj3460++
-	if yyhl3460 {
-		yyb3460 = yyj3460 > l
+	yyj3465++
+	if yyhl3465 {
+		yyb3465 = yyj3465 > l
 	} else {
-		yyb3460 = r.CheckBreak()
+		yyb3465 = r.CheckBreak()
 	}
-	if yyb3460 {
+	if yyb3465 {
 		r.ReadEnd()
 		return
 	}
@@ -39968,29 +40005,29 @@ func (x *RangeAllocation) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj3460++
-	if yyhl3460 {
-		yyb3460 = yyj3460 > l
+	yyj3465++
+	if yyhl3465 {
+		yyb3465 = yyj3465 > l
 	} else {
-		yyb3460 = r.CheckBreak()
+		yyb3465 = r.CheckBreak()
 	}
-	if yyb3460 {
+	if yyb3465 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = ObjectMeta{}
 	} else {
-		yyv3463 := &x.ObjectMeta
-		yyv3463.CodecDecodeSelf(d)
+		yyv3468 := &x.ObjectMeta
+		yyv3468.CodecDecodeSelf(d)
 	}
-	yyj3460++
-	if yyhl3460 {
-		yyb3460 = yyj3460 > l
+	yyj3465++
+	if yyhl3465 {
+		yyb3465 = yyj3465 > l
 	} else {
-		yyb3460 = r.CheckBreak()
+		yyb3465 = r.CheckBreak()
 	}
-	if yyb3460 {
+	if yyb3465 {
 		r.ReadEnd()
 		return
 	}
@@ -39999,38 +40036,38 @@ func (x *RangeAllocation) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Range = string(r.DecodeString())
 	}
-	yyj3460++
-	if yyhl3460 {
-		yyb3460 = yyj3460 > l
+	yyj3465++
+	if yyhl3465 {
+		yyb3465 = yyj3465 > l
 	} else {
-		yyb3460 = r.CheckBreak()
+		yyb3465 = r.CheckBreak()
 	}
-	if yyb3460 {
+	if yyb3465 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Data = nil
 	} else {
-		yyv3465 := &x.Data
-		yym3466 := z.DecBinary()
-		_ = yym3466
+		yyv3470 := &x.Data
+		yym3471 := z.DecBinary()
+		_ = yym3471
 		if false {
 		} else {
-			*yyv3465 = r.DecodeBytes(*(*[]byte)(yyv3465), false, false)
+			*yyv3470 = r.DecodeBytes(*(*[]byte)(yyv3470), false, false)
 		}
 	}
 	for {
-		yyj3460++
-		if yyhl3460 {
-			yyb3460 = yyj3460 > l
+		yyj3465++
+		if yyhl3465 {
+			yyb3465 = yyj3465 > l
 		} else {
-			yyb3460 = r.CheckBreak()
+			yyb3465 = r.CheckBreak()
 		}
-		if yyb3460 {
+		if yyb3465 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj3460-1, "")
+		z.DecStructFieldNotFound(yyj3465-1, "")
 	}
 	r.ReadEnd()
 }
@@ -40040,8 +40077,8 @@ func (x codecSelfer1234) encSlicePersistentVolumeAccessMode(v []PersistentVolume
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3467 := range v {
-		yyv3467.CodecEncodeSelf(e)
+	for _, yyv3472 := range v {
+		yyv3472.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -40051,77 +40088,77 @@ func (x codecSelfer1234) decSlicePersistentVolumeAccessMode(v *[]PersistentVolum
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3468 := *v
-	yyh3468, yyl3468 := z.DecSliceHelperStart()
+	yyv3473 := *v
+	yyh3473, yyl3473 := z.DecSliceHelperStart()
 
-	var yyrr3468, yyrl3468 int
-	var yyc3468, yyrt3468 bool
-	_, _, _ = yyc3468, yyrt3468, yyrl3468
-	yyrr3468 = yyl3468
+	var yyrr3473, yyrl3473 int
+	var yyc3473, yyrt3473 bool
+	_, _, _ = yyc3473, yyrt3473, yyrl3473
+	yyrr3473 = yyl3473
 
-	if yyv3468 == nil {
-		if yyrl3468, yyrt3468 = z.DecInferLen(yyl3468, z.DecBasicHandle().MaxInitLen, 16); yyrt3468 {
-			yyrr3468 = yyrl3468
+	if yyv3473 == nil {
+		if yyrl3473, yyrt3473 = z.DecInferLen(yyl3473, z.DecBasicHandle().MaxInitLen, 16); yyrt3473 {
+			yyrr3473 = yyrl3473
 		}
-		yyv3468 = make([]PersistentVolumeAccessMode, yyrl3468)
-		yyc3468 = true
+		yyv3473 = make([]PersistentVolumeAccessMode, yyrl3473)
+		yyc3473 = true
 	}
 
-	if yyl3468 == 0 {
-		if len(yyv3468) != 0 {
-			yyv3468 = yyv3468[:0]
-			yyc3468 = true
+	if yyl3473 == 0 {
+		if len(yyv3473) != 0 {
+			yyv3473 = yyv3473[:0]
+			yyc3473 = true
 		}
-	} else if yyl3468 > 0 {
+	} else if yyl3473 > 0 {
 
-		if yyl3468 > cap(yyv3468) {
-			yyrl3468, yyrt3468 = z.DecInferLen(yyl3468, z.DecBasicHandle().MaxInitLen, 16)
+		if yyl3473 > cap(yyv3473) {
+			yyrl3473, yyrt3473 = z.DecInferLen(yyl3473, z.DecBasicHandle().MaxInitLen, 16)
 
-			yyv23468 := yyv3468
-			yyv3468 = make([]PersistentVolumeAccessMode, yyrl3468)
-			if len(yyv3468) > 0 {
-				copy(yyv3468, yyv23468[:cap(yyv23468)])
+			yyv23473 := yyv3473
+			yyv3473 = make([]PersistentVolumeAccessMode, yyrl3473)
+			if len(yyv3473) > 0 {
+				copy(yyv3473, yyv23473[:cap(yyv23473)])
 			}
-			yyc3468 = true
+			yyc3473 = true
 
-			yyrr3468 = len(yyv3468)
-		} else if yyl3468 != len(yyv3468) {
-			yyv3468 = yyv3468[:yyl3468]
-			yyc3468 = true
+			yyrr3473 = len(yyv3473)
+		} else if yyl3473 != len(yyv3473) {
+			yyv3473 = yyv3473[:yyl3473]
+			yyc3473 = true
 		}
-		yyj3468 := 0
-		for ; yyj3468 < yyrr3468; yyj3468++ {
+		yyj3473 := 0
+		for ; yyj3473 < yyrr3473; yyj3473++ {
 			if r.TryDecodeAsNil() {
-				yyv3468[yyj3468] = ""
+				yyv3473[yyj3473] = ""
 			} else {
-				yyv3468[yyj3468] = PersistentVolumeAccessMode(r.DecodeString())
+				yyv3473[yyj3473] = PersistentVolumeAccessMode(r.DecodeString())
 			}
 
 		}
-		if yyrt3468 {
-			for ; yyj3468 < yyl3468; yyj3468++ {
-				yyv3468 = append(yyv3468, "")
+		if yyrt3473 {
+			for ; yyj3473 < yyl3473; yyj3473++ {
+				yyv3473 = append(yyv3473, "")
 				if r.TryDecodeAsNil() {
-					yyv3468[yyj3468] = ""
+					yyv3473[yyj3473] = ""
 				} else {
-					yyv3468[yyj3468] = PersistentVolumeAccessMode(r.DecodeString())
+					yyv3473[yyj3473] = PersistentVolumeAccessMode(r.DecodeString())
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3468 := 0; !r.CheckBreak(); yyj3468++ {
-			if yyj3468 >= len(yyv3468) {
-				yyv3468 = append(yyv3468, "") // var yyz3468 PersistentVolumeAccessMode
-				yyc3468 = true
+		for yyj3473 := 0; !r.CheckBreak(); yyj3473++ {
+			if yyj3473 >= len(yyv3473) {
+				yyv3473 = append(yyv3473, "") // var yyz3473 PersistentVolumeAccessMode
+				yyc3473 = true
 			}
 
-			if yyj3468 < len(yyv3468) {
+			if yyj3473 < len(yyv3473) {
 				if r.TryDecodeAsNil() {
-					yyv3468[yyj3468] = ""
+					yyv3473[yyj3473] = ""
 				} else {
-					yyv3468[yyj3468] = PersistentVolumeAccessMode(r.DecodeString())
+					yyv3473[yyj3473] = PersistentVolumeAccessMode(r.DecodeString())
 				}
 
 			} else {
@@ -40129,10 +40166,10 @@ func (x codecSelfer1234) decSlicePersistentVolumeAccessMode(v *[]PersistentVolum
 			}
 
 		}
-		yyh3468.End()
+		yyh3473.End()
 	}
-	if yyc3468 {
-		*v = yyv3468
+	if yyc3473 {
+		*v = yyv3473
 	}
 
 }
@@ -40142,9 +40179,9 @@ func (x codecSelfer1234) encSlicePersistentVolume(v []PersistentVolume, e *codec
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3472 := range v {
-		yy3473 := &yyv3472
-		yy3473.CodecEncodeSelf(e)
+	for _, yyv3477 := range v {
+		yy3478 := &yyv3477
+		yy3478.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -40154,75 +40191,75 @@ func (x codecSelfer1234) decSlicePersistentVolume(v *[]PersistentVolume, d *code
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3474 := *v
-	yyh3474, yyl3474 := z.DecSliceHelperStart()
+	yyv3479 := *v
+	yyh3479, yyl3479 := z.DecSliceHelperStart()
 
-	var yyrr3474, yyrl3474 int
-	var yyc3474, yyrt3474 bool
-	_, _, _ = yyc3474, yyrt3474, yyrl3474
-	yyrr3474 = yyl3474
+	var yyrr3479, yyrl3479 int
+	var yyc3479, yyrt3479 bool
+	_, _, _ = yyc3479, yyrt3479, yyrl3479
+	yyrr3479 = yyl3479
 
-	if yyv3474 == nil {
-		if yyrl3474, yyrt3474 = z.DecInferLen(yyl3474, z.DecBasicHandle().MaxInitLen, 384); yyrt3474 {
-			yyrr3474 = yyrl3474
+	if yyv3479 == nil {
+		if yyrl3479, yyrt3479 = z.DecInferLen(yyl3479, z.DecBasicHandle().MaxInitLen, 384); yyrt3479 {
+			yyrr3479 = yyrl3479
 		}
-		yyv3474 = make([]PersistentVolume, yyrl3474)
-		yyc3474 = true
+		yyv3479 = make([]PersistentVolume, yyrl3479)
+		yyc3479 = true
 	}
 
-	if yyl3474 == 0 {
-		if len(yyv3474) != 0 {
-			yyv3474 = yyv3474[:0]
-			yyc3474 = true
+	if yyl3479 == 0 {
+		if len(yyv3479) != 0 {
+			yyv3479 = yyv3479[:0]
+			yyc3479 = true
 		}
-	} else if yyl3474 > 0 {
+	} else if yyl3479 > 0 {
 
-		if yyl3474 > cap(yyv3474) {
-			yyrl3474, yyrt3474 = z.DecInferLen(yyl3474, z.DecBasicHandle().MaxInitLen, 384)
-			yyv3474 = make([]PersistentVolume, yyrl3474)
-			yyc3474 = true
+		if yyl3479 > cap(yyv3479) {
+			yyrl3479, yyrt3479 = z.DecInferLen(yyl3479, z.DecBasicHandle().MaxInitLen, 384)
+			yyv3479 = make([]PersistentVolume, yyrl3479)
+			yyc3479 = true
 
-			yyrr3474 = len(yyv3474)
-		} else if yyl3474 != len(yyv3474) {
-			yyv3474 = yyv3474[:yyl3474]
-			yyc3474 = true
+			yyrr3479 = len(yyv3479)
+		} else if yyl3479 != len(yyv3479) {
+			yyv3479 = yyv3479[:yyl3479]
+			yyc3479 = true
 		}
-		yyj3474 := 0
-		for ; yyj3474 < yyrr3474; yyj3474++ {
+		yyj3479 := 0
+		for ; yyj3479 < yyrr3479; yyj3479++ {
 			if r.TryDecodeAsNil() {
-				yyv3474[yyj3474] = PersistentVolume{}
+				yyv3479[yyj3479] = PersistentVolume{}
 			} else {
-				yyv3475 := &yyv3474[yyj3474]
-				yyv3475.CodecDecodeSelf(d)
+				yyv3480 := &yyv3479[yyj3479]
+				yyv3480.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3474 {
-			for ; yyj3474 < yyl3474; yyj3474++ {
-				yyv3474 = append(yyv3474, PersistentVolume{})
+		if yyrt3479 {
+			for ; yyj3479 < yyl3479; yyj3479++ {
+				yyv3479 = append(yyv3479, PersistentVolume{})
 				if r.TryDecodeAsNil() {
-					yyv3474[yyj3474] = PersistentVolume{}
+					yyv3479[yyj3479] = PersistentVolume{}
 				} else {
-					yyv3476 := &yyv3474[yyj3474]
-					yyv3476.CodecDecodeSelf(d)
+					yyv3481 := &yyv3479[yyj3479]
+					yyv3481.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3474 := 0; !r.CheckBreak(); yyj3474++ {
-			if yyj3474 >= len(yyv3474) {
-				yyv3474 = append(yyv3474, PersistentVolume{}) // var yyz3474 PersistentVolume
-				yyc3474 = true
+		for yyj3479 := 0; !r.CheckBreak(); yyj3479++ {
+			if yyj3479 >= len(yyv3479) {
+				yyv3479 = append(yyv3479, PersistentVolume{}) // var yyz3479 PersistentVolume
+				yyc3479 = true
 			}
 
-			if yyj3474 < len(yyv3474) {
+			if yyj3479 < len(yyv3479) {
 				if r.TryDecodeAsNil() {
-					yyv3474[yyj3474] = PersistentVolume{}
+					yyv3479[yyj3479] = PersistentVolume{}
 				} else {
-					yyv3477 := &yyv3474[yyj3474]
-					yyv3477.CodecDecodeSelf(d)
+					yyv3482 := &yyv3479[yyj3479]
+					yyv3482.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -40230,10 +40267,10 @@ func (x codecSelfer1234) decSlicePersistentVolume(v *[]PersistentVolume, d *code
 			}
 
 		}
-		yyh3474.End()
+		yyh3479.End()
 	}
-	if yyc3474 {
-		*v = yyv3474
+	if yyc3479 {
+		*v = yyv3479
 	}
 
 }
@@ -40243,114 +40280,14 @@ func (x codecSelfer1234) encSlicePersistentVolumeClaim(v []PersistentVolumeClaim
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3478 := range v {
-		yy3479 := &yyv3478
-		yy3479.CodecEncodeSelf(e)
+	for _, yyv3483 := range v {
+		yy3484 := &yyv3483
+		yy3484.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
 
 func (x codecSelfer1234) decSlicePersistentVolumeClaim(v *[]PersistentVolumeClaim, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-
-	yyv3480 := *v
-	yyh3480, yyl3480 := z.DecSliceHelperStart()
-
-	var yyrr3480, yyrl3480 int
-	var yyc3480, yyrt3480 bool
-	_, _, _ = yyc3480, yyrt3480, yyrl3480
-	yyrr3480 = yyl3480
-
-	if yyv3480 == nil {
-		if yyrl3480, yyrt3480 = z.DecInferLen(yyl3480, z.DecBasicHandle().MaxInitLen, 296); yyrt3480 {
-			yyrr3480 = yyrl3480
-		}
-		yyv3480 = make([]PersistentVolumeClaim, yyrl3480)
-		yyc3480 = true
-	}
-
-	if yyl3480 == 0 {
-		if len(yyv3480) != 0 {
-			yyv3480 = yyv3480[:0]
-			yyc3480 = true
-		}
-	} else if yyl3480 > 0 {
-
-		if yyl3480 > cap(yyv3480) {
-			yyrl3480, yyrt3480 = z.DecInferLen(yyl3480, z.DecBasicHandle().MaxInitLen, 296)
-			yyv3480 = make([]PersistentVolumeClaim, yyrl3480)
-			yyc3480 = true
-
-			yyrr3480 = len(yyv3480)
-		} else if yyl3480 != len(yyv3480) {
-			yyv3480 = yyv3480[:yyl3480]
-			yyc3480 = true
-		}
-		yyj3480 := 0
-		for ; yyj3480 < yyrr3480; yyj3480++ {
-			if r.TryDecodeAsNil() {
-				yyv3480[yyj3480] = PersistentVolumeClaim{}
-			} else {
-				yyv3481 := &yyv3480[yyj3480]
-				yyv3481.CodecDecodeSelf(d)
-			}
-
-		}
-		if yyrt3480 {
-			for ; yyj3480 < yyl3480; yyj3480++ {
-				yyv3480 = append(yyv3480, PersistentVolumeClaim{})
-				if r.TryDecodeAsNil() {
-					yyv3480[yyj3480] = PersistentVolumeClaim{}
-				} else {
-					yyv3482 := &yyv3480[yyj3480]
-					yyv3482.CodecDecodeSelf(d)
-				}
-
-			}
-		}
-
-	} else {
-		for yyj3480 := 0; !r.CheckBreak(); yyj3480++ {
-			if yyj3480 >= len(yyv3480) {
-				yyv3480 = append(yyv3480, PersistentVolumeClaim{}) // var yyz3480 PersistentVolumeClaim
-				yyc3480 = true
-			}
-
-			if yyj3480 < len(yyv3480) {
-				if r.TryDecodeAsNil() {
-					yyv3480[yyj3480] = PersistentVolumeClaim{}
-				} else {
-					yyv3483 := &yyv3480[yyj3480]
-					yyv3483.CodecDecodeSelf(d)
-				}
-
-			} else {
-				z.DecSwallow()
-			}
-
-		}
-		yyh3480.End()
-	}
-	if yyc3480 {
-		*v = yyv3480
-	}
-
-}
-
-func (x codecSelfer1234) encSliceCapability(v []Capability, e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	r.EncodeArrayStart(len(v))
-	for _, yyv3484 := range v {
-		yyv3484.CodecEncodeSelf(e)
-	}
-	r.EncodeEnd()
-}
-
-func (x codecSelfer1234) decSliceCapability(v *[]Capability, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -40364,10 +40301,10 @@ func (x codecSelfer1234) decSliceCapability(v *[]Capability, d *codec1978.Decode
 	yyrr3485 = yyl3485
 
 	if yyv3485 == nil {
-		if yyrl3485, yyrt3485 = z.DecInferLen(yyl3485, z.DecBasicHandle().MaxInitLen, 16); yyrt3485 {
+		if yyrl3485, yyrt3485 = z.DecInferLen(yyl3485, z.DecBasicHandle().MaxInitLen, 296); yyrt3485 {
 			yyrr3485 = yyrl3485
 		}
-		yyv3485 = make([]Capability, yyrl3485)
+		yyv3485 = make([]PersistentVolumeClaim, yyrl3485)
 		yyc3485 = true
 	}
 
@@ -40379,13 +40316,8 @@ func (x codecSelfer1234) decSliceCapability(v *[]Capability, d *codec1978.Decode
 	} else if yyl3485 > 0 {
 
 		if yyl3485 > cap(yyv3485) {
-			yyrl3485, yyrt3485 = z.DecInferLen(yyl3485, z.DecBasicHandle().MaxInitLen, 16)
-
-			yyv23485 := yyv3485
-			yyv3485 = make([]Capability, yyrl3485)
-			if len(yyv3485) > 0 {
-				copy(yyv3485, yyv23485[:cap(yyv23485)])
-			}
+			yyrl3485, yyrt3485 = z.DecInferLen(yyl3485, z.DecBasicHandle().MaxInitLen, 296)
+			yyv3485 = make([]PersistentVolumeClaim, yyrl3485)
 			yyc3485 = true
 
 			yyrr3485 = len(yyv3485)
@@ -40396,19 +40328,21 @@ func (x codecSelfer1234) decSliceCapability(v *[]Capability, d *codec1978.Decode
 		yyj3485 := 0
 		for ; yyj3485 < yyrr3485; yyj3485++ {
 			if r.TryDecodeAsNil() {
-				yyv3485[yyj3485] = ""
+				yyv3485[yyj3485] = PersistentVolumeClaim{}
 			} else {
-				yyv3485[yyj3485] = Capability(r.DecodeString())
+				yyv3486 := &yyv3485[yyj3485]
+				yyv3486.CodecDecodeSelf(d)
 			}
 
 		}
 		if yyrt3485 {
 			for ; yyj3485 < yyl3485; yyj3485++ {
-				yyv3485 = append(yyv3485, "")
+				yyv3485 = append(yyv3485, PersistentVolumeClaim{})
 				if r.TryDecodeAsNil() {
-					yyv3485[yyj3485] = ""
+					yyv3485[yyj3485] = PersistentVolumeClaim{}
 				} else {
-					yyv3485[yyj3485] = Capability(r.DecodeString())
+					yyv3487 := &yyv3485[yyj3485]
+					yyv3487.CodecDecodeSelf(d)
 				}
 
 			}
@@ -40417,15 +40351,16 @@ func (x codecSelfer1234) decSliceCapability(v *[]Capability, d *codec1978.Decode
 	} else {
 		for yyj3485 := 0; !r.CheckBreak(); yyj3485++ {
 			if yyj3485 >= len(yyv3485) {
-				yyv3485 = append(yyv3485, "") // var yyz3485 Capability
+				yyv3485 = append(yyv3485, PersistentVolumeClaim{}) // var yyz3485 PersistentVolumeClaim
 				yyc3485 = true
 			}
 
 			if yyj3485 < len(yyv3485) {
 				if r.TryDecodeAsNil() {
-					yyv3485[yyj3485] = ""
+					yyv3485[yyj3485] = PersistentVolumeClaim{}
 				} else {
-					yyv3485[yyj3485] = Capability(r.DecodeString())
+					yyv3488 := &yyv3485[yyj3485]
+					yyv3488.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -40441,14 +40376,116 @@ func (x codecSelfer1234) decSliceCapability(v *[]Capability, d *codec1978.Decode
 
 }
 
-func (x codecSelfer1234) encSliceContainerPort(v []ContainerPort, e *codec1978.Encoder) {
+func (x codecSelfer1234) encSliceCapability(v []Capability, e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3489 := range v {
-		yy3490 := &yyv3489
-		yy3490.CodecEncodeSelf(e)
+		yyv3489.CodecEncodeSelf(e)
+	}
+	r.EncodeEnd()
+}
+
+func (x codecSelfer1234) decSliceCapability(v *[]Capability, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv3490 := *v
+	yyh3490, yyl3490 := z.DecSliceHelperStart()
+
+	var yyrr3490, yyrl3490 int
+	var yyc3490, yyrt3490 bool
+	_, _, _ = yyc3490, yyrt3490, yyrl3490
+	yyrr3490 = yyl3490
+
+	if yyv3490 == nil {
+		if yyrl3490, yyrt3490 = z.DecInferLen(yyl3490, z.DecBasicHandle().MaxInitLen, 16); yyrt3490 {
+			yyrr3490 = yyrl3490
+		}
+		yyv3490 = make([]Capability, yyrl3490)
+		yyc3490 = true
+	}
+
+	if yyl3490 == 0 {
+		if len(yyv3490) != 0 {
+			yyv3490 = yyv3490[:0]
+			yyc3490 = true
+		}
+	} else if yyl3490 > 0 {
+
+		if yyl3490 > cap(yyv3490) {
+			yyrl3490, yyrt3490 = z.DecInferLen(yyl3490, z.DecBasicHandle().MaxInitLen, 16)
+
+			yyv23490 := yyv3490
+			yyv3490 = make([]Capability, yyrl3490)
+			if len(yyv3490) > 0 {
+				copy(yyv3490, yyv23490[:cap(yyv23490)])
+			}
+			yyc3490 = true
+
+			yyrr3490 = len(yyv3490)
+		} else if yyl3490 != len(yyv3490) {
+			yyv3490 = yyv3490[:yyl3490]
+			yyc3490 = true
+		}
+		yyj3490 := 0
+		for ; yyj3490 < yyrr3490; yyj3490++ {
+			if r.TryDecodeAsNil() {
+				yyv3490[yyj3490] = ""
+			} else {
+				yyv3490[yyj3490] = Capability(r.DecodeString())
+			}
+
+		}
+		if yyrt3490 {
+			for ; yyj3490 < yyl3490; yyj3490++ {
+				yyv3490 = append(yyv3490, "")
+				if r.TryDecodeAsNil() {
+					yyv3490[yyj3490] = ""
+				} else {
+					yyv3490[yyj3490] = Capability(r.DecodeString())
+				}
+
+			}
+		}
+
+	} else {
+		for yyj3490 := 0; !r.CheckBreak(); yyj3490++ {
+			if yyj3490 >= len(yyv3490) {
+				yyv3490 = append(yyv3490, "") // var yyz3490 Capability
+				yyc3490 = true
+			}
+
+			if yyj3490 < len(yyv3490) {
+				if r.TryDecodeAsNil() {
+					yyv3490[yyj3490] = ""
+				} else {
+					yyv3490[yyj3490] = Capability(r.DecodeString())
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		yyh3490.End()
+	}
+	if yyc3490 {
+		*v = yyv3490
+	}
+
+}
+
+func (x codecSelfer1234) encSliceContainerPort(v []ContainerPort, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv3494 := range v {
+		yy3495 := &yyv3494
+		yy3495.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -40458,75 +40495,75 @@ func (x codecSelfer1234) decSliceContainerPort(v *[]ContainerPort, d *codec1978.
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3491 := *v
-	yyh3491, yyl3491 := z.DecSliceHelperStart()
+	yyv3496 := *v
+	yyh3496, yyl3496 := z.DecSliceHelperStart()
 
-	var yyrr3491, yyrl3491 int
-	var yyc3491, yyrt3491 bool
-	_, _, _ = yyc3491, yyrt3491, yyrl3491
-	yyrr3491 = yyl3491
+	var yyrr3496, yyrl3496 int
+	var yyc3496, yyrt3496 bool
+	_, _, _ = yyc3496, yyrt3496, yyrl3496
+	yyrr3496 = yyl3496
 
-	if yyv3491 == nil {
-		if yyrl3491, yyrt3491 = z.DecInferLen(yyl3491, z.DecBasicHandle().MaxInitLen, 64); yyrt3491 {
-			yyrr3491 = yyrl3491
+	if yyv3496 == nil {
+		if yyrl3496, yyrt3496 = z.DecInferLen(yyl3496, z.DecBasicHandle().MaxInitLen, 64); yyrt3496 {
+			yyrr3496 = yyrl3496
 		}
-		yyv3491 = make([]ContainerPort, yyrl3491)
-		yyc3491 = true
+		yyv3496 = make([]ContainerPort, yyrl3496)
+		yyc3496 = true
 	}
 
-	if yyl3491 == 0 {
-		if len(yyv3491) != 0 {
-			yyv3491 = yyv3491[:0]
-			yyc3491 = true
+	if yyl3496 == 0 {
+		if len(yyv3496) != 0 {
+			yyv3496 = yyv3496[:0]
+			yyc3496 = true
 		}
-	} else if yyl3491 > 0 {
+	} else if yyl3496 > 0 {
 
-		if yyl3491 > cap(yyv3491) {
-			yyrl3491, yyrt3491 = z.DecInferLen(yyl3491, z.DecBasicHandle().MaxInitLen, 64)
-			yyv3491 = make([]ContainerPort, yyrl3491)
-			yyc3491 = true
+		if yyl3496 > cap(yyv3496) {
+			yyrl3496, yyrt3496 = z.DecInferLen(yyl3496, z.DecBasicHandle().MaxInitLen, 64)
+			yyv3496 = make([]ContainerPort, yyrl3496)
+			yyc3496 = true
 
-			yyrr3491 = len(yyv3491)
-		} else if yyl3491 != len(yyv3491) {
-			yyv3491 = yyv3491[:yyl3491]
-			yyc3491 = true
+			yyrr3496 = len(yyv3496)
+		} else if yyl3496 != len(yyv3496) {
+			yyv3496 = yyv3496[:yyl3496]
+			yyc3496 = true
 		}
-		yyj3491 := 0
-		for ; yyj3491 < yyrr3491; yyj3491++ {
+		yyj3496 := 0
+		for ; yyj3496 < yyrr3496; yyj3496++ {
 			if r.TryDecodeAsNil() {
-				yyv3491[yyj3491] = ContainerPort{}
+				yyv3496[yyj3496] = ContainerPort{}
 			} else {
-				yyv3492 := &yyv3491[yyj3491]
-				yyv3492.CodecDecodeSelf(d)
+				yyv3497 := &yyv3496[yyj3496]
+				yyv3497.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3491 {
-			for ; yyj3491 < yyl3491; yyj3491++ {
-				yyv3491 = append(yyv3491, ContainerPort{})
+		if yyrt3496 {
+			for ; yyj3496 < yyl3496; yyj3496++ {
+				yyv3496 = append(yyv3496, ContainerPort{})
 				if r.TryDecodeAsNil() {
-					yyv3491[yyj3491] = ContainerPort{}
+					yyv3496[yyj3496] = ContainerPort{}
 				} else {
-					yyv3493 := &yyv3491[yyj3491]
-					yyv3493.CodecDecodeSelf(d)
+					yyv3498 := &yyv3496[yyj3496]
+					yyv3498.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3491 := 0; !r.CheckBreak(); yyj3491++ {
-			if yyj3491 >= len(yyv3491) {
-				yyv3491 = append(yyv3491, ContainerPort{}) // var yyz3491 ContainerPort
-				yyc3491 = true
+		for yyj3496 := 0; !r.CheckBreak(); yyj3496++ {
+			if yyj3496 >= len(yyv3496) {
+				yyv3496 = append(yyv3496, ContainerPort{}) // var yyz3496 ContainerPort
+				yyc3496 = true
 			}
 
-			if yyj3491 < len(yyv3491) {
+			if yyj3496 < len(yyv3496) {
 				if r.TryDecodeAsNil() {
-					yyv3491[yyj3491] = ContainerPort{}
+					yyv3496[yyj3496] = ContainerPort{}
 				} else {
-					yyv3494 := &yyv3491[yyj3491]
-					yyv3494.CodecDecodeSelf(d)
+					yyv3499 := &yyv3496[yyj3496]
+					yyv3499.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -40534,10 +40571,10 @@ func (x codecSelfer1234) decSliceContainerPort(v *[]ContainerPort, d *codec1978.
 			}
 
 		}
-		yyh3491.End()
+		yyh3496.End()
 	}
-	if yyc3491 {
-		*v = yyv3491
+	if yyc3496 {
+		*v = yyv3496
 	}
 
 }
@@ -40547,9 +40584,9 @@ func (x codecSelfer1234) encSliceEnvVar(v []EnvVar, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3495 := range v {
-		yy3496 := &yyv3495
-		yy3496.CodecEncodeSelf(e)
+	for _, yyv3500 := range v {
+		yy3501 := &yyv3500
+		yy3501.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -40559,75 +40596,75 @@ func (x codecSelfer1234) decSliceEnvVar(v *[]EnvVar, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3497 := *v
-	yyh3497, yyl3497 := z.DecSliceHelperStart()
+	yyv3502 := *v
+	yyh3502, yyl3502 := z.DecSliceHelperStart()
 
-	var yyrr3497, yyrl3497 int
-	var yyc3497, yyrt3497 bool
-	_, _, _ = yyc3497, yyrt3497, yyrl3497
-	yyrr3497 = yyl3497
+	var yyrr3502, yyrl3502 int
+	var yyc3502, yyrt3502 bool
+	_, _, _ = yyc3502, yyrt3502, yyrl3502
+	yyrr3502 = yyl3502
 
-	if yyv3497 == nil {
-		if yyrl3497, yyrt3497 = z.DecInferLen(yyl3497, z.DecBasicHandle().MaxInitLen, 40); yyrt3497 {
-			yyrr3497 = yyrl3497
+	if yyv3502 == nil {
+		if yyrl3502, yyrt3502 = z.DecInferLen(yyl3502, z.DecBasicHandle().MaxInitLen, 40); yyrt3502 {
+			yyrr3502 = yyrl3502
 		}
-		yyv3497 = make([]EnvVar, yyrl3497)
-		yyc3497 = true
+		yyv3502 = make([]EnvVar, yyrl3502)
+		yyc3502 = true
 	}
 
-	if yyl3497 == 0 {
-		if len(yyv3497) != 0 {
-			yyv3497 = yyv3497[:0]
-			yyc3497 = true
+	if yyl3502 == 0 {
+		if len(yyv3502) != 0 {
+			yyv3502 = yyv3502[:0]
+			yyc3502 = true
 		}
-	} else if yyl3497 > 0 {
+	} else if yyl3502 > 0 {
 
-		if yyl3497 > cap(yyv3497) {
-			yyrl3497, yyrt3497 = z.DecInferLen(yyl3497, z.DecBasicHandle().MaxInitLen, 40)
-			yyv3497 = make([]EnvVar, yyrl3497)
-			yyc3497 = true
+		if yyl3502 > cap(yyv3502) {
+			yyrl3502, yyrt3502 = z.DecInferLen(yyl3502, z.DecBasicHandle().MaxInitLen, 40)
+			yyv3502 = make([]EnvVar, yyrl3502)
+			yyc3502 = true
 
-			yyrr3497 = len(yyv3497)
-		} else if yyl3497 != len(yyv3497) {
-			yyv3497 = yyv3497[:yyl3497]
-			yyc3497 = true
+			yyrr3502 = len(yyv3502)
+		} else if yyl3502 != len(yyv3502) {
+			yyv3502 = yyv3502[:yyl3502]
+			yyc3502 = true
 		}
-		yyj3497 := 0
-		for ; yyj3497 < yyrr3497; yyj3497++ {
+		yyj3502 := 0
+		for ; yyj3502 < yyrr3502; yyj3502++ {
 			if r.TryDecodeAsNil() {
-				yyv3497[yyj3497] = EnvVar{}
+				yyv3502[yyj3502] = EnvVar{}
 			} else {
-				yyv3498 := &yyv3497[yyj3497]
-				yyv3498.CodecDecodeSelf(d)
+				yyv3503 := &yyv3502[yyj3502]
+				yyv3503.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3497 {
-			for ; yyj3497 < yyl3497; yyj3497++ {
-				yyv3497 = append(yyv3497, EnvVar{})
+		if yyrt3502 {
+			for ; yyj3502 < yyl3502; yyj3502++ {
+				yyv3502 = append(yyv3502, EnvVar{})
 				if r.TryDecodeAsNil() {
-					yyv3497[yyj3497] = EnvVar{}
+					yyv3502[yyj3502] = EnvVar{}
 				} else {
-					yyv3499 := &yyv3497[yyj3497]
-					yyv3499.CodecDecodeSelf(d)
+					yyv3504 := &yyv3502[yyj3502]
+					yyv3504.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3497 := 0; !r.CheckBreak(); yyj3497++ {
-			if yyj3497 >= len(yyv3497) {
-				yyv3497 = append(yyv3497, EnvVar{}) // var yyz3497 EnvVar
-				yyc3497 = true
+		for yyj3502 := 0; !r.CheckBreak(); yyj3502++ {
+			if yyj3502 >= len(yyv3502) {
+				yyv3502 = append(yyv3502, EnvVar{}) // var yyz3502 EnvVar
+				yyc3502 = true
 			}
 
-			if yyj3497 < len(yyv3497) {
+			if yyj3502 < len(yyv3502) {
 				if r.TryDecodeAsNil() {
-					yyv3497[yyj3497] = EnvVar{}
+					yyv3502[yyj3502] = EnvVar{}
 				} else {
-					yyv3500 := &yyv3497[yyj3497]
-					yyv3500.CodecDecodeSelf(d)
+					yyv3505 := &yyv3502[yyj3502]
+					yyv3505.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -40635,10 +40672,10 @@ func (x codecSelfer1234) decSliceEnvVar(v *[]EnvVar, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3497.End()
+		yyh3502.End()
 	}
-	if yyc3497 {
-		*v = yyv3497
+	if yyc3502 {
+		*v = yyv3502
 	}
 
 }
@@ -40648,9 +40685,9 @@ func (x codecSelfer1234) encSliceVolumeMount(v []VolumeMount, e *codec1978.Encod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3501 := range v {
-		yy3502 := &yyv3501
-		yy3502.CodecEncodeSelf(e)
+	for _, yyv3506 := range v {
+		yy3507 := &yyv3506
+		yy3507.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -40660,75 +40697,75 @@ func (x codecSelfer1234) decSliceVolumeMount(v *[]VolumeMount, d *codec1978.Deco
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3503 := *v
-	yyh3503, yyl3503 := z.DecSliceHelperStart()
+	yyv3508 := *v
+	yyh3508, yyl3508 := z.DecSliceHelperStart()
 
-	var yyrr3503, yyrl3503 int
-	var yyc3503, yyrt3503 bool
-	_, _, _ = yyc3503, yyrt3503, yyrl3503
-	yyrr3503 = yyl3503
+	var yyrr3508, yyrl3508 int
+	var yyc3508, yyrt3508 bool
+	_, _, _ = yyc3508, yyrt3508, yyrl3508
+	yyrr3508 = yyl3508
 
-	if yyv3503 == nil {
-		if yyrl3503, yyrt3503 = z.DecInferLen(yyl3503, z.DecBasicHandle().MaxInitLen, 40); yyrt3503 {
-			yyrr3503 = yyrl3503
+	if yyv3508 == nil {
+		if yyrl3508, yyrt3508 = z.DecInferLen(yyl3508, z.DecBasicHandle().MaxInitLen, 40); yyrt3508 {
+			yyrr3508 = yyrl3508
 		}
-		yyv3503 = make([]VolumeMount, yyrl3503)
-		yyc3503 = true
+		yyv3508 = make([]VolumeMount, yyrl3508)
+		yyc3508 = true
 	}
 
-	if yyl3503 == 0 {
-		if len(yyv3503) != 0 {
-			yyv3503 = yyv3503[:0]
-			yyc3503 = true
+	if yyl3508 == 0 {
+		if len(yyv3508) != 0 {
+			yyv3508 = yyv3508[:0]
+			yyc3508 = true
 		}
-	} else if yyl3503 > 0 {
+	} else if yyl3508 > 0 {
 
-		if yyl3503 > cap(yyv3503) {
-			yyrl3503, yyrt3503 = z.DecInferLen(yyl3503, z.DecBasicHandle().MaxInitLen, 40)
-			yyv3503 = make([]VolumeMount, yyrl3503)
-			yyc3503 = true
+		if yyl3508 > cap(yyv3508) {
+			yyrl3508, yyrt3508 = z.DecInferLen(yyl3508, z.DecBasicHandle().MaxInitLen, 40)
+			yyv3508 = make([]VolumeMount, yyrl3508)
+			yyc3508 = true
 
-			yyrr3503 = len(yyv3503)
-		} else if yyl3503 != len(yyv3503) {
-			yyv3503 = yyv3503[:yyl3503]
-			yyc3503 = true
+			yyrr3508 = len(yyv3508)
+		} else if yyl3508 != len(yyv3508) {
+			yyv3508 = yyv3508[:yyl3508]
+			yyc3508 = true
 		}
-		yyj3503 := 0
-		for ; yyj3503 < yyrr3503; yyj3503++ {
+		yyj3508 := 0
+		for ; yyj3508 < yyrr3508; yyj3508++ {
 			if r.TryDecodeAsNil() {
-				yyv3503[yyj3503] = VolumeMount{}
+				yyv3508[yyj3508] = VolumeMount{}
 			} else {
-				yyv3504 := &yyv3503[yyj3503]
-				yyv3504.CodecDecodeSelf(d)
+				yyv3509 := &yyv3508[yyj3508]
+				yyv3509.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3503 {
-			for ; yyj3503 < yyl3503; yyj3503++ {
-				yyv3503 = append(yyv3503, VolumeMount{})
+		if yyrt3508 {
+			for ; yyj3508 < yyl3508; yyj3508++ {
+				yyv3508 = append(yyv3508, VolumeMount{})
 				if r.TryDecodeAsNil() {
-					yyv3503[yyj3503] = VolumeMount{}
+					yyv3508[yyj3508] = VolumeMount{}
 				} else {
-					yyv3505 := &yyv3503[yyj3503]
-					yyv3505.CodecDecodeSelf(d)
+					yyv3510 := &yyv3508[yyj3508]
+					yyv3510.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3503 := 0; !r.CheckBreak(); yyj3503++ {
-			if yyj3503 >= len(yyv3503) {
-				yyv3503 = append(yyv3503, VolumeMount{}) // var yyz3503 VolumeMount
-				yyc3503 = true
+		for yyj3508 := 0; !r.CheckBreak(); yyj3508++ {
+			if yyj3508 >= len(yyv3508) {
+				yyv3508 = append(yyv3508, VolumeMount{}) // var yyz3508 VolumeMount
+				yyc3508 = true
 			}
 
-			if yyj3503 < len(yyv3503) {
+			if yyj3508 < len(yyv3508) {
 				if r.TryDecodeAsNil() {
-					yyv3503[yyj3503] = VolumeMount{}
+					yyv3508[yyj3508] = VolumeMount{}
 				} else {
-					yyv3506 := &yyv3503[yyj3503]
-					yyv3506.CodecDecodeSelf(d)
+					yyv3511 := &yyv3508[yyj3508]
+					yyv3511.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -40736,10 +40773,10 @@ func (x codecSelfer1234) decSliceVolumeMount(v *[]VolumeMount, d *codec1978.Deco
 			}
 
 		}
-		yyh3503.End()
+		yyh3508.End()
 	}
-	if yyc3503 {
-		*v = yyv3503
+	if yyc3508 {
+		*v = yyv3508
 	}
 
 }
@@ -40749,9 +40786,9 @@ func (x codecSelfer1234) encSliceVolume(v []Volume, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3507 := range v {
-		yy3508 := &yyv3507
-		yy3508.CodecEncodeSelf(e)
+	for _, yyv3512 := range v {
+		yy3513 := &yyv3512
+		yy3513.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -40761,75 +40798,75 @@ func (x codecSelfer1234) decSliceVolume(v *[]Volume, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3509 := *v
-	yyh3509, yyl3509 := z.DecSliceHelperStart()
+	yyv3514 := *v
+	yyh3514, yyl3514 := z.DecSliceHelperStart()
 
-	var yyrr3509, yyrl3509 int
-	var yyc3509, yyrt3509 bool
-	_, _, _ = yyc3509, yyrt3509, yyrl3509
-	yyrr3509 = yyl3509
+	var yyrr3514, yyrl3514 int
+	var yyc3514, yyrt3514 bool
+	_, _, _ = yyc3514, yyrt3514, yyrl3514
+	yyrr3514 = yyl3514
 
-	if yyv3509 == nil {
-		if yyrl3509, yyrt3509 = z.DecInferLen(yyl3509, z.DecBasicHandle().MaxInitLen, 144); yyrt3509 {
-			yyrr3509 = yyrl3509
+	if yyv3514 == nil {
+		if yyrl3514, yyrt3514 = z.DecInferLen(yyl3514, z.DecBasicHandle().MaxInitLen, 144); yyrt3514 {
+			yyrr3514 = yyrl3514
 		}
-		yyv3509 = make([]Volume, yyrl3509)
-		yyc3509 = true
+		yyv3514 = make([]Volume, yyrl3514)
+		yyc3514 = true
 	}
 
-	if yyl3509 == 0 {
-		if len(yyv3509) != 0 {
-			yyv3509 = yyv3509[:0]
-			yyc3509 = true
+	if yyl3514 == 0 {
+		if len(yyv3514) != 0 {
+			yyv3514 = yyv3514[:0]
+			yyc3514 = true
 		}
-	} else if yyl3509 > 0 {
+	} else if yyl3514 > 0 {
 
-		if yyl3509 > cap(yyv3509) {
-			yyrl3509, yyrt3509 = z.DecInferLen(yyl3509, z.DecBasicHandle().MaxInitLen, 144)
-			yyv3509 = make([]Volume, yyrl3509)
-			yyc3509 = true
+		if yyl3514 > cap(yyv3514) {
+			yyrl3514, yyrt3514 = z.DecInferLen(yyl3514, z.DecBasicHandle().MaxInitLen, 144)
+			yyv3514 = make([]Volume, yyrl3514)
+			yyc3514 = true
 
-			yyrr3509 = len(yyv3509)
-		} else if yyl3509 != len(yyv3509) {
-			yyv3509 = yyv3509[:yyl3509]
-			yyc3509 = true
+			yyrr3514 = len(yyv3514)
+		} else if yyl3514 != len(yyv3514) {
+			yyv3514 = yyv3514[:yyl3514]
+			yyc3514 = true
 		}
-		yyj3509 := 0
-		for ; yyj3509 < yyrr3509; yyj3509++ {
+		yyj3514 := 0
+		for ; yyj3514 < yyrr3514; yyj3514++ {
 			if r.TryDecodeAsNil() {
-				yyv3509[yyj3509] = Volume{}
+				yyv3514[yyj3514] = Volume{}
 			} else {
-				yyv3510 := &yyv3509[yyj3509]
-				yyv3510.CodecDecodeSelf(d)
+				yyv3515 := &yyv3514[yyj3514]
+				yyv3515.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3509 {
-			for ; yyj3509 < yyl3509; yyj3509++ {
-				yyv3509 = append(yyv3509, Volume{})
+		if yyrt3514 {
+			for ; yyj3514 < yyl3514; yyj3514++ {
+				yyv3514 = append(yyv3514, Volume{})
 				if r.TryDecodeAsNil() {
-					yyv3509[yyj3509] = Volume{}
+					yyv3514[yyj3514] = Volume{}
 				} else {
-					yyv3511 := &yyv3509[yyj3509]
-					yyv3511.CodecDecodeSelf(d)
+					yyv3516 := &yyv3514[yyj3514]
+					yyv3516.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3509 := 0; !r.CheckBreak(); yyj3509++ {
-			if yyj3509 >= len(yyv3509) {
-				yyv3509 = append(yyv3509, Volume{}) // var yyz3509 Volume
-				yyc3509 = true
+		for yyj3514 := 0; !r.CheckBreak(); yyj3514++ {
+			if yyj3514 >= len(yyv3514) {
+				yyv3514 = append(yyv3514, Volume{}) // var yyz3514 Volume
+				yyc3514 = true
 			}
 
-			if yyj3509 < len(yyv3509) {
+			if yyj3514 < len(yyv3514) {
 				if r.TryDecodeAsNil() {
-					yyv3509[yyj3509] = Volume{}
+					yyv3514[yyj3514] = Volume{}
 				} else {
-					yyv3512 := &yyv3509[yyj3509]
-					yyv3512.CodecDecodeSelf(d)
+					yyv3517 := &yyv3514[yyj3514]
+					yyv3517.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -40837,10 +40874,10 @@ func (x codecSelfer1234) decSliceVolume(v *[]Volume, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3509.End()
+		yyh3514.End()
 	}
-	if yyc3509 {
-		*v = yyv3509
+	if yyc3514 {
+		*v = yyv3514
 	}
 
 }
@@ -40850,9 +40887,9 @@ func (x codecSelfer1234) encSliceContainer(v []Container, e *codec1978.Encoder) 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3513 := range v {
-		yy3514 := &yyv3513
-		yy3514.CodecEncodeSelf(e)
+	for _, yyv3518 := range v {
+		yy3519 := &yyv3518
+		yy3519.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -40862,75 +40899,75 @@ func (x codecSelfer1234) decSliceContainer(v *[]Container, d *codec1978.Decoder)
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3515 := *v
-	yyh3515, yyl3515 := z.DecSliceHelperStart()
+	yyv3520 := *v
+	yyh3520, yyl3520 := z.DecSliceHelperStart()
 
-	var yyrr3515, yyrl3515 int
-	var yyc3515, yyrt3515 bool
-	_, _, _ = yyc3515, yyrt3515, yyrl3515
-	yyrr3515 = yyl3515
+	var yyrr3520, yyrl3520 int
+	var yyc3520, yyrt3520 bool
+	_, _, _ = yyc3520, yyrt3520, yyrl3520
+	yyrr3520 = yyl3520
 
-	if yyv3515 == nil {
-		if yyrl3515, yyrt3515 = z.DecInferLen(yyl3515, z.DecBasicHandle().MaxInitLen, 256); yyrt3515 {
-			yyrr3515 = yyrl3515
+	if yyv3520 == nil {
+		if yyrl3520, yyrt3520 = z.DecInferLen(yyl3520, z.DecBasicHandle().MaxInitLen, 256); yyrt3520 {
+			yyrr3520 = yyrl3520
 		}
-		yyv3515 = make([]Container, yyrl3515)
-		yyc3515 = true
+		yyv3520 = make([]Container, yyrl3520)
+		yyc3520 = true
 	}
 
-	if yyl3515 == 0 {
-		if len(yyv3515) != 0 {
-			yyv3515 = yyv3515[:0]
-			yyc3515 = true
+	if yyl3520 == 0 {
+		if len(yyv3520) != 0 {
+			yyv3520 = yyv3520[:0]
+			yyc3520 = true
 		}
-	} else if yyl3515 > 0 {
+	} else if yyl3520 > 0 {
 
-		if yyl3515 > cap(yyv3515) {
-			yyrl3515, yyrt3515 = z.DecInferLen(yyl3515, z.DecBasicHandle().MaxInitLen, 256)
-			yyv3515 = make([]Container, yyrl3515)
-			yyc3515 = true
+		if yyl3520 > cap(yyv3520) {
+			yyrl3520, yyrt3520 = z.DecInferLen(yyl3520, z.DecBasicHandle().MaxInitLen, 256)
+			yyv3520 = make([]Container, yyrl3520)
+			yyc3520 = true
 
-			yyrr3515 = len(yyv3515)
-		} else if yyl3515 != len(yyv3515) {
-			yyv3515 = yyv3515[:yyl3515]
-			yyc3515 = true
+			yyrr3520 = len(yyv3520)
+		} else if yyl3520 != len(yyv3520) {
+			yyv3520 = yyv3520[:yyl3520]
+			yyc3520 = true
 		}
-		yyj3515 := 0
-		for ; yyj3515 < yyrr3515; yyj3515++ {
+		yyj3520 := 0
+		for ; yyj3520 < yyrr3520; yyj3520++ {
 			if r.TryDecodeAsNil() {
-				yyv3515[yyj3515] = Container{}
+				yyv3520[yyj3520] = Container{}
 			} else {
-				yyv3516 := &yyv3515[yyj3515]
-				yyv3516.CodecDecodeSelf(d)
+				yyv3521 := &yyv3520[yyj3520]
+				yyv3521.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3515 {
-			for ; yyj3515 < yyl3515; yyj3515++ {
-				yyv3515 = append(yyv3515, Container{})
+		if yyrt3520 {
+			for ; yyj3520 < yyl3520; yyj3520++ {
+				yyv3520 = append(yyv3520, Container{})
 				if r.TryDecodeAsNil() {
-					yyv3515[yyj3515] = Container{}
+					yyv3520[yyj3520] = Container{}
 				} else {
-					yyv3517 := &yyv3515[yyj3515]
-					yyv3517.CodecDecodeSelf(d)
+					yyv3522 := &yyv3520[yyj3520]
+					yyv3522.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3515 := 0; !r.CheckBreak(); yyj3515++ {
-			if yyj3515 >= len(yyv3515) {
-				yyv3515 = append(yyv3515, Container{}) // var yyz3515 Container
-				yyc3515 = true
+		for yyj3520 := 0; !r.CheckBreak(); yyj3520++ {
+			if yyj3520 >= len(yyv3520) {
+				yyv3520 = append(yyv3520, Container{}) // var yyz3520 Container
+				yyc3520 = true
 			}
 
-			if yyj3515 < len(yyv3515) {
+			if yyj3520 < len(yyv3520) {
 				if r.TryDecodeAsNil() {
-					yyv3515[yyj3515] = Container{}
+					yyv3520[yyj3520] = Container{}
 				} else {
-					yyv3518 := &yyv3515[yyj3515]
-					yyv3518.CodecDecodeSelf(d)
+					yyv3523 := &yyv3520[yyj3520]
+					yyv3523.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -40938,10 +40975,10 @@ func (x codecSelfer1234) decSliceContainer(v *[]Container, d *codec1978.Decoder)
 			}
 
 		}
-		yyh3515.End()
+		yyh3520.End()
 	}
-	if yyc3515 {
-		*v = yyv3515
+	if yyc3520 {
+		*v = yyv3520
 	}
 
 }
@@ -40951,9 +40988,9 @@ func (x codecSelfer1234) encSliceLocalObjectReference(v []LocalObjectReference, 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3519 := range v {
-		yy3520 := &yyv3519
-		yy3520.CodecEncodeSelf(e)
+	for _, yyv3524 := range v {
+		yy3525 := &yyv3524
+		yy3525.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -40963,75 +41000,75 @@ func (x codecSelfer1234) decSliceLocalObjectReference(v *[]LocalObjectReference,
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3521 := *v
-	yyh3521, yyl3521 := z.DecSliceHelperStart()
+	yyv3526 := *v
+	yyh3526, yyl3526 := z.DecSliceHelperStart()
 
-	var yyrr3521, yyrl3521 int
-	var yyc3521, yyrt3521 bool
-	_, _, _ = yyc3521, yyrt3521, yyrl3521
-	yyrr3521 = yyl3521
+	var yyrr3526, yyrl3526 int
+	var yyc3526, yyrt3526 bool
+	_, _, _ = yyc3526, yyrt3526, yyrl3526
+	yyrr3526 = yyl3526
 
-	if yyv3521 == nil {
-		if yyrl3521, yyrt3521 = z.DecInferLen(yyl3521, z.DecBasicHandle().MaxInitLen, 16); yyrt3521 {
-			yyrr3521 = yyrl3521
+	if yyv3526 == nil {
+		if yyrl3526, yyrt3526 = z.DecInferLen(yyl3526, z.DecBasicHandle().MaxInitLen, 16); yyrt3526 {
+			yyrr3526 = yyrl3526
 		}
-		yyv3521 = make([]LocalObjectReference, yyrl3521)
-		yyc3521 = true
+		yyv3526 = make([]LocalObjectReference, yyrl3526)
+		yyc3526 = true
 	}
 
-	if yyl3521 == 0 {
-		if len(yyv3521) != 0 {
-			yyv3521 = yyv3521[:0]
-			yyc3521 = true
+	if yyl3526 == 0 {
+		if len(yyv3526) != 0 {
+			yyv3526 = yyv3526[:0]
+			yyc3526 = true
 		}
-	} else if yyl3521 > 0 {
+	} else if yyl3526 > 0 {
 
-		if yyl3521 > cap(yyv3521) {
-			yyrl3521, yyrt3521 = z.DecInferLen(yyl3521, z.DecBasicHandle().MaxInitLen, 16)
-			yyv3521 = make([]LocalObjectReference, yyrl3521)
-			yyc3521 = true
+		if yyl3526 > cap(yyv3526) {
+			yyrl3526, yyrt3526 = z.DecInferLen(yyl3526, z.DecBasicHandle().MaxInitLen, 16)
+			yyv3526 = make([]LocalObjectReference, yyrl3526)
+			yyc3526 = true
 
-			yyrr3521 = len(yyv3521)
-		} else if yyl3521 != len(yyv3521) {
-			yyv3521 = yyv3521[:yyl3521]
-			yyc3521 = true
+			yyrr3526 = len(yyv3526)
+		} else if yyl3526 != len(yyv3526) {
+			yyv3526 = yyv3526[:yyl3526]
+			yyc3526 = true
 		}
-		yyj3521 := 0
-		for ; yyj3521 < yyrr3521; yyj3521++ {
+		yyj3526 := 0
+		for ; yyj3526 < yyrr3526; yyj3526++ {
 			if r.TryDecodeAsNil() {
-				yyv3521[yyj3521] = LocalObjectReference{}
+				yyv3526[yyj3526] = LocalObjectReference{}
 			} else {
-				yyv3522 := &yyv3521[yyj3521]
-				yyv3522.CodecDecodeSelf(d)
+				yyv3527 := &yyv3526[yyj3526]
+				yyv3527.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3521 {
-			for ; yyj3521 < yyl3521; yyj3521++ {
-				yyv3521 = append(yyv3521, LocalObjectReference{})
+		if yyrt3526 {
+			for ; yyj3526 < yyl3526; yyj3526++ {
+				yyv3526 = append(yyv3526, LocalObjectReference{})
 				if r.TryDecodeAsNil() {
-					yyv3521[yyj3521] = LocalObjectReference{}
+					yyv3526[yyj3526] = LocalObjectReference{}
 				} else {
-					yyv3523 := &yyv3521[yyj3521]
-					yyv3523.CodecDecodeSelf(d)
+					yyv3528 := &yyv3526[yyj3526]
+					yyv3528.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3521 := 0; !r.CheckBreak(); yyj3521++ {
-			if yyj3521 >= len(yyv3521) {
-				yyv3521 = append(yyv3521, LocalObjectReference{}) // var yyz3521 LocalObjectReference
-				yyc3521 = true
+		for yyj3526 := 0; !r.CheckBreak(); yyj3526++ {
+			if yyj3526 >= len(yyv3526) {
+				yyv3526 = append(yyv3526, LocalObjectReference{}) // var yyz3526 LocalObjectReference
+				yyc3526 = true
 			}
 
-			if yyj3521 < len(yyv3521) {
+			if yyj3526 < len(yyv3526) {
 				if r.TryDecodeAsNil() {
-					yyv3521[yyj3521] = LocalObjectReference{}
+					yyv3526[yyj3526] = LocalObjectReference{}
 				} else {
-					yyv3524 := &yyv3521[yyj3521]
-					yyv3524.CodecDecodeSelf(d)
+					yyv3529 := &yyv3526[yyj3526]
+					yyv3529.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41039,10 +41076,10 @@ func (x codecSelfer1234) decSliceLocalObjectReference(v *[]LocalObjectReference,
 			}
 
 		}
-		yyh3521.End()
+		yyh3526.End()
 	}
-	if yyc3521 {
-		*v = yyv3521
+	if yyc3526 {
+		*v = yyv3526
 	}
 
 }
@@ -41052,9 +41089,9 @@ func (x codecSelfer1234) encSlicePodCondition(v []PodCondition, e *codec1978.Enc
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3525 := range v {
-		yy3526 := &yyv3525
-		yy3526.CodecEncodeSelf(e)
+	for _, yyv3530 := range v {
+		yy3531 := &yyv3530
+		yy3531.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41064,75 +41101,75 @@ func (x codecSelfer1234) decSlicePodCondition(v *[]PodCondition, d *codec1978.De
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3527 := *v
-	yyh3527, yyl3527 := z.DecSliceHelperStart()
+	yyv3532 := *v
+	yyh3532, yyl3532 := z.DecSliceHelperStart()
 
-	var yyrr3527, yyrl3527 int
-	var yyc3527, yyrt3527 bool
-	_, _, _ = yyc3527, yyrt3527, yyrl3527
-	yyrr3527 = yyl3527
+	var yyrr3532, yyrl3532 int
+	var yyc3532, yyrt3532 bool
+	_, _, _ = yyc3532, yyrt3532, yyrl3532
+	yyrr3532 = yyl3532
 
-	if yyv3527 == nil {
-		if yyrl3527, yyrt3527 = z.DecInferLen(yyl3527, z.DecBasicHandle().MaxInitLen, 112); yyrt3527 {
-			yyrr3527 = yyrl3527
+	if yyv3532 == nil {
+		if yyrl3532, yyrt3532 = z.DecInferLen(yyl3532, z.DecBasicHandle().MaxInitLen, 112); yyrt3532 {
+			yyrr3532 = yyrl3532
 		}
-		yyv3527 = make([]PodCondition, yyrl3527)
-		yyc3527 = true
+		yyv3532 = make([]PodCondition, yyrl3532)
+		yyc3532 = true
 	}
 
-	if yyl3527 == 0 {
-		if len(yyv3527) != 0 {
-			yyv3527 = yyv3527[:0]
-			yyc3527 = true
+	if yyl3532 == 0 {
+		if len(yyv3532) != 0 {
+			yyv3532 = yyv3532[:0]
+			yyc3532 = true
 		}
-	} else if yyl3527 > 0 {
+	} else if yyl3532 > 0 {
 
-		if yyl3527 > cap(yyv3527) {
-			yyrl3527, yyrt3527 = z.DecInferLen(yyl3527, z.DecBasicHandle().MaxInitLen, 112)
-			yyv3527 = make([]PodCondition, yyrl3527)
-			yyc3527 = true
+		if yyl3532 > cap(yyv3532) {
+			yyrl3532, yyrt3532 = z.DecInferLen(yyl3532, z.DecBasicHandle().MaxInitLen, 112)
+			yyv3532 = make([]PodCondition, yyrl3532)
+			yyc3532 = true
 
-			yyrr3527 = len(yyv3527)
-		} else if yyl3527 != len(yyv3527) {
-			yyv3527 = yyv3527[:yyl3527]
-			yyc3527 = true
+			yyrr3532 = len(yyv3532)
+		} else if yyl3532 != len(yyv3532) {
+			yyv3532 = yyv3532[:yyl3532]
+			yyc3532 = true
 		}
-		yyj3527 := 0
-		for ; yyj3527 < yyrr3527; yyj3527++ {
+		yyj3532 := 0
+		for ; yyj3532 < yyrr3532; yyj3532++ {
 			if r.TryDecodeAsNil() {
-				yyv3527[yyj3527] = PodCondition{}
+				yyv3532[yyj3532] = PodCondition{}
 			} else {
-				yyv3528 := &yyv3527[yyj3527]
-				yyv3528.CodecDecodeSelf(d)
+				yyv3533 := &yyv3532[yyj3532]
+				yyv3533.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3527 {
-			for ; yyj3527 < yyl3527; yyj3527++ {
-				yyv3527 = append(yyv3527, PodCondition{})
+		if yyrt3532 {
+			for ; yyj3532 < yyl3532; yyj3532++ {
+				yyv3532 = append(yyv3532, PodCondition{})
 				if r.TryDecodeAsNil() {
-					yyv3527[yyj3527] = PodCondition{}
+					yyv3532[yyj3532] = PodCondition{}
 				} else {
-					yyv3529 := &yyv3527[yyj3527]
-					yyv3529.CodecDecodeSelf(d)
+					yyv3534 := &yyv3532[yyj3532]
+					yyv3534.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3527 := 0; !r.CheckBreak(); yyj3527++ {
-			if yyj3527 >= len(yyv3527) {
-				yyv3527 = append(yyv3527, PodCondition{}) // var yyz3527 PodCondition
-				yyc3527 = true
+		for yyj3532 := 0; !r.CheckBreak(); yyj3532++ {
+			if yyj3532 >= len(yyv3532) {
+				yyv3532 = append(yyv3532, PodCondition{}) // var yyz3532 PodCondition
+				yyc3532 = true
 			}
 
-			if yyj3527 < len(yyv3527) {
+			if yyj3532 < len(yyv3532) {
 				if r.TryDecodeAsNil() {
-					yyv3527[yyj3527] = PodCondition{}
+					yyv3532[yyj3532] = PodCondition{}
 				} else {
-					yyv3530 := &yyv3527[yyj3527]
-					yyv3530.CodecDecodeSelf(d)
+					yyv3535 := &yyv3532[yyj3532]
+					yyv3535.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41140,10 +41177,10 @@ func (x codecSelfer1234) decSlicePodCondition(v *[]PodCondition, d *codec1978.De
 			}
 
 		}
-		yyh3527.End()
+		yyh3532.End()
 	}
-	if yyc3527 {
-		*v = yyv3527
+	if yyc3532 {
+		*v = yyv3532
 	}
 
 }
@@ -41153,9 +41190,9 @@ func (x codecSelfer1234) encSliceContainerStatus(v []ContainerStatus, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3531 := range v {
-		yy3532 := &yyv3531
-		yy3532.CodecEncodeSelf(e)
+	for _, yyv3536 := range v {
+		yy3537 := &yyv3536
+		yy3537.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41165,75 +41202,75 @@ func (x codecSelfer1234) decSliceContainerStatus(v *[]ContainerStatus, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3533 := *v
-	yyh3533, yyl3533 := z.DecSliceHelperStart()
+	yyv3538 := *v
+	yyh3538, yyl3538 := z.DecSliceHelperStart()
 
-	var yyrr3533, yyrl3533 int
-	var yyc3533, yyrt3533 bool
-	_, _, _ = yyc3533, yyrt3533, yyrl3533
-	yyrr3533 = yyl3533
+	var yyrr3538, yyrl3538 int
+	var yyc3538, yyrt3538 bool
+	_, _, _ = yyc3538, yyrt3538, yyrl3538
+	yyrr3538 = yyl3538
 
-	if yyv3533 == nil {
-		if yyrl3533, yyrt3533 = z.DecInferLen(yyl3533, z.DecBasicHandle().MaxInitLen, 128); yyrt3533 {
-			yyrr3533 = yyrl3533
+	if yyv3538 == nil {
+		if yyrl3538, yyrt3538 = z.DecInferLen(yyl3538, z.DecBasicHandle().MaxInitLen, 128); yyrt3538 {
+			yyrr3538 = yyrl3538
 		}
-		yyv3533 = make([]ContainerStatus, yyrl3533)
-		yyc3533 = true
+		yyv3538 = make([]ContainerStatus, yyrl3538)
+		yyc3538 = true
 	}
 
-	if yyl3533 == 0 {
-		if len(yyv3533) != 0 {
-			yyv3533 = yyv3533[:0]
-			yyc3533 = true
+	if yyl3538 == 0 {
+		if len(yyv3538) != 0 {
+			yyv3538 = yyv3538[:0]
+			yyc3538 = true
 		}
-	} else if yyl3533 > 0 {
+	} else if yyl3538 > 0 {
 
-		if yyl3533 > cap(yyv3533) {
-			yyrl3533, yyrt3533 = z.DecInferLen(yyl3533, z.DecBasicHandle().MaxInitLen, 128)
-			yyv3533 = make([]ContainerStatus, yyrl3533)
-			yyc3533 = true
+		if yyl3538 > cap(yyv3538) {
+			yyrl3538, yyrt3538 = z.DecInferLen(yyl3538, z.DecBasicHandle().MaxInitLen, 128)
+			yyv3538 = make([]ContainerStatus, yyrl3538)
+			yyc3538 = true
 
-			yyrr3533 = len(yyv3533)
-		} else if yyl3533 != len(yyv3533) {
-			yyv3533 = yyv3533[:yyl3533]
-			yyc3533 = true
+			yyrr3538 = len(yyv3538)
+		} else if yyl3538 != len(yyv3538) {
+			yyv3538 = yyv3538[:yyl3538]
+			yyc3538 = true
 		}
-		yyj3533 := 0
-		for ; yyj3533 < yyrr3533; yyj3533++ {
+		yyj3538 := 0
+		for ; yyj3538 < yyrr3538; yyj3538++ {
 			if r.TryDecodeAsNil() {
-				yyv3533[yyj3533] = ContainerStatus{}
+				yyv3538[yyj3538] = ContainerStatus{}
 			} else {
-				yyv3534 := &yyv3533[yyj3533]
-				yyv3534.CodecDecodeSelf(d)
+				yyv3539 := &yyv3538[yyj3538]
+				yyv3539.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3533 {
-			for ; yyj3533 < yyl3533; yyj3533++ {
-				yyv3533 = append(yyv3533, ContainerStatus{})
+		if yyrt3538 {
+			for ; yyj3538 < yyl3538; yyj3538++ {
+				yyv3538 = append(yyv3538, ContainerStatus{})
 				if r.TryDecodeAsNil() {
-					yyv3533[yyj3533] = ContainerStatus{}
+					yyv3538[yyj3538] = ContainerStatus{}
 				} else {
-					yyv3535 := &yyv3533[yyj3533]
-					yyv3535.CodecDecodeSelf(d)
+					yyv3540 := &yyv3538[yyj3538]
+					yyv3540.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3533 := 0; !r.CheckBreak(); yyj3533++ {
-			if yyj3533 >= len(yyv3533) {
-				yyv3533 = append(yyv3533, ContainerStatus{}) // var yyz3533 ContainerStatus
-				yyc3533 = true
+		for yyj3538 := 0; !r.CheckBreak(); yyj3538++ {
+			if yyj3538 >= len(yyv3538) {
+				yyv3538 = append(yyv3538, ContainerStatus{}) // var yyz3538 ContainerStatus
+				yyc3538 = true
 			}
 
-			if yyj3533 < len(yyv3533) {
+			if yyj3538 < len(yyv3538) {
 				if r.TryDecodeAsNil() {
-					yyv3533[yyj3533] = ContainerStatus{}
+					yyv3538[yyj3538] = ContainerStatus{}
 				} else {
-					yyv3536 := &yyv3533[yyj3533]
-					yyv3536.CodecDecodeSelf(d)
+					yyv3541 := &yyv3538[yyj3538]
+					yyv3541.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41241,10 +41278,10 @@ func (x codecSelfer1234) decSliceContainerStatus(v *[]ContainerStatus, d *codec1
 			}
 
 		}
-		yyh3533.End()
+		yyh3538.End()
 	}
-	if yyc3533 {
-		*v = yyv3533
+	if yyc3538 {
+		*v = yyv3538
 	}
 
 }
@@ -41254,9 +41291,9 @@ func (x codecSelfer1234) encSlicePod(v []Pod, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3537 := range v {
-		yy3538 := &yyv3537
-		yy3538.CodecEncodeSelf(e)
+	for _, yyv3542 := range v {
+		yy3543 := &yyv3542
+		yy3543.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41266,75 +41303,75 @@ func (x codecSelfer1234) decSlicePod(v *[]Pod, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3539 := *v
-	yyh3539, yyl3539 := z.DecSliceHelperStart()
+	yyv3544 := *v
+	yyh3544, yyl3544 := z.DecSliceHelperStart()
 
-	var yyrr3539, yyrl3539 int
-	var yyc3539, yyrt3539 bool
-	_, _, _ = yyc3539, yyrt3539, yyrl3539
-	yyrr3539 = yyl3539
+	var yyrr3544, yyrl3544 int
+	var yyc3544, yyrt3544 bool
+	_, _, _ = yyc3544, yyrt3544, yyrl3544
+	yyrr3544 = yyl3544
 
-	if yyv3539 == nil {
-		if yyrl3539, yyrt3539 = z.DecInferLen(yyl3539, z.DecBasicHandle().MaxInitLen, 520); yyrt3539 {
-			yyrr3539 = yyrl3539
+	if yyv3544 == nil {
+		if yyrl3544, yyrt3544 = z.DecInferLen(yyl3544, z.DecBasicHandle().MaxInitLen, 520); yyrt3544 {
+			yyrr3544 = yyrl3544
 		}
-		yyv3539 = make([]Pod, yyrl3539)
-		yyc3539 = true
+		yyv3544 = make([]Pod, yyrl3544)
+		yyc3544 = true
 	}
 
-	if yyl3539 == 0 {
-		if len(yyv3539) != 0 {
-			yyv3539 = yyv3539[:0]
-			yyc3539 = true
+	if yyl3544 == 0 {
+		if len(yyv3544) != 0 {
+			yyv3544 = yyv3544[:0]
+			yyc3544 = true
 		}
-	} else if yyl3539 > 0 {
+	} else if yyl3544 > 0 {
 
-		if yyl3539 > cap(yyv3539) {
-			yyrl3539, yyrt3539 = z.DecInferLen(yyl3539, z.DecBasicHandle().MaxInitLen, 520)
-			yyv3539 = make([]Pod, yyrl3539)
-			yyc3539 = true
+		if yyl3544 > cap(yyv3544) {
+			yyrl3544, yyrt3544 = z.DecInferLen(yyl3544, z.DecBasicHandle().MaxInitLen, 520)
+			yyv3544 = make([]Pod, yyrl3544)
+			yyc3544 = true
 
-			yyrr3539 = len(yyv3539)
-		} else if yyl3539 != len(yyv3539) {
-			yyv3539 = yyv3539[:yyl3539]
-			yyc3539 = true
+			yyrr3544 = len(yyv3544)
+		} else if yyl3544 != len(yyv3544) {
+			yyv3544 = yyv3544[:yyl3544]
+			yyc3544 = true
 		}
-		yyj3539 := 0
-		for ; yyj3539 < yyrr3539; yyj3539++ {
+		yyj3544 := 0
+		for ; yyj3544 < yyrr3544; yyj3544++ {
 			if r.TryDecodeAsNil() {
-				yyv3539[yyj3539] = Pod{}
+				yyv3544[yyj3544] = Pod{}
 			} else {
-				yyv3540 := &yyv3539[yyj3539]
-				yyv3540.CodecDecodeSelf(d)
+				yyv3545 := &yyv3544[yyj3544]
+				yyv3545.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3539 {
-			for ; yyj3539 < yyl3539; yyj3539++ {
-				yyv3539 = append(yyv3539, Pod{})
+		if yyrt3544 {
+			for ; yyj3544 < yyl3544; yyj3544++ {
+				yyv3544 = append(yyv3544, Pod{})
 				if r.TryDecodeAsNil() {
-					yyv3539[yyj3539] = Pod{}
+					yyv3544[yyj3544] = Pod{}
 				} else {
-					yyv3541 := &yyv3539[yyj3539]
-					yyv3541.CodecDecodeSelf(d)
+					yyv3546 := &yyv3544[yyj3544]
+					yyv3546.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3539 := 0; !r.CheckBreak(); yyj3539++ {
-			if yyj3539 >= len(yyv3539) {
-				yyv3539 = append(yyv3539, Pod{}) // var yyz3539 Pod
-				yyc3539 = true
+		for yyj3544 := 0; !r.CheckBreak(); yyj3544++ {
+			if yyj3544 >= len(yyv3544) {
+				yyv3544 = append(yyv3544, Pod{}) // var yyz3544 Pod
+				yyc3544 = true
 			}
 
-			if yyj3539 < len(yyv3539) {
+			if yyj3544 < len(yyv3544) {
 				if r.TryDecodeAsNil() {
-					yyv3539[yyj3539] = Pod{}
+					yyv3544[yyj3544] = Pod{}
 				} else {
-					yyv3542 := &yyv3539[yyj3539]
-					yyv3542.CodecDecodeSelf(d)
+					yyv3547 := &yyv3544[yyj3544]
+					yyv3547.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41342,10 +41379,10 @@ func (x codecSelfer1234) decSlicePod(v *[]Pod, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3539.End()
+		yyh3544.End()
 	}
-	if yyc3539 {
-		*v = yyv3539
+	if yyc3544 {
+		*v = yyv3544
 	}
 
 }
@@ -41355,9 +41392,9 @@ func (x codecSelfer1234) encSlicePodTemplate(v []PodTemplate, e *codec1978.Encod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3543 := range v {
-		yy3544 := &yyv3543
-		yy3544.CodecEncodeSelf(e)
+	for _, yyv3548 := range v {
+		yy3549 := &yyv3548
+		yy3549.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41367,75 +41404,75 @@ func (x codecSelfer1234) decSlicePodTemplate(v *[]PodTemplate, d *codec1978.Deco
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3545 := *v
-	yyh3545, yyl3545 := z.DecSliceHelperStart()
+	yyv3550 := *v
+	yyh3550, yyl3550 := z.DecSliceHelperStart()
 
-	var yyrr3545, yyrl3545 int
-	var yyc3545, yyrt3545 bool
-	_, _, _ = yyc3545, yyrt3545, yyrl3545
-	yyrr3545 = yyl3545
+	var yyrr3550, yyrl3550 int
+	var yyc3550, yyrt3550 bool
+	_, _, _ = yyc3550, yyrt3550, yyrl3550
+	yyrr3550 = yyl3550
 
-	if yyv3545 == nil {
-		if yyrl3545, yyrt3545 = z.DecInferLen(yyl3545, z.DecBasicHandle().MaxInitLen, 544); yyrt3545 {
-			yyrr3545 = yyrl3545
+	if yyv3550 == nil {
+		if yyrl3550, yyrt3550 = z.DecInferLen(yyl3550, z.DecBasicHandle().MaxInitLen, 544); yyrt3550 {
+			yyrr3550 = yyrl3550
 		}
-		yyv3545 = make([]PodTemplate, yyrl3545)
-		yyc3545 = true
+		yyv3550 = make([]PodTemplate, yyrl3550)
+		yyc3550 = true
 	}
 
-	if yyl3545 == 0 {
-		if len(yyv3545) != 0 {
-			yyv3545 = yyv3545[:0]
-			yyc3545 = true
+	if yyl3550 == 0 {
+		if len(yyv3550) != 0 {
+			yyv3550 = yyv3550[:0]
+			yyc3550 = true
 		}
-	} else if yyl3545 > 0 {
+	} else if yyl3550 > 0 {
 
-		if yyl3545 > cap(yyv3545) {
-			yyrl3545, yyrt3545 = z.DecInferLen(yyl3545, z.DecBasicHandle().MaxInitLen, 544)
-			yyv3545 = make([]PodTemplate, yyrl3545)
-			yyc3545 = true
+		if yyl3550 > cap(yyv3550) {
+			yyrl3550, yyrt3550 = z.DecInferLen(yyl3550, z.DecBasicHandle().MaxInitLen, 544)
+			yyv3550 = make([]PodTemplate, yyrl3550)
+			yyc3550 = true
 
-			yyrr3545 = len(yyv3545)
-		} else if yyl3545 != len(yyv3545) {
-			yyv3545 = yyv3545[:yyl3545]
-			yyc3545 = true
+			yyrr3550 = len(yyv3550)
+		} else if yyl3550 != len(yyv3550) {
+			yyv3550 = yyv3550[:yyl3550]
+			yyc3550 = true
 		}
-		yyj3545 := 0
-		for ; yyj3545 < yyrr3545; yyj3545++ {
+		yyj3550 := 0
+		for ; yyj3550 < yyrr3550; yyj3550++ {
 			if r.TryDecodeAsNil() {
-				yyv3545[yyj3545] = PodTemplate{}
+				yyv3550[yyj3550] = PodTemplate{}
 			} else {
-				yyv3546 := &yyv3545[yyj3545]
-				yyv3546.CodecDecodeSelf(d)
+				yyv3551 := &yyv3550[yyj3550]
+				yyv3551.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3545 {
-			for ; yyj3545 < yyl3545; yyj3545++ {
-				yyv3545 = append(yyv3545, PodTemplate{})
+		if yyrt3550 {
+			for ; yyj3550 < yyl3550; yyj3550++ {
+				yyv3550 = append(yyv3550, PodTemplate{})
 				if r.TryDecodeAsNil() {
-					yyv3545[yyj3545] = PodTemplate{}
+					yyv3550[yyj3550] = PodTemplate{}
 				} else {
-					yyv3547 := &yyv3545[yyj3545]
-					yyv3547.CodecDecodeSelf(d)
+					yyv3552 := &yyv3550[yyj3550]
+					yyv3552.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3545 := 0; !r.CheckBreak(); yyj3545++ {
-			if yyj3545 >= len(yyv3545) {
-				yyv3545 = append(yyv3545, PodTemplate{}) // var yyz3545 PodTemplate
-				yyc3545 = true
+		for yyj3550 := 0; !r.CheckBreak(); yyj3550++ {
+			if yyj3550 >= len(yyv3550) {
+				yyv3550 = append(yyv3550, PodTemplate{}) // var yyz3550 PodTemplate
+				yyc3550 = true
 			}
 
-			if yyj3545 < len(yyv3545) {
+			if yyj3550 < len(yyv3550) {
 				if r.TryDecodeAsNil() {
-					yyv3545[yyj3545] = PodTemplate{}
+					yyv3550[yyj3550] = PodTemplate{}
 				} else {
-					yyv3548 := &yyv3545[yyj3545]
-					yyv3548.CodecDecodeSelf(d)
+					yyv3553 := &yyv3550[yyj3550]
+					yyv3553.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41443,10 +41480,10 @@ func (x codecSelfer1234) decSlicePodTemplate(v *[]PodTemplate, d *codec1978.Deco
 			}
 
 		}
-		yyh3545.End()
+		yyh3550.End()
 	}
-	if yyc3545 {
-		*v = yyv3545
+	if yyc3550 {
+		*v = yyv3550
 	}
 
 }
@@ -41456,9 +41493,9 @@ func (x codecSelfer1234) encSliceReplicationController(v []ReplicationController
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3549 := range v {
-		yy3550 := &yyv3549
-		yy3550.CodecEncodeSelf(e)
+	for _, yyv3554 := range v {
+		yy3555 := &yyv3554
+		yy3555.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41468,75 +41505,75 @@ func (x codecSelfer1234) decSliceReplicationController(v *[]ReplicationControlle
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3551 := *v
-	yyh3551, yyl3551 := z.DecSliceHelperStart()
+	yyv3556 := *v
+	yyh3556, yyl3556 := z.DecSliceHelperStart()
 
-	var yyrr3551, yyrl3551 int
-	var yyc3551, yyrt3551 bool
-	_, _, _ = yyc3551, yyrt3551, yyrl3551
-	yyrr3551 = yyl3551
+	var yyrr3556, yyrl3556 int
+	var yyc3556, yyrt3556 bool
+	_, _, _ = yyc3556, yyrt3556, yyrl3556
+	yyrr3556 = yyl3556
 
-	if yyv3551 == nil {
-		if yyrl3551, yyrt3551 = z.DecInferLen(yyl3551, z.DecBasicHandle().MaxInitLen, 232); yyrt3551 {
-			yyrr3551 = yyrl3551
+	if yyv3556 == nil {
+		if yyrl3556, yyrt3556 = z.DecInferLen(yyl3556, z.DecBasicHandle().MaxInitLen, 232); yyrt3556 {
+			yyrr3556 = yyrl3556
 		}
-		yyv3551 = make([]ReplicationController, yyrl3551)
-		yyc3551 = true
+		yyv3556 = make([]ReplicationController, yyrl3556)
+		yyc3556 = true
 	}
 
-	if yyl3551 == 0 {
-		if len(yyv3551) != 0 {
-			yyv3551 = yyv3551[:0]
-			yyc3551 = true
+	if yyl3556 == 0 {
+		if len(yyv3556) != 0 {
+			yyv3556 = yyv3556[:0]
+			yyc3556 = true
 		}
-	} else if yyl3551 > 0 {
+	} else if yyl3556 > 0 {
 
-		if yyl3551 > cap(yyv3551) {
-			yyrl3551, yyrt3551 = z.DecInferLen(yyl3551, z.DecBasicHandle().MaxInitLen, 232)
-			yyv3551 = make([]ReplicationController, yyrl3551)
-			yyc3551 = true
+		if yyl3556 > cap(yyv3556) {
+			yyrl3556, yyrt3556 = z.DecInferLen(yyl3556, z.DecBasicHandle().MaxInitLen, 232)
+			yyv3556 = make([]ReplicationController, yyrl3556)
+			yyc3556 = true
 
-			yyrr3551 = len(yyv3551)
-		} else if yyl3551 != len(yyv3551) {
-			yyv3551 = yyv3551[:yyl3551]
-			yyc3551 = true
+			yyrr3556 = len(yyv3556)
+		} else if yyl3556 != len(yyv3556) {
+			yyv3556 = yyv3556[:yyl3556]
+			yyc3556 = true
 		}
-		yyj3551 := 0
-		for ; yyj3551 < yyrr3551; yyj3551++ {
+		yyj3556 := 0
+		for ; yyj3556 < yyrr3556; yyj3556++ {
 			if r.TryDecodeAsNil() {
-				yyv3551[yyj3551] = ReplicationController{}
+				yyv3556[yyj3556] = ReplicationController{}
 			} else {
-				yyv3552 := &yyv3551[yyj3551]
-				yyv3552.CodecDecodeSelf(d)
+				yyv3557 := &yyv3556[yyj3556]
+				yyv3557.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3551 {
-			for ; yyj3551 < yyl3551; yyj3551++ {
-				yyv3551 = append(yyv3551, ReplicationController{})
+		if yyrt3556 {
+			for ; yyj3556 < yyl3556; yyj3556++ {
+				yyv3556 = append(yyv3556, ReplicationController{})
 				if r.TryDecodeAsNil() {
-					yyv3551[yyj3551] = ReplicationController{}
+					yyv3556[yyj3556] = ReplicationController{}
 				} else {
-					yyv3553 := &yyv3551[yyj3551]
-					yyv3553.CodecDecodeSelf(d)
+					yyv3558 := &yyv3556[yyj3556]
+					yyv3558.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3551 := 0; !r.CheckBreak(); yyj3551++ {
-			if yyj3551 >= len(yyv3551) {
-				yyv3551 = append(yyv3551, ReplicationController{}) // var yyz3551 ReplicationController
-				yyc3551 = true
+		for yyj3556 := 0; !r.CheckBreak(); yyj3556++ {
+			if yyj3556 >= len(yyv3556) {
+				yyv3556 = append(yyv3556, ReplicationController{}) // var yyz3556 ReplicationController
+				yyc3556 = true
 			}
 
-			if yyj3551 < len(yyv3551) {
+			if yyj3556 < len(yyv3556) {
 				if r.TryDecodeAsNil() {
-					yyv3551[yyj3551] = ReplicationController{}
+					yyv3556[yyj3556] = ReplicationController{}
 				} else {
-					yyv3554 := &yyv3551[yyj3551]
-					yyv3554.CodecDecodeSelf(d)
+					yyv3559 := &yyv3556[yyj3556]
+					yyv3559.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41544,10 +41581,10 @@ func (x codecSelfer1234) decSliceReplicationController(v *[]ReplicationControlle
 			}
 
 		}
-		yyh3551.End()
+		yyh3556.End()
 	}
-	if yyc3551 {
-		*v = yyv3551
+	if yyc3556 {
+		*v = yyv3556
 	}
 
 }
@@ -41557,9 +41594,9 @@ func (x codecSelfer1234) encSliceLoadBalancerIngress(v []LoadBalancerIngress, e 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3555 := range v {
-		yy3556 := &yyv3555
-		yy3556.CodecEncodeSelf(e)
+	for _, yyv3560 := range v {
+		yy3561 := &yyv3560
+		yy3561.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41569,75 +41606,75 @@ func (x codecSelfer1234) decSliceLoadBalancerIngress(v *[]LoadBalancerIngress, d
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3557 := *v
-	yyh3557, yyl3557 := z.DecSliceHelperStart()
+	yyv3562 := *v
+	yyh3562, yyl3562 := z.DecSliceHelperStart()
 
-	var yyrr3557, yyrl3557 int
-	var yyc3557, yyrt3557 bool
-	_, _, _ = yyc3557, yyrt3557, yyrl3557
-	yyrr3557 = yyl3557
+	var yyrr3562, yyrl3562 int
+	var yyc3562, yyrt3562 bool
+	_, _, _ = yyc3562, yyrt3562, yyrl3562
+	yyrr3562 = yyl3562
 
-	if yyv3557 == nil {
-		if yyrl3557, yyrt3557 = z.DecInferLen(yyl3557, z.DecBasicHandle().MaxInitLen, 32); yyrt3557 {
-			yyrr3557 = yyrl3557
+	if yyv3562 == nil {
+		if yyrl3562, yyrt3562 = z.DecInferLen(yyl3562, z.DecBasicHandle().MaxInitLen, 32); yyrt3562 {
+			yyrr3562 = yyrl3562
 		}
-		yyv3557 = make([]LoadBalancerIngress, yyrl3557)
-		yyc3557 = true
+		yyv3562 = make([]LoadBalancerIngress, yyrl3562)
+		yyc3562 = true
 	}
 
-	if yyl3557 == 0 {
-		if len(yyv3557) != 0 {
-			yyv3557 = yyv3557[:0]
-			yyc3557 = true
+	if yyl3562 == 0 {
+		if len(yyv3562) != 0 {
+			yyv3562 = yyv3562[:0]
+			yyc3562 = true
 		}
-	} else if yyl3557 > 0 {
+	} else if yyl3562 > 0 {
 
-		if yyl3557 > cap(yyv3557) {
-			yyrl3557, yyrt3557 = z.DecInferLen(yyl3557, z.DecBasicHandle().MaxInitLen, 32)
-			yyv3557 = make([]LoadBalancerIngress, yyrl3557)
-			yyc3557 = true
+		if yyl3562 > cap(yyv3562) {
+			yyrl3562, yyrt3562 = z.DecInferLen(yyl3562, z.DecBasicHandle().MaxInitLen, 32)
+			yyv3562 = make([]LoadBalancerIngress, yyrl3562)
+			yyc3562 = true
 
-			yyrr3557 = len(yyv3557)
-		} else if yyl3557 != len(yyv3557) {
-			yyv3557 = yyv3557[:yyl3557]
-			yyc3557 = true
+			yyrr3562 = len(yyv3562)
+		} else if yyl3562 != len(yyv3562) {
+			yyv3562 = yyv3562[:yyl3562]
+			yyc3562 = true
 		}
-		yyj3557 := 0
-		for ; yyj3557 < yyrr3557; yyj3557++ {
+		yyj3562 := 0
+		for ; yyj3562 < yyrr3562; yyj3562++ {
 			if r.TryDecodeAsNil() {
-				yyv3557[yyj3557] = LoadBalancerIngress{}
+				yyv3562[yyj3562] = LoadBalancerIngress{}
 			} else {
-				yyv3558 := &yyv3557[yyj3557]
-				yyv3558.CodecDecodeSelf(d)
+				yyv3563 := &yyv3562[yyj3562]
+				yyv3563.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3557 {
-			for ; yyj3557 < yyl3557; yyj3557++ {
-				yyv3557 = append(yyv3557, LoadBalancerIngress{})
+		if yyrt3562 {
+			for ; yyj3562 < yyl3562; yyj3562++ {
+				yyv3562 = append(yyv3562, LoadBalancerIngress{})
 				if r.TryDecodeAsNil() {
-					yyv3557[yyj3557] = LoadBalancerIngress{}
+					yyv3562[yyj3562] = LoadBalancerIngress{}
 				} else {
-					yyv3559 := &yyv3557[yyj3557]
-					yyv3559.CodecDecodeSelf(d)
+					yyv3564 := &yyv3562[yyj3562]
+					yyv3564.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3557 := 0; !r.CheckBreak(); yyj3557++ {
-			if yyj3557 >= len(yyv3557) {
-				yyv3557 = append(yyv3557, LoadBalancerIngress{}) // var yyz3557 LoadBalancerIngress
-				yyc3557 = true
+		for yyj3562 := 0; !r.CheckBreak(); yyj3562++ {
+			if yyj3562 >= len(yyv3562) {
+				yyv3562 = append(yyv3562, LoadBalancerIngress{}) // var yyz3562 LoadBalancerIngress
+				yyc3562 = true
 			}
 
-			if yyj3557 < len(yyv3557) {
+			if yyj3562 < len(yyv3562) {
 				if r.TryDecodeAsNil() {
-					yyv3557[yyj3557] = LoadBalancerIngress{}
+					yyv3562[yyj3562] = LoadBalancerIngress{}
 				} else {
-					yyv3560 := &yyv3557[yyj3557]
-					yyv3560.CodecDecodeSelf(d)
+					yyv3565 := &yyv3562[yyj3562]
+					yyv3565.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41645,10 +41682,10 @@ func (x codecSelfer1234) decSliceLoadBalancerIngress(v *[]LoadBalancerIngress, d
 			}
 
 		}
-		yyh3557.End()
+		yyh3562.End()
 	}
-	if yyc3557 {
-		*v = yyv3557
+	if yyc3562 {
+		*v = yyv3562
 	}
 
 }
@@ -41658,9 +41695,9 @@ func (x codecSelfer1234) encSliceServicePort(v []ServicePort, e *codec1978.Encod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3561 := range v {
-		yy3562 := &yyv3561
-		yy3562.CodecEncodeSelf(e)
+	for _, yyv3566 := range v {
+		yy3567 := &yyv3566
+		yy3567.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41670,75 +41707,75 @@ func (x codecSelfer1234) decSliceServicePort(v *[]ServicePort, d *codec1978.Deco
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3563 := *v
-	yyh3563, yyl3563 := z.DecSliceHelperStart()
+	yyv3568 := *v
+	yyh3568, yyl3568 := z.DecSliceHelperStart()
 
-	var yyrr3563, yyrl3563 int
-	var yyc3563, yyrt3563 bool
-	_, _, _ = yyc3563, yyrt3563, yyrl3563
-	yyrr3563 = yyl3563
+	var yyrr3568, yyrl3568 int
+	var yyc3568, yyrt3568 bool
+	_, _, _ = yyc3568, yyrt3568, yyrl3568
+	yyrr3568 = yyl3568
 
-	if yyv3563 == nil {
-		if yyrl3563, yyrt3563 = z.DecInferLen(yyl3563, z.DecBasicHandle().MaxInitLen, 80); yyrt3563 {
-			yyrr3563 = yyrl3563
+	if yyv3568 == nil {
+		if yyrl3568, yyrt3568 = z.DecInferLen(yyl3568, z.DecBasicHandle().MaxInitLen, 80); yyrt3568 {
+			yyrr3568 = yyrl3568
 		}
-		yyv3563 = make([]ServicePort, yyrl3563)
-		yyc3563 = true
+		yyv3568 = make([]ServicePort, yyrl3568)
+		yyc3568 = true
 	}
 
-	if yyl3563 == 0 {
-		if len(yyv3563) != 0 {
-			yyv3563 = yyv3563[:0]
-			yyc3563 = true
+	if yyl3568 == 0 {
+		if len(yyv3568) != 0 {
+			yyv3568 = yyv3568[:0]
+			yyc3568 = true
 		}
-	} else if yyl3563 > 0 {
+	} else if yyl3568 > 0 {
 
-		if yyl3563 > cap(yyv3563) {
-			yyrl3563, yyrt3563 = z.DecInferLen(yyl3563, z.DecBasicHandle().MaxInitLen, 80)
-			yyv3563 = make([]ServicePort, yyrl3563)
-			yyc3563 = true
+		if yyl3568 > cap(yyv3568) {
+			yyrl3568, yyrt3568 = z.DecInferLen(yyl3568, z.DecBasicHandle().MaxInitLen, 80)
+			yyv3568 = make([]ServicePort, yyrl3568)
+			yyc3568 = true
 
-			yyrr3563 = len(yyv3563)
-		} else if yyl3563 != len(yyv3563) {
-			yyv3563 = yyv3563[:yyl3563]
-			yyc3563 = true
+			yyrr3568 = len(yyv3568)
+		} else if yyl3568 != len(yyv3568) {
+			yyv3568 = yyv3568[:yyl3568]
+			yyc3568 = true
 		}
-		yyj3563 := 0
-		for ; yyj3563 < yyrr3563; yyj3563++ {
+		yyj3568 := 0
+		for ; yyj3568 < yyrr3568; yyj3568++ {
 			if r.TryDecodeAsNil() {
-				yyv3563[yyj3563] = ServicePort{}
+				yyv3568[yyj3568] = ServicePort{}
 			} else {
-				yyv3564 := &yyv3563[yyj3563]
-				yyv3564.CodecDecodeSelf(d)
+				yyv3569 := &yyv3568[yyj3568]
+				yyv3569.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3563 {
-			for ; yyj3563 < yyl3563; yyj3563++ {
-				yyv3563 = append(yyv3563, ServicePort{})
+		if yyrt3568 {
+			for ; yyj3568 < yyl3568; yyj3568++ {
+				yyv3568 = append(yyv3568, ServicePort{})
 				if r.TryDecodeAsNil() {
-					yyv3563[yyj3563] = ServicePort{}
+					yyv3568[yyj3568] = ServicePort{}
 				} else {
-					yyv3565 := &yyv3563[yyj3563]
-					yyv3565.CodecDecodeSelf(d)
+					yyv3570 := &yyv3568[yyj3568]
+					yyv3570.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3563 := 0; !r.CheckBreak(); yyj3563++ {
-			if yyj3563 >= len(yyv3563) {
-				yyv3563 = append(yyv3563, ServicePort{}) // var yyz3563 ServicePort
-				yyc3563 = true
+		for yyj3568 := 0; !r.CheckBreak(); yyj3568++ {
+			if yyj3568 >= len(yyv3568) {
+				yyv3568 = append(yyv3568, ServicePort{}) // var yyz3568 ServicePort
+				yyc3568 = true
 			}
 
-			if yyj3563 < len(yyv3563) {
+			if yyj3568 < len(yyv3568) {
 				if r.TryDecodeAsNil() {
-					yyv3563[yyj3563] = ServicePort{}
+					yyv3568[yyj3568] = ServicePort{}
 				} else {
-					yyv3566 := &yyv3563[yyj3563]
-					yyv3566.CodecDecodeSelf(d)
+					yyv3571 := &yyv3568[yyj3568]
+					yyv3571.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41746,10 +41783,10 @@ func (x codecSelfer1234) decSliceServicePort(v *[]ServicePort, d *codec1978.Deco
 			}
 
 		}
-		yyh3563.End()
+		yyh3568.End()
 	}
-	if yyc3563 {
-		*v = yyv3563
+	if yyc3568 {
+		*v = yyv3568
 	}
 
 }
@@ -41759,9 +41796,9 @@ func (x codecSelfer1234) encSliceService(v []Service, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3567 := range v {
-		yy3568 := &yyv3567
-		yy3568.CodecEncodeSelf(e)
+	for _, yyv3572 := range v {
+		yy3573 := &yyv3572
+		yy3573.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41771,75 +41808,75 @@ func (x codecSelfer1234) decSliceService(v *[]Service, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3569 := *v
-	yyh3569, yyl3569 := z.DecSliceHelperStart()
+	yyv3574 := *v
+	yyh3574, yyl3574 := z.DecSliceHelperStart()
 
-	var yyrr3569, yyrl3569 int
-	var yyc3569, yyrt3569 bool
-	_, _, _ = yyc3569, yyrt3569, yyrl3569
-	yyrr3569 = yyl3569
+	var yyrr3574, yyrl3574 int
+	var yyc3574, yyrt3574 bool
+	_, _, _ = yyc3574, yyrt3574, yyrl3574
+	yyrr3574 = yyl3574
 
-	if yyv3569 == nil {
-		if yyrl3569, yyrt3569 = z.DecInferLen(yyl3569, z.DecBasicHandle().MaxInitLen, 360); yyrt3569 {
-			yyrr3569 = yyrl3569
+	if yyv3574 == nil {
+		if yyrl3574, yyrt3574 = z.DecInferLen(yyl3574, z.DecBasicHandle().MaxInitLen, 360); yyrt3574 {
+			yyrr3574 = yyrl3574
 		}
-		yyv3569 = make([]Service, yyrl3569)
-		yyc3569 = true
+		yyv3574 = make([]Service, yyrl3574)
+		yyc3574 = true
 	}
 
-	if yyl3569 == 0 {
-		if len(yyv3569) != 0 {
-			yyv3569 = yyv3569[:0]
-			yyc3569 = true
+	if yyl3574 == 0 {
+		if len(yyv3574) != 0 {
+			yyv3574 = yyv3574[:0]
+			yyc3574 = true
 		}
-	} else if yyl3569 > 0 {
+	} else if yyl3574 > 0 {
 
-		if yyl3569 > cap(yyv3569) {
-			yyrl3569, yyrt3569 = z.DecInferLen(yyl3569, z.DecBasicHandle().MaxInitLen, 360)
-			yyv3569 = make([]Service, yyrl3569)
-			yyc3569 = true
+		if yyl3574 > cap(yyv3574) {
+			yyrl3574, yyrt3574 = z.DecInferLen(yyl3574, z.DecBasicHandle().MaxInitLen, 360)
+			yyv3574 = make([]Service, yyrl3574)
+			yyc3574 = true
 
-			yyrr3569 = len(yyv3569)
-		} else if yyl3569 != len(yyv3569) {
-			yyv3569 = yyv3569[:yyl3569]
-			yyc3569 = true
+			yyrr3574 = len(yyv3574)
+		} else if yyl3574 != len(yyv3574) {
+			yyv3574 = yyv3574[:yyl3574]
+			yyc3574 = true
 		}
-		yyj3569 := 0
-		for ; yyj3569 < yyrr3569; yyj3569++ {
+		yyj3574 := 0
+		for ; yyj3574 < yyrr3574; yyj3574++ {
 			if r.TryDecodeAsNil() {
-				yyv3569[yyj3569] = Service{}
+				yyv3574[yyj3574] = Service{}
 			} else {
-				yyv3570 := &yyv3569[yyj3569]
-				yyv3570.CodecDecodeSelf(d)
+				yyv3575 := &yyv3574[yyj3574]
+				yyv3575.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3569 {
-			for ; yyj3569 < yyl3569; yyj3569++ {
-				yyv3569 = append(yyv3569, Service{})
+		if yyrt3574 {
+			for ; yyj3574 < yyl3574; yyj3574++ {
+				yyv3574 = append(yyv3574, Service{})
 				if r.TryDecodeAsNil() {
-					yyv3569[yyj3569] = Service{}
+					yyv3574[yyj3574] = Service{}
 				} else {
-					yyv3571 := &yyv3569[yyj3569]
-					yyv3571.CodecDecodeSelf(d)
+					yyv3576 := &yyv3574[yyj3574]
+					yyv3576.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3569 := 0; !r.CheckBreak(); yyj3569++ {
-			if yyj3569 >= len(yyv3569) {
-				yyv3569 = append(yyv3569, Service{}) // var yyz3569 Service
-				yyc3569 = true
+		for yyj3574 := 0; !r.CheckBreak(); yyj3574++ {
+			if yyj3574 >= len(yyv3574) {
+				yyv3574 = append(yyv3574, Service{}) // var yyz3574 Service
+				yyc3574 = true
 			}
 
-			if yyj3569 < len(yyv3569) {
+			if yyj3574 < len(yyv3574) {
 				if r.TryDecodeAsNil() {
-					yyv3569[yyj3569] = Service{}
+					yyv3574[yyj3574] = Service{}
 				} else {
-					yyv3572 := &yyv3569[yyj3569]
-					yyv3572.CodecDecodeSelf(d)
+					yyv3577 := &yyv3574[yyj3574]
+					yyv3577.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41847,10 +41884,10 @@ func (x codecSelfer1234) decSliceService(v *[]Service, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3569.End()
+		yyh3574.End()
 	}
-	if yyc3569 {
-		*v = yyv3569
+	if yyc3574 {
+		*v = yyv3574
 	}
 
 }
@@ -41860,9 +41897,9 @@ func (x codecSelfer1234) encSliceObjectReference(v []ObjectReference, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3573 := range v {
-		yy3574 := &yyv3573
-		yy3574.CodecEncodeSelf(e)
+	for _, yyv3578 := range v {
+		yy3579 := &yyv3578
+		yy3579.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41872,75 +41909,75 @@ func (x codecSelfer1234) decSliceObjectReference(v *[]ObjectReference, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3575 := *v
-	yyh3575, yyl3575 := z.DecSliceHelperStart()
+	yyv3580 := *v
+	yyh3580, yyl3580 := z.DecSliceHelperStart()
 
-	var yyrr3575, yyrl3575 int
-	var yyc3575, yyrt3575 bool
-	_, _, _ = yyc3575, yyrt3575, yyrl3575
-	yyrr3575 = yyl3575
+	var yyrr3580, yyrl3580 int
+	var yyc3580, yyrt3580 bool
+	_, _, _ = yyc3580, yyrt3580, yyrl3580
+	yyrr3580 = yyl3580
 
-	if yyv3575 == nil {
-		if yyrl3575, yyrt3575 = z.DecInferLen(yyl3575, z.DecBasicHandle().MaxInitLen, 112); yyrt3575 {
-			yyrr3575 = yyrl3575
+	if yyv3580 == nil {
+		if yyrl3580, yyrt3580 = z.DecInferLen(yyl3580, z.DecBasicHandle().MaxInitLen, 112); yyrt3580 {
+			yyrr3580 = yyrl3580
 		}
-		yyv3575 = make([]ObjectReference, yyrl3575)
-		yyc3575 = true
+		yyv3580 = make([]ObjectReference, yyrl3580)
+		yyc3580 = true
 	}
 
-	if yyl3575 == 0 {
-		if len(yyv3575) != 0 {
-			yyv3575 = yyv3575[:0]
-			yyc3575 = true
+	if yyl3580 == 0 {
+		if len(yyv3580) != 0 {
+			yyv3580 = yyv3580[:0]
+			yyc3580 = true
 		}
-	} else if yyl3575 > 0 {
+	} else if yyl3580 > 0 {
 
-		if yyl3575 > cap(yyv3575) {
-			yyrl3575, yyrt3575 = z.DecInferLen(yyl3575, z.DecBasicHandle().MaxInitLen, 112)
-			yyv3575 = make([]ObjectReference, yyrl3575)
-			yyc3575 = true
+		if yyl3580 > cap(yyv3580) {
+			yyrl3580, yyrt3580 = z.DecInferLen(yyl3580, z.DecBasicHandle().MaxInitLen, 112)
+			yyv3580 = make([]ObjectReference, yyrl3580)
+			yyc3580 = true
 
-			yyrr3575 = len(yyv3575)
-		} else if yyl3575 != len(yyv3575) {
-			yyv3575 = yyv3575[:yyl3575]
-			yyc3575 = true
+			yyrr3580 = len(yyv3580)
+		} else if yyl3580 != len(yyv3580) {
+			yyv3580 = yyv3580[:yyl3580]
+			yyc3580 = true
 		}
-		yyj3575 := 0
-		for ; yyj3575 < yyrr3575; yyj3575++ {
+		yyj3580 := 0
+		for ; yyj3580 < yyrr3580; yyj3580++ {
 			if r.TryDecodeAsNil() {
-				yyv3575[yyj3575] = ObjectReference{}
+				yyv3580[yyj3580] = ObjectReference{}
 			} else {
-				yyv3576 := &yyv3575[yyj3575]
-				yyv3576.CodecDecodeSelf(d)
+				yyv3581 := &yyv3580[yyj3580]
+				yyv3581.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3575 {
-			for ; yyj3575 < yyl3575; yyj3575++ {
-				yyv3575 = append(yyv3575, ObjectReference{})
+		if yyrt3580 {
+			for ; yyj3580 < yyl3580; yyj3580++ {
+				yyv3580 = append(yyv3580, ObjectReference{})
 				if r.TryDecodeAsNil() {
-					yyv3575[yyj3575] = ObjectReference{}
+					yyv3580[yyj3580] = ObjectReference{}
 				} else {
-					yyv3577 := &yyv3575[yyj3575]
-					yyv3577.CodecDecodeSelf(d)
+					yyv3582 := &yyv3580[yyj3580]
+					yyv3582.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3575 := 0; !r.CheckBreak(); yyj3575++ {
-			if yyj3575 >= len(yyv3575) {
-				yyv3575 = append(yyv3575, ObjectReference{}) // var yyz3575 ObjectReference
-				yyc3575 = true
+		for yyj3580 := 0; !r.CheckBreak(); yyj3580++ {
+			if yyj3580 >= len(yyv3580) {
+				yyv3580 = append(yyv3580, ObjectReference{}) // var yyz3580 ObjectReference
+				yyc3580 = true
 			}
 
-			if yyj3575 < len(yyv3575) {
+			if yyj3580 < len(yyv3580) {
 				if r.TryDecodeAsNil() {
-					yyv3575[yyj3575] = ObjectReference{}
+					yyv3580[yyj3580] = ObjectReference{}
 				} else {
-					yyv3578 := &yyv3575[yyj3575]
-					yyv3578.CodecDecodeSelf(d)
+					yyv3583 := &yyv3580[yyj3580]
+					yyv3583.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -41948,10 +41985,10 @@ func (x codecSelfer1234) decSliceObjectReference(v *[]ObjectReference, d *codec1
 			}
 
 		}
-		yyh3575.End()
+		yyh3580.End()
 	}
-	if yyc3575 {
-		*v = yyv3575
+	if yyc3580 {
+		*v = yyv3580
 	}
 
 }
@@ -41961,9 +41998,9 @@ func (x codecSelfer1234) encSliceServiceAccount(v []ServiceAccount, e *codec1978
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3579 := range v {
-		yy3580 := &yyv3579
-		yy3580.CodecEncodeSelf(e)
+	for _, yyv3584 := range v {
+		yy3585 := &yyv3584
+		yy3585.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -41973,75 +42010,75 @@ func (x codecSelfer1234) decSliceServiceAccount(v *[]ServiceAccount, d *codec197
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3581 := *v
-	yyh3581, yyl3581 := z.DecSliceHelperStart()
+	yyv3586 := *v
+	yyh3586, yyl3586 := z.DecSliceHelperStart()
 
-	var yyrr3581, yyrl3581 int
-	var yyc3581, yyrt3581 bool
-	_, _, _ = yyc3581, yyrt3581, yyrl3581
-	yyrr3581 = yyl3581
+	var yyrr3586, yyrl3586 int
+	var yyc3586, yyrt3586 bool
+	_, _, _ = yyc3586, yyrt3586, yyrl3586
+	yyrr3586 = yyl3586
 
-	if yyv3581 == nil {
-		if yyrl3581, yyrt3581 = z.DecInferLen(yyl3581, z.DecBasicHandle().MaxInitLen, 240); yyrt3581 {
-			yyrr3581 = yyrl3581
+	if yyv3586 == nil {
+		if yyrl3586, yyrt3586 = z.DecInferLen(yyl3586, z.DecBasicHandle().MaxInitLen, 240); yyrt3586 {
+			yyrr3586 = yyrl3586
 		}
-		yyv3581 = make([]ServiceAccount, yyrl3581)
-		yyc3581 = true
+		yyv3586 = make([]ServiceAccount, yyrl3586)
+		yyc3586 = true
 	}
 
-	if yyl3581 == 0 {
-		if len(yyv3581) != 0 {
-			yyv3581 = yyv3581[:0]
-			yyc3581 = true
+	if yyl3586 == 0 {
+		if len(yyv3586) != 0 {
+			yyv3586 = yyv3586[:0]
+			yyc3586 = true
 		}
-	} else if yyl3581 > 0 {
+	} else if yyl3586 > 0 {
 
-		if yyl3581 > cap(yyv3581) {
-			yyrl3581, yyrt3581 = z.DecInferLen(yyl3581, z.DecBasicHandle().MaxInitLen, 240)
-			yyv3581 = make([]ServiceAccount, yyrl3581)
-			yyc3581 = true
+		if yyl3586 > cap(yyv3586) {
+			yyrl3586, yyrt3586 = z.DecInferLen(yyl3586, z.DecBasicHandle().MaxInitLen, 240)
+			yyv3586 = make([]ServiceAccount, yyrl3586)
+			yyc3586 = true
 
-			yyrr3581 = len(yyv3581)
-		} else if yyl3581 != len(yyv3581) {
-			yyv3581 = yyv3581[:yyl3581]
-			yyc3581 = true
+			yyrr3586 = len(yyv3586)
+		} else if yyl3586 != len(yyv3586) {
+			yyv3586 = yyv3586[:yyl3586]
+			yyc3586 = true
 		}
-		yyj3581 := 0
-		for ; yyj3581 < yyrr3581; yyj3581++ {
+		yyj3586 := 0
+		for ; yyj3586 < yyrr3586; yyj3586++ {
 			if r.TryDecodeAsNil() {
-				yyv3581[yyj3581] = ServiceAccount{}
+				yyv3586[yyj3586] = ServiceAccount{}
 			} else {
-				yyv3582 := &yyv3581[yyj3581]
-				yyv3582.CodecDecodeSelf(d)
+				yyv3587 := &yyv3586[yyj3586]
+				yyv3587.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3581 {
-			for ; yyj3581 < yyl3581; yyj3581++ {
-				yyv3581 = append(yyv3581, ServiceAccount{})
+		if yyrt3586 {
+			for ; yyj3586 < yyl3586; yyj3586++ {
+				yyv3586 = append(yyv3586, ServiceAccount{})
 				if r.TryDecodeAsNil() {
-					yyv3581[yyj3581] = ServiceAccount{}
+					yyv3586[yyj3586] = ServiceAccount{}
 				} else {
-					yyv3583 := &yyv3581[yyj3581]
-					yyv3583.CodecDecodeSelf(d)
+					yyv3588 := &yyv3586[yyj3586]
+					yyv3588.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3581 := 0; !r.CheckBreak(); yyj3581++ {
-			if yyj3581 >= len(yyv3581) {
-				yyv3581 = append(yyv3581, ServiceAccount{}) // var yyz3581 ServiceAccount
-				yyc3581 = true
+		for yyj3586 := 0; !r.CheckBreak(); yyj3586++ {
+			if yyj3586 >= len(yyv3586) {
+				yyv3586 = append(yyv3586, ServiceAccount{}) // var yyz3586 ServiceAccount
+				yyc3586 = true
 			}
 
-			if yyj3581 < len(yyv3581) {
+			if yyj3586 < len(yyv3586) {
 				if r.TryDecodeAsNil() {
-					yyv3581[yyj3581] = ServiceAccount{}
+					yyv3586[yyj3586] = ServiceAccount{}
 				} else {
-					yyv3584 := &yyv3581[yyj3581]
-					yyv3584.CodecDecodeSelf(d)
+					yyv3589 := &yyv3586[yyj3586]
+					yyv3589.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -42049,10 +42086,10 @@ func (x codecSelfer1234) decSliceServiceAccount(v *[]ServiceAccount, d *codec197
 			}
 
 		}
-		yyh3581.End()
+		yyh3586.End()
 	}
-	if yyc3581 {
-		*v = yyv3581
+	if yyc3586 {
+		*v = yyv3586
 	}
 
 }
@@ -42062,9 +42099,9 @@ func (x codecSelfer1234) encSliceEndpointSubset(v []EndpointSubset, e *codec1978
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3585 := range v {
-		yy3586 := &yyv3585
-		yy3586.CodecEncodeSelf(e)
+	for _, yyv3590 := range v {
+		yy3591 := &yyv3590
+		yy3591.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -42074,75 +42111,75 @@ func (x codecSelfer1234) decSliceEndpointSubset(v *[]EndpointSubset, d *codec197
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3587 := *v
-	yyh3587, yyl3587 := z.DecSliceHelperStart()
+	yyv3592 := *v
+	yyh3592, yyl3592 := z.DecSliceHelperStart()
 
-	var yyrr3587, yyrl3587 int
-	var yyc3587, yyrt3587 bool
-	_, _, _ = yyc3587, yyrt3587, yyrl3587
-	yyrr3587 = yyl3587
+	var yyrr3592, yyrl3592 int
+	var yyc3592, yyrt3592 bool
+	_, _, _ = yyc3592, yyrt3592, yyrl3592
+	yyrr3592 = yyl3592
 
-	if yyv3587 == nil {
-		if yyrl3587, yyrt3587 = z.DecInferLen(yyl3587, z.DecBasicHandle().MaxInitLen, 72); yyrt3587 {
-			yyrr3587 = yyrl3587
+	if yyv3592 == nil {
+		if yyrl3592, yyrt3592 = z.DecInferLen(yyl3592, z.DecBasicHandle().MaxInitLen, 72); yyrt3592 {
+			yyrr3592 = yyrl3592
 		}
-		yyv3587 = make([]EndpointSubset, yyrl3587)
-		yyc3587 = true
+		yyv3592 = make([]EndpointSubset, yyrl3592)
+		yyc3592 = true
 	}
 
-	if yyl3587 == 0 {
-		if len(yyv3587) != 0 {
-			yyv3587 = yyv3587[:0]
-			yyc3587 = true
+	if yyl3592 == 0 {
+		if len(yyv3592) != 0 {
+			yyv3592 = yyv3592[:0]
+			yyc3592 = true
 		}
-	} else if yyl3587 > 0 {
+	} else if yyl3592 > 0 {
 
-		if yyl3587 > cap(yyv3587) {
-			yyrl3587, yyrt3587 = z.DecInferLen(yyl3587, z.DecBasicHandle().MaxInitLen, 72)
-			yyv3587 = make([]EndpointSubset, yyrl3587)
-			yyc3587 = true
+		if yyl3592 > cap(yyv3592) {
+			yyrl3592, yyrt3592 = z.DecInferLen(yyl3592, z.DecBasicHandle().MaxInitLen, 72)
+			yyv3592 = make([]EndpointSubset, yyrl3592)
+			yyc3592 = true
 
-			yyrr3587 = len(yyv3587)
-		} else if yyl3587 != len(yyv3587) {
-			yyv3587 = yyv3587[:yyl3587]
-			yyc3587 = true
+			yyrr3592 = len(yyv3592)
+		} else if yyl3592 != len(yyv3592) {
+			yyv3592 = yyv3592[:yyl3592]
+			yyc3592 = true
 		}
-		yyj3587 := 0
-		for ; yyj3587 < yyrr3587; yyj3587++ {
+		yyj3592 := 0
+		for ; yyj3592 < yyrr3592; yyj3592++ {
 			if r.TryDecodeAsNil() {
-				yyv3587[yyj3587] = EndpointSubset{}
+				yyv3592[yyj3592] = EndpointSubset{}
 			} else {
-				yyv3588 := &yyv3587[yyj3587]
-				yyv3588.CodecDecodeSelf(d)
+				yyv3593 := &yyv3592[yyj3592]
+				yyv3593.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3587 {
-			for ; yyj3587 < yyl3587; yyj3587++ {
-				yyv3587 = append(yyv3587, EndpointSubset{})
+		if yyrt3592 {
+			for ; yyj3592 < yyl3592; yyj3592++ {
+				yyv3592 = append(yyv3592, EndpointSubset{})
 				if r.TryDecodeAsNil() {
-					yyv3587[yyj3587] = EndpointSubset{}
+					yyv3592[yyj3592] = EndpointSubset{}
 				} else {
-					yyv3589 := &yyv3587[yyj3587]
-					yyv3589.CodecDecodeSelf(d)
+					yyv3594 := &yyv3592[yyj3592]
+					yyv3594.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3587 := 0; !r.CheckBreak(); yyj3587++ {
-			if yyj3587 >= len(yyv3587) {
-				yyv3587 = append(yyv3587, EndpointSubset{}) // var yyz3587 EndpointSubset
-				yyc3587 = true
+		for yyj3592 := 0; !r.CheckBreak(); yyj3592++ {
+			if yyj3592 >= len(yyv3592) {
+				yyv3592 = append(yyv3592, EndpointSubset{}) // var yyz3592 EndpointSubset
+				yyc3592 = true
 			}
 
-			if yyj3587 < len(yyv3587) {
+			if yyj3592 < len(yyv3592) {
 				if r.TryDecodeAsNil() {
-					yyv3587[yyj3587] = EndpointSubset{}
+					yyv3592[yyj3592] = EndpointSubset{}
 				} else {
-					yyv3590 := &yyv3587[yyj3587]
-					yyv3590.CodecDecodeSelf(d)
+					yyv3595 := &yyv3592[yyj3592]
+					yyv3595.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -42150,10 +42187,10 @@ func (x codecSelfer1234) decSliceEndpointSubset(v *[]EndpointSubset, d *codec197
 			}
 
 		}
-		yyh3587.End()
+		yyh3592.End()
 	}
-	if yyc3587 {
-		*v = yyv3587
+	if yyc3592 {
+		*v = yyv3592
 	}
 
 }
@@ -42163,9 +42200,9 @@ func (x codecSelfer1234) encSliceEndpointAddress(v []EndpointAddress, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3591 := range v {
-		yy3592 := &yyv3591
-		yy3592.CodecEncodeSelf(e)
+	for _, yyv3596 := range v {
+		yy3597 := &yyv3596
+		yy3597.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -42175,75 +42212,75 @@ func (x codecSelfer1234) decSliceEndpointAddress(v *[]EndpointAddress, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3593 := *v
-	yyh3593, yyl3593 := z.DecSliceHelperStart()
+	yyv3598 := *v
+	yyh3598, yyl3598 := z.DecSliceHelperStart()
 
-	var yyrr3593, yyrl3593 int
-	var yyc3593, yyrt3593 bool
-	_, _, _ = yyc3593, yyrt3593, yyrl3593
-	yyrr3593 = yyl3593
+	var yyrr3598, yyrl3598 int
+	var yyc3598, yyrt3598 bool
+	_, _, _ = yyc3598, yyrt3598, yyrl3598
+	yyrr3598 = yyl3598
 
-	if yyv3593 == nil {
-		if yyrl3593, yyrt3593 = z.DecInferLen(yyl3593, z.DecBasicHandle().MaxInitLen, 24); yyrt3593 {
-			yyrr3593 = yyrl3593
+	if yyv3598 == nil {
+		if yyrl3598, yyrt3598 = z.DecInferLen(yyl3598, z.DecBasicHandle().MaxInitLen, 24); yyrt3598 {
+			yyrr3598 = yyrl3598
 		}
-		yyv3593 = make([]EndpointAddress, yyrl3593)
-		yyc3593 = true
+		yyv3598 = make([]EndpointAddress, yyrl3598)
+		yyc3598 = true
 	}
 
-	if yyl3593 == 0 {
-		if len(yyv3593) != 0 {
-			yyv3593 = yyv3593[:0]
-			yyc3593 = true
+	if yyl3598 == 0 {
+		if len(yyv3598) != 0 {
+			yyv3598 = yyv3598[:0]
+			yyc3598 = true
 		}
-	} else if yyl3593 > 0 {
+	} else if yyl3598 > 0 {
 
-		if yyl3593 > cap(yyv3593) {
-			yyrl3593, yyrt3593 = z.DecInferLen(yyl3593, z.DecBasicHandle().MaxInitLen, 24)
-			yyv3593 = make([]EndpointAddress, yyrl3593)
-			yyc3593 = true
+		if yyl3598 > cap(yyv3598) {
+			yyrl3598, yyrt3598 = z.DecInferLen(yyl3598, z.DecBasicHandle().MaxInitLen, 24)
+			yyv3598 = make([]EndpointAddress, yyrl3598)
+			yyc3598 = true
 
-			yyrr3593 = len(yyv3593)
-		} else if yyl3593 != len(yyv3593) {
-			yyv3593 = yyv3593[:yyl3593]
-			yyc3593 = true
+			yyrr3598 = len(yyv3598)
+		} else if yyl3598 != len(yyv3598) {
+			yyv3598 = yyv3598[:yyl3598]
+			yyc3598 = true
 		}
-		yyj3593 := 0
-		for ; yyj3593 < yyrr3593; yyj3593++ {
+		yyj3598 := 0
+		for ; yyj3598 < yyrr3598; yyj3598++ {
 			if r.TryDecodeAsNil() {
-				yyv3593[yyj3593] = EndpointAddress{}
+				yyv3598[yyj3598] = EndpointAddress{}
 			} else {
-				yyv3594 := &yyv3593[yyj3593]
-				yyv3594.CodecDecodeSelf(d)
+				yyv3599 := &yyv3598[yyj3598]
+				yyv3599.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3593 {
-			for ; yyj3593 < yyl3593; yyj3593++ {
-				yyv3593 = append(yyv3593, EndpointAddress{})
+		if yyrt3598 {
+			for ; yyj3598 < yyl3598; yyj3598++ {
+				yyv3598 = append(yyv3598, EndpointAddress{})
 				if r.TryDecodeAsNil() {
-					yyv3593[yyj3593] = EndpointAddress{}
+					yyv3598[yyj3598] = EndpointAddress{}
 				} else {
-					yyv3595 := &yyv3593[yyj3593]
-					yyv3595.CodecDecodeSelf(d)
+					yyv3600 := &yyv3598[yyj3598]
+					yyv3600.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3593 := 0; !r.CheckBreak(); yyj3593++ {
-			if yyj3593 >= len(yyv3593) {
-				yyv3593 = append(yyv3593, EndpointAddress{}) // var yyz3593 EndpointAddress
-				yyc3593 = true
+		for yyj3598 := 0; !r.CheckBreak(); yyj3598++ {
+			if yyj3598 >= len(yyv3598) {
+				yyv3598 = append(yyv3598, EndpointAddress{}) // var yyz3598 EndpointAddress
+				yyc3598 = true
 			}
 
-			if yyj3593 < len(yyv3593) {
+			if yyj3598 < len(yyv3598) {
 				if r.TryDecodeAsNil() {
-					yyv3593[yyj3593] = EndpointAddress{}
+					yyv3598[yyj3598] = EndpointAddress{}
 				} else {
-					yyv3596 := &yyv3593[yyj3593]
-					yyv3596.CodecDecodeSelf(d)
+					yyv3601 := &yyv3598[yyj3598]
+					yyv3601.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -42251,10 +42288,10 @@ func (x codecSelfer1234) decSliceEndpointAddress(v *[]EndpointAddress, d *codec1
 			}
 
 		}
-		yyh3593.End()
+		yyh3598.End()
 	}
-	if yyc3593 {
-		*v = yyv3593
+	if yyc3598 {
+		*v = yyv3598
 	}
 
 }
@@ -42264,9 +42301,9 @@ func (x codecSelfer1234) encSliceEndpointPort(v []EndpointPort, e *codec1978.Enc
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3597 := range v {
-		yy3598 := &yyv3597
-		yy3598.CodecEncodeSelf(e)
+	for _, yyv3602 := range v {
+		yy3603 := &yyv3602
+		yy3603.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -42276,75 +42313,75 @@ func (x codecSelfer1234) decSliceEndpointPort(v *[]EndpointPort, d *codec1978.De
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3599 := *v
-	yyh3599, yyl3599 := z.DecSliceHelperStart()
+	yyv3604 := *v
+	yyh3604, yyl3604 := z.DecSliceHelperStart()
 
-	var yyrr3599, yyrl3599 int
-	var yyc3599, yyrt3599 bool
-	_, _, _ = yyc3599, yyrt3599, yyrl3599
-	yyrr3599 = yyl3599
+	var yyrr3604, yyrl3604 int
+	var yyc3604, yyrt3604 bool
+	_, _, _ = yyc3604, yyrt3604, yyrl3604
+	yyrr3604 = yyl3604
 
-	if yyv3599 == nil {
-		if yyrl3599, yyrt3599 = z.DecInferLen(yyl3599, z.DecBasicHandle().MaxInitLen, 40); yyrt3599 {
-			yyrr3599 = yyrl3599
+	if yyv3604 == nil {
+		if yyrl3604, yyrt3604 = z.DecInferLen(yyl3604, z.DecBasicHandle().MaxInitLen, 40); yyrt3604 {
+			yyrr3604 = yyrl3604
 		}
-		yyv3599 = make([]EndpointPort, yyrl3599)
-		yyc3599 = true
+		yyv3604 = make([]EndpointPort, yyrl3604)
+		yyc3604 = true
 	}
 
-	if yyl3599 == 0 {
-		if len(yyv3599) != 0 {
-			yyv3599 = yyv3599[:0]
-			yyc3599 = true
+	if yyl3604 == 0 {
+		if len(yyv3604) != 0 {
+			yyv3604 = yyv3604[:0]
+			yyc3604 = true
 		}
-	} else if yyl3599 > 0 {
+	} else if yyl3604 > 0 {
 
-		if yyl3599 > cap(yyv3599) {
-			yyrl3599, yyrt3599 = z.DecInferLen(yyl3599, z.DecBasicHandle().MaxInitLen, 40)
-			yyv3599 = make([]EndpointPort, yyrl3599)
-			yyc3599 = true
+		if yyl3604 > cap(yyv3604) {
+			yyrl3604, yyrt3604 = z.DecInferLen(yyl3604, z.DecBasicHandle().MaxInitLen, 40)
+			yyv3604 = make([]EndpointPort, yyrl3604)
+			yyc3604 = true
 
-			yyrr3599 = len(yyv3599)
-		} else if yyl3599 != len(yyv3599) {
-			yyv3599 = yyv3599[:yyl3599]
-			yyc3599 = true
+			yyrr3604 = len(yyv3604)
+		} else if yyl3604 != len(yyv3604) {
+			yyv3604 = yyv3604[:yyl3604]
+			yyc3604 = true
 		}
-		yyj3599 := 0
-		for ; yyj3599 < yyrr3599; yyj3599++ {
+		yyj3604 := 0
+		for ; yyj3604 < yyrr3604; yyj3604++ {
 			if r.TryDecodeAsNil() {
-				yyv3599[yyj3599] = EndpointPort{}
+				yyv3604[yyj3604] = EndpointPort{}
 			} else {
-				yyv3600 := &yyv3599[yyj3599]
-				yyv3600.CodecDecodeSelf(d)
+				yyv3605 := &yyv3604[yyj3604]
+				yyv3605.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3599 {
-			for ; yyj3599 < yyl3599; yyj3599++ {
-				yyv3599 = append(yyv3599, EndpointPort{})
+		if yyrt3604 {
+			for ; yyj3604 < yyl3604; yyj3604++ {
+				yyv3604 = append(yyv3604, EndpointPort{})
 				if r.TryDecodeAsNil() {
-					yyv3599[yyj3599] = EndpointPort{}
+					yyv3604[yyj3604] = EndpointPort{}
 				} else {
-					yyv3601 := &yyv3599[yyj3599]
-					yyv3601.CodecDecodeSelf(d)
+					yyv3606 := &yyv3604[yyj3604]
+					yyv3606.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3599 := 0; !r.CheckBreak(); yyj3599++ {
-			if yyj3599 >= len(yyv3599) {
-				yyv3599 = append(yyv3599, EndpointPort{}) // var yyz3599 EndpointPort
-				yyc3599 = true
+		for yyj3604 := 0; !r.CheckBreak(); yyj3604++ {
+			if yyj3604 >= len(yyv3604) {
+				yyv3604 = append(yyv3604, EndpointPort{}) // var yyz3604 EndpointPort
+				yyc3604 = true
 			}
 
-			if yyj3599 < len(yyv3599) {
+			if yyj3604 < len(yyv3604) {
 				if r.TryDecodeAsNil() {
-					yyv3599[yyj3599] = EndpointPort{}
+					yyv3604[yyj3604] = EndpointPort{}
 				} else {
-					yyv3602 := &yyv3599[yyj3599]
-					yyv3602.CodecDecodeSelf(d)
+					yyv3607 := &yyv3604[yyj3604]
+					yyv3607.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -42352,10 +42389,10 @@ func (x codecSelfer1234) decSliceEndpointPort(v *[]EndpointPort, d *codec1978.De
 			}
 
 		}
-		yyh3599.End()
+		yyh3604.End()
 	}
-	if yyc3599 {
-		*v = yyv3599
+	if yyc3604 {
+		*v = yyv3604
 	}
 
 }
@@ -42365,9 +42402,9 @@ func (x codecSelfer1234) encSliceEndpoints(v []Endpoints, e *codec1978.Encoder) 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3603 := range v {
-		yy3604 := &yyv3603
-		yy3604.CodecEncodeSelf(e)
+	for _, yyv3608 := range v {
+		yy3609 := &yyv3608
+		yy3609.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -42377,75 +42414,75 @@ func (x codecSelfer1234) decSliceEndpoints(v *[]Endpoints, d *codec1978.Decoder)
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3605 := *v
-	yyh3605, yyl3605 := z.DecSliceHelperStart()
+	yyv3610 := *v
+	yyh3610, yyl3610 := z.DecSliceHelperStart()
 
-	var yyrr3605, yyrl3605 int
-	var yyc3605, yyrt3605 bool
-	_, _, _ = yyc3605, yyrt3605, yyrl3605
-	yyrr3605 = yyl3605
+	var yyrr3610, yyrl3610 int
+	var yyc3610, yyrt3610 bool
+	_, _, _ = yyc3610, yyrt3610, yyrl3610
+	yyrr3610 = yyl3610
 
-	if yyv3605 == nil {
-		if yyrl3605, yyrt3605 = z.DecInferLen(yyl3605, z.DecBasicHandle().MaxInitLen, 216); yyrt3605 {
-			yyrr3605 = yyrl3605
+	if yyv3610 == nil {
+		if yyrl3610, yyrt3610 = z.DecInferLen(yyl3610, z.DecBasicHandle().MaxInitLen, 216); yyrt3610 {
+			yyrr3610 = yyrl3610
 		}
-		yyv3605 = make([]Endpoints, yyrl3605)
-		yyc3605 = true
+		yyv3610 = make([]Endpoints, yyrl3610)
+		yyc3610 = true
 	}
 
-	if yyl3605 == 0 {
-		if len(yyv3605) != 0 {
-			yyv3605 = yyv3605[:0]
-			yyc3605 = true
+	if yyl3610 == 0 {
+		if len(yyv3610) != 0 {
+			yyv3610 = yyv3610[:0]
+			yyc3610 = true
 		}
-	} else if yyl3605 > 0 {
+	} else if yyl3610 > 0 {
 
-		if yyl3605 > cap(yyv3605) {
-			yyrl3605, yyrt3605 = z.DecInferLen(yyl3605, z.DecBasicHandle().MaxInitLen, 216)
-			yyv3605 = make([]Endpoints, yyrl3605)
-			yyc3605 = true
+		if yyl3610 > cap(yyv3610) {
+			yyrl3610, yyrt3610 = z.DecInferLen(yyl3610, z.DecBasicHandle().MaxInitLen, 216)
+			yyv3610 = make([]Endpoints, yyrl3610)
+			yyc3610 = true
 
-			yyrr3605 = len(yyv3605)
-		} else if yyl3605 != len(yyv3605) {
-			yyv3605 = yyv3605[:yyl3605]
-			yyc3605 = true
+			yyrr3610 = len(yyv3610)
+		} else if yyl3610 != len(yyv3610) {
+			yyv3610 = yyv3610[:yyl3610]
+			yyc3610 = true
 		}
-		yyj3605 := 0
-		for ; yyj3605 < yyrr3605; yyj3605++ {
+		yyj3610 := 0
+		for ; yyj3610 < yyrr3610; yyj3610++ {
 			if r.TryDecodeAsNil() {
-				yyv3605[yyj3605] = Endpoints{}
+				yyv3610[yyj3610] = Endpoints{}
 			} else {
-				yyv3606 := &yyv3605[yyj3605]
-				yyv3606.CodecDecodeSelf(d)
+				yyv3611 := &yyv3610[yyj3610]
+				yyv3611.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3605 {
-			for ; yyj3605 < yyl3605; yyj3605++ {
-				yyv3605 = append(yyv3605, Endpoints{})
+		if yyrt3610 {
+			for ; yyj3610 < yyl3610; yyj3610++ {
+				yyv3610 = append(yyv3610, Endpoints{})
 				if r.TryDecodeAsNil() {
-					yyv3605[yyj3605] = Endpoints{}
+					yyv3610[yyj3610] = Endpoints{}
 				} else {
-					yyv3607 := &yyv3605[yyj3605]
-					yyv3607.CodecDecodeSelf(d)
+					yyv3612 := &yyv3610[yyj3610]
+					yyv3612.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3605 := 0; !r.CheckBreak(); yyj3605++ {
-			if yyj3605 >= len(yyv3605) {
-				yyv3605 = append(yyv3605, Endpoints{}) // var yyz3605 Endpoints
-				yyc3605 = true
+		for yyj3610 := 0; !r.CheckBreak(); yyj3610++ {
+			if yyj3610 >= len(yyv3610) {
+				yyv3610 = append(yyv3610, Endpoints{}) // var yyz3610 Endpoints
+				yyc3610 = true
 			}
 
-			if yyj3605 < len(yyv3605) {
+			if yyj3610 < len(yyv3610) {
 				if r.TryDecodeAsNil() {
-					yyv3605[yyj3605] = Endpoints{}
+					yyv3610[yyj3610] = Endpoints{}
 				} else {
-					yyv3608 := &yyv3605[yyj3605]
-					yyv3608.CodecDecodeSelf(d)
+					yyv3613 := &yyv3610[yyj3610]
+					yyv3613.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -42453,10 +42490,10 @@ func (x codecSelfer1234) decSliceEndpoints(v *[]Endpoints, d *codec1978.Decoder)
 			}
 
 		}
-		yyh3605.End()
+		yyh3610.End()
 	}
-	if yyc3605 {
-		*v = yyv3605
+	if yyc3610 {
+		*v = yyv3610
 	}
 
 }
@@ -42466,9 +42503,9 @@ func (x codecSelfer1234) encSliceNodeCondition(v []NodeCondition, e *codec1978.E
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3609 := range v {
-		yy3610 := &yyv3609
-		yy3610.CodecEncodeSelf(e)
+	for _, yyv3614 := range v {
+		yy3615 := &yyv3614
+		yy3615.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -42478,75 +42515,75 @@ func (x codecSelfer1234) decSliceNodeCondition(v *[]NodeCondition, d *codec1978.
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3611 := *v
-	yyh3611, yyl3611 := z.DecSliceHelperStart()
+	yyv3616 := *v
+	yyh3616, yyl3616 := z.DecSliceHelperStart()
 
-	var yyrr3611, yyrl3611 int
-	var yyc3611, yyrt3611 bool
-	_, _, _ = yyc3611, yyrt3611, yyrl3611
-	yyrr3611 = yyl3611
+	var yyrr3616, yyrl3616 int
+	var yyc3616, yyrt3616 bool
+	_, _, _ = yyc3616, yyrt3616, yyrl3616
+	yyrr3616 = yyl3616
 
-	if yyv3611 == nil {
-		if yyrl3611, yyrt3611 = z.DecInferLen(yyl3611, z.DecBasicHandle().MaxInitLen, 112); yyrt3611 {
-			yyrr3611 = yyrl3611
+	if yyv3616 == nil {
+		if yyrl3616, yyrt3616 = z.DecInferLen(yyl3616, z.DecBasicHandle().MaxInitLen, 112); yyrt3616 {
+			yyrr3616 = yyrl3616
 		}
-		yyv3611 = make([]NodeCondition, yyrl3611)
-		yyc3611 = true
+		yyv3616 = make([]NodeCondition, yyrl3616)
+		yyc3616 = true
 	}
 
-	if yyl3611 == 0 {
-		if len(yyv3611) != 0 {
-			yyv3611 = yyv3611[:0]
-			yyc3611 = true
+	if yyl3616 == 0 {
+		if len(yyv3616) != 0 {
+			yyv3616 = yyv3616[:0]
+			yyc3616 = true
 		}
-	} else if yyl3611 > 0 {
+	} else if yyl3616 > 0 {
 
-		if yyl3611 > cap(yyv3611) {
-			yyrl3611, yyrt3611 = z.DecInferLen(yyl3611, z.DecBasicHandle().MaxInitLen, 112)
-			yyv3611 = make([]NodeCondition, yyrl3611)
-			yyc3611 = true
+		if yyl3616 > cap(yyv3616) {
+			yyrl3616, yyrt3616 = z.DecInferLen(yyl3616, z.DecBasicHandle().MaxInitLen, 112)
+			yyv3616 = make([]NodeCondition, yyrl3616)
+			yyc3616 = true
 
-			yyrr3611 = len(yyv3611)
-		} else if yyl3611 != len(yyv3611) {
-			yyv3611 = yyv3611[:yyl3611]
-			yyc3611 = true
+			yyrr3616 = len(yyv3616)
+		} else if yyl3616 != len(yyv3616) {
+			yyv3616 = yyv3616[:yyl3616]
+			yyc3616 = true
 		}
-		yyj3611 := 0
-		for ; yyj3611 < yyrr3611; yyj3611++ {
+		yyj3616 := 0
+		for ; yyj3616 < yyrr3616; yyj3616++ {
 			if r.TryDecodeAsNil() {
-				yyv3611[yyj3611] = NodeCondition{}
+				yyv3616[yyj3616] = NodeCondition{}
 			} else {
-				yyv3612 := &yyv3611[yyj3611]
-				yyv3612.CodecDecodeSelf(d)
+				yyv3617 := &yyv3616[yyj3616]
+				yyv3617.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3611 {
-			for ; yyj3611 < yyl3611; yyj3611++ {
-				yyv3611 = append(yyv3611, NodeCondition{})
+		if yyrt3616 {
+			for ; yyj3616 < yyl3616; yyj3616++ {
+				yyv3616 = append(yyv3616, NodeCondition{})
 				if r.TryDecodeAsNil() {
-					yyv3611[yyj3611] = NodeCondition{}
+					yyv3616[yyj3616] = NodeCondition{}
 				} else {
-					yyv3613 := &yyv3611[yyj3611]
-					yyv3613.CodecDecodeSelf(d)
+					yyv3618 := &yyv3616[yyj3616]
+					yyv3618.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3611 := 0; !r.CheckBreak(); yyj3611++ {
-			if yyj3611 >= len(yyv3611) {
-				yyv3611 = append(yyv3611, NodeCondition{}) // var yyz3611 NodeCondition
-				yyc3611 = true
+		for yyj3616 := 0; !r.CheckBreak(); yyj3616++ {
+			if yyj3616 >= len(yyv3616) {
+				yyv3616 = append(yyv3616, NodeCondition{}) // var yyz3616 NodeCondition
+				yyc3616 = true
 			}
 
-			if yyj3611 < len(yyv3611) {
+			if yyj3616 < len(yyv3616) {
 				if r.TryDecodeAsNil() {
-					yyv3611[yyj3611] = NodeCondition{}
+					yyv3616[yyj3616] = NodeCondition{}
 				} else {
-					yyv3614 := &yyv3611[yyj3611]
-					yyv3614.CodecDecodeSelf(d)
+					yyv3619 := &yyv3616[yyj3616]
+					yyv3619.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -42554,10 +42591,10 @@ func (x codecSelfer1234) decSliceNodeCondition(v *[]NodeCondition, d *codec1978.
 			}
 
 		}
-		yyh3611.End()
+		yyh3616.End()
 	}
-	if yyc3611 {
-		*v = yyv3611
+	if yyc3616 {
+		*v = yyv3616
 	}
 
 }
@@ -42567,9 +42604,9 @@ func (x codecSelfer1234) encSliceNodeAddress(v []NodeAddress, e *codec1978.Encod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3615 := range v {
-		yy3616 := &yyv3615
-		yy3616.CodecEncodeSelf(e)
+	for _, yyv3620 := range v {
+		yy3621 := &yyv3620
+		yy3621.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -42579,75 +42616,75 @@ func (x codecSelfer1234) decSliceNodeAddress(v *[]NodeAddress, d *codec1978.Deco
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3617 := *v
-	yyh3617, yyl3617 := z.DecSliceHelperStart()
+	yyv3622 := *v
+	yyh3622, yyl3622 := z.DecSliceHelperStart()
 
-	var yyrr3617, yyrl3617 int
-	var yyc3617, yyrt3617 bool
-	_, _, _ = yyc3617, yyrt3617, yyrl3617
-	yyrr3617 = yyl3617
+	var yyrr3622, yyrl3622 int
+	var yyc3622, yyrt3622 bool
+	_, _, _ = yyc3622, yyrt3622, yyrl3622
+	yyrr3622 = yyl3622
 
-	if yyv3617 == nil {
-		if yyrl3617, yyrt3617 = z.DecInferLen(yyl3617, z.DecBasicHandle().MaxInitLen, 32); yyrt3617 {
-			yyrr3617 = yyrl3617
+	if yyv3622 == nil {
+		if yyrl3622, yyrt3622 = z.DecInferLen(yyl3622, z.DecBasicHandle().MaxInitLen, 48); yyrt3622 {
+			yyrr3622 = yyrl3622
 		}
-		yyv3617 = make([]NodeAddress, yyrl3617)
-		yyc3617 = true
+		yyv3622 = make([]NodeAddress, yyrl3622)
+		yyc3622 = true
 	}
 
-	if yyl3617 == 0 {
-		if len(yyv3617) != 0 {
-			yyv3617 = yyv3617[:0]
-			yyc3617 = true
+	if yyl3622 == 0 {
+		if len(yyv3622) != 0 {
+			yyv3622 = yyv3622[:0]
+			yyc3622 = true
 		}
-	} else if yyl3617 > 0 {
+	} else if yyl3622 > 0 {
 
-		if yyl3617 > cap(yyv3617) {
-			yyrl3617, yyrt3617 = z.DecInferLen(yyl3617, z.DecBasicHandle().MaxInitLen, 32)
-			yyv3617 = make([]NodeAddress, yyrl3617)
-			yyc3617 = true
+		if yyl3622 > cap(yyv3622) {
+			yyrl3622, yyrt3622 = z.DecInferLen(yyl3622, z.DecBasicHandle().MaxInitLen, 48)
+			yyv3622 = make([]NodeAddress, yyrl3622)
+			yyc3622 = true
 
-			yyrr3617 = len(yyv3617)
-		} else if yyl3617 != len(yyv3617) {
-			yyv3617 = yyv3617[:yyl3617]
-			yyc3617 = true
+			yyrr3622 = len(yyv3622)
+		} else if yyl3622 != len(yyv3622) {
+			yyv3622 = yyv3622[:yyl3622]
+			yyc3622 = true
 		}
-		yyj3617 := 0
-		for ; yyj3617 < yyrr3617; yyj3617++ {
+		yyj3622 := 0
+		for ; yyj3622 < yyrr3622; yyj3622++ {
 			if r.TryDecodeAsNil() {
-				yyv3617[yyj3617] = NodeAddress{}
+				yyv3622[yyj3622] = NodeAddress{}
 			} else {
-				yyv3618 := &yyv3617[yyj3617]
-				yyv3618.CodecDecodeSelf(d)
+				yyv3623 := &yyv3622[yyj3622]
+				yyv3623.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3617 {
-			for ; yyj3617 < yyl3617; yyj3617++ {
-				yyv3617 = append(yyv3617, NodeAddress{})
+		if yyrt3622 {
+			for ; yyj3622 < yyl3622; yyj3622++ {
+				yyv3622 = append(yyv3622, NodeAddress{})
 				if r.TryDecodeAsNil() {
-					yyv3617[yyj3617] = NodeAddress{}
+					yyv3622[yyj3622] = NodeAddress{}
 				} else {
-					yyv3619 := &yyv3617[yyj3617]
-					yyv3619.CodecDecodeSelf(d)
+					yyv3624 := &yyv3622[yyj3622]
+					yyv3624.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3617 := 0; !r.CheckBreak(); yyj3617++ {
-			if yyj3617 >= len(yyv3617) {
-				yyv3617 = append(yyv3617, NodeAddress{}) // var yyz3617 NodeAddress
-				yyc3617 = true
+		for yyj3622 := 0; !r.CheckBreak(); yyj3622++ {
+			if yyj3622 >= len(yyv3622) {
+				yyv3622 = append(yyv3622, NodeAddress{}) // var yyz3622 NodeAddress
+				yyc3622 = true
 			}
 
-			if yyj3617 < len(yyv3617) {
+			if yyj3622 < len(yyv3622) {
 				if r.TryDecodeAsNil() {
-					yyv3617[yyj3617] = NodeAddress{}
+					yyv3622[yyj3622] = NodeAddress{}
 				} else {
-					yyv3620 := &yyv3617[yyj3617]
-					yyv3620.CodecDecodeSelf(d)
+					yyv3625 := &yyv3622[yyj3622]
+					yyv3625.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -42655,10 +42692,10 @@ func (x codecSelfer1234) decSliceNodeAddress(v *[]NodeAddress, d *codec1978.Deco
 			}
 
 		}
-		yyh3617.End()
+		yyh3622.End()
 	}
-	if yyc3617 {
-		*v = yyv3617
+	if yyc3622 {
+		*v = yyv3622
 	}
 
 }
@@ -42668,17 +42705,17 @@ func (x codecSelfer1234) encResourceList(v ResourceList, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeMapStart(len(v))
-	for yyk3621, yyv3621 := range v {
-		yyk3621.CodecEncodeSelf(e)
-		yy3622 := &yyv3621
-		yym3623 := z.EncBinary()
-		_ = yym3623
+	for yyk3626, yyv3626 := range v {
+		yyk3626.CodecEncodeSelf(e)
+		yy3627 := &yyv3626
+		yym3628 := z.EncBinary()
+		_ = yym3628
 		if false {
-		} else if z.HasExtensions() && z.EncExt(yy3622) {
-		} else if !yym3623 && z.IsJSONHandle() {
-			z.EncJSONMarshal(yy3622)
+		} else if z.HasExtensions() && z.EncExt(yy3627) {
+		} else if !yym3628 && z.IsJSONHandle() {
+			z.EncJSONMarshal(yy3627)
 		} else {
-			z.EncFallback(yy3622)
+			z.EncFallback(yy3627)
 		}
 	}
 	r.EncodeEnd()
@@ -42689,82 +42726,82 @@ func (x codecSelfer1234) decResourceList(v *ResourceList, d *codec1978.Decoder) 
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3624 := *v
-	yyl3624 := r.ReadMapStart()
-	yybh3624 := z.DecBasicHandle()
-	if yyv3624 == nil {
-		yyrl3624, _ := z.DecInferLen(yyl3624, yybh3624.MaxInitLen, 40)
-		yyv3624 = make(map[ResourceName]pkg3_resource.Quantity, yyrl3624)
-		*v = yyv3624
+	yyv3629 := *v
+	yyl3629 := r.ReadMapStart()
+	yybh3629 := z.DecBasicHandle()
+	if yyv3629 == nil {
+		yyrl3629, _ := z.DecInferLen(yyl3629, yybh3629.MaxInitLen, 40)
+		yyv3629 = make(map[ResourceName]pkg3_resource.Quantity, yyrl3629)
+		*v = yyv3629
 	}
-	var yymk3624 ResourceName
-	var yymv3624 pkg3_resource.Quantity
-	var yymg3624 bool
-	if yybh3624.MapValueReset {
-		yymg3624 = true
+	var yymk3629 ResourceName
+	var yymv3629 pkg3_resource.Quantity
+	var yymg3629 bool
+	if yybh3629.MapValueReset {
+		yymg3629 = true
 	}
-	if yyl3624 > 0 {
-		for yyj3624 := 0; yyj3624 < yyl3624; yyj3624++ {
+	if yyl3629 > 0 {
+		for yyj3629 := 0; yyj3629 < yyl3629; yyj3629++ {
 			if r.TryDecodeAsNil() {
-				yymk3624 = ""
+				yymk3629 = ""
 			} else {
-				yymk3624 = ResourceName(r.DecodeString())
+				yymk3629 = ResourceName(r.DecodeString())
 			}
 
-			if yymg3624 {
-				yymv3624 = yyv3624[yymk3624]
+			if yymg3629 {
+				yymv3629 = yyv3629[yymk3629]
 			} else {
-				yymv3624 = pkg3_resource.Quantity{}
+				yymv3629 = pkg3_resource.Quantity{}
 			}
 			if r.TryDecodeAsNil() {
-				yymv3624 = pkg3_resource.Quantity{}
+				yymv3629 = pkg3_resource.Quantity{}
 			} else {
-				yyv3626 := &yymv3624
-				yym3627 := z.DecBinary()
-				_ = yym3627
+				yyv3631 := &yymv3629
+				yym3632 := z.DecBinary()
+				_ = yym3632
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3626) {
-				} else if !yym3627 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv3626)
+				} else if z.HasExtensions() && z.DecExt(yyv3631) {
+				} else if !yym3632 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv3631)
 				} else {
-					z.DecFallback(yyv3626, false)
+					z.DecFallback(yyv3631, false)
 				}
 			}
 
-			if yyv3624 != nil {
-				yyv3624[yymk3624] = yymv3624
+			if yyv3629 != nil {
+				yyv3629[yymk3629] = yymv3629
 			}
 		}
-	} else if yyl3624 < 0 {
-		for yyj3624 := 0; !r.CheckBreak(); yyj3624++ {
+	} else if yyl3629 < 0 {
+		for yyj3629 := 0; !r.CheckBreak(); yyj3629++ {
 			if r.TryDecodeAsNil() {
-				yymk3624 = ""
+				yymk3629 = ""
 			} else {
-				yymk3624 = ResourceName(r.DecodeString())
+				yymk3629 = ResourceName(r.DecodeString())
 			}
 
-			if yymg3624 {
-				yymv3624 = yyv3624[yymk3624]
+			if yymg3629 {
+				yymv3629 = yyv3629[yymk3629]
 			} else {
-				yymv3624 = pkg3_resource.Quantity{}
+				yymv3629 = pkg3_resource.Quantity{}
 			}
 			if r.TryDecodeAsNil() {
-				yymv3624 = pkg3_resource.Quantity{}
+				yymv3629 = pkg3_resource.Quantity{}
 			} else {
-				yyv3629 := &yymv3624
-				yym3630 := z.DecBinary()
-				_ = yym3630
+				yyv3634 := &yymv3629
+				yym3635 := z.DecBinary()
+				_ = yym3635
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3629) {
-				} else if !yym3630 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv3629)
+				} else if z.HasExtensions() && z.DecExt(yyv3634) {
+				} else if !yym3635 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv3634)
 				} else {
-					z.DecFallback(yyv3629, false)
+					z.DecFallback(yyv3634, false)
 				}
 			}
 
-			if yyv3624 != nil {
-				yyv3624[yymk3624] = yymv3624
+			if yyv3629 != nil {
+				yyv3629[yymk3629] = yymv3629
 			}
 		}
 		r.ReadEnd()
@@ -42776,114 +42813,14 @@ func (x codecSelfer1234) encSliceNode(v []Node, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3631 := range v {
-		yy3632 := &yyv3631
-		yy3632.CodecEncodeSelf(e)
+	for _, yyv3636 := range v {
+		yy3637 := &yyv3636
+		yy3637.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
 
 func (x codecSelfer1234) decSliceNode(v *[]Node, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-
-	yyv3633 := *v
-	yyh3633, yyl3633 := z.DecSliceHelperStart()
-
-	var yyrr3633, yyrl3633 int
-	var yyc3633, yyrt3633 bool
-	_, _, _ = yyc3633, yyrt3633, yyrl3633
-	yyrr3633 = yyl3633
-
-	if yyv3633 == nil {
-		if yyrl3633, yyrt3633 = z.DecInferLen(yyl3633, z.DecBasicHandle().MaxInitLen, 456); yyrt3633 {
-			yyrr3633 = yyrl3633
-		}
-		yyv3633 = make([]Node, yyrl3633)
-		yyc3633 = true
-	}
-
-	if yyl3633 == 0 {
-		if len(yyv3633) != 0 {
-			yyv3633 = yyv3633[:0]
-			yyc3633 = true
-		}
-	} else if yyl3633 > 0 {
-
-		if yyl3633 > cap(yyv3633) {
-			yyrl3633, yyrt3633 = z.DecInferLen(yyl3633, z.DecBasicHandle().MaxInitLen, 456)
-			yyv3633 = make([]Node, yyrl3633)
-			yyc3633 = true
-
-			yyrr3633 = len(yyv3633)
-		} else if yyl3633 != len(yyv3633) {
-			yyv3633 = yyv3633[:yyl3633]
-			yyc3633 = true
-		}
-		yyj3633 := 0
-		for ; yyj3633 < yyrr3633; yyj3633++ {
-			if r.TryDecodeAsNil() {
-				yyv3633[yyj3633] = Node{}
-			} else {
-				yyv3634 := &yyv3633[yyj3633]
-				yyv3634.CodecDecodeSelf(d)
-			}
-
-		}
-		if yyrt3633 {
-			for ; yyj3633 < yyl3633; yyj3633++ {
-				yyv3633 = append(yyv3633, Node{})
-				if r.TryDecodeAsNil() {
-					yyv3633[yyj3633] = Node{}
-				} else {
-					yyv3635 := &yyv3633[yyj3633]
-					yyv3635.CodecDecodeSelf(d)
-				}
-
-			}
-		}
-
-	} else {
-		for yyj3633 := 0; !r.CheckBreak(); yyj3633++ {
-			if yyj3633 >= len(yyv3633) {
-				yyv3633 = append(yyv3633, Node{}) // var yyz3633 Node
-				yyc3633 = true
-			}
-
-			if yyj3633 < len(yyv3633) {
-				if r.TryDecodeAsNil() {
-					yyv3633[yyj3633] = Node{}
-				} else {
-					yyv3636 := &yyv3633[yyj3633]
-					yyv3636.CodecDecodeSelf(d)
-				}
-
-			} else {
-				z.DecSwallow()
-			}
-
-		}
-		yyh3633.End()
-	}
-	if yyc3633 {
-		*v = yyv3633
-	}
-
-}
-
-func (x codecSelfer1234) encSliceFinalizerName(v []FinalizerName, e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	r.EncodeArrayStart(len(v))
-	for _, yyv3637 := range v {
-		yyv3637.CodecEncodeSelf(e)
-	}
-	r.EncodeEnd()
-}
-
-func (x codecSelfer1234) decSliceFinalizerName(v *[]FinalizerName, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -42897,10 +42834,10 @@ func (x codecSelfer1234) decSliceFinalizerName(v *[]FinalizerName, d *codec1978.
 	yyrr3638 = yyl3638
 
 	if yyv3638 == nil {
-		if yyrl3638, yyrt3638 = z.DecInferLen(yyl3638, z.DecBasicHandle().MaxInitLen, 16); yyrt3638 {
+		if yyrl3638, yyrt3638 = z.DecInferLen(yyl3638, z.DecBasicHandle().MaxInitLen, 456); yyrt3638 {
 			yyrr3638 = yyrl3638
 		}
-		yyv3638 = make([]FinalizerName, yyrl3638)
+		yyv3638 = make([]Node, yyrl3638)
 		yyc3638 = true
 	}
 
@@ -42912,13 +42849,8 @@ func (x codecSelfer1234) decSliceFinalizerName(v *[]FinalizerName, d *codec1978.
 	} else if yyl3638 > 0 {
 
 		if yyl3638 > cap(yyv3638) {
-			yyrl3638, yyrt3638 = z.DecInferLen(yyl3638, z.DecBasicHandle().MaxInitLen, 16)
-
-			yyv23638 := yyv3638
-			yyv3638 = make([]FinalizerName, yyrl3638)
-			if len(yyv3638) > 0 {
-				copy(yyv3638, yyv23638[:cap(yyv23638)])
-			}
+			yyrl3638, yyrt3638 = z.DecInferLen(yyl3638, z.DecBasicHandle().MaxInitLen, 456)
+			yyv3638 = make([]Node, yyrl3638)
 			yyc3638 = true
 
 			yyrr3638 = len(yyv3638)
@@ -42929,19 +42861,21 @@ func (x codecSelfer1234) decSliceFinalizerName(v *[]FinalizerName, d *codec1978.
 		yyj3638 := 0
 		for ; yyj3638 < yyrr3638; yyj3638++ {
 			if r.TryDecodeAsNil() {
-				yyv3638[yyj3638] = ""
+				yyv3638[yyj3638] = Node{}
 			} else {
-				yyv3638[yyj3638] = FinalizerName(r.DecodeString())
+				yyv3639 := &yyv3638[yyj3638]
+				yyv3639.CodecDecodeSelf(d)
 			}
 
 		}
 		if yyrt3638 {
 			for ; yyj3638 < yyl3638; yyj3638++ {
-				yyv3638 = append(yyv3638, "")
+				yyv3638 = append(yyv3638, Node{})
 				if r.TryDecodeAsNil() {
-					yyv3638[yyj3638] = ""
+					yyv3638[yyj3638] = Node{}
 				} else {
-					yyv3638[yyj3638] = FinalizerName(r.DecodeString())
+					yyv3640 := &yyv3638[yyj3638]
+					yyv3640.CodecDecodeSelf(d)
 				}
 
 			}
@@ -42950,15 +42884,16 @@ func (x codecSelfer1234) decSliceFinalizerName(v *[]FinalizerName, d *codec1978.
 	} else {
 		for yyj3638 := 0; !r.CheckBreak(); yyj3638++ {
 			if yyj3638 >= len(yyv3638) {
-				yyv3638 = append(yyv3638, "") // var yyz3638 FinalizerName
+				yyv3638 = append(yyv3638, Node{}) // var yyz3638 Node
 				yyc3638 = true
 			}
 
 			if yyj3638 < len(yyv3638) {
 				if r.TryDecodeAsNil() {
-					yyv3638[yyj3638] = ""
+					yyv3638[yyj3638] = Node{}
 				} else {
-					yyv3638[yyj3638] = FinalizerName(r.DecodeString())
+					yyv3641 := &yyv3638[yyj3638]
+					yyv3641.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -42974,14 +42909,116 @@ func (x codecSelfer1234) decSliceFinalizerName(v *[]FinalizerName, d *codec1978.
 
 }
 
-func (x codecSelfer1234) encSliceNamespace(v []Namespace, e *codec1978.Encoder) {
+func (x codecSelfer1234) encSliceFinalizerName(v []FinalizerName, e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv3642 := range v {
-		yy3643 := &yyv3642
-		yy3643.CodecEncodeSelf(e)
+		yyv3642.CodecEncodeSelf(e)
+	}
+	r.EncodeEnd()
+}
+
+func (x codecSelfer1234) decSliceFinalizerName(v *[]FinalizerName, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+
+	yyv3643 := *v
+	yyh3643, yyl3643 := z.DecSliceHelperStart()
+
+	var yyrr3643, yyrl3643 int
+	var yyc3643, yyrt3643 bool
+	_, _, _ = yyc3643, yyrt3643, yyrl3643
+	yyrr3643 = yyl3643
+
+	if yyv3643 == nil {
+		if yyrl3643, yyrt3643 = z.DecInferLen(yyl3643, z.DecBasicHandle().MaxInitLen, 16); yyrt3643 {
+			yyrr3643 = yyrl3643
+		}
+		yyv3643 = make([]FinalizerName, yyrl3643)
+		yyc3643 = true
+	}
+
+	if yyl3643 == 0 {
+		if len(yyv3643) != 0 {
+			yyv3643 = yyv3643[:0]
+			yyc3643 = true
+		}
+	} else if yyl3643 > 0 {
+
+		if yyl3643 > cap(yyv3643) {
+			yyrl3643, yyrt3643 = z.DecInferLen(yyl3643, z.DecBasicHandle().MaxInitLen, 16)
+
+			yyv23643 := yyv3643
+			yyv3643 = make([]FinalizerName, yyrl3643)
+			if len(yyv3643) > 0 {
+				copy(yyv3643, yyv23643[:cap(yyv23643)])
+			}
+			yyc3643 = true
+
+			yyrr3643 = len(yyv3643)
+		} else if yyl3643 != len(yyv3643) {
+			yyv3643 = yyv3643[:yyl3643]
+			yyc3643 = true
+		}
+		yyj3643 := 0
+		for ; yyj3643 < yyrr3643; yyj3643++ {
+			if r.TryDecodeAsNil() {
+				yyv3643[yyj3643] = ""
+			} else {
+				yyv3643[yyj3643] = FinalizerName(r.DecodeString())
+			}
+
+		}
+		if yyrt3643 {
+			for ; yyj3643 < yyl3643; yyj3643++ {
+				yyv3643 = append(yyv3643, "")
+				if r.TryDecodeAsNil() {
+					yyv3643[yyj3643] = ""
+				} else {
+					yyv3643[yyj3643] = FinalizerName(r.DecodeString())
+				}
+
+			}
+		}
+
+	} else {
+		for yyj3643 := 0; !r.CheckBreak(); yyj3643++ {
+			if yyj3643 >= len(yyv3643) {
+				yyv3643 = append(yyv3643, "") // var yyz3643 FinalizerName
+				yyc3643 = true
+			}
+
+			if yyj3643 < len(yyv3643) {
+				if r.TryDecodeAsNil() {
+					yyv3643[yyj3643] = ""
+				} else {
+					yyv3643[yyj3643] = FinalizerName(r.DecodeString())
+				}
+
+			} else {
+				z.DecSwallow()
+			}
+
+		}
+		yyh3643.End()
+	}
+	if yyc3643 {
+		*v = yyv3643
+	}
+
+}
+
+func (x codecSelfer1234) encSliceNamespace(v []Namespace, e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	r.EncodeArrayStart(len(v))
+	for _, yyv3647 := range v {
+		yy3648 := &yyv3647
+		yy3648.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -42991,75 +43028,75 @@ func (x codecSelfer1234) decSliceNamespace(v *[]Namespace, d *codec1978.Decoder)
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3644 := *v
-	yyh3644, yyl3644 := z.DecSliceHelperStart()
+	yyv3649 := *v
+	yyh3649, yyl3649 := z.DecSliceHelperStart()
 
-	var yyrr3644, yyrl3644 int
-	var yyc3644, yyrt3644 bool
-	_, _, _ = yyc3644, yyrt3644, yyrl3644
-	yyrr3644 = yyl3644
+	var yyrr3649, yyrl3649 int
+	var yyc3649, yyrt3649 bool
+	_, _, _ = yyc3649, yyrt3649, yyrl3649
+	yyrr3649 = yyl3649
 
-	if yyv3644 == nil {
-		if yyrl3644, yyrt3644 = z.DecInferLen(yyl3644, z.DecBasicHandle().MaxInitLen, 232); yyrt3644 {
-			yyrr3644 = yyrl3644
+	if yyv3649 == nil {
+		if yyrl3649, yyrt3649 = z.DecInferLen(yyl3649, z.DecBasicHandle().MaxInitLen, 232); yyrt3649 {
+			yyrr3649 = yyrl3649
 		}
-		yyv3644 = make([]Namespace, yyrl3644)
-		yyc3644 = true
+		yyv3649 = make([]Namespace, yyrl3649)
+		yyc3649 = true
 	}
 
-	if yyl3644 == 0 {
-		if len(yyv3644) != 0 {
-			yyv3644 = yyv3644[:0]
-			yyc3644 = true
+	if yyl3649 == 0 {
+		if len(yyv3649) != 0 {
+			yyv3649 = yyv3649[:0]
+			yyc3649 = true
 		}
-	} else if yyl3644 > 0 {
+	} else if yyl3649 > 0 {
 
-		if yyl3644 > cap(yyv3644) {
-			yyrl3644, yyrt3644 = z.DecInferLen(yyl3644, z.DecBasicHandle().MaxInitLen, 232)
-			yyv3644 = make([]Namespace, yyrl3644)
-			yyc3644 = true
+		if yyl3649 > cap(yyv3649) {
+			yyrl3649, yyrt3649 = z.DecInferLen(yyl3649, z.DecBasicHandle().MaxInitLen, 232)
+			yyv3649 = make([]Namespace, yyrl3649)
+			yyc3649 = true
 
-			yyrr3644 = len(yyv3644)
-		} else if yyl3644 != len(yyv3644) {
-			yyv3644 = yyv3644[:yyl3644]
-			yyc3644 = true
+			yyrr3649 = len(yyv3649)
+		} else if yyl3649 != len(yyv3649) {
+			yyv3649 = yyv3649[:yyl3649]
+			yyc3649 = true
 		}
-		yyj3644 := 0
-		for ; yyj3644 < yyrr3644; yyj3644++ {
+		yyj3649 := 0
+		for ; yyj3649 < yyrr3649; yyj3649++ {
 			if r.TryDecodeAsNil() {
-				yyv3644[yyj3644] = Namespace{}
+				yyv3649[yyj3649] = Namespace{}
 			} else {
-				yyv3645 := &yyv3644[yyj3644]
-				yyv3645.CodecDecodeSelf(d)
+				yyv3650 := &yyv3649[yyj3649]
+				yyv3650.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3644 {
-			for ; yyj3644 < yyl3644; yyj3644++ {
-				yyv3644 = append(yyv3644, Namespace{})
+		if yyrt3649 {
+			for ; yyj3649 < yyl3649; yyj3649++ {
+				yyv3649 = append(yyv3649, Namespace{})
 				if r.TryDecodeAsNil() {
-					yyv3644[yyj3644] = Namespace{}
+					yyv3649[yyj3649] = Namespace{}
 				} else {
-					yyv3646 := &yyv3644[yyj3644]
-					yyv3646.CodecDecodeSelf(d)
+					yyv3651 := &yyv3649[yyj3649]
+					yyv3651.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3644 := 0; !r.CheckBreak(); yyj3644++ {
-			if yyj3644 >= len(yyv3644) {
-				yyv3644 = append(yyv3644, Namespace{}) // var yyz3644 Namespace
-				yyc3644 = true
+		for yyj3649 := 0; !r.CheckBreak(); yyj3649++ {
+			if yyj3649 >= len(yyv3649) {
+				yyv3649 = append(yyv3649, Namespace{}) // var yyz3649 Namespace
+				yyc3649 = true
 			}
 
-			if yyj3644 < len(yyv3644) {
+			if yyj3649 < len(yyv3649) {
 				if r.TryDecodeAsNil() {
-					yyv3644[yyj3644] = Namespace{}
+					yyv3649[yyj3649] = Namespace{}
 				} else {
-					yyv3647 := &yyv3644[yyj3644]
-					yyv3647.CodecDecodeSelf(d)
+					yyv3652 := &yyv3649[yyj3649]
+					yyv3652.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -43067,10 +43104,10 @@ func (x codecSelfer1234) decSliceNamespace(v *[]Namespace, d *codec1978.Decoder)
 			}
 
 		}
-		yyh3644.End()
+		yyh3649.End()
 	}
-	if yyc3644 {
-		*v = yyv3644
+	if yyc3649 {
+		*v = yyv3649
 	}
 
 }
@@ -43080,9 +43117,9 @@ func (x codecSelfer1234) encSliceEvent(v []Event, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3648 := range v {
-		yy3649 := &yyv3648
-		yy3649.CodecEncodeSelf(e)
+	for _, yyv3653 := range v {
+		yy3654 := &yyv3653
+		yy3654.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -43092,75 +43129,75 @@ func (x codecSelfer1234) decSliceEvent(v *[]Event, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3650 := *v
-	yyh3650, yyl3650 := z.DecSliceHelperStart()
+	yyv3655 := *v
+	yyh3655, yyl3655 := z.DecSliceHelperStart()
 
-	var yyrr3650, yyrl3650 int
-	var yyc3650, yyrt3650 bool
-	_, _, _ = yyc3650, yyrt3650, yyrl3650
-	yyrr3650 = yyl3650
+	var yyrr3655, yyrl3655 int
+	var yyc3655, yyrt3655 bool
+	_, _, _ = yyc3655, yyrt3655, yyrl3655
+	yyrr3655 = yyl3655
 
-	if yyv3650 == nil {
-		if yyrl3650, yyrt3650 = z.DecInferLen(yyl3650, z.DecBasicHandle().MaxInitLen, 424); yyrt3650 {
-			yyrr3650 = yyrl3650
+	if yyv3655 == nil {
+		if yyrl3655, yyrt3655 = z.DecInferLen(yyl3655, z.DecBasicHandle().MaxInitLen, 424); yyrt3655 {
+			yyrr3655 = yyrl3655
 		}
-		yyv3650 = make([]Event, yyrl3650)
-		yyc3650 = true
+		yyv3655 = make([]Event, yyrl3655)
+		yyc3655 = true
 	}
 
-	if yyl3650 == 0 {
-		if len(yyv3650) != 0 {
-			yyv3650 = yyv3650[:0]
-			yyc3650 = true
+	if yyl3655 == 0 {
+		if len(yyv3655) != 0 {
+			yyv3655 = yyv3655[:0]
+			yyc3655 = true
 		}
-	} else if yyl3650 > 0 {
+	} else if yyl3655 > 0 {
 
-		if yyl3650 > cap(yyv3650) {
-			yyrl3650, yyrt3650 = z.DecInferLen(yyl3650, z.DecBasicHandle().MaxInitLen, 424)
-			yyv3650 = make([]Event, yyrl3650)
-			yyc3650 = true
+		if yyl3655 > cap(yyv3655) {
+			yyrl3655, yyrt3655 = z.DecInferLen(yyl3655, z.DecBasicHandle().MaxInitLen, 424)
+			yyv3655 = make([]Event, yyrl3655)
+			yyc3655 = true
 
-			yyrr3650 = len(yyv3650)
-		} else if yyl3650 != len(yyv3650) {
-			yyv3650 = yyv3650[:yyl3650]
-			yyc3650 = true
+			yyrr3655 = len(yyv3655)
+		} else if yyl3655 != len(yyv3655) {
+			yyv3655 = yyv3655[:yyl3655]
+			yyc3655 = true
 		}
-		yyj3650 := 0
-		for ; yyj3650 < yyrr3650; yyj3650++ {
+		yyj3655 := 0
+		for ; yyj3655 < yyrr3655; yyj3655++ {
 			if r.TryDecodeAsNil() {
-				yyv3650[yyj3650] = Event{}
+				yyv3655[yyj3655] = Event{}
 			} else {
-				yyv3651 := &yyv3650[yyj3650]
-				yyv3651.CodecDecodeSelf(d)
+				yyv3656 := &yyv3655[yyj3655]
+				yyv3656.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3650 {
-			for ; yyj3650 < yyl3650; yyj3650++ {
-				yyv3650 = append(yyv3650, Event{})
+		if yyrt3655 {
+			for ; yyj3655 < yyl3655; yyj3655++ {
+				yyv3655 = append(yyv3655, Event{})
 				if r.TryDecodeAsNil() {
-					yyv3650[yyj3650] = Event{}
+					yyv3655[yyj3655] = Event{}
 				} else {
-					yyv3652 := &yyv3650[yyj3650]
-					yyv3652.CodecDecodeSelf(d)
+					yyv3657 := &yyv3655[yyj3655]
+					yyv3657.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3650 := 0; !r.CheckBreak(); yyj3650++ {
-			if yyj3650 >= len(yyv3650) {
-				yyv3650 = append(yyv3650, Event{}) // var yyz3650 Event
-				yyc3650 = true
+		for yyj3655 := 0; !r.CheckBreak(); yyj3655++ {
+			if yyj3655 >= len(yyv3655) {
+				yyv3655 = append(yyv3655, Event{}) // var yyz3655 Event
+				yyc3655 = true
 			}
 
-			if yyj3650 < len(yyv3650) {
+			if yyj3655 < len(yyv3655) {
 				if r.TryDecodeAsNil() {
-					yyv3650[yyj3650] = Event{}
+					yyv3655[yyj3655] = Event{}
 				} else {
-					yyv3653 := &yyv3650[yyj3650]
-					yyv3653.CodecDecodeSelf(d)
+					yyv3658 := &yyv3655[yyj3655]
+					yyv3658.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -43168,10 +43205,10 @@ func (x codecSelfer1234) decSliceEvent(v *[]Event, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3650.End()
+		yyh3655.End()
 	}
-	if yyc3650 {
-		*v = yyv3650
+	if yyc3655 {
+		*v = yyv3655
 	}
 
 }
@@ -43181,16 +43218,16 @@ func (x codecSelfer1234) encSliceruntime_RawExtension(v []pkg6_runtime.RawExtens
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3654 := range v {
-		yy3655 := &yyv3654
-		yym3656 := z.EncBinary()
-		_ = yym3656
+	for _, yyv3659 := range v {
+		yy3660 := &yyv3659
+		yym3661 := z.EncBinary()
+		_ = yym3661
 		if false {
-		} else if z.HasExtensions() && z.EncExt(yy3655) {
-		} else if !yym3656 && z.IsJSONHandle() {
-			z.EncJSONMarshal(yy3655)
+		} else if z.HasExtensions() && z.EncExt(yy3660) {
+		} else if !yym3661 && z.IsJSONHandle() {
+			z.EncJSONMarshal(yy3660)
 		} else {
-			z.EncFallback(yy3655)
+			z.EncFallback(yy3660)
 		}
 	}
 	r.EncodeEnd()
@@ -43201,72 +43238,72 @@ func (x codecSelfer1234) decSliceruntime_RawExtension(v *[]pkg6_runtime.RawExten
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3657 := *v
-	yyh3657, yyl3657 := z.DecSliceHelperStart()
+	yyv3662 := *v
+	yyh3662, yyl3662 := z.DecSliceHelperStart()
 
-	var yyrr3657, yyrl3657 int
-	var yyc3657, yyrt3657 bool
-	_, _, _ = yyc3657, yyrt3657, yyrl3657
-	yyrr3657 = yyl3657
+	var yyrr3662, yyrl3662 int
+	var yyc3662, yyrt3662 bool
+	_, _, _ = yyc3662, yyrt3662, yyrl3662
+	yyrr3662 = yyl3662
 
-	if yyv3657 == nil {
-		if yyrl3657, yyrt3657 = z.DecInferLen(yyl3657, z.DecBasicHandle().MaxInitLen, 24); yyrt3657 {
-			yyrr3657 = yyrl3657
+	if yyv3662 == nil {
+		if yyrl3662, yyrt3662 = z.DecInferLen(yyl3662, z.DecBasicHandle().MaxInitLen, 24); yyrt3662 {
+			yyrr3662 = yyrl3662
 		}
-		yyv3657 = make([]pkg6_runtime.RawExtension, yyrl3657)
-		yyc3657 = true
+		yyv3662 = make([]pkg6_runtime.RawExtension, yyrl3662)
+		yyc3662 = true
 	}
 
-	if yyl3657 == 0 {
-		if len(yyv3657) != 0 {
-			yyv3657 = yyv3657[:0]
-			yyc3657 = true
+	if yyl3662 == 0 {
+		if len(yyv3662) != 0 {
+			yyv3662 = yyv3662[:0]
+			yyc3662 = true
 		}
-	} else if yyl3657 > 0 {
+	} else if yyl3662 > 0 {
 
-		if yyl3657 > cap(yyv3657) {
-			yyrl3657, yyrt3657 = z.DecInferLen(yyl3657, z.DecBasicHandle().MaxInitLen, 24)
-			yyv3657 = make([]pkg6_runtime.RawExtension, yyrl3657)
-			yyc3657 = true
+		if yyl3662 > cap(yyv3662) {
+			yyrl3662, yyrt3662 = z.DecInferLen(yyl3662, z.DecBasicHandle().MaxInitLen, 24)
+			yyv3662 = make([]pkg6_runtime.RawExtension, yyrl3662)
+			yyc3662 = true
 
-			yyrr3657 = len(yyv3657)
-		} else if yyl3657 != len(yyv3657) {
-			yyv3657 = yyv3657[:yyl3657]
-			yyc3657 = true
+			yyrr3662 = len(yyv3662)
+		} else if yyl3662 != len(yyv3662) {
+			yyv3662 = yyv3662[:yyl3662]
+			yyc3662 = true
 		}
-		yyj3657 := 0
-		for ; yyj3657 < yyrr3657; yyj3657++ {
+		yyj3662 := 0
+		for ; yyj3662 < yyrr3662; yyj3662++ {
 			if r.TryDecodeAsNil() {
-				yyv3657[yyj3657] = pkg6_runtime.RawExtension{}
+				yyv3662[yyj3662] = pkg6_runtime.RawExtension{}
 			} else {
-				yyv3658 := &yyv3657[yyj3657]
-				yym3659 := z.DecBinary()
-				_ = yym3659
+				yyv3663 := &yyv3662[yyj3662]
+				yym3664 := z.DecBinary()
+				_ = yym3664
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv3658) {
-				} else if !yym3659 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv3658)
+				} else if z.HasExtensions() && z.DecExt(yyv3663) {
+				} else if !yym3664 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv3663)
 				} else {
-					z.DecFallback(yyv3658, false)
+					z.DecFallback(yyv3663, false)
 				}
 			}
 
 		}
-		if yyrt3657 {
-			for ; yyj3657 < yyl3657; yyj3657++ {
-				yyv3657 = append(yyv3657, pkg6_runtime.RawExtension{})
+		if yyrt3662 {
+			for ; yyj3662 < yyl3662; yyj3662++ {
+				yyv3662 = append(yyv3662, pkg6_runtime.RawExtension{})
 				if r.TryDecodeAsNil() {
-					yyv3657[yyj3657] = pkg6_runtime.RawExtension{}
+					yyv3662[yyj3662] = pkg6_runtime.RawExtension{}
 				} else {
-					yyv3660 := &yyv3657[yyj3657]
-					yym3661 := z.DecBinary()
-					_ = yym3661
+					yyv3665 := &yyv3662[yyj3662]
+					yym3666 := z.DecBinary()
+					_ = yym3666
 					if false {
-					} else if z.HasExtensions() && z.DecExt(yyv3660) {
-					} else if !yym3661 && z.IsJSONHandle() {
-						z.DecJSONUnmarshal(yyv3660)
+					} else if z.HasExtensions() && z.DecExt(yyv3665) {
+					} else if !yym3666 && z.IsJSONHandle() {
+						z.DecJSONUnmarshal(yyv3665)
 					} else {
-						z.DecFallback(yyv3660, false)
+						z.DecFallback(yyv3665, false)
 					}
 				}
 
@@ -43274,25 +43311,25 @@ func (x codecSelfer1234) decSliceruntime_RawExtension(v *[]pkg6_runtime.RawExten
 		}
 
 	} else {
-		for yyj3657 := 0; !r.CheckBreak(); yyj3657++ {
-			if yyj3657 >= len(yyv3657) {
-				yyv3657 = append(yyv3657, pkg6_runtime.RawExtension{}) // var yyz3657 pkg6_runtime.RawExtension
-				yyc3657 = true
+		for yyj3662 := 0; !r.CheckBreak(); yyj3662++ {
+			if yyj3662 >= len(yyv3662) {
+				yyv3662 = append(yyv3662, pkg6_runtime.RawExtension{}) // var yyz3662 pkg6_runtime.RawExtension
+				yyc3662 = true
 			}
 
-			if yyj3657 < len(yyv3657) {
+			if yyj3662 < len(yyv3662) {
 				if r.TryDecodeAsNil() {
-					yyv3657[yyj3657] = pkg6_runtime.RawExtension{}
+					yyv3662[yyj3662] = pkg6_runtime.RawExtension{}
 				} else {
-					yyv3662 := &yyv3657[yyj3657]
-					yym3663 := z.DecBinary()
-					_ = yym3663
+					yyv3667 := &yyv3662[yyj3662]
+					yym3668 := z.DecBinary()
+					_ = yym3668
 					if false {
-					} else if z.HasExtensions() && z.DecExt(yyv3662) {
-					} else if !yym3663 && z.IsJSONHandle() {
-						z.DecJSONUnmarshal(yyv3662)
+					} else if z.HasExtensions() && z.DecExt(yyv3667) {
+					} else if !yym3668 && z.IsJSONHandle() {
+						z.DecJSONUnmarshal(yyv3667)
 					} else {
-						z.DecFallback(yyv3662, false)
+						z.DecFallback(yyv3667, false)
 					}
 				}
 
@@ -43301,10 +43338,10 @@ func (x codecSelfer1234) decSliceruntime_RawExtension(v *[]pkg6_runtime.RawExten
 			}
 
 		}
-		yyh3657.End()
+		yyh3662.End()
 	}
-	if yyc3657 {
-		*v = yyv3657
+	if yyc3662 {
+		*v = yyv3662
 	}
 
 }
@@ -43314,9 +43351,9 @@ func (x codecSelfer1234) encSliceLimitRangeItem(v []LimitRangeItem, e *codec1978
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3664 := range v {
-		yy3665 := &yyv3664
-		yy3665.CodecEncodeSelf(e)
+	for _, yyv3669 := range v {
+		yy3670 := &yyv3669
+		yy3670.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -43326,75 +43363,75 @@ func (x codecSelfer1234) decSliceLimitRangeItem(v *[]LimitRangeItem, d *codec197
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3666 := *v
-	yyh3666, yyl3666 := z.DecSliceHelperStart()
+	yyv3671 := *v
+	yyh3671, yyl3671 := z.DecSliceHelperStart()
 
-	var yyrr3666, yyrl3666 int
-	var yyc3666, yyrt3666 bool
-	_, _, _ = yyc3666, yyrt3666, yyrl3666
-	yyrr3666 = yyl3666
+	var yyrr3671, yyrl3671 int
+	var yyc3671, yyrt3671 bool
+	_, _, _ = yyc3671, yyrt3671, yyrl3671
+	yyrr3671 = yyl3671
 
-	if yyv3666 == nil {
-		if yyrl3666, yyrt3666 = z.DecInferLen(yyl3666, z.DecBasicHandle().MaxInitLen, 56); yyrt3666 {
-			yyrr3666 = yyrl3666
+	if yyv3671 == nil {
+		if yyrl3671, yyrt3671 = z.DecInferLen(yyl3671, z.DecBasicHandle().MaxInitLen, 56); yyrt3671 {
+			yyrr3671 = yyrl3671
 		}
-		yyv3666 = make([]LimitRangeItem, yyrl3666)
-		yyc3666 = true
+		yyv3671 = make([]LimitRangeItem, yyrl3671)
+		yyc3671 = true
 	}
 
-	if yyl3666 == 0 {
-		if len(yyv3666) != 0 {
-			yyv3666 = yyv3666[:0]
-			yyc3666 = true
+	if yyl3671 == 0 {
+		if len(yyv3671) != 0 {
+			yyv3671 = yyv3671[:0]
+			yyc3671 = true
 		}
-	} else if yyl3666 > 0 {
+	} else if yyl3671 > 0 {
 
-		if yyl3666 > cap(yyv3666) {
-			yyrl3666, yyrt3666 = z.DecInferLen(yyl3666, z.DecBasicHandle().MaxInitLen, 56)
-			yyv3666 = make([]LimitRangeItem, yyrl3666)
-			yyc3666 = true
+		if yyl3671 > cap(yyv3671) {
+			yyrl3671, yyrt3671 = z.DecInferLen(yyl3671, z.DecBasicHandle().MaxInitLen, 56)
+			yyv3671 = make([]LimitRangeItem, yyrl3671)
+			yyc3671 = true
 
-			yyrr3666 = len(yyv3666)
-		} else if yyl3666 != len(yyv3666) {
-			yyv3666 = yyv3666[:yyl3666]
-			yyc3666 = true
+			yyrr3671 = len(yyv3671)
+		} else if yyl3671 != len(yyv3671) {
+			yyv3671 = yyv3671[:yyl3671]
+			yyc3671 = true
 		}
-		yyj3666 := 0
-		for ; yyj3666 < yyrr3666; yyj3666++ {
+		yyj3671 := 0
+		for ; yyj3671 < yyrr3671; yyj3671++ {
 			if r.TryDecodeAsNil() {
-				yyv3666[yyj3666] = LimitRangeItem{}
+				yyv3671[yyj3671] = LimitRangeItem{}
 			} else {
-				yyv3667 := &yyv3666[yyj3666]
-				yyv3667.CodecDecodeSelf(d)
+				yyv3672 := &yyv3671[yyj3671]
+				yyv3672.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3666 {
-			for ; yyj3666 < yyl3666; yyj3666++ {
-				yyv3666 = append(yyv3666, LimitRangeItem{})
+		if yyrt3671 {
+			for ; yyj3671 < yyl3671; yyj3671++ {
+				yyv3671 = append(yyv3671, LimitRangeItem{})
 				if r.TryDecodeAsNil() {
-					yyv3666[yyj3666] = LimitRangeItem{}
+					yyv3671[yyj3671] = LimitRangeItem{}
 				} else {
-					yyv3668 := &yyv3666[yyj3666]
-					yyv3668.CodecDecodeSelf(d)
+					yyv3673 := &yyv3671[yyj3671]
+					yyv3673.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3666 := 0; !r.CheckBreak(); yyj3666++ {
-			if yyj3666 >= len(yyv3666) {
-				yyv3666 = append(yyv3666, LimitRangeItem{}) // var yyz3666 LimitRangeItem
-				yyc3666 = true
+		for yyj3671 := 0; !r.CheckBreak(); yyj3671++ {
+			if yyj3671 >= len(yyv3671) {
+				yyv3671 = append(yyv3671, LimitRangeItem{}) // var yyz3671 LimitRangeItem
+				yyc3671 = true
 			}
 
-			if yyj3666 < len(yyv3666) {
+			if yyj3671 < len(yyv3671) {
 				if r.TryDecodeAsNil() {
-					yyv3666[yyj3666] = LimitRangeItem{}
+					yyv3671[yyj3671] = LimitRangeItem{}
 				} else {
-					yyv3669 := &yyv3666[yyj3666]
-					yyv3669.CodecDecodeSelf(d)
+					yyv3674 := &yyv3671[yyj3671]
+					yyv3674.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -43402,10 +43439,10 @@ func (x codecSelfer1234) decSliceLimitRangeItem(v *[]LimitRangeItem, d *codec197
 			}
 
 		}
-		yyh3666.End()
+		yyh3671.End()
 	}
-	if yyc3666 {
-		*v = yyv3666
+	if yyc3671 {
+		*v = yyv3671
 	}
 
 }
@@ -43415,9 +43452,9 @@ func (x codecSelfer1234) encSliceLimitRange(v []LimitRange, e *codec1978.Encoder
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3670 := range v {
-		yy3671 := &yyv3670
-		yy3671.CodecEncodeSelf(e)
+	for _, yyv3675 := range v {
+		yy3676 := &yyv3675
+		yy3676.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -43427,75 +43464,75 @@ func (x codecSelfer1234) decSliceLimitRange(v *[]LimitRange, d *codec1978.Decode
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3672 := *v
-	yyh3672, yyl3672 := z.DecSliceHelperStart()
+	yyv3677 := *v
+	yyh3677, yyl3677 := z.DecSliceHelperStart()
 
-	var yyrr3672, yyrl3672 int
-	var yyc3672, yyrt3672 bool
-	_, _, _ = yyc3672, yyrt3672, yyrl3672
-	yyrr3672 = yyl3672
+	var yyrr3677, yyrl3677 int
+	var yyc3677, yyrt3677 bool
+	_, _, _ = yyc3677, yyrt3677, yyrl3677
+	yyrr3677 = yyl3677
 
-	if yyv3672 == nil {
-		if yyrl3672, yyrt3672 = z.DecInferLen(yyl3672, z.DecBasicHandle().MaxInitLen, 216); yyrt3672 {
-			yyrr3672 = yyrl3672
+	if yyv3677 == nil {
+		if yyrl3677, yyrt3677 = z.DecInferLen(yyl3677, z.DecBasicHandle().MaxInitLen, 216); yyrt3677 {
+			yyrr3677 = yyrl3677
 		}
-		yyv3672 = make([]LimitRange, yyrl3672)
-		yyc3672 = true
+		yyv3677 = make([]LimitRange, yyrl3677)
+		yyc3677 = true
 	}
 
-	if yyl3672 == 0 {
-		if len(yyv3672) != 0 {
-			yyv3672 = yyv3672[:0]
-			yyc3672 = true
+	if yyl3677 == 0 {
+		if len(yyv3677) != 0 {
+			yyv3677 = yyv3677[:0]
+			yyc3677 = true
 		}
-	} else if yyl3672 > 0 {
+	} else if yyl3677 > 0 {
 
-		if yyl3672 > cap(yyv3672) {
-			yyrl3672, yyrt3672 = z.DecInferLen(yyl3672, z.DecBasicHandle().MaxInitLen, 216)
-			yyv3672 = make([]LimitRange, yyrl3672)
-			yyc3672 = true
+		if yyl3677 > cap(yyv3677) {
+			yyrl3677, yyrt3677 = z.DecInferLen(yyl3677, z.DecBasicHandle().MaxInitLen, 216)
+			yyv3677 = make([]LimitRange, yyrl3677)
+			yyc3677 = true
 
-			yyrr3672 = len(yyv3672)
-		} else if yyl3672 != len(yyv3672) {
-			yyv3672 = yyv3672[:yyl3672]
-			yyc3672 = true
+			yyrr3677 = len(yyv3677)
+		} else if yyl3677 != len(yyv3677) {
+			yyv3677 = yyv3677[:yyl3677]
+			yyc3677 = true
 		}
-		yyj3672 := 0
-		for ; yyj3672 < yyrr3672; yyj3672++ {
+		yyj3677 := 0
+		for ; yyj3677 < yyrr3677; yyj3677++ {
 			if r.TryDecodeAsNil() {
-				yyv3672[yyj3672] = LimitRange{}
+				yyv3677[yyj3677] = LimitRange{}
 			} else {
-				yyv3673 := &yyv3672[yyj3672]
-				yyv3673.CodecDecodeSelf(d)
+				yyv3678 := &yyv3677[yyj3677]
+				yyv3678.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3672 {
-			for ; yyj3672 < yyl3672; yyj3672++ {
-				yyv3672 = append(yyv3672, LimitRange{})
+		if yyrt3677 {
+			for ; yyj3677 < yyl3677; yyj3677++ {
+				yyv3677 = append(yyv3677, LimitRange{})
 				if r.TryDecodeAsNil() {
-					yyv3672[yyj3672] = LimitRange{}
+					yyv3677[yyj3677] = LimitRange{}
 				} else {
-					yyv3674 := &yyv3672[yyj3672]
-					yyv3674.CodecDecodeSelf(d)
+					yyv3679 := &yyv3677[yyj3677]
+					yyv3679.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3672 := 0; !r.CheckBreak(); yyj3672++ {
-			if yyj3672 >= len(yyv3672) {
-				yyv3672 = append(yyv3672, LimitRange{}) // var yyz3672 LimitRange
-				yyc3672 = true
+		for yyj3677 := 0; !r.CheckBreak(); yyj3677++ {
+			if yyj3677 >= len(yyv3677) {
+				yyv3677 = append(yyv3677, LimitRange{}) // var yyz3677 LimitRange
+				yyc3677 = true
 			}
 
-			if yyj3672 < len(yyv3672) {
+			if yyj3677 < len(yyv3677) {
 				if r.TryDecodeAsNil() {
-					yyv3672[yyj3672] = LimitRange{}
+					yyv3677[yyj3677] = LimitRange{}
 				} else {
-					yyv3675 := &yyv3672[yyj3672]
-					yyv3675.CodecDecodeSelf(d)
+					yyv3680 := &yyv3677[yyj3677]
+					yyv3680.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -43503,10 +43540,10 @@ func (x codecSelfer1234) decSliceLimitRange(v *[]LimitRange, d *codec1978.Decode
 			}
 
 		}
-		yyh3672.End()
+		yyh3677.End()
 	}
-	if yyc3672 {
-		*v = yyv3672
+	if yyc3677 {
+		*v = yyv3677
 	}
 
 }
@@ -43516,9 +43553,9 @@ func (x codecSelfer1234) encSliceResourceQuota(v []ResourceQuota, e *codec1978.E
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3676 := range v {
-		yy3677 := &yyv3676
-		yy3677.CodecEncodeSelf(e)
+	for _, yyv3681 := range v {
+		yy3682 := &yyv3681
+		yy3682.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -43528,75 +43565,75 @@ func (x codecSelfer1234) decSliceResourceQuota(v *[]ResourceQuota, d *codec1978.
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3678 := *v
-	yyh3678, yyl3678 := z.DecSliceHelperStart()
+	yyv3683 := *v
+	yyh3683, yyl3683 := z.DecSliceHelperStart()
 
-	var yyrr3678, yyrl3678 int
-	var yyc3678, yyrt3678 bool
-	_, _, _ = yyc3678, yyrt3678, yyrl3678
-	yyrr3678 = yyl3678
+	var yyrr3683, yyrl3683 int
+	var yyc3683, yyrt3683 bool
+	_, _, _ = yyc3683, yyrt3683, yyrl3683
+	yyrr3683 = yyl3683
 
-	if yyv3678 == nil {
-		if yyrl3678, yyrt3678 = z.DecInferLen(yyl3678, z.DecBasicHandle().MaxInitLen, 216); yyrt3678 {
-			yyrr3678 = yyrl3678
+	if yyv3683 == nil {
+		if yyrl3683, yyrt3683 = z.DecInferLen(yyl3683, z.DecBasicHandle().MaxInitLen, 216); yyrt3683 {
+			yyrr3683 = yyrl3683
 		}
-		yyv3678 = make([]ResourceQuota, yyrl3678)
-		yyc3678 = true
+		yyv3683 = make([]ResourceQuota, yyrl3683)
+		yyc3683 = true
 	}
 
-	if yyl3678 == 0 {
-		if len(yyv3678) != 0 {
-			yyv3678 = yyv3678[:0]
-			yyc3678 = true
+	if yyl3683 == 0 {
+		if len(yyv3683) != 0 {
+			yyv3683 = yyv3683[:0]
+			yyc3683 = true
 		}
-	} else if yyl3678 > 0 {
+	} else if yyl3683 > 0 {
 
-		if yyl3678 > cap(yyv3678) {
-			yyrl3678, yyrt3678 = z.DecInferLen(yyl3678, z.DecBasicHandle().MaxInitLen, 216)
-			yyv3678 = make([]ResourceQuota, yyrl3678)
-			yyc3678 = true
+		if yyl3683 > cap(yyv3683) {
+			yyrl3683, yyrt3683 = z.DecInferLen(yyl3683, z.DecBasicHandle().MaxInitLen, 216)
+			yyv3683 = make([]ResourceQuota, yyrl3683)
+			yyc3683 = true
 
-			yyrr3678 = len(yyv3678)
-		} else if yyl3678 != len(yyv3678) {
-			yyv3678 = yyv3678[:yyl3678]
-			yyc3678 = true
+			yyrr3683 = len(yyv3683)
+		} else if yyl3683 != len(yyv3683) {
+			yyv3683 = yyv3683[:yyl3683]
+			yyc3683 = true
 		}
-		yyj3678 := 0
-		for ; yyj3678 < yyrr3678; yyj3678++ {
+		yyj3683 := 0
+		for ; yyj3683 < yyrr3683; yyj3683++ {
 			if r.TryDecodeAsNil() {
-				yyv3678[yyj3678] = ResourceQuota{}
+				yyv3683[yyj3683] = ResourceQuota{}
 			} else {
-				yyv3679 := &yyv3678[yyj3678]
-				yyv3679.CodecDecodeSelf(d)
+				yyv3684 := &yyv3683[yyj3683]
+				yyv3684.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3678 {
-			for ; yyj3678 < yyl3678; yyj3678++ {
-				yyv3678 = append(yyv3678, ResourceQuota{})
+		if yyrt3683 {
+			for ; yyj3683 < yyl3683; yyj3683++ {
+				yyv3683 = append(yyv3683, ResourceQuota{})
 				if r.TryDecodeAsNil() {
-					yyv3678[yyj3678] = ResourceQuota{}
+					yyv3683[yyj3683] = ResourceQuota{}
 				} else {
-					yyv3680 := &yyv3678[yyj3678]
-					yyv3680.CodecDecodeSelf(d)
+					yyv3685 := &yyv3683[yyj3683]
+					yyv3685.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3678 := 0; !r.CheckBreak(); yyj3678++ {
-			if yyj3678 >= len(yyv3678) {
-				yyv3678 = append(yyv3678, ResourceQuota{}) // var yyz3678 ResourceQuota
-				yyc3678 = true
+		for yyj3683 := 0; !r.CheckBreak(); yyj3683++ {
+			if yyj3683 >= len(yyv3683) {
+				yyv3683 = append(yyv3683, ResourceQuota{}) // var yyz3683 ResourceQuota
+				yyc3683 = true
 			}
 
-			if yyj3678 < len(yyv3678) {
+			if yyj3683 < len(yyv3683) {
 				if r.TryDecodeAsNil() {
-					yyv3678[yyj3678] = ResourceQuota{}
+					yyv3683[yyj3683] = ResourceQuota{}
 				} else {
-					yyv3681 := &yyv3678[yyj3678]
-					yyv3681.CodecDecodeSelf(d)
+					yyv3686 := &yyv3683[yyj3683]
+					yyv3686.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -43604,10 +43641,10 @@ func (x codecSelfer1234) decSliceResourceQuota(v *[]ResourceQuota, d *codec1978.
 			}
 
 		}
-		yyh3678.End()
+		yyh3683.End()
 	}
-	if yyc3678 {
-		*v = yyv3678
+	if yyc3683 {
+		*v = yyv3683
 	}
 
 }
@@ -43617,21 +43654,21 @@ func (x codecSelfer1234) encMapstringSliceuint8(v map[string][]uint8, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeMapStart(len(v))
-	for yyk3682, yyv3682 := range v {
-		yym3683 := z.EncBinary()
-		_ = yym3683
+	for yyk3687, yyv3687 := range v {
+		yym3688 := z.EncBinary()
+		_ = yym3688
 		if false {
 		} else {
-			r.EncodeString(codecSelferC_UTF81234, string(yyk3682))
+			r.EncodeString(codecSelferC_UTF81234, string(yyk3687))
 		}
-		if yyv3682 == nil {
+		if yyv3687 == nil {
 			r.EncodeNil()
 		} else {
-			yym3684 := z.EncBinary()
-			_ = yym3684
+			yym3689 := z.EncBinary()
+			_ = yym3689
 			if false {
 			} else {
-				r.EncodeStringBytes(codecSelferC_RAW1234, []byte(yyv3682))
+				r.EncodeStringBytes(codecSelferC_RAW1234, []byte(yyv3687))
 			}
 		}
 	}
@@ -43643,76 +43680,76 @@ func (x codecSelfer1234) decMapstringSliceuint8(v *map[string][]uint8, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3685 := *v
-	yyl3685 := r.ReadMapStart()
-	yybh3685 := z.DecBasicHandle()
-	if yyv3685 == nil {
-		yyrl3685, _ := z.DecInferLen(yyl3685, yybh3685.MaxInitLen, 40)
-		yyv3685 = make(map[string][]uint8, yyrl3685)
-		*v = yyv3685
+	yyv3690 := *v
+	yyl3690 := r.ReadMapStart()
+	yybh3690 := z.DecBasicHandle()
+	if yyv3690 == nil {
+		yyrl3690, _ := z.DecInferLen(yyl3690, yybh3690.MaxInitLen, 40)
+		yyv3690 = make(map[string][]uint8, yyrl3690)
+		*v = yyv3690
 	}
-	var yymk3685 string
-	var yymv3685 []uint8
-	var yymg3685 bool
-	if yybh3685.MapValueReset {
-		yymg3685 = true
+	var yymk3690 string
+	var yymv3690 []uint8
+	var yymg3690 bool
+	if yybh3690.MapValueReset {
+		yymg3690 = true
 	}
-	if yyl3685 > 0 {
-		for yyj3685 := 0; yyj3685 < yyl3685; yyj3685++ {
+	if yyl3690 > 0 {
+		for yyj3690 := 0; yyj3690 < yyl3690; yyj3690++ {
 			if r.TryDecodeAsNil() {
-				yymk3685 = ""
+				yymk3690 = ""
 			} else {
-				yymk3685 = string(r.DecodeString())
+				yymk3690 = string(r.DecodeString())
 			}
 
-			if yymg3685 {
-				yymv3685 = yyv3685[yymk3685]
+			if yymg3690 {
+				yymv3690 = yyv3690[yymk3690]
 			} else {
-				yymv3685 = nil
+				yymv3690 = nil
 			}
 			if r.TryDecodeAsNil() {
-				yymv3685 = nil
+				yymv3690 = nil
 			} else {
-				yyv3687 := &yymv3685
-				yym3688 := z.DecBinary()
-				_ = yym3688
+				yyv3692 := &yymv3690
+				yym3693 := z.DecBinary()
+				_ = yym3693
 				if false {
 				} else {
-					*yyv3687 = r.DecodeBytes(*(*[]byte)(yyv3687), false, false)
+					*yyv3692 = r.DecodeBytes(*(*[]byte)(yyv3692), false, false)
 				}
 			}
 
-			if yyv3685 != nil {
-				yyv3685[yymk3685] = yymv3685
+			if yyv3690 != nil {
+				yyv3690[yymk3690] = yymv3690
 			}
 		}
-	} else if yyl3685 < 0 {
-		for yyj3685 := 0; !r.CheckBreak(); yyj3685++ {
+	} else if yyl3690 < 0 {
+		for yyj3690 := 0; !r.CheckBreak(); yyj3690++ {
 			if r.TryDecodeAsNil() {
-				yymk3685 = ""
+				yymk3690 = ""
 			} else {
-				yymk3685 = string(r.DecodeString())
+				yymk3690 = string(r.DecodeString())
 			}
 
-			if yymg3685 {
-				yymv3685 = yyv3685[yymk3685]
+			if yymg3690 {
+				yymv3690 = yyv3690[yymk3690]
 			} else {
-				yymv3685 = nil
+				yymv3690 = nil
 			}
 			if r.TryDecodeAsNil() {
-				yymv3685 = nil
+				yymv3690 = nil
 			} else {
-				yyv3690 := &yymv3685
-				yym3691 := z.DecBinary()
-				_ = yym3691
+				yyv3695 := &yymv3690
+				yym3696 := z.DecBinary()
+				_ = yym3696
 				if false {
 				} else {
-					*yyv3690 = r.DecodeBytes(*(*[]byte)(yyv3690), false, false)
+					*yyv3695 = r.DecodeBytes(*(*[]byte)(yyv3695), false, false)
 				}
 			}
 
-			if yyv3685 != nil {
-				yyv3685[yymk3685] = yymv3685
+			if yyv3690 != nil {
+				yyv3690[yymk3690] = yymv3690
 			}
 		}
 		r.ReadEnd()
@@ -43724,9 +43761,9 @@ func (x codecSelfer1234) encSliceSecret(v []Secret, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3692 := range v {
-		yy3693 := &yyv3692
-		yy3693.CodecEncodeSelf(e)
+	for _, yyv3697 := range v {
+		yy3698 := &yyv3697
+		yy3698.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -43736,75 +43773,75 @@ func (x codecSelfer1234) decSliceSecret(v *[]Secret, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3694 := *v
-	yyh3694, yyl3694 := z.DecSliceHelperStart()
+	yyv3699 := *v
+	yyh3699, yyl3699 := z.DecSliceHelperStart()
 
-	var yyrr3694, yyrl3694 int
-	var yyc3694, yyrt3694 bool
-	_, _, _ = yyc3694, yyrt3694, yyrl3694
-	yyrr3694 = yyl3694
+	var yyrr3699, yyrl3699 int
+	var yyc3699, yyrt3699 bool
+	_, _, _ = yyc3699, yyrt3699, yyrl3699
+	yyrr3699 = yyl3699
 
-	if yyv3694 == nil {
-		if yyrl3694, yyrt3694 = z.DecInferLen(yyl3694, z.DecBasicHandle().MaxInitLen, 216); yyrt3694 {
-			yyrr3694 = yyrl3694
+	if yyv3699 == nil {
+		if yyrl3699, yyrt3699 = z.DecInferLen(yyl3699, z.DecBasicHandle().MaxInitLen, 216); yyrt3699 {
+			yyrr3699 = yyrl3699
 		}
-		yyv3694 = make([]Secret, yyrl3694)
-		yyc3694 = true
+		yyv3699 = make([]Secret, yyrl3699)
+		yyc3699 = true
 	}
 
-	if yyl3694 == 0 {
-		if len(yyv3694) != 0 {
-			yyv3694 = yyv3694[:0]
-			yyc3694 = true
+	if yyl3699 == 0 {
+		if len(yyv3699) != 0 {
+			yyv3699 = yyv3699[:0]
+			yyc3699 = true
 		}
-	} else if yyl3694 > 0 {
+	} else if yyl3699 > 0 {
 
-		if yyl3694 > cap(yyv3694) {
-			yyrl3694, yyrt3694 = z.DecInferLen(yyl3694, z.DecBasicHandle().MaxInitLen, 216)
-			yyv3694 = make([]Secret, yyrl3694)
-			yyc3694 = true
+		if yyl3699 > cap(yyv3699) {
+			yyrl3699, yyrt3699 = z.DecInferLen(yyl3699, z.DecBasicHandle().MaxInitLen, 216)
+			yyv3699 = make([]Secret, yyrl3699)
+			yyc3699 = true
 
-			yyrr3694 = len(yyv3694)
-		} else if yyl3694 != len(yyv3694) {
-			yyv3694 = yyv3694[:yyl3694]
-			yyc3694 = true
+			yyrr3699 = len(yyv3699)
+		} else if yyl3699 != len(yyv3699) {
+			yyv3699 = yyv3699[:yyl3699]
+			yyc3699 = true
 		}
-		yyj3694 := 0
-		for ; yyj3694 < yyrr3694; yyj3694++ {
+		yyj3699 := 0
+		for ; yyj3699 < yyrr3699; yyj3699++ {
 			if r.TryDecodeAsNil() {
-				yyv3694[yyj3694] = Secret{}
+				yyv3699[yyj3699] = Secret{}
 			} else {
-				yyv3695 := &yyv3694[yyj3694]
-				yyv3695.CodecDecodeSelf(d)
+				yyv3700 := &yyv3699[yyj3699]
+				yyv3700.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3694 {
-			for ; yyj3694 < yyl3694; yyj3694++ {
-				yyv3694 = append(yyv3694, Secret{})
+		if yyrt3699 {
+			for ; yyj3699 < yyl3699; yyj3699++ {
+				yyv3699 = append(yyv3699, Secret{})
 				if r.TryDecodeAsNil() {
-					yyv3694[yyj3694] = Secret{}
+					yyv3699[yyj3699] = Secret{}
 				} else {
-					yyv3696 := &yyv3694[yyj3694]
-					yyv3696.CodecDecodeSelf(d)
+					yyv3701 := &yyv3699[yyj3699]
+					yyv3701.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3694 := 0; !r.CheckBreak(); yyj3694++ {
-			if yyj3694 >= len(yyv3694) {
-				yyv3694 = append(yyv3694, Secret{}) // var yyz3694 Secret
-				yyc3694 = true
+		for yyj3699 := 0; !r.CheckBreak(); yyj3699++ {
+			if yyj3699 >= len(yyv3699) {
+				yyv3699 = append(yyv3699, Secret{}) // var yyz3699 Secret
+				yyc3699 = true
 			}
 
-			if yyj3694 < len(yyv3694) {
+			if yyj3699 < len(yyv3699) {
 				if r.TryDecodeAsNil() {
-					yyv3694[yyj3694] = Secret{}
+					yyv3699[yyj3699] = Secret{}
 				} else {
-					yyv3697 := &yyv3694[yyj3694]
-					yyv3697.CodecDecodeSelf(d)
+					yyv3702 := &yyv3699[yyj3699]
+					yyv3702.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -43812,10 +43849,10 @@ func (x codecSelfer1234) decSliceSecret(v *[]Secret, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh3694.End()
+		yyh3699.End()
 	}
-	if yyc3694 {
-		*v = yyv3694
+	if yyc3699 {
+		*v = yyv3699
 	}
 
 }
@@ -43825,9 +43862,9 @@ func (x codecSelfer1234) encSliceComponentCondition(v []ComponentCondition, e *c
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3698 := range v {
-		yy3699 := &yyv3698
-		yy3699.CodecEncodeSelf(e)
+	for _, yyv3703 := range v {
+		yy3704 := &yyv3703
+		yy3704.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -43837,75 +43874,75 @@ func (x codecSelfer1234) decSliceComponentCondition(v *[]ComponentCondition, d *
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3700 := *v
-	yyh3700, yyl3700 := z.DecSliceHelperStart()
+	yyv3705 := *v
+	yyh3705, yyl3705 := z.DecSliceHelperStart()
 
-	var yyrr3700, yyrl3700 int
-	var yyc3700, yyrt3700 bool
-	_, _, _ = yyc3700, yyrt3700, yyrl3700
-	yyrr3700 = yyl3700
+	var yyrr3705, yyrl3705 int
+	var yyc3705, yyrt3705 bool
+	_, _, _ = yyc3705, yyrt3705, yyrl3705
+	yyrr3705 = yyl3705
 
-	if yyv3700 == nil {
-		if yyrl3700, yyrt3700 = z.DecInferLen(yyl3700, z.DecBasicHandle().MaxInitLen, 64); yyrt3700 {
-			yyrr3700 = yyrl3700
+	if yyv3705 == nil {
+		if yyrl3705, yyrt3705 = z.DecInferLen(yyl3705, z.DecBasicHandle().MaxInitLen, 64); yyrt3705 {
+			yyrr3705 = yyrl3705
 		}
-		yyv3700 = make([]ComponentCondition, yyrl3700)
-		yyc3700 = true
+		yyv3705 = make([]ComponentCondition, yyrl3705)
+		yyc3705 = true
 	}
 
-	if yyl3700 == 0 {
-		if len(yyv3700) != 0 {
-			yyv3700 = yyv3700[:0]
-			yyc3700 = true
+	if yyl3705 == 0 {
+		if len(yyv3705) != 0 {
+			yyv3705 = yyv3705[:0]
+			yyc3705 = true
 		}
-	} else if yyl3700 > 0 {
+	} else if yyl3705 > 0 {
 
-		if yyl3700 > cap(yyv3700) {
-			yyrl3700, yyrt3700 = z.DecInferLen(yyl3700, z.DecBasicHandle().MaxInitLen, 64)
-			yyv3700 = make([]ComponentCondition, yyrl3700)
-			yyc3700 = true
+		if yyl3705 > cap(yyv3705) {
+			yyrl3705, yyrt3705 = z.DecInferLen(yyl3705, z.DecBasicHandle().MaxInitLen, 64)
+			yyv3705 = make([]ComponentCondition, yyrl3705)
+			yyc3705 = true
 
-			yyrr3700 = len(yyv3700)
-		} else if yyl3700 != len(yyv3700) {
-			yyv3700 = yyv3700[:yyl3700]
-			yyc3700 = true
+			yyrr3705 = len(yyv3705)
+		} else if yyl3705 != len(yyv3705) {
+			yyv3705 = yyv3705[:yyl3705]
+			yyc3705 = true
 		}
-		yyj3700 := 0
-		for ; yyj3700 < yyrr3700; yyj3700++ {
+		yyj3705 := 0
+		for ; yyj3705 < yyrr3705; yyj3705++ {
 			if r.TryDecodeAsNil() {
-				yyv3700[yyj3700] = ComponentCondition{}
+				yyv3705[yyj3705] = ComponentCondition{}
 			} else {
-				yyv3701 := &yyv3700[yyj3700]
-				yyv3701.CodecDecodeSelf(d)
+				yyv3706 := &yyv3705[yyj3705]
+				yyv3706.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3700 {
-			for ; yyj3700 < yyl3700; yyj3700++ {
-				yyv3700 = append(yyv3700, ComponentCondition{})
+		if yyrt3705 {
+			for ; yyj3705 < yyl3705; yyj3705++ {
+				yyv3705 = append(yyv3705, ComponentCondition{})
 				if r.TryDecodeAsNil() {
-					yyv3700[yyj3700] = ComponentCondition{}
+					yyv3705[yyj3705] = ComponentCondition{}
 				} else {
-					yyv3702 := &yyv3700[yyj3700]
-					yyv3702.CodecDecodeSelf(d)
+					yyv3707 := &yyv3705[yyj3705]
+					yyv3707.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3700 := 0; !r.CheckBreak(); yyj3700++ {
-			if yyj3700 >= len(yyv3700) {
-				yyv3700 = append(yyv3700, ComponentCondition{}) // var yyz3700 ComponentCondition
-				yyc3700 = true
+		for yyj3705 := 0; !r.CheckBreak(); yyj3705++ {
+			if yyj3705 >= len(yyv3705) {
+				yyv3705 = append(yyv3705, ComponentCondition{}) // var yyz3705 ComponentCondition
+				yyc3705 = true
 			}
 
-			if yyj3700 < len(yyv3700) {
+			if yyj3705 < len(yyv3705) {
 				if r.TryDecodeAsNil() {
-					yyv3700[yyj3700] = ComponentCondition{}
+					yyv3705[yyj3705] = ComponentCondition{}
 				} else {
-					yyv3703 := &yyv3700[yyj3700]
-					yyv3703.CodecDecodeSelf(d)
+					yyv3708 := &yyv3705[yyj3705]
+					yyv3708.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -43913,10 +43950,10 @@ func (x codecSelfer1234) decSliceComponentCondition(v *[]ComponentCondition, d *
 			}
 
 		}
-		yyh3700.End()
+		yyh3705.End()
 	}
-	if yyc3700 {
-		*v = yyv3700
+	if yyc3705 {
+		*v = yyv3705
 	}
 
 }
@@ -43926,9 +43963,9 @@ func (x codecSelfer1234) encSliceComponentStatus(v []ComponentStatus, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3704 := range v {
-		yy3705 := &yyv3704
-		yy3705.CodecEncodeSelf(e)
+	for _, yyv3709 := range v {
+		yy3710 := &yyv3709
+		yy3710.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -43938,75 +43975,75 @@ func (x codecSelfer1234) decSliceComponentStatus(v *[]ComponentStatus, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3706 := *v
-	yyh3706, yyl3706 := z.DecSliceHelperStart()
+	yyv3711 := *v
+	yyh3711, yyl3711 := z.DecSliceHelperStart()
 
-	var yyrr3706, yyrl3706 int
-	var yyc3706, yyrt3706 bool
-	_, _, _ = yyc3706, yyrt3706, yyrl3706
-	yyrr3706 = yyl3706
+	var yyrr3711, yyrl3711 int
+	var yyc3711, yyrt3711 bool
+	_, _, _ = yyc3711, yyrt3711, yyrl3711
+	yyrr3711 = yyl3711
 
-	if yyv3706 == nil {
-		if yyrl3706, yyrt3706 = z.DecInferLen(yyl3706, z.DecBasicHandle().MaxInitLen, 216); yyrt3706 {
-			yyrr3706 = yyrl3706
+	if yyv3711 == nil {
+		if yyrl3711, yyrt3711 = z.DecInferLen(yyl3711, z.DecBasicHandle().MaxInitLen, 216); yyrt3711 {
+			yyrr3711 = yyrl3711
 		}
-		yyv3706 = make([]ComponentStatus, yyrl3706)
-		yyc3706 = true
+		yyv3711 = make([]ComponentStatus, yyrl3711)
+		yyc3711 = true
 	}
 
-	if yyl3706 == 0 {
-		if len(yyv3706) != 0 {
-			yyv3706 = yyv3706[:0]
-			yyc3706 = true
+	if yyl3711 == 0 {
+		if len(yyv3711) != 0 {
+			yyv3711 = yyv3711[:0]
+			yyc3711 = true
 		}
-	} else if yyl3706 > 0 {
+	} else if yyl3711 > 0 {
 
-		if yyl3706 > cap(yyv3706) {
-			yyrl3706, yyrt3706 = z.DecInferLen(yyl3706, z.DecBasicHandle().MaxInitLen, 216)
-			yyv3706 = make([]ComponentStatus, yyrl3706)
-			yyc3706 = true
+		if yyl3711 > cap(yyv3711) {
+			yyrl3711, yyrt3711 = z.DecInferLen(yyl3711, z.DecBasicHandle().MaxInitLen, 216)
+			yyv3711 = make([]ComponentStatus, yyrl3711)
+			yyc3711 = true
 
-			yyrr3706 = len(yyv3706)
-		} else if yyl3706 != len(yyv3706) {
-			yyv3706 = yyv3706[:yyl3706]
-			yyc3706 = true
+			yyrr3711 = len(yyv3711)
+		} else if yyl3711 != len(yyv3711) {
+			yyv3711 = yyv3711[:yyl3711]
+			yyc3711 = true
 		}
-		yyj3706 := 0
-		for ; yyj3706 < yyrr3706; yyj3706++ {
+		yyj3711 := 0
+		for ; yyj3711 < yyrr3711; yyj3711++ {
 			if r.TryDecodeAsNil() {
-				yyv3706[yyj3706] = ComponentStatus{}
+				yyv3711[yyj3711] = ComponentStatus{}
 			} else {
-				yyv3707 := &yyv3706[yyj3706]
-				yyv3707.CodecDecodeSelf(d)
+				yyv3712 := &yyv3711[yyj3711]
+				yyv3712.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3706 {
-			for ; yyj3706 < yyl3706; yyj3706++ {
-				yyv3706 = append(yyv3706, ComponentStatus{})
+		if yyrt3711 {
+			for ; yyj3711 < yyl3711; yyj3711++ {
+				yyv3711 = append(yyv3711, ComponentStatus{})
 				if r.TryDecodeAsNil() {
-					yyv3706[yyj3706] = ComponentStatus{}
+					yyv3711[yyj3711] = ComponentStatus{}
 				} else {
-					yyv3708 := &yyv3706[yyj3706]
-					yyv3708.CodecDecodeSelf(d)
+					yyv3713 := &yyv3711[yyj3711]
+					yyv3713.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3706 := 0; !r.CheckBreak(); yyj3706++ {
-			if yyj3706 >= len(yyv3706) {
-				yyv3706 = append(yyv3706, ComponentStatus{}) // var yyz3706 ComponentStatus
-				yyc3706 = true
+		for yyj3711 := 0; !r.CheckBreak(); yyj3711++ {
+			if yyj3711 >= len(yyv3711) {
+				yyv3711 = append(yyv3711, ComponentStatus{}) // var yyz3711 ComponentStatus
+				yyc3711 = true
 			}
 
-			if yyj3706 < len(yyv3706) {
+			if yyj3711 < len(yyv3711) {
 				if r.TryDecodeAsNil() {
-					yyv3706[yyj3706] = ComponentStatus{}
+					yyv3711[yyj3711] = ComponentStatus{}
 				} else {
-					yyv3709 := &yyv3706[yyj3706]
-					yyv3709.CodecDecodeSelf(d)
+					yyv3714 := &yyv3711[yyj3711]
+					yyv3714.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -44014,10 +44051,10 @@ func (x codecSelfer1234) decSliceComponentStatus(v *[]ComponentStatus, d *codec1
 			}
 
 		}
-		yyh3706.End()
+		yyh3711.End()
 	}
-	if yyc3706 {
-		*v = yyv3706
+	if yyc3711 {
+		*v = yyv3711
 	}
 
 }
@@ -44027,9 +44064,9 @@ func (x codecSelfer1234) encSliceDownwardAPIVolumeFile(v []DownwardAPIVolumeFile
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv3710 := range v {
-		yy3711 := &yyv3710
-		yy3711.CodecEncodeSelf(e)
+	for _, yyv3715 := range v {
+		yy3716 := &yyv3715
+		yy3716.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -44039,75 +44076,75 @@ func (x codecSelfer1234) decSliceDownwardAPIVolumeFile(v *[]DownwardAPIVolumeFil
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv3712 := *v
-	yyh3712, yyl3712 := z.DecSliceHelperStart()
+	yyv3717 := *v
+	yyh3717, yyl3717 := z.DecSliceHelperStart()
 
-	var yyrr3712, yyrl3712 int
-	var yyc3712, yyrt3712 bool
-	_, _, _ = yyc3712, yyrt3712, yyrl3712
-	yyrr3712 = yyl3712
+	var yyrr3717, yyrl3717 int
+	var yyc3717, yyrt3717 bool
+	_, _, _ = yyc3717, yyrt3717, yyrl3717
+	yyrr3717 = yyl3717
 
-	if yyv3712 == nil {
-		if yyrl3712, yyrt3712 = z.DecInferLen(yyl3712, z.DecBasicHandle().MaxInitLen, 48); yyrt3712 {
-			yyrr3712 = yyrl3712
+	if yyv3717 == nil {
+		if yyrl3717, yyrt3717 = z.DecInferLen(yyl3717, z.DecBasicHandle().MaxInitLen, 48); yyrt3717 {
+			yyrr3717 = yyrl3717
 		}
-		yyv3712 = make([]DownwardAPIVolumeFile, yyrl3712)
-		yyc3712 = true
+		yyv3717 = make([]DownwardAPIVolumeFile, yyrl3717)
+		yyc3717 = true
 	}
 
-	if yyl3712 == 0 {
-		if len(yyv3712) != 0 {
-			yyv3712 = yyv3712[:0]
-			yyc3712 = true
+	if yyl3717 == 0 {
+		if len(yyv3717) != 0 {
+			yyv3717 = yyv3717[:0]
+			yyc3717 = true
 		}
-	} else if yyl3712 > 0 {
+	} else if yyl3717 > 0 {
 
-		if yyl3712 > cap(yyv3712) {
-			yyrl3712, yyrt3712 = z.DecInferLen(yyl3712, z.DecBasicHandle().MaxInitLen, 48)
-			yyv3712 = make([]DownwardAPIVolumeFile, yyrl3712)
-			yyc3712 = true
+		if yyl3717 > cap(yyv3717) {
+			yyrl3717, yyrt3717 = z.DecInferLen(yyl3717, z.DecBasicHandle().MaxInitLen, 48)
+			yyv3717 = make([]DownwardAPIVolumeFile, yyrl3717)
+			yyc3717 = true
 
-			yyrr3712 = len(yyv3712)
-		} else if yyl3712 != len(yyv3712) {
-			yyv3712 = yyv3712[:yyl3712]
-			yyc3712 = true
+			yyrr3717 = len(yyv3717)
+		} else if yyl3717 != len(yyv3717) {
+			yyv3717 = yyv3717[:yyl3717]
+			yyc3717 = true
 		}
-		yyj3712 := 0
-		for ; yyj3712 < yyrr3712; yyj3712++ {
+		yyj3717 := 0
+		for ; yyj3717 < yyrr3717; yyj3717++ {
 			if r.TryDecodeAsNil() {
-				yyv3712[yyj3712] = DownwardAPIVolumeFile{}
+				yyv3717[yyj3717] = DownwardAPIVolumeFile{}
 			} else {
-				yyv3713 := &yyv3712[yyj3712]
-				yyv3713.CodecDecodeSelf(d)
+				yyv3718 := &yyv3717[yyj3717]
+				yyv3718.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt3712 {
-			for ; yyj3712 < yyl3712; yyj3712++ {
-				yyv3712 = append(yyv3712, DownwardAPIVolumeFile{})
+		if yyrt3717 {
+			for ; yyj3717 < yyl3717; yyj3717++ {
+				yyv3717 = append(yyv3717, DownwardAPIVolumeFile{})
 				if r.TryDecodeAsNil() {
-					yyv3712[yyj3712] = DownwardAPIVolumeFile{}
+					yyv3717[yyj3717] = DownwardAPIVolumeFile{}
 				} else {
-					yyv3714 := &yyv3712[yyj3712]
-					yyv3714.CodecDecodeSelf(d)
+					yyv3719 := &yyv3717[yyj3717]
+					yyv3719.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj3712 := 0; !r.CheckBreak(); yyj3712++ {
-			if yyj3712 >= len(yyv3712) {
-				yyv3712 = append(yyv3712, DownwardAPIVolumeFile{}) // var yyz3712 DownwardAPIVolumeFile
-				yyc3712 = true
+		for yyj3717 := 0; !r.CheckBreak(); yyj3717++ {
+			if yyj3717 >= len(yyv3717) {
+				yyv3717 = append(yyv3717, DownwardAPIVolumeFile{}) // var yyz3717 DownwardAPIVolumeFile
+				yyc3717 = true
 			}
 
-			if yyj3712 < len(yyv3712) {
+			if yyj3717 < len(yyv3717) {
 				if r.TryDecodeAsNil() {
-					yyv3712[yyj3712] = DownwardAPIVolumeFile{}
+					yyv3717[yyj3717] = DownwardAPIVolumeFile{}
 				} else {
-					yyv3715 := &yyv3712[yyj3712]
-					yyv3715.CodecDecodeSelf(d)
+					yyv3720 := &yyv3717[yyj3717]
+					yyv3720.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -44115,10 +44152,10 @@ func (x codecSelfer1234) decSliceDownwardAPIVolumeFile(v *[]DownwardAPIVolumeFil
 			}
 
 		}
-		yyh3712.End()
+		yyh3717.End()
 	}
-	if yyc3712 {
-		*v = yyv3712
+	if yyc3717 {
+		*v = yyv3717
 	}
 
 }

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -1904,6 +1904,8 @@ type NodeAddress struct {
 	Type NodeAddressType `json:"type"`
 	// The node address.
 	Address string `json:"address"`
+	// The node subnet.
+	Subnet string `json:"subnet"`
 }
 
 // ResourceName is the name identifying various resources in a ResourceList.

--- a/pkg/api/v1/types_swagger_doc_generated.go
+++ b/pkg/api/v1/types_swagger_doc_generated.go
@@ -646,6 +646,7 @@ var map_NodeAddress = map[string]string{
 	"":        "NodeAddress contains information for the node's address.",
 	"type":    "Node address type, one of Hostname, ExternalIP or InternalIP.",
 	"address": "The node address.",
+	"subnet":  "The node subnet.",
 }
 
 func (NodeAddress) SwaggerDoc() map[string]string {

--- a/pkg/apis/extensions/types.generated.go
+++ b/pkg/apis/extensions/types.generated.go
@@ -524,43 +524,55 @@ func (x *Scale) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr31 || yy2arr31 {
 				if yyq31[2] {
 					yy39 := &x.ObjectMeta
-					yy39.CodecEncodeSelf(e)
+					yym40 := z.EncBinary()
+					_ = yym40
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy39) {
+					} else {
+						z.EncFallback(yy39)
+					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
 				if yyq31[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy40 := &x.ObjectMeta
-					yy40.CodecEncodeSelf(e)
+					yy41 := &x.ObjectMeta
+					yym42 := z.EncBinary()
+					_ = yym42
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy41) {
+					} else {
+						z.EncFallback(yy41)
+					}
 				}
 			}
 			if yyr31 || yy2arr31 {
 				if yyq31[3] {
-					yy42 := &x.Spec
-					yy42.CodecEncodeSelf(e)
+					yy44 := &x.Spec
+					yy44.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
 				if yyq31[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy43 := &x.Spec
-					yy43.CodecEncodeSelf(e)
+					yy45 := &x.Spec
+					yy45.CodecEncodeSelf(e)
 				}
 			}
 			if yyr31 || yy2arr31 {
 				if yyq31[4] {
-					yy45 := &x.Status
-					yy45.CodecEncodeSelf(e)
+					yy47 := &x.Status
+					yy47.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
 				if yyq31[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy46 := &x.Status
-					yy46.CodecEncodeSelf(e)
+					yy48 := &x.Status
+					yy48.CodecEncodeSelf(e)
 				}
 			}
 			if yysep31 {
@@ -574,24 +586,24 @@ func (x *Scale) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym47 := z.DecBinary()
-	_ = yym47
+	yym49 := z.DecBinary()
+	_ = yym49
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl48 := r.ReadMapStart()
-			if yyl48 == 0 {
+			yyl50 := r.ReadMapStart()
+			if yyl50 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl48, d)
+				x.codecDecodeSelfFromMap(yyl50, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl48 := r.ReadArrayStart()
-			if yyl48 == 0 {
+			yyl50 := r.ReadArrayStart()
+			if yyl50 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl48, d)
+				x.codecDecodeSelfFromArray(yyl50, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -603,12 +615,12 @@ func (x *Scale) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys49Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys49Slc
-	var yyhl49 bool = l >= 0
-	for yyj49 := 0; ; yyj49++ {
-		if yyhl49 {
-			if yyj49 >= l {
+	var yys51Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys51Slc
+	var yyhl51 bool = l >= 0
+	for yyj51 := 0; ; yyj51++ {
+		if yyhl51 {
+			if yyj51 >= l {
 				break
 			}
 		} else {
@@ -616,9 +628,9 @@ func (x *Scale) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys49Slc = r.DecodeBytes(yys49Slc, true, true)
-		yys49 := string(yys49Slc)
-		switch yys49 {
+		yys51Slc = r.DecodeBytes(yys51Slc, true, true)
+		yys51 := string(yys51Slc)
+		switch yys51 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -635,28 +647,34 @@ func (x *Scale) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv52 := &x.ObjectMeta
-				yyv52.CodecDecodeSelf(d)
+				yyv54 := &x.ObjectMeta
+				yym55 := z.DecBinary()
+				_ = yym55
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv54) {
+				} else {
+					z.DecFallback(yyv54, false)
+				}
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = ScaleSpec{}
 			} else {
-				yyv53 := &x.Spec
-				yyv53.CodecDecodeSelf(d)
+				yyv56 := &x.Spec
+				yyv56.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = ScaleStatus{}
 			} else {
-				yyv54 := &x.Status
-				yyv54.CodecDecodeSelf(d)
+				yyv57 := &x.Status
+				yyv57.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys49)
-		} // end switch yys49
-	} // end for yyj49
-	if !yyhl49 {
+			z.DecStructFieldNotFound(-1, yys51)
+		} // end switch yys51
+	} // end for yyj51
+	if !yyhl51 {
 		r.ReadEnd()
 	}
 }
@@ -665,16 +683,16 @@ func (x *Scale) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj55 int
-	var yyb55 bool
-	var yyhl55 bool = l >= 0
-	yyj55++
-	if yyhl55 {
-		yyb55 = yyj55 > l
+	var yyj58 int
+	var yyb58 bool
+	var yyhl58 bool = l >= 0
+	yyj58++
+	if yyhl58 {
+		yyb58 = yyj58 > l
 	} else {
-		yyb55 = r.CheckBreak()
+		yyb58 = r.CheckBreak()
 	}
-	if yyb55 {
+	if yyb58 {
 		r.ReadEnd()
 		return
 	}
@@ -683,13 +701,13 @@ func (x *Scale) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj55++
-	if yyhl55 {
-		yyb55 = yyj55 > l
+	yyj58++
+	if yyhl58 {
+		yyb58 = yyj58 > l
 	} else {
-		yyb55 = r.CheckBreak()
+		yyb58 = r.CheckBreak()
 	}
-	if yyb55 {
+	if yyb58 {
 		r.ReadEnd()
 		return
 	}
@@ -698,65 +716,71 @@ func (x *Scale) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj55++
-	if yyhl55 {
-		yyb55 = yyj55 > l
+	yyj58++
+	if yyhl58 {
+		yyb58 = yyj58 > l
 	} else {
-		yyb55 = r.CheckBreak()
+		yyb58 = r.CheckBreak()
 	}
-	if yyb55 {
+	if yyb58 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv58 := &x.ObjectMeta
-		yyv58.CodecDecodeSelf(d)
+		yyv61 := &x.ObjectMeta
+		yym62 := z.DecBinary()
+		_ = yym62
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv61) {
+		} else {
+			z.DecFallback(yyv61, false)
+		}
 	}
-	yyj55++
-	if yyhl55 {
-		yyb55 = yyj55 > l
+	yyj58++
+	if yyhl58 {
+		yyb58 = yyj58 > l
 	} else {
-		yyb55 = r.CheckBreak()
+		yyb58 = r.CheckBreak()
 	}
-	if yyb55 {
+	if yyb58 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = ScaleSpec{}
 	} else {
-		yyv59 := &x.Spec
-		yyv59.CodecDecodeSelf(d)
+		yyv63 := &x.Spec
+		yyv63.CodecDecodeSelf(d)
 	}
-	yyj55++
-	if yyhl55 {
-		yyb55 = yyj55 > l
+	yyj58++
+	if yyhl58 {
+		yyb58 = yyj58 > l
 	} else {
-		yyb55 = r.CheckBreak()
+		yyb58 = r.CheckBreak()
 	}
-	if yyb55 {
+	if yyb58 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = ScaleStatus{}
 	} else {
-		yyv60 := &x.Status
-		yyv60.CodecDecodeSelf(d)
+		yyv64 := &x.Status
+		yyv64.CodecDecodeSelf(d)
 	}
 	for {
-		yyj55++
-		if yyhl55 {
-			yyb55 = yyj55 > l
+		yyj58++
+		if yyhl58 {
+			yyb58 = yyj58 > l
 		} else {
-			yyb55 = r.CheckBreak()
+			yyb58 = r.CheckBreak()
 		}
-		if yyb55 {
+		if yyb58 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj55-1, "")
+		z.DecStructFieldNotFound(yyj58-1, "")
 	}
 	r.ReadEnd()
 }
@@ -768,74 +792,74 @@ func (x *ReplicationControllerDummy) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym61 := z.EncBinary()
-		_ = yym61
+		yym65 := z.EncBinary()
+		_ = yym65
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep62 := !z.EncBinary()
-			yy2arr62 := z.EncBasicHandle().StructToArray
-			var yyq62 [2]bool
-			_, _, _ = yysep62, yyq62, yy2arr62
-			const yyr62 bool = false
-			yyq62[0] = x.Kind != ""
-			yyq62[1] = x.APIVersion != ""
-			if yyr62 || yy2arr62 {
+			yysep66 := !z.EncBinary()
+			yy2arr66 := z.EncBasicHandle().StructToArray
+			var yyq66 [2]bool
+			_, _, _ = yysep66, yyq66, yy2arr66
+			const yyr66 bool = false
+			yyq66[0] = x.Kind != ""
+			yyq66[1] = x.APIVersion != ""
+			if yyr66 || yy2arr66 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn62 int = 0
-				for _, b := range yyq62 {
+				var yynn66 int = 0
+				for _, b := range yyq66 {
 					if b {
-						yynn62++
+						yynn66++
 					}
 				}
-				r.EncodeMapStart(yynn62)
+				r.EncodeMapStart(yynn66)
 			}
-			if yyr62 || yy2arr62 {
-				if yyq62[0] {
-					yym64 := z.EncBinary()
-					_ = yym64
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq62[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym65 := z.EncBinary()
-					_ = yym65
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr62 || yy2arr62 {
-				if yyq62[1] {
-					yym67 := z.EncBinary()
-					_ = yym67
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq62[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr66 || yy2arr66 {
+				if yyq66[0] {
 					yym68 := z.EncBinary()
 					_ = yym68
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq66[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym69 := z.EncBinary()
+					_ = yym69
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr66 || yy2arr66 {
+				if yyq66[1] {
+					yym71 := z.EncBinary()
+					_ = yym71
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq66[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym72 := z.EncBinary()
+					_ = yym72
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yysep62 {
+			if yysep66 {
 				r.EncodeEnd()
 			}
 		}
@@ -846,24 +870,24 @@ func (x *ReplicationControllerDummy) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym69 := z.DecBinary()
-	_ = yym69
+	yym73 := z.DecBinary()
+	_ = yym73
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl70 := r.ReadMapStart()
-			if yyl70 == 0 {
+			yyl74 := r.ReadMapStart()
+			if yyl74 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl70, d)
+				x.codecDecodeSelfFromMap(yyl74, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl70 := r.ReadArrayStart()
-			if yyl70 == 0 {
+			yyl74 := r.ReadArrayStart()
+			if yyl74 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl70, d)
+				x.codecDecodeSelfFromArray(yyl74, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -875,12 +899,12 @@ func (x *ReplicationControllerDummy) codecDecodeSelfFromMap(l int, d *codec1978.
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys71Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys71Slc
-	var yyhl71 bool = l >= 0
-	for yyj71 := 0; ; yyj71++ {
-		if yyhl71 {
-			if yyj71 >= l {
+	var yys75Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys75Slc
+	var yyhl75 bool = l >= 0
+	for yyj75 := 0; ; yyj75++ {
+		if yyhl75 {
+			if yyj75 >= l {
 				break
 			}
 		} else {
@@ -888,9 +912,9 @@ func (x *ReplicationControllerDummy) codecDecodeSelfFromMap(l int, d *codec1978.
 				break
 			}
 		}
-		yys71Slc = r.DecodeBytes(yys71Slc, true, true)
-		yys71 := string(yys71Slc)
-		switch yys71 {
+		yys75Slc = r.DecodeBytes(yys75Slc, true, true)
+		yys75 := string(yys75Slc)
+		switch yys75 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -904,10 +928,10 @@ func (x *ReplicationControllerDummy) codecDecodeSelfFromMap(l int, d *codec1978.
 				x.APIVersion = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys71)
-		} // end switch yys71
-	} // end for yyj71
-	if !yyhl71 {
+			z.DecStructFieldNotFound(-1, yys75)
+		} // end switch yys75
+	} // end for yyj75
+	if !yyhl75 {
 		r.ReadEnd()
 	}
 }
@@ -916,16 +940,16 @@ func (x *ReplicationControllerDummy) codecDecodeSelfFromArray(l int, d *codec197
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj74 int
-	var yyb74 bool
-	var yyhl74 bool = l >= 0
-	yyj74++
-	if yyhl74 {
-		yyb74 = yyj74 > l
+	var yyj78 int
+	var yyb78 bool
+	var yyhl78 bool = l >= 0
+	yyj78++
+	if yyhl78 {
+		yyb78 = yyj78 > l
 	} else {
-		yyb74 = r.CheckBreak()
+		yyb78 = r.CheckBreak()
 	}
-	if yyb74 {
+	if yyb78 {
 		r.ReadEnd()
 		return
 	}
@@ -934,13 +958,13 @@ func (x *ReplicationControllerDummy) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj74++
-	if yyhl74 {
-		yyb74 = yyj74 > l
+	yyj78++
+	if yyhl78 {
+		yyb78 = yyj78 > l
 	} else {
-		yyb74 = r.CheckBreak()
+		yyb78 = r.CheckBreak()
 	}
-	if yyb74 {
+	if yyb78 {
 		r.ReadEnd()
 		return
 	}
@@ -950,16 +974,16 @@ func (x *ReplicationControllerDummy) codecDecodeSelfFromArray(l int, d *codec197
 		x.APIVersion = string(r.DecodeString())
 	}
 	for {
-		yyj74++
-		if yyhl74 {
-			yyb74 = yyj74 > l
+		yyj78++
+		if yyhl78 {
+			yyb78 = yyj78 > l
 		} else {
-			yyb74 = r.CheckBreak()
+			yyb78 = r.CheckBreak()
 		}
-		if yyb74 {
+		if yyb78 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj74-1, "")
+		z.DecStructFieldNotFound(yyj78-1, "")
 	}
 	r.ReadEnd()
 }
@@ -971,124 +995,124 @@ func (x *SubresourceReference) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym77 := z.EncBinary()
-		_ = yym77
+		yym81 := z.EncBinary()
+		_ = yym81
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep78 := !z.EncBinary()
-			yy2arr78 := z.EncBasicHandle().StructToArray
-			var yyq78 [5]bool
-			_, _, _ = yysep78, yyq78, yy2arr78
-			const yyr78 bool = false
-			yyq78[0] = x.Kind != ""
-			yyq78[1] = x.Namespace != ""
-			yyq78[2] = x.Name != ""
-			yyq78[3] = x.APIVersion != ""
-			yyq78[4] = x.Subresource != ""
-			if yyr78 || yy2arr78 {
+			yysep82 := !z.EncBinary()
+			yy2arr82 := z.EncBasicHandle().StructToArray
+			var yyq82 [5]bool
+			_, _, _ = yysep82, yyq82, yy2arr82
+			const yyr82 bool = false
+			yyq82[0] = x.Kind != ""
+			yyq82[1] = x.Namespace != ""
+			yyq82[2] = x.Name != ""
+			yyq82[3] = x.APIVersion != ""
+			yyq82[4] = x.Subresource != ""
+			if yyr82 || yy2arr82 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn78 int = 0
-				for _, b := range yyq78 {
+				var yynn82 int = 0
+				for _, b := range yyq82 {
 					if b {
-						yynn78++
+						yynn82++
 					}
 				}
-				r.EncodeMapStart(yynn78)
+				r.EncodeMapStart(yynn82)
 			}
-			if yyr78 || yy2arr78 {
-				if yyq78[0] {
-					yym80 := z.EncBinary()
-					_ = yym80
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq78[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym81 := z.EncBinary()
-					_ = yym81
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr78 || yy2arr78 {
-				if yyq78[1] {
-					yym83 := z.EncBinary()
-					_ = yym83
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Namespace))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq78[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("namespace"))
+			if yyr82 || yy2arr82 {
+				if yyq82[0] {
 					yym84 := z.EncBinary()
 					_ = yym84
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Namespace))
-					}
-				}
-			}
-			if yyr78 || yy2arr78 {
-				if yyq78[2] {
-					yym86 := z.EncBinary()
-					_ = yym86
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq78[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("name"))
+				if yyq82[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym85 := z.EncBinary()
+					_ = yym85
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr82 || yy2arr82 {
+				if yyq82[1] {
 					yym87 := z.EncBinary()
 					_ = yym87
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
-					}
-				}
-			}
-			if yyr78 || yy2arr78 {
-				if yyq78[3] {
-					yym89 := z.EncBinary()
-					_ = yym89
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Namespace))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq78[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+				if yyq82[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("namespace"))
+					yym88 := z.EncBinary()
+					_ = yym88
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Namespace))
+					}
+				}
+			}
+			if yyr82 || yy2arr82 {
+				if yyq82[2] {
 					yym90 := z.EncBinary()
 					_ = yym90
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq82[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("name"))
+					yym91 := z.EncBinary()
+					_ = yym91
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+					}
+				}
+			}
+			if yyr82 || yy2arr82 {
+				if yyq82[3] {
+					yym93 := z.EncBinary()
+					_ = yym93
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq82[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym94 := z.EncBinary()
+					_ = yym94
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr78 || yy2arr78 {
-				if yyq78[4] {
-					yym92 := z.EncBinary()
-					_ = yym92
+			if yyr82 || yy2arr82 {
+				if yyq82[4] {
+					yym96 := z.EncBinary()
+					_ = yym96
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Subresource))
@@ -1097,17 +1121,17 @@ func (x *SubresourceReference) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq78[4] {
+				if yyq82[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("subresource"))
-					yym93 := z.EncBinary()
-					_ = yym93
+					yym97 := z.EncBinary()
+					_ = yym97
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Subresource))
 					}
 				}
 			}
-			if yysep78 {
+			if yysep82 {
 				r.EncodeEnd()
 			}
 		}
@@ -1118,24 +1142,24 @@ func (x *SubresourceReference) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym94 := z.DecBinary()
-	_ = yym94
+	yym98 := z.DecBinary()
+	_ = yym98
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl95 := r.ReadMapStart()
-			if yyl95 == 0 {
+			yyl99 := r.ReadMapStart()
+			if yyl99 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl95, d)
+				x.codecDecodeSelfFromMap(yyl99, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl95 := r.ReadArrayStart()
-			if yyl95 == 0 {
+			yyl99 := r.ReadArrayStart()
+			if yyl99 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl95, d)
+				x.codecDecodeSelfFromArray(yyl99, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -1147,12 +1171,12 @@ func (x *SubresourceReference) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys96Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys96Slc
-	var yyhl96 bool = l >= 0
-	for yyj96 := 0; ; yyj96++ {
-		if yyhl96 {
-			if yyj96 >= l {
+	var yys100Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys100Slc
+	var yyhl100 bool = l >= 0
+	for yyj100 := 0; ; yyj100++ {
+		if yyhl100 {
+			if yyj100 >= l {
 				break
 			}
 		} else {
@@ -1160,9 +1184,9 @@ func (x *SubresourceReference) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
-		yys96Slc = r.DecodeBytes(yys96Slc, true, true)
-		yys96 := string(yys96Slc)
-		switch yys96 {
+		yys100Slc = r.DecodeBytes(yys100Slc, true, true)
+		yys100 := string(yys100Slc)
+		switch yys100 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -1194,10 +1218,10 @@ func (x *SubresourceReference) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				x.Subresource = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys96)
-		} // end switch yys96
-	} // end for yyj96
-	if !yyhl96 {
+			z.DecStructFieldNotFound(-1, yys100)
+		} // end switch yys100
+	} // end for yyj100
+	if !yyhl100 {
 		r.ReadEnd()
 	}
 }
@@ -1206,16 +1230,16 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj102 int
-	var yyb102 bool
-	var yyhl102 bool = l >= 0
-	yyj102++
-	if yyhl102 {
-		yyb102 = yyj102 > l
+	var yyj106 int
+	var yyb106 bool
+	var yyhl106 bool = l >= 0
+	yyj106++
+	if yyhl106 {
+		yyb106 = yyj106 > l
 	} else {
-		yyb102 = r.CheckBreak()
+		yyb106 = r.CheckBreak()
 	}
-	if yyb102 {
+	if yyb106 {
 		r.ReadEnd()
 		return
 	}
@@ -1224,13 +1248,13 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj102++
-	if yyhl102 {
-		yyb102 = yyj102 > l
+	yyj106++
+	if yyhl106 {
+		yyb106 = yyj106 > l
 	} else {
-		yyb102 = r.CheckBreak()
+		yyb106 = r.CheckBreak()
 	}
-	if yyb102 {
+	if yyb106 {
 		r.ReadEnd()
 		return
 	}
@@ -1239,13 +1263,13 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.Namespace = string(r.DecodeString())
 	}
-	yyj102++
-	if yyhl102 {
-		yyb102 = yyj102 > l
+	yyj106++
+	if yyhl106 {
+		yyb106 = yyj106 > l
 	} else {
-		yyb102 = r.CheckBreak()
+		yyb106 = r.CheckBreak()
 	}
-	if yyb102 {
+	if yyb106 {
 		r.ReadEnd()
 		return
 	}
@@ -1254,13 +1278,13 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.Name = string(r.DecodeString())
 	}
-	yyj102++
-	if yyhl102 {
-		yyb102 = yyj102 > l
+	yyj106++
+	if yyhl106 {
+		yyb106 = yyj106 > l
 	} else {
-		yyb102 = r.CheckBreak()
+		yyb106 = r.CheckBreak()
 	}
-	if yyb102 {
+	if yyb106 {
 		r.ReadEnd()
 		return
 	}
@@ -1269,13 +1293,13 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj102++
-	if yyhl102 {
-		yyb102 = yyj102 > l
+	yyj106++
+	if yyhl106 {
+		yyb106 = yyj106 > l
 	} else {
-		yyb102 = r.CheckBreak()
+		yyb106 = r.CheckBreak()
 	}
-	if yyb102 {
+	if yyb106 {
 		r.ReadEnd()
 		return
 	}
@@ -1285,16 +1309,16 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		x.Subresource = string(r.DecodeString())
 	}
 	for {
-		yyj102++
-		if yyhl102 {
-			yyb102 = yyj102 > l
+		yyj106++
+		if yyhl106 {
+			yyb106 = yyj106 > l
 		} else {
-			yyb102 = r.CheckBreak()
+			yyb106 = r.CheckBreak()
 		}
-		if yyb102 {
+		if yyb106 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj102-1, "")
+		z.DecStructFieldNotFound(yyj106-1, "")
 	}
 	r.ReadEnd()
 }
@@ -1306,44 +1330,44 @@ func (x *CPUTargetUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym108 := z.EncBinary()
-		_ = yym108
+		yym112 := z.EncBinary()
+		_ = yym112
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep109 := !z.EncBinary()
-			yy2arr109 := z.EncBasicHandle().StructToArray
-			var yyq109 [1]bool
-			_, _, _ = yysep109, yyq109, yy2arr109
-			const yyr109 bool = false
-			if yyr109 || yy2arr109 {
+			yysep113 := !z.EncBinary()
+			yy2arr113 := z.EncBasicHandle().StructToArray
+			var yyq113 [1]bool
+			_, _, _ = yysep113, yyq113, yy2arr113
+			const yyr113 bool = false
+			if yyr113 || yy2arr113 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn109 int = 1
-				for _, b := range yyq109 {
+				var yynn113 int = 1
+				for _, b := range yyq113 {
 					if b {
-						yynn109++
+						yynn113++
 					}
 				}
-				r.EncodeMapStart(yynn109)
+				r.EncodeMapStart(yynn113)
 			}
-			if yyr109 || yy2arr109 {
-				yym111 := z.EncBinary()
-				_ = yym111
+			if yyr113 || yy2arr113 {
+				yym115 := z.EncBinary()
+				_ = yym115
 				if false {
 				} else {
 					r.EncodeInt(int64(x.TargetPercentage))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("targetPercentage"))
-				yym112 := z.EncBinary()
-				_ = yym112
+				yym116 := z.EncBinary()
+				_ = yym116
 				if false {
 				} else {
 					r.EncodeInt(int64(x.TargetPercentage))
 				}
 			}
-			if yysep109 {
+			if yysep113 {
 				r.EncodeEnd()
 			}
 		}
@@ -1354,24 +1378,24 @@ func (x *CPUTargetUtilization) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym113 := z.DecBinary()
-	_ = yym113
+	yym117 := z.DecBinary()
+	_ = yym117
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl114 := r.ReadMapStart()
-			if yyl114 == 0 {
+			yyl118 := r.ReadMapStart()
+			if yyl118 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl114, d)
+				x.codecDecodeSelfFromMap(yyl118, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl114 := r.ReadArrayStart()
-			if yyl114 == 0 {
+			yyl118 := r.ReadArrayStart()
+			if yyl118 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl114, d)
+				x.codecDecodeSelfFromArray(yyl118, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -1383,12 +1407,12 @@ func (x *CPUTargetUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys115Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys115Slc
-	var yyhl115 bool = l >= 0
-	for yyj115 := 0; ; yyj115++ {
-		if yyhl115 {
-			if yyj115 >= l {
+	var yys119Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys119Slc
+	var yyhl119 bool = l >= 0
+	for yyj119 := 0; ; yyj119++ {
+		if yyhl119 {
+			if yyj119 >= l {
 				break
 			}
 		} else {
@@ -1396,9 +1420,9 @@ func (x *CPUTargetUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
-		yys115Slc = r.DecodeBytes(yys115Slc, true, true)
-		yys115 := string(yys115Slc)
-		switch yys115 {
+		yys119Slc = r.DecodeBytes(yys119Slc, true, true)
+		yys119 := string(yys119Slc)
+		switch yys119 {
 		case "targetPercentage":
 			if r.TryDecodeAsNil() {
 				x.TargetPercentage = 0
@@ -1406,10 +1430,10 @@ func (x *CPUTargetUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				x.TargetPercentage = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys115)
-		} // end switch yys115
-	} // end for yyj115
-	if !yyhl115 {
+			z.DecStructFieldNotFound(-1, yys119)
+		} // end switch yys119
+	} // end for yyj119
+	if !yyhl119 {
 		r.ReadEnd()
 	}
 }
@@ -1418,16 +1442,16 @@ func (x *CPUTargetUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj117 int
-	var yyb117 bool
-	var yyhl117 bool = l >= 0
-	yyj117++
-	if yyhl117 {
-		yyb117 = yyj117 > l
+	var yyj121 int
+	var yyb121 bool
+	var yyhl121 bool = l >= 0
+	yyj121++
+	if yyhl121 {
+		yyb121 = yyj121 > l
 	} else {
-		yyb117 = r.CheckBreak()
+		yyb121 = r.CheckBreak()
 	}
-	if yyb117 {
+	if yyb121 {
 		r.ReadEnd()
 		return
 	}
@@ -1437,16 +1461,16 @@ func (x *CPUTargetUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		x.TargetPercentage = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj117++
-		if yyhl117 {
-			yyb117 = yyj117 > l
+		yyj121++
+		if yyhl121 {
+			yyb121 = yyj121 > l
 		} else {
-			yyb117 = r.CheckBreak()
+			yyb121 = r.CheckBreak()
 		}
-		if yyb117 {
+		if yyb121 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj117-1, "")
+		z.DecStructFieldNotFound(yyj121-1, "")
 	}
 	r.ReadEnd()
 }
@@ -1458,87 +1482,87 @@ func (x *HorizontalPodAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym119 := z.EncBinary()
-		_ = yym119
+		yym123 := z.EncBinary()
+		_ = yym123
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep120 := !z.EncBinary()
-			yy2arr120 := z.EncBasicHandle().StructToArray
-			var yyq120 [4]bool
-			_, _, _ = yysep120, yyq120, yy2arr120
-			const yyr120 bool = false
-			yyq120[1] = x.MinReplicas != nil
-			yyq120[3] = x.CPUUtilization != nil
-			if yyr120 || yy2arr120 {
+			yysep124 := !z.EncBinary()
+			yy2arr124 := z.EncBasicHandle().StructToArray
+			var yyq124 [4]bool
+			_, _, _ = yysep124, yyq124, yy2arr124
+			const yyr124 bool = false
+			yyq124[1] = x.MinReplicas != nil
+			yyq124[3] = x.CPUUtilization != nil
+			if yyr124 || yy2arr124 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn120 int = 2
-				for _, b := range yyq120 {
+				var yynn124 int = 2
+				for _, b := range yyq124 {
 					if b {
-						yynn120++
+						yynn124++
 					}
 				}
-				r.EncodeMapStart(yynn120)
+				r.EncodeMapStart(yynn124)
 			}
-			if yyr120 || yy2arr120 {
-				yy122 := &x.ScaleRef
-				yy122.CodecEncodeSelf(e)
+			if yyr124 || yy2arr124 {
+				yy126 := &x.ScaleRef
+				yy126.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("scaleRef"))
-				yy123 := &x.ScaleRef
-				yy123.CodecEncodeSelf(e)
+				yy127 := &x.ScaleRef
+				yy127.CodecEncodeSelf(e)
 			}
-			if yyr120 || yy2arr120 {
-				if yyq120[1] {
+			if yyr124 || yy2arr124 {
+				if yyq124[1] {
 					if x.MinReplicas == nil {
 						r.EncodeNil()
 					} else {
-						yy125 := *x.MinReplicas
-						yym126 := z.EncBinary()
-						_ = yym126
+						yy129 := *x.MinReplicas
+						yym130 := z.EncBinary()
+						_ = yym130
 						if false {
 						} else {
-							r.EncodeInt(int64(yy125))
+							r.EncodeInt(int64(yy129))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq120[1] {
+				if yyq124[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("minReplicas"))
 					if x.MinReplicas == nil {
 						r.EncodeNil()
 					} else {
-						yy127 := *x.MinReplicas
-						yym128 := z.EncBinary()
-						_ = yym128
+						yy131 := *x.MinReplicas
+						yym132 := z.EncBinary()
+						_ = yym132
 						if false {
 						} else {
-							r.EncodeInt(int64(yy127))
+							r.EncodeInt(int64(yy131))
 						}
 					}
 				}
 			}
-			if yyr120 || yy2arr120 {
-				yym130 := z.EncBinary()
-				_ = yym130
+			if yyr124 || yy2arr124 {
+				yym134 := z.EncBinary()
+				_ = yym134
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MaxReplicas))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("maxReplicas"))
-				yym131 := z.EncBinary()
-				_ = yym131
+				yym135 := z.EncBinary()
+				_ = yym135
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MaxReplicas))
 				}
 			}
-			if yyr120 || yy2arr120 {
-				if yyq120[3] {
+			if yyr124 || yy2arr124 {
+				if yyq124[3] {
 					if x.CPUUtilization == nil {
 						r.EncodeNil()
 					} else {
@@ -1548,7 +1572,7 @@ func (x *HorizontalPodAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq120[3] {
+				if yyq124[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("cpuUtilization"))
 					if x.CPUUtilization == nil {
 						r.EncodeNil()
@@ -1557,7 +1581,7 @@ func (x *HorizontalPodAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep120 {
+			if yysep124 {
 				r.EncodeEnd()
 			}
 		}
@@ -1568,24 +1592,24 @@ func (x *HorizontalPodAutoscalerSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym133 := z.DecBinary()
-	_ = yym133
+	yym137 := z.DecBinary()
+	_ = yym137
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl134 := r.ReadMapStart()
-			if yyl134 == 0 {
+			yyl138 := r.ReadMapStart()
+			if yyl138 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl134, d)
+				x.codecDecodeSelfFromMap(yyl138, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl134 := r.ReadArrayStart()
-			if yyl134 == 0 {
+			yyl138 := r.ReadArrayStart()
+			if yyl138 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl134, d)
+				x.codecDecodeSelfFromArray(yyl138, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -1597,12 +1621,12 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys135Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys135Slc
-	var yyhl135 bool = l >= 0
-	for yyj135 := 0; ; yyj135++ {
-		if yyhl135 {
-			if yyj135 >= l {
+	var yys139Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys139Slc
+	var yyhl139 bool = l >= 0
+	for yyj139 := 0; ; yyj139++ {
+		if yyhl139 {
+			if yyj139 >= l {
 				break
 			}
 		} else {
@@ -1610,15 +1634,15 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978
 				break
 			}
 		}
-		yys135Slc = r.DecodeBytes(yys135Slc, true, true)
-		yys135 := string(yys135Slc)
-		switch yys135 {
+		yys139Slc = r.DecodeBytes(yys139Slc, true, true)
+		yys139 := string(yys139Slc)
+		switch yys139 {
 		case "scaleRef":
 			if r.TryDecodeAsNil() {
 				x.ScaleRef = SubresourceReference{}
 			} else {
-				yyv136 := &x.ScaleRef
-				yyv136.CodecDecodeSelf(d)
+				yyv140 := &x.ScaleRef
+				yyv140.CodecDecodeSelf(d)
 			}
 		case "minReplicas":
 			if r.TryDecodeAsNil() {
@@ -1629,8 +1653,8 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978
 				if x.MinReplicas == nil {
 					x.MinReplicas = new(int)
 				}
-				yym138 := z.DecBinary()
-				_ = yym138
+				yym142 := z.DecBinary()
+				_ = yym142
 				if false {
 				} else {
 					*((*int)(x.MinReplicas)) = int(r.DecodeInt(codecSelferBitsize1234))
@@ -1654,10 +1678,10 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978
 				x.CPUUtilization.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys135)
-		} // end switch yys135
-	} // end for yyj135
-	if !yyhl135 {
+			z.DecStructFieldNotFound(-1, yys139)
+		} // end switch yys139
+	} // end for yyj139
+	if !yyhl139 {
 		r.ReadEnd()
 	}
 }
@@ -1666,32 +1690,32 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec19
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj141 int
-	var yyb141 bool
-	var yyhl141 bool = l >= 0
-	yyj141++
-	if yyhl141 {
-		yyb141 = yyj141 > l
+	var yyj145 int
+	var yyb145 bool
+	var yyhl145 bool = l >= 0
+	yyj145++
+	if yyhl145 {
+		yyb145 = yyj145 > l
 	} else {
-		yyb141 = r.CheckBreak()
+		yyb145 = r.CheckBreak()
 	}
-	if yyb141 {
+	if yyb145 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ScaleRef = SubresourceReference{}
 	} else {
-		yyv142 := &x.ScaleRef
-		yyv142.CodecDecodeSelf(d)
+		yyv146 := &x.ScaleRef
+		yyv146.CodecDecodeSelf(d)
 	}
-	yyj141++
-	if yyhl141 {
-		yyb141 = yyj141 > l
+	yyj145++
+	if yyhl145 {
+		yyb145 = yyj145 > l
 	} else {
-		yyb141 = r.CheckBreak()
+		yyb145 = r.CheckBreak()
 	}
-	if yyb141 {
+	if yyb145 {
 		r.ReadEnd()
 		return
 	}
@@ -1703,20 +1727,20 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec19
 		if x.MinReplicas == nil {
 			x.MinReplicas = new(int)
 		}
-		yym144 := z.DecBinary()
-		_ = yym144
+		yym148 := z.DecBinary()
+		_ = yym148
 		if false {
 		} else {
 			*((*int)(x.MinReplicas)) = int(r.DecodeInt(codecSelferBitsize1234))
 		}
 	}
-	yyj141++
-	if yyhl141 {
-		yyb141 = yyj141 > l
+	yyj145++
+	if yyhl145 {
+		yyb145 = yyj145 > l
 	} else {
-		yyb141 = r.CheckBreak()
+		yyb145 = r.CheckBreak()
 	}
-	if yyb141 {
+	if yyb145 {
 		r.ReadEnd()
 		return
 	}
@@ -1725,13 +1749,13 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec19
 	} else {
 		x.MaxReplicas = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj141++
-	if yyhl141 {
-		yyb141 = yyj141 > l
+	yyj145++
+	if yyhl145 {
+		yyb145 = yyj145 > l
 	} else {
-		yyb141 = r.CheckBreak()
+		yyb145 = r.CheckBreak()
 	}
-	if yyb141 {
+	if yyb145 {
 		r.ReadEnd()
 		return
 	}
@@ -1746,16 +1770,16 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec19
 		x.CPUUtilization.CodecDecodeSelf(d)
 	}
 	for {
-		yyj141++
-		if yyhl141 {
-			yyb141 = yyj141 > l
+		yyj145++
+		if yyhl145 {
+			yyb145 = yyj145 > l
 		} else {
-			yyb141 = r.CheckBreak()
+			yyb145 = r.CheckBreak()
 		}
-		if yyb141 {
+		if yyb145 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj141-1, "")
+		z.DecStructFieldNotFound(yyj145-1, "")
 	}
 	r.ReadEnd()
 }
@@ -1767,74 +1791,74 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym147 := z.EncBinary()
-		_ = yym147
+		yym151 := z.EncBinary()
+		_ = yym151
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep148 := !z.EncBinary()
-			yy2arr148 := z.EncBasicHandle().StructToArray
-			var yyq148 [5]bool
-			_, _, _ = yysep148, yyq148, yy2arr148
-			const yyr148 bool = false
-			yyq148[0] = x.ObservedGeneration != nil
-			yyq148[1] = x.LastScaleTime != nil
-			yyq148[4] = x.CurrentCPUUtilizationPercentage != nil
-			if yyr148 || yy2arr148 {
+			yysep152 := !z.EncBinary()
+			yy2arr152 := z.EncBasicHandle().StructToArray
+			var yyq152 [5]bool
+			_, _, _ = yysep152, yyq152, yy2arr152
+			const yyr152 bool = false
+			yyq152[0] = x.ObservedGeneration != nil
+			yyq152[1] = x.LastScaleTime != nil
+			yyq152[4] = x.CurrentCPUUtilizationPercentage != nil
+			if yyr152 || yy2arr152 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn148 int = 2
-				for _, b := range yyq148 {
+				var yynn152 int = 2
+				for _, b := range yyq152 {
 					if b {
-						yynn148++
+						yynn152++
 					}
 				}
-				r.EncodeMapStart(yynn148)
+				r.EncodeMapStart(yynn152)
 			}
-			if yyr148 || yy2arr148 {
-				if yyq148[0] {
+			if yyr152 || yy2arr152 {
+				if yyq152[0] {
 					if x.ObservedGeneration == nil {
 						r.EncodeNil()
 					} else {
-						yy150 := *x.ObservedGeneration
-						yym151 := z.EncBinary()
-						_ = yym151
+						yy154 := *x.ObservedGeneration
+						yym155 := z.EncBinary()
+						_ = yym155
 						if false {
 						} else {
-							r.EncodeInt(int64(yy150))
+							r.EncodeInt(int64(yy154))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq148[0] {
+				if yyq152[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("observedGeneration"))
 					if x.ObservedGeneration == nil {
 						r.EncodeNil()
 					} else {
-						yy152 := *x.ObservedGeneration
-						yym153 := z.EncBinary()
-						_ = yym153
+						yy156 := *x.ObservedGeneration
+						yym157 := z.EncBinary()
+						_ = yym157
 						if false {
 						} else {
-							r.EncodeInt(int64(yy152))
+							r.EncodeInt(int64(yy156))
 						}
 					}
 				}
 			}
-			if yyr148 || yy2arr148 {
-				if yyq148[1] {
+			if yyr152 || yy2arr152 {
+				if yyq152[1] {
 					if x.LastScaleTime == nil {
 						r.EncodeNil()
 					} else {
-						yym155 := z.EncBinary()
-						_ = yym155
+						yym159 := z.EncBinary()
+						_ = yym159
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.LastScaleTime) {
-						} else if yym155 {
+						} else if yym159 {
 							z.EncBinaryMarshal(x.LastScaleTime)
-						} else if !yym155 && z.IsJSONHandle() {
+						} else if !yym159 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.LastScaleTime)
 						} else {
 							z.EncFallback(x.LastScaleTime)
@@ -1844,18 +1868,18 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq148[1] {
+				if yyq152[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("lastScaleTime"))
 					if x.LastScaleTime == nil {
 						r.EncodeNil()
 					} else {
-						yym156 := z.EncBinary()
-						_ = yym156
+						yym160 := z.EncBinary()
+						_ = yym160
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.LastScaleTime) {
-						} else if yym156 {
+						} else if yym160 {
 							z.EncBinaryMarshal(x.LastScaleTime)
-						} else if !yym156 && z.IsJSONHandle() {
+						} else if !yym160 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.LastScaleTime)
 						} else {
 							z.EncFallback(x.LastScaleTime)
@@ -1863,71 +1887,71 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr148 || yy2arr148 {
-				yym158 := z.EncBinary()
-				_ = yym158
+			if yyr152 || yy2arr152 {
+				yym162 := z.EncBinary()
+				_ = yym162
 				if false {
 				} else {
 					r.EncodeInt(int64(x.CurrentReplicas))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("currentReplicas"))
-				yym159 := z.EncBinary()
-				_ = yym159
+				yym163 := z.EncBinary()
+				_ = yym163
 				if false {
 				} else {
 					r.EncodeInt(int64(x.CurrentReplicas))
 				}
 			}
-			if yyr148 || yy2arr148 {
-				yym161 := z.EncBinary()
-				_ = yym161
+			if yyr152 || yy2arr152 {
+				yym165 := z.EncBinary()
+				_ = yym165
 				if false {
 				} else {
 					r.EncodeInt(int64(x.DesiredReplicas))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("desiredReplicas"))
-				yym162 := z.EncBinary()
-				_ = yym162
+				yym166 := z.EncBinary()
+				_ = yym166
 				if false {
 				} else {
 					r.EncodeInt(int64(x.DesiredReplicas))
 				}
 			}
-			if yyr148 || yy2arr148 {
-				if yyq148[4] {
+			if yyr152 || yy2arr152 {
+				if yyq152[4] {
 					if x.CurrentCPUUtilizationPercentage == nil {
 						r.EncodeNil()
 					} else {
-						yy164 := *x.CurrentCPUUtilizationPercentage
-						yym165 := z.EncBinary()
-						_ = yym165
+						yy168 := *x.CurrentCPUUtilizationPercentage
+						yym169 := z.EncBinary()
+						_ = yym169
 						if false {
 						} else {
-							r.EncodeInt(int64(yy164))
+							r.EncodeInt(int64(yy168))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq148[4] {
+				if yyq152[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("currentCPUUtilizationPercentage"))
 					if x.CurrentCPUUtilizationPercentage == nil {
 						r.EncodeNil()
 					} else {
-						yy166 := *x.CurrentCPUUtilizationPercentage
-						yym167 := z.EncBinary()
-						_ = yym167
+						yy170 := *x.CurrentCPUUtilizationPercentage
+						yym171 := z.EncBinary()
+						_ = yym171
 						if false {
 						} else {
-							r.EncodeInt(int64(yy166))
+							r.EncodeInt(int64(yy170))
 						}
 					}
 				}
 			}
-			if yysep148 {
+			if yysep152 {
 				r.EncodeEnd()
 			}
 		}
@@ -1938,24 +1962,24 @@ func (x *HorizontalPodAutoscalerStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym168 := z.DecBinary()
-	_ = yym168
+	yym172 := z.DecBinary()
+	_ = yym172
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl169 := r.ReadMapStart()
-			if yyl169 == 0 {
+			yyl173 := r.ReadMapStart()
+			if yyl173 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl169, d)
+				x.codecDecodeSelfFromMap(yyl173, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl169 := r.ReadArrayStart()
-			if yyl169 == 0 {
+			yyl173 := r.ReadArrayStart()
+			if yyl173 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl169, d)
+				x.codecDecodeSelfFromArray(yyl173, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -1967,12 +1991,12 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromMap(l int, d *codec19
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys170Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys170Slc
-	var yyhl170 bool = l >= 0
-	for yyj170 := 0; ; yyj170++ {
-		if yyhl170 {
-			if yyj170 >= l {
+	var yys174Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys174Slc
+	var yyhl174 bool = l >= 0
+	for yyj174 := 0; ; yyj174++ {
+		if yyhl174 {
+			if yyj174 >= l {
 				break
 			}
 		} else {
@@ -1980,9 +2004,9 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromMap(l int, d *codec19
 				break
 			}
 		}
-		yys170Slc = r.DecodeBytes(yys170Slc, true, true)
-		yys170 := string(yys170Slc)
-		switch yys170 {
+		yys174Slc = r.DecodeBytes(yys174Slc, true, true)
+		yys174 := string(yys174Slc)
+		switch yys174 {
 		case "observedGeneration":
 			if r.TryDecodeAsNil() {
 				if x.ObservedGeneration != nil {
@@ -1992,8 +2016,8 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromMap(l int, d *codec19
 				if x.ObservedGeneration == nil {
 					x.ObservedGeneration = new(int64)
 				}
-				yym172 := z.DecBinary()
-				_ = yym172
+				yym176 := z.DecBinary()
+				_ = yym176
 				if false {
 				} else {
 					*((*int64)(x.ObservedGeneration)) = int64(r.DecodeInt(64))
@@ -2008,13 +2032,13 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromMap(l int, d *codec19
 				if x.LastScaleTime == nil {
 					x.LastScaleTime = new(pkg1_unversioned.Time)
 				}
-				yym174 := z.DecBinary()
-				_ = yym174
+				yym178 := z.DecBinary()
+				_ = yym178
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.LastScaleTime) {
-				} else if yym174 {
+				} else if yym178 {
 					z.DecBinaryUnmarshal(x.LastScaleTime)
-				} else if !yym174 && z.IsJSONHandle() {
+				} else if !yym178 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.LastScaleTime)
 				} else {
 					z.DecFallback(x.LastScaleTime, false)
@@ -2041,18 +2065,18 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromMap(l int, d *codec19
 				if x.CurrentCPUUtilizationPercentage == nil {
 					x.CurrentCPUUtilizationPercentage = new(int)
 				}
-				yym178 := z.DecBinary()
-				_ = yym178
+				yym182 := z.DecBinary()
+				_ = yym182
 				if false {
 				} else {
 					*((*int)(x.CurrentCPUUtilizationPercentage)) = int(r.DecodeInt(codecSelferBitsize1234))
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys170)
-		} // end switch yys170
-	} // end for yyj170
-	if !yyhl170 {
+			z.DecStructFieldNotFound(-1, yys174)
+		} // end switch yys174
+	} // end for yyj174
+	if !yyhl174 {
 		r.ReadEnd()
 	}
 }
@@ -2061,16 +2085,16 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj179 int
-	var yyb179 bool
-	var yyhl179 bool = l >= 0
-	yyj179++
-	if yyhl179 {
-		yyb179 = yyj179 > l
+	var yyj183 int
+	var yyb183 bool
+	var yyhl183 bool = l >= 0
+	yyj183++
+	if yyhl183 {
+		yyb183 = yyj183 > l
 	} else {
-		yyb179 = r.CheckBreak()
+		yyb183 = r.CheckBreak()
 	}
-	if yyb179 {
+	if yyb183 {
 		r.ReadEnd()
 		return
 	}
@@ -2082,20 +2106,20 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 		if x.ObservedGeneration == nil {
 			x.ObservedGeneration = new(int64)
 		}
-		yym181 := z.DecBinary()
-		_ = yym181
+		yym185 := z.DecBinary()
+		_ = yym185
 		if false {
 		} else {
 			*((*int64)(x.ObservedGeneration)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj179++
-	if yyhl179 {
-		yyb179 = yyj179 > l
+	yyj183++
+	if yyhl183 {
+		yyb183 = yyj183 > l
 	} else {
-		yyb179 = r.CheckBreak()
+		yyb183 = r.CheckBreak()
 	}
-	if yyb179 {
+	if yyb183 {
 		r.ReadEnd()
 		return
 	}
@@ -2107,25 +2131,25 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 		if x.LastScaleTime == nil {
 			x.LastScaleTime = new(pkg1_unversioned.Time)
 		}
-		yym183 := z.DecBinary()
-		_ = yym183
+		yym187 := z.DecBinary()
+		_ = yym187
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.LastScaleTime) {
-		} else if yym183 {
+		} else if yym187 {
 			z.DecBinaryUnmarshal(x.LastScaleTime)
-		} else if !yym183 && z.IsJSONHandle() {
+		} else if !yym187 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.LastScaleTime)
 		} else {
 			z.DecFallback(x.LastScaleTime, false)
 		}
 	}
-	yyj179++
-	if yyhl179 {
-		yyb179 = yyj179 > l
+	yyj183++
+	if yyhl183 {
+		yyb183 = yyj183 > l
 	} else {
-		yyb179 = r.CheckBreak()
+		yyb183 = r.CheckBreak()
 	}
-	if yyb179 {
+	if yyb183 {
 		r.ReadEnd()
 		return
 	}
@@ -2134,13 +2158,13 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 	} else {
 		x.CurrentReplicas = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj179++
-	if yyhl179 {
-		yyb179 = yyj179 > l
+	yyj183++
+	if yyhl183 {
+		yyb183 = yyj183 > l
 	} else {
-		yyb179 = r.CheckBreak()
+		yyb183 = r.CheckBreak()
 	}
-	if yyb179 {
+	if yyb183 {
 		r.ReadEnd()
 		return
 	}
@@ -2149,13 +2173,13 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 	} else {
 		x.DesiredReplicas = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj179++
-	if yyhl179 {
-		yyb179 = yyj179 > l
+	yyj183++
+	if yyhl183 {
+		yyb183 = yyj183 > l
 	} else {
-		yyb179 = r.CheckBreak()
+		yyb183 = r.CheckBreak()
 	}
-	if yyb179 {
+	if yyb183 {
 		r.ReadEnd()
 		return
 	}
@@ -2167,24 +2191,24 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 		if x.CurrentCPUUtilizationPercentage == nil {
 			x.CurrentCPUUtilizationPercentage = new(int)
 		}
-		yym187 := z.DecBinary()
-		_ = yym187
+		yym191 := z.DecBinary()
+		_ = yym191
 		if false {
 		} else {
 			*((*int)(x.CurrentCPUUtilizationPercentage)) = int(r.DecodeInt(codecSelferBitsize1234))
 		}
 	}
 	for {
-		yyj179++
-		if yyhl179 {
-			yyb179 = yyj179 > l
+		yyj183++
+		if yyhl183 {
+			yyb183 = yyj183 > l
 		} else {
-			yyb179 = r.CheckBreak()
+			yyb183 = r.CheckBreak()
 		}
-		if yyb179 {
+		if yyb183 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj179-1, "")
+		z.DecStructFieldNotFound(yyj183-1, "")
 	}
 	r.ReadEnd()
 }
@@ -2196,119 +2220,131 @@ func (x *HorizontalPodAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym188 := z.EncBinary()
-		_ = yym188
+		yym192 := z.EncBinary()
+		_ = yym192
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep189 := !z.EncBinary()
-			yy2arr189 := z.EncBasicHandle().StructToArray
-			var yyq189 [5]bool
-			_, _, _ = yysep189, yyq189, yy2arr189
-			const yyr189 bool = false
-			yyq189[0] = x.Kind != ""
-			yyq189[1] = x.APIVersion != ""
-			yyq189[2] = true
-			yyq189[3] = true
-			yyq189[4] = true
-			if yyr189 || yy2arr189 {
+			yysep193 := !z.EncBinary()
+			yy2arr193 := z.EncBasicHandle().StructToArray
+			var yyq193 [5]bool
+			_, _, _ = yysep193, yyq193, yy2arr193
+			const yyr193 bool = false
+			yyq193[0] = x.Kind != ""
+			yyq193[1] = x.APIVersion != ""
+			yyq193[2] = true
+			yyq193[3] = true
+			yyq193[4] = true
+			if yyr193 || yy2arr193 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn189 int = 0
-				for _, b := range yyq189 {
+				var yynn193 int = 0
+				for _, b := range yyq193 {
 					if b {
-						yynn189++
+						yynn193++
 					}
 				}
-				r.EncodeMapStart(yynn189)
+				r.EncodeMapStart(yynn193)
 			}
-			if yyr189 || yy2arr189 {
-				if yyq189[0] {
-					yym191 := z.EncBinary()
-					_ = yym191
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq189[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym192 := z.EncBinary()
-					_ = yym192
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr189 || yy2arr189 {
-				if yyq189[1] {
-					yym194 := z.EncBinary()
-					_ = yym194
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq189[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr193 || yy2arr193 {
+				if yyq193[0] {
 					yym195 := z.EncBinary()
 					_ = yym195
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq193[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym196 := z.EncBinary()
+					_ = yym196
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr193 || yy2arr193 {
+				if yyq193[1] {
+					yym198 := z.EncBinary()
+					_ = yym198
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq193[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym199 := z.EncBinary()
+					_ = yym199
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr189 || yy2arr189 {
-				if yyq189[2] {
-					yy197 := &x.ObjectMeta
-					yy197.CodecEncodeSelf(e)
+			if yyr193 || yy2arr193 {
+				if yyq193[2] {
+					yy201 := &x.ObjectMeta
+					yym202 := z.EncBinary()
+					_ = yym202
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy201) {
+					} else {
+						z.EncFallback(yy201)
+					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq189[2] {
+				if yyq193[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy198 := &x.ObjectMeta
-					yy198.CodecEncodeSelf(e)
+					yy203 := &x.ObjectMeta
+					yym204 := z.EncBinary()
+					_ = yym204
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy203) {
+					} else {
+						z.EncFallback(yy203)
+					}
 				}
 			}
-			if yyr189 || yy2arr189 {
-				if yyq189[3] {
-					yy200 := &x.Spec
-					yy200.CodecEncodeSelf(e)
+			if yyr193 || yy2arr193 {
+				if yyq193[3] {
+					yy206 := &x.Spec
+					yy206.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq189[3] {
+				if yyq193[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy201 := &x.Spec
-					yy201.CodecEncodeSelf(e)
+					yy207 := &x.Spec
+					yy207.CodecEncodeSelf(e)
 				}
 			}
-			if yyr189 || yy2arr189 {
-				if yyq189[4] {
-					yy203 := &x.Status
-					yy203.CodecEncodeSelf(e)
+			if yyr193 || yy2arr193 {
+				if yyq193[4] {
+					yy209 := &x.Status
+					yy209.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq189[4] {
+				if yyq193[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy204 := &x.Status
-					yy204.CodecEncodeSelf(e)
+					yy210 := &x.Status
+					yy210.CodecEncodeSelf(e)
 				}
 			}
-			if yysep189 {
+			if yysep193 {
 				r.EncodeEnd()
 			}
 		}
@@ -2319,24 +2355,24 @@ func (x *HorizontalPodAutoscaler) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym205 := z.DecBinary()
-	_ = yym205
+	yym211 := z.DecBinary()
+	_ = yym211
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl206 := r.ReadMapStart()
-			if yyl206 == 0 {
+			yyl212 := r.ReadMapStart()
+			if yyl212 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl206, d)
+				x.codecDecodeSelfFromMap(yyl212, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl206 := r.ReadArrayStart()
-			if yyl206 == 0 {
+			yyl212 := r.ReadArrayStart()
+			if yyl212 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl206, d)
+				x.codecDecodeSelfFromArray(yyl212, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -2348,12 +2384,12 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys207Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys207Slc
-	var yyhl207 bool = l >= 0
-	for yyj207 := 0; ; yyj207++ {
-		if yyhl207 {
-			if yyj207 >= l {
+	var yys213Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys213Slc
+	var yyhl213 bool = l >= 0
+	for yyj213 := 0; ; yyj213++ {
+		if yyhl213 {
+			if yyj213 >= l {
 				break
 			}
 		} else {
@@ -2361,9 +2397,9 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				break
 			}
 		}
-		yys207Slc = r.DecodeBytes(yys207Slc, true, true)
-		yys207 := string(yys207Slc)
-		switch yys207 {
+		yys213Slc = r.DecodeBytes(yys213Slc, true, true)
+		yys213 := string(yys213Slc)
+		switch yys213 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -2380,28 +2416,34 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv210 := &x.ObjectMeta
-				yyv210.CodecDecodeSelf(d)
+				yyv216 := &x.ObjectMeta
+				yym217 := z.DecBinary()
+				_ = yym217
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv216) {
+				} else {
+					z.DecFallback(yyv216, false)
+				}
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = HorizontalPodAutoscalerSpec{}
 			} else {
-				yyv211 := &x.Spec
-				yyv211.CodecDecodeSelf(d)
+				yyv218 := &x.Spec
+				yyv218.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = HorizontalPodAutoscalerStatus{}
 			} else {
-				yyv212 := &x.Status
-				yyv212.CodecDecodeSelf(d)
+				yyv219 := &x.Status
+				yyv219.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys207)
-		} // end switch yys207
-	} // end for yyj207
-	if !yyhl207 {
+			z.DecStructFieldNotFound(-1, yys213)
+		} // end switch yys213
+	} // end for yyj213
+	if !yyhl213 {
 		r.ReadEnd()
 	}
 }
@@ -2410,16 +2452,16 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.D
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj213 int
-	var yyb213 bool
-	var yyhl213 bool = l >= 0
-	yyj213++
-	if yyhl213 {
-		yyb213 = yyj213 > l
+	var yyj220 int
+	var yyb220 bool
+	var yyhl220 bool = l >= 0
+	yyj220++
+	if yyhl220 {
+		yyb220 = yyj220 > l
 	} else {
-		yyb213 = r.CheckBreak()
+		yyb220 = r.CheckBreak()
 	}
-	if yyb213 {
+	if yyb220 {
 		r.ReadEnd()
 		return
 	}
@@ -2428,13 +2470,13 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.D
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj213++
-	if yyhl213 {
-		yyb213 = yyj213 > l
+	yyj220++
+	if yyhl220 {
+		yyb220 = yyj220 > l
 	} else {
-		yyb213 = r.CheckBreak()
+		yyb220 = r.CheckBreak()
 	}
-	if yyb213 {
+	if yyb220 {
 		r.ReadEnd()
 		return
 	}
@@ -2443,65 +2485,71 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.D
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj213++
-	if yyhl213 {
-		yyb213 = yyj213 > l
+	yyj220++
+	if yyhl220 {
+		yyb220 = yyj220 > l
 	} else {
-		yyb213 = r.CheckBreak()
+		yyb220 = r.CheckBreak()
 	}
-	if yyb213 {
+	if yyb220 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv216 := &x.ObjectMeta
-		yyv216.CodecDecodeSelf(d)
+		yyv223 := &x.ObjectMeta
+		yym224 := z.DecBinary()
+		_ = yym224
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv223) {
+		} else {
+			z.DecFallback(yyv223, false)
+		}
 	}
-	yyj213++
-	if yyhl213 {
-		yyb213 = yyj213 > l
+	yyj220++
+	if yyhl220 {
+		yyb220 = yyj220 > l
 	} else {
-		yyb213 = r.CheckBreak()
+		yyb220 = r.CheckBreak()
 	}
-	if yyb213 {
+	if yyb220 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = HorizontalPodAutoscalerSpec{}
 	} else {
-		yyv217 := &x.Spec
-		yyv217.CodecDecodeSelf(d)
+		yyv225 := &x.Spec
+		yyv225.CodecDecodeSelf(d)
 	}
-	yyj213++
-	if yyhl213 {
-		yyb213 = yyj213 > l
+	yyj220++
+	if yyhl220 {
+		yyb220 = yyj220 > l
 	} else {
-		yyb213 = r.CheckBreak()
+		yyb220 = r.CheckBreak()
 	}
-	if yyb213 {
+	if yyb220 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = HorizontalPodAutoscalerStatus{}
 	} else {
-		yyv218 := &x.Status
-		yyv218.CodecDecodeSelf(d)
+		yyv226 := &x.Status
+		yyv226.CodecDecodeSelf(d)
 	}
 	for {
-		yyj213++
-		if yyhl213 {
-			yyb213 = yyj213 > l
+		yyj220++
+		if yyhl220 {
+			yyb220 = yyj220 > l
 		} else {
-			yyb213 = r.CheckBreak()
+			yyb220 = r.CheckBreak()
 		}
-		if yyb213 {
+		if yyb220 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj213-1, "")
+		z.DecStructFieldNotFound(yyj220-1, "")
 	}
 	r.ReadEnd()
 }
@@ -2513,34 +2561,34 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym219 := z.EncBinary()
-		_ = yym219
+		yym227 := z.EncBinary()
+		_ = yym227
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep220 := !z.EncBinary()
-			yy2arr220 := z.EncBasicHandle().StructToArray
-			var yyq220 [4]bool
-			_, _, _ = yysep220, yyq220, yy2arr220
-			const yyr220 bool = false
-			yyq220[0] = x.Kind != ""
-			yyq220[1] = x.APIVersion != ""
-			yyq220[2] = true
-			if yyr220 || yy2arr220 {
+			yysep228 := !z.EncBinary()
+			yy2arr228 := z.EncBasicHandle().StructToArray
+			var yyq228 [4]bool
+			_, _, _ = yysep228, yyq228, yy2arr228
+			const yyr228 bool = false
+			yyq228[0] = x.Kind != ""
+			yyq228[1] = x.APIVersion != ""
+			yyq228[2] = true
+			if yyr228 || yy2arr228 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn220 int = 1
-				for _, b := range yyq220 {
+				var yynn228 int = 1
+				for _, b := range yyq228 {
 					if b {
-						yynn220++
+						yynn228++
 					}
 				}
-				r.EncodeMapStart(yynn220)
+				r.EncodeMapStart(yynn228)
 			}
-			if yyr220 || yy2arr220 {
-				if yyq220[0] {
-					yym222 := z.EncBinary()
-					_ = yym222
+			if yyr228 || yy2arr228 {
+				if yyq228[0] {
+					yym230 := z.EncBinary()
+					_ = yym230
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -2549,70 +2597,70 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq220[0] {
+				if yyq228[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym223 := z.EncBinary()
-					_ = yym223
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr220 || yy2arr220 {
-				if yyq220[1] {
-					yym225 := z.EncBinary()
-					_ = yym225
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq220[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym226 := z.EncBinary()
-					_ = yym226
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr220 || yy2arr220 {
-				if yyq220[2] {
-					yy228 := &x.ListMeta
-					yym229 := z.EncBinary()
-					_ = yym229
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy228) {
-					} else {
-						z.EncFallback(yy228)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq220[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy230 := &x.ListMeta
 					yym231 := z.EncBinary()
 					_ = yym231
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy230) {
 					} else {
-						z.EncFallback(yy230)
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr220 || yy2arr220 {
+			if yyr228 || yy2arr228 {
+				if yyq228[1] {
+					yym233 := z.EncBinary()
+					_ = yym233
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq228[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym234 := z.EncBinary()
+					_ = yym234
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr228 || yy2arr228 {
+				if yyq228[2] {
+					yy236 := &x.ListMeta
+					yym237 := z.EncBinary()
+					_ = yym237
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy236) {
+					} else {
+						z.EncFallback(yy236)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq228[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy238 := &x.ListMeta
+					yym239 := z.EncBinary()
+					_ = yym239
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy238) {
+					} else {
+						z.EncFallback(yy238)
+					}
+				}
+			}
+			if yyr228 || yy2arr228 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym233 := z.EncBinary()
-					_ = yym233
+					yym241 := z.EncBinary()
+					_ = yym241
 					if false {
 					} else {
 						h.encSliceHorizontalPodAutoscaler(([]HorizontalPodAutoscaler)(x.Items), e)
@@ -2623,15 +2671,15 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym234 := z.EncBinary()
-					_ = yym234
+					yym242 := z.EncBinary()
+					_ = yym242
 					if false {
 					} else {
 						h.encSliceHorizontalPodAutoscaler(([]HorizontalPodAutoscaler)(x.Items), e)
 					}
 				}
 			}
-			if yysep220 {
+			if yysep228 {
 				r.EncodeEnd()
 			}
 		}
@@ -2642,24 +2690,24 @@ func (x *HorizontalPodAutoscalerList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym235 := z.DecBinary()
-	_ = yym235
+	yym243 := z.DecBinary()
+	_ = yym243
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl236 := r.ReadMapStart()
-			if yyl236 == 0 {
+			yyl244 := r.ReadMapStart()
+			if yyl244 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl236, d)
+				x.codecDecodeSelfFromMap(yyl244, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl236 := r.ReadArrayStart()
-			if yyl236 == 0 {
+			yyl244 := r.ReadArrayStart()
+			if yyl244 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl236, d)
+				x.codecDecodeSelfFromArray(yyl244, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -2671,12 +2719,12 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys237Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys237Slc
-	var yyhl237 bool = l >= 0
-	for yyj237 := 0; ; yyj237++ {
-		if yyhl237 {
-			if yyj237 >= l {
+	var yys245Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys245Slc
+	var yyhl245 bool = l >= 0
+	for yyj245 := 0; ; yyj245++ {
+		if yyhl245 {
+			if yyj245 >= l {
 				break
 			}
 		} else {
@@ -2684,9 +2732,9 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978
 				break
 			}
 		}
-		yys237Slc = r.DecodeBytes(yys237Slc, true, true)
-		yys237 := string(yys237Slc)
-		switch yys237 {
+		yys245Slc = r.DecodeBytes(yys245Slc, true, true)
+		yys245 := string(yys245Slc)
+		switch yys245 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -2703,32 +2751,32 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv240 := &x.ListMeta
-				yym241 := z.DecBinary()
-				_ = yym241
+				yyv248 := &x.ListMeta
+				yym249 := z.DecBinary()
+				_ = yym249
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv240) {
+				} else if z.HasExtensions() && z.DecExt(yyv248) {
 				} else {
-					z.DecFallback(yyv240, false)
+					z.DecFallback(yyv248, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv242 := &x.Items
-				yym243 := z.DecBinary()
-				_ = yym243
+				yyv250 := &x.Items
+				yym251 := z.DecBinary()
+				_ = yym251
 				if false {
 				} else {
-					h.decSliceHorizontalPodAutoscaler((*[]HorizontalPodAutoscaler)(yyv242), d)
+					h.decSliceHorizontalPodAutoscaler((*[]HorizontalPodAutoscaler)(yyv250), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys237)
-		} // end switch yys237
-	} // end for yyj237
-	if !yyhl237 {
+			z.DecStructFieldNotFound(-1, yys245)
+		} // end switch yys245
+	} // end for yyj245
+	if !yyhl245 {
 		r.ReadEnd()
 	}
 }
@@ -2737,16 +2785,16 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromArray(l int, d *codec19
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj244 int
-	var yyb244 bool
-	var yyhl244 bool = l >= 0
-	yyj244++
-	if yyhl244 {
-		yyb244 = yyj244 > l
+	var yyj252 int
+	var yyb252 bool
+	var yyhl252 bool = l >= 0
+	yyj252++
+	if yyhl252 {
+		yyb252 = yyj252 > l
 	} else {
-		yyb244 = r.CheckBreak()
+		yyb252 = r.CheckBreak()
 	}
-	if yyb244 {
+	if yyb252 {
 		r.ReadEnd()
 		return
 	}
@@ -2755,13 +2803,13 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromArray(l int, d *codec19
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj244++
-	if yyhl244 {
-		yyb244 = yyj244 > l
+	yyj252++
+	if yyhl252 {
+		yyb252 = yyj252 > l
 	} else {
-		yyb244 = r.CheckBreak()
+		yyb252 = r.CheckBreak()
 	}
-	if yyb244 {
+	if yyb252 {
 		r.ReadEnd()
 		return
 	}
@@ -2770,60 +2818,60 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromArray(l int, d *codec19
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj244++
-	if yyhl244 {
-		yyb244 = yyj244 > l
+	yyj252++
+	if yyhl252 {
+		yyb252 = yyj252 > l
 	} else {
-		yyb244 = r.CheckBreak()
+		yyb252 = r.CheckBreak()
 	}
-	if yyb244 {
+	if yyb252 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv247 := &x.ListMeta
-		yym248 := z.DecBinary()
-		_ = yym248
+		yyv255 := &x.ListMeta
+		yym256 := z.DecBinary()
+		_ = yym256
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv247) {
+		} else if z.HasExtensions() && z.DecExt(yyv255) {
 		} else {
-			z.DecFallback(yyv247, false)
+			z.DecFallback(yyv255, false)
 		}
 	}
-	yyj244++
-	if yyhl244 {
-		yyb244 = yyj244 > l
+	yyj252++
+	if yyhl252 {
+		yyb252 = yyj252 > l
 	} else {
-		yyb244 = r.CheckBreak()
+		yyb252 = r.CheckBreak()
 	}
-	if yyb244 {
+	if yyb252 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv249 := &x.Items
-		yym250 := z.DecBinary()
-		_ = yym250
+		yyv257 := &x.Items
+		yym258 := z.DecBinary()
+		_ = yym258
 		if false {
 		} else {
-			h.decSliceHorizontalPodAutoscaler((*[]HorizontalPodAutoscaler)(yyv249), d)
+			h.decSliceHorizontalPodAutoscaler((*[]HorizontalPodAutoscaler)(yyv257), d)
 		}
 	}
 	for {
-		yyj244++
-		if yyhl244 {
-			yyb244 = yyj244 > l
+		yyj252++
+		if yyhl252 {
+			yyb252 = yyj252 > l
 		} else {
-			yyb244 = r.CheckBreak()
+			yyb252 = r.CheckBreak()
 		}
-		if yyb244 {
+		if yyb252 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj244-1, "")
+		z.DecStructFieldNotFound(yyj252-1, "")
 	}
 	r.ReadEnd()
 }
@@ -2835,36 +2883,36 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym251 := z.EncBinary()
-		_ = yym251
+		yym259 := z.EncBinary()
+		_ = yym259
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep252 := !z.EncBinary()
-			yy2arr252 := z.EncBasicHandle().StructToArray
-			var yyq252 [5]bool
-			_, _, _ = yysep252, yyq252, yy2arr252
-			const yyr252 bool = false
-			yyq252[0] = x.Kind != ""
-			yyq252[1] = x.APIVersion != ""
-			yyq252[2] = true
-			yyq252[3] = x.Description != ""
-			yyq252[4] = len(x.Versions) != 0
-			if yyr252 || yy2arr252 {
+			yysep260 := !z.EncBinary()
+			yy2arr260 := z.EncBasicHandle().StructToArray
+			var yyq260 [5]bool
+			_, _, _ = yysep260, yyq260, yy2arr260
+			const yyr260 bool = false
+			yyq260[0] = x.Kind != ""
+			yyq260[1] = x.APIVersion != ""
+			yyq260[2] = true
+			yyq260[3] = x.Description != ""
+			yyq260[4] = len(x.Versions) != 0
+			if yyr260 || yy2arr260 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn252 int = 0
-				for _, b := range yyq252 {
+				var yynn260 int = 0
+				for _, b := range yyq260 {
 					if b {
-						yynn252++
+						yynn260++
 					}
 				}
-				r.EncodeMapStart(yynn252)
+				r.EncodeMapStart(yynn260)
 			}
-			if yyr252 || yy2arr252 {
-				if yyq252[0] {
-					yym254 := z.EncBinary()
-					_ = yym254
+			if yyr260 || yy2arr260 {
+				if yyq260[0] {
+					yym262 := z.EncBinary()
+					_ = yym262
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -2873,81 +2921,93 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq252[0] {
+				if yyq260[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym255 := z.EncBinary()
-					_ = yym255
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr252 || yy2arr252 {
-				if yyq252[1] {
-					yym257 := z.EncBinary()
-					_ = yym257
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq252[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym258 := z.EncBinary()
-					_ = yym258
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr252 || yy2arr252 {
-				if yyq252[2] {
-					yy260 := &x.ObjectMeta
-					yy260.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq252[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy261 := &x.ObjectMeta
-					yy261.CodecEncodeSelf(e)
-				}
-			}
-			if yyr252 || yy2arr252 {
-				if yyq252[3] {
 					yym263 := z.EncBinary()
 					_ = yym263
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr260 || yy2arr260 {
+				if yyq260[1] {
+					yym265 := z.EncBinary()
+					_ = yym265
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq260[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym266 := z.EncBinary()
+					_ = yym266
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr260 || yy2arr260 {
+				if yyq260[2] {
+					yy268 := &x.ObjectMeta
+					yym269 := z.EncBinary()
+					_ = yym269
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy268) {
+					} else {
+						z.EncFallback(yy268)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq260[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy270 := &x.ObjectMeta
+					yym271 := z.EncBinary()
+					_ = yym271
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy270) {
+					} else {
+						z.EncFallback(yy270)
+					}
+				}
+			}
+			if yyr260 || yy2arr260 {
+				if yyq260[3] {
+					yym273 := z.EncBinary()
+					_ = yym273
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Description))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq252[3] {
+				if yyq260[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("description"))
-					yym264 := z.EncBinary()
-					_ = yym264
+					yym274 := z.EncBinary()
+					_ = yym274
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Description))
 					}
 				}
 			}
-			if yyr252 || yy2arr252 {
-				if yyq252[4] {
+			if yyr260 || yy2arr260 {
+				if yyq260[4] {
 					if x.Versions == nil {
 						r.EncodeNil()
 					} else {
-						yym266 := z.EncBinary()
-						_ = yym266
+						yym276 := z.EncBinary()
+						_ = yym276
 						if false {
 						} else {
 							h.encSliceAPIVersion(([]APIVersion)(x.Versions), e)
@@ -2957,13 +3017,13 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq252[4] {
+				if yyq260[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("versions"))
 					if x.Versions == nil {
 						r.EncodeNil()
 					} else {
-						yym267 := z.EncBinary()
-						_ = yym267
+						yym277 := z.EncBinary()
+						_ = yym277
 						if false {
 						} else {
 							h.encSliceAPIVersion(([]APIVersion)(x.Versions), e)
@@ -2971,7 +3031,7 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep252 {
+			if yysep260 {
 				r.EncodeEnd()
 			}
 		}
@@ -2982,24 +3042,24 @@ func (x *ThirdPartyResource) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym268 := z.DecBinary()
-	_ = yym268
+	yym278 := z.DecBinary()
+	_ = yym278
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl269 := r.ReadMapStart()
-			if yyl269 == 0 {
+			yyl279 := r.ReadMapStart()
+			if yyl279 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl269, d)
+				x.codecDecodeSelfFromMap(yyl279, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl269 := r.ReadArrayStart()
-			if yyl269 == 0 {
+			yyl279 := r.ReadArrayStart()
+			if yyl279 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl269, d)
+				x.codecDecodeSelfFromArray(yyl279, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -3011,12 +3071,12 @@ func (x *ThirdPartyResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys270Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys270Slc
-	var yyhl270 bool = l >= 0
-	for yyj270 := 0; ; yyj270++ {
-		if yyhl270 {
-			if yyj270 >= l {
+	var yys280Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys280Slc
+	var yyhl280 bool = l >= 0
+	for yyj280 := 0; ; yyj280++ {
+		if yyhl280 {
+			if yyj280 >= l {
 				break
 			}
 		} else {
@@ -3024,9 +3084,9 @@ func (x *ThirdPartyResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
-		yys270Slc = r.DecodeBytes(yys270Slc, true, true)
-		yys270 := string(yys270Slc)
-		switch yys270 {
+		yys280Slc = r.DecodeBytes(yys280Slc, true, true)
+		yys280 := string(yys280Slc)
+		switch yys280 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -3043,8 +3103,14 @@ func (x *ThirdPartyResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv273 := &x.ObjectMeta
-				yyv273.CodecDecodeSelf(d)
+				yyv283 := &x.ObjectMeta
+				yym284 := z.DecBinary()
+				_ = yym284
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv283) {
+				} else {
+					z.DecFallback(yyv283, false)
+				}
 			}
 		case "description":
 			if r.TryDecodeAsNil() {
@@ -3056,19 +3122,19 @@ func (x *ThirdPartyResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			if r.TryDecodeAsNil() {
 				x.Versions = nil
 			} else {
-				yyv275 := &x.Versions
-				yym276 := z.DecBinary()
-				_ = yym276
+				yyv286 := &x.Versions
+				yym287 := z.DecBinary()
+				_ = yym287
 				if false {
 				} else {
-					h.decSliceAPIVersion((*[]APIVersion)(yyv275), d)
+					h.decSliceAPIVersion((*[]APIVersion)(yyv286), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys270)
-		} // end switch yys270
-	} // end for yyj270
-	if !yyhl270 {
+			z.DecStructFieldNotFound(-1, yys280)
+		} // end switch yys280
+	} // end for yyj280
+	if !yyhl280 {
 		r.ReadEnd()
 	}
 }
@@ -3077,16 +3143,16 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj277 int
-	var yyb277 bool
-	var yyhl277 bool = l >= 0
-	yyj277++
-	if yyhl277 {
-		yyb277 = yyj277 > l
+	var yyj288 int
+	var yyb288 bool
+	var yyhl288 bool = l >= 0
+	yyj288++
+	if yyhl288 {
+		yyb288 = yyj288 > l
 	} else {
-		yyb277 = r.CheckBreak()
+		yyb288 = r.CheckBreak()
 	}
-	if yyb277 {
+	if yyb288 {
 		r.ReadEnd()
 		return
 	}
@@ -3095,13 +3161,13 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj277++
-	if yyhl277 {
-		yyb277 = yyj277 > l
+	yyj288++
+	if yyhl288 {
+		yyb288 = yyj288 > l
 	} else {
-		yyb277 = r.CheckBreak()
+		yyb288 = r.CheckBreak()
 	}
-	if yyb277 {
+	if yyb288 {
 		r.ReadEnd()
 		return
 	}
@@ -3110,29 +3176,35 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj277++
-	if yyhl277 {
-		yyb277 = yyj277 > l
+	yyj288++
+	if yyhl288 {
+		yyb288 = yyj288 > l
 	} else {
-		yyb277 = r.CheckBreak()
+		yyb288 = r.CheckBreak()
 	}
-	if yyb277 {
+	if yyb288 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv280 := &x.ObjectMeta
-		yyv280.CodecDecodeSelf(d)
+		yyv291 := &x.ObjectMeta
+		yym292 := z.DecBinary()
+		_ = yym292
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv291) {
+		} else {
+			z.DecFallback(yyv291, false)
+		}
 	}
-	yyj277++
-	if yyhl277 {
-		yyb277 = yyj277 > l
+	yyj288++
+	if yyhl288 {
+		yyb288 = yyj288 > l
 	} else {
-		yyb277 = r.CheckBreak()
+		yyb288 = r.CheckBreak()
 	}
-	if yyb277 {
+	if yyb288 {
 		r.ReadEnd()
 		return
 	}
@@ -3141,38 +3213,38 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.Description = string(r.DecodeString())
 	}
-	yyj277++
-	if yyhl277 {
-		yyb277 = yyj277 > l
+	yyj288++
+	if yyhl288 {
+		yyb288 = yyj288 > l
 	} else {
-		yyb277 = r.CheckBreak()
+		yyb288 = r.CheckBreak()
 	}
-	if yyb277 {
+	if yyb288 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Versions = nil
 	} else {
-		yyv282 := &x.Versions
-		yym283 := z.DecBinary()
-		_ = yym283
+		yyv294 := &x.Versions
+		yym295 := z.DecBinary()
+		_ = yym295
 		if false {
 		} else {
-			h.decSliceAPIVersion((*[]APIVersion)(yyv282), d)
+			h.decSliceAPIVersion((*[]APIVersion)(yyv294), d)
 		}
 	}
 	for {
-		yyj277++
-		if yyhl277 {
-			yyb277 = yyj277 > l
+		yyj288++
+		if yyhl288 {
+			yyb288 = yyj288 > l
 		} else {
-			yyb277 = r.CheckBreak()
+			yyb288 = r.CheckBreak()
 		}
-		if yyb277 {
+		if yyb288 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj277-1, "")
+		z.DecStructFieldNotFound(yyj288-1, "")
 	}
 	r.ReadEnd()
 }
@@ -3184,34 +3256,34 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym284 := z.EncBinary()
-		_ = yym284
+		yym296 := z.EncBinary()
+		_ = yym296
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep285 := !z.EncBinary()
-			yy2arr285 := z.EncBasicHandle().StructToArray
-			var yyq285 [4]bool
-			_, _, _ = yysep285, yyq285, yy2arr285
-			const yyr285 bool = false
-			yyq285[0] = x.Kind != ""
-			yyq285[1] = x.APIVersion != ""
-			yyq285[2] = true
-			if yyr285 || yy2arr285 {
+			yysep297 := !z.EncBinary()
+			yy2arr297 := z.EncBasicHandle().StructToArray
+			var yyq297 [4]bool
+			_, _, _ = yysep297, yyq297, yy2arr297
+			const yyr297 bool = false
+			yyq297[0] = x.Kind != ""
+			yyq297[1] = x.APIVersion != ""
+			yyq297[2] = true
+			if yyr297 || yy2arr297 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn285 int = 1
-				for _, b := range yyq285 {
+				var yynn297 int = 1
+				for _, b := range yyq297 {
 					if b {
-						yynn285++
+						yynn297++
 					}
 				}
-				r.EncodeMapStart(yynn285)
+				r.EncodeMapStart(yynn297)
 			}
-			if yyr285 || yy2arr285 {
-				if yyq285[0] {
-					yym287 := z.EncBinary()
-					_ = yym287
+			if yyr297 || yy2arr297 {
+				if yyq297[0] {
+					yym299 := z.EncBinary()
+					_ = yym299
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -3220,20 +3292,20 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq285[0] {
+				if yyq297[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym288 := z.EncBinary()
-					_ = yym288
+					yym300 := z.EncBinary()
+					_ = yym300
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr285 || yy2arr285 {
-				if yyq285[1] {
-					yym290 := z.EncBinary()
-					_ = yym290
+			if yyr297 || yy2arr297 {
+				if yyq297[1] {
+					yym302 := z.EncBinary()
+					_ = yym302
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -3242,48 +3314,48 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq285[1] {
+				if yyq297[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym291 := z.EncBinary()
-					_ = yym291
+					yym303 := z.EncBinary()
+					_ = yym303
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr285 || yy2arr285 {
-				if yyq285[2] {
-					yy293 := &x.ListMeta
-					yym294 := z.EncBinary()
-					_ = yym294
+			if yyr297 || yy2arr297 {
+				if yyq297[2] {
+					yy305 := &x.ListMeta
+					yym306 := z.EncBinary()
+					_ = yym306
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy293) {
+					} else if z.HasExtensions() && z.EncExt(yy305) {
 					} else {
-						z.EncFallback(yy293)
+						z.EncFallback(yy305)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq285[2] {
+				if yyq297[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy295 := &x.ListMeta
-					yym296 := z.EncBinary()
-					_ = yym296
+					yy307 := &x.ListMeta
+					yym308 := z.EncBinary()
+					_ = yym308
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy295) {
+					} else if z.HasExtensions() && z.EncExt(yy307) {
 					} else {
-						z.EncFallback(yy295)
+						z.EncFallback(yy307)
 					}
 				}
 			}
-			if yyr285 || yy2arr285 {
+			if yyr297 || yy2arr297 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym298 := z.EncBinary()
-					_ = yym298
+					yym310 := z.EncBinary()
+					_ = yym310
 					if false {
 					} else {
 						h.encSliceThirdPartyResource(([]ThirdPartyResource)(x.Items), e)
@@ -3294,15 +3366,15 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym299 := z.EncBinary()
-					_ = yym299
+					yym311 := z.EncBinary()
+					_ = yym311
 					if false {
 					} else {
 						h.encSliceThirdPartyResource(([]ThirdPartyResource)(x.Items), e)
 					}
 				}
 			}
-			if yysep285 {
+			if yysep297 {
 				r.EncodeEnd()
 			}
 		}
@@ -3313,24 +3385,24 @@ func (x *ThirdPartyResourceList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym300 := z.DecBinary()
-	_ = yym300
+	yym312 := z.DecBinary()
+	_ = yym312
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl301 := r.ReadMapStart()
-			if yyl301 == 0 {
+			yyl313 := r.ReadMapStart()
+			if yyl313 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl301, d)
+				x.codecDecodeSelfFromMap(yyl313, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl301 := r.ReadArrayStart()
-			if yyl301 == 0 {
+			yyl313 := r.ReadArrayStart()
+			if yyl313 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl301, d)
+				x.codecDecodeSelfFromArray(yyl313, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -3342,12 +3414,12 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys302Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys302Slc
-	var yyhl302 bool = l >= 0
-	for yyj302 := 0; ; yyj302++ {
-		if yyhl302 {
-			if yyj302 >= l {
+	var yys314Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys314Slc
+	var yyhl314 bool = l >= 0
+	for yyj314 := 0; ; yyj314++ {
+		if yyhl314 {
+			if yyj314 >= l {
 				break
 			}
 		} else {
@@ -3355,9 +3427,9 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				break
 			}
 		}
-		yys302Slc = r.DecodeBytes(yys302Slc, true, true)
-		yys302 := string(yys302Slc)
-		switch yys302 {
+		yys314Slc = r.DecodeBytes(yys314Slc, true, true)
+		yys314 := string(yys314Slc)
+		switch yys314 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -3374,32 +3446,32 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv305 := &x.ListMeta
-				yym306 := z.DecBinary()
-				_ = yym306
+				yyv317 := &x.ListMeta
+				yym318 := z.DecBinary()
+				_ = yym318
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv305) {
+				} else if z.HasExtensions() && z.DecExt(yyv317) {
 				} else {
-					z.DecFallback(yyv305, false)
+					z.DecFallback(yyv317, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv307 := &x.Items
-				yym308 := z.DecBinary()
-				_ = yym308
+				yyv319 := &x.Items
+				yym320 := z.DecBinary()
+				_ = yym320
 				if false {
 				} else {
-					h.decSliceThirdPartyResource((*[]ThirdPartyResource)(yyv307), d)
+					h.decSliceThirdPartyResource((*[]ThirdPartyResource)(yyv319), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys302)
-		} // end switch yys302
-	} // end for yyj302
-	if !yyhl302 {
+			z.DecStructFieldNotFound(-1, yys314)
+		} // end switch yys314
+	} // end for yyj314
+	if !yyhl314 {
 		r.ReadEnd()
 	}
 }
@@ -3408,16 +3480,16 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromArray(l int, d *codec1978.De
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj309 int
-	var yyb309 bool
-	var yyhl309 bool = l >= 0
-	yyj309++
-	if yyhl309 {
-		yyb309 = yyj309 > l
+	var yyj321 int
+	var yyb321 bool
+	var yyhl321 bool = l >= 0
+	yyj321++
+	if yyhl321 {
+		yyb321 = yyj321 > l
 	} else {
-		yyb309 = r.CheckBreak()
+		yyb321 = r.CheckBreak()
 	}
-	if yyb309 {
+	if yyb321 {
 		r.ReadEnd()
 		return
 	}
@@ -3426,13 +3498,13 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromArray(l int, d *codec1978.De
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj309++
-	if yyhl309 {
-		yyb309 = yyj309 > l
+	yyj321++
+	if yyhl321 {
+		yyb321 = yyj321 > l
 	} else {
-		yyb309 = r.CheckBreak()
+		yyb321 = r.CheckBreak()
 	}
-	if yyb309 {
+	if yyb321 {
 		r.ReadEnd()
 		return
 	}
@@ -3441,60 +3513,60 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromArray(l int, d *codec1978.De
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj309++
-	if yyhl309 {
-		yyb309 = yyj309 > l
+	yyj321++
+	if yyhl321 {
+		yyb321 = yyj321 > l
 	} else {
-		yyb309 = r.CheckBreak()
+		yyb321 = r.CheckBreak()
 	}
-	if yyb309 {
+	if yyb321 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv312 := &x.ListMeta
-		yym313 := z.DecBinary()
-		_ = yym313
+		yyv324 := &x.ListMeta
+		yym325 := z.DecBinary()
+		_ = yym325
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv312) {
+		} else if z.HasExtensions() && z.DecExt(yyv324) {
 		} else {
-			z.DecFallback(yyv312, false)
+			z.DecFallback(yyv324, false)
 		}
 	}
-	yyj309++
-	if yyhl309 {
-		yyb309 = yyj309 > l
+	yyj321++
+	if yyhl321 {
+		yyb321 = yyj321 > l
 	} else {
-		yyb309 = r.CheckBreak()
+		yyb321 = r.CheckBreak()
 	}
-	if yyb309 {
+	if yyb321 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv314 := &x.Items
-		yym315 := z.DecBinary()
-		_ = yym315
+		yyv326 := &x.Items
+		yym327 := z.DecBinary()
+		_ = yym327
 		if false {
 		} else {
-			h.decSliceThirdPartyResource((*[]ThirdPartyResource)(yyv314), d)
+			h.decSliceThirdPartyResource((*[]ThirdPartyResource)(yyv326), d)
 		}
 	}
 	for {
-		yyj309++
-		if yyhl309 {
-			yyb309 = yyj309 > l
+		yyj321++
+		if yyhl321 {
+			yyb321 = yyj321 > l
 		} else {
-			yyb309 = r.CheckBreak()
+			yyb321 = r.CheckBreak()
 		}
-		if yyb309 {
+		if yyb321 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj309-1, "")
+		z.DecStructFieldNotFound(yyj321-1, "")
 	}
 	r.ReadEnd()
 }
@@ -3506,33 +3578,33 @@ func (x *APIVersion) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym316 := z.EncBinary()
-		_ = yym316
+		yym328 := z.EncBinary()
+		_ = yym328
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep317 := !z.EncBinary()
-			yy2arr317 := z.EncBasicHandle().StructToArray
-			var yyq317 [2]bool
-			_, _, _ = yysep317, yyq317, yy2arr317
-			const yyr317 bool = false
-			yyq317[0] = x.Name != ""
-			yyq317[1] = x.APIGroup != ""
-			if yyr317 || yy2arr317 {
+			yysep329 := !z.EncBinary()
+			yy2arr329 := z.EncBasicHandle().StructToArray
+			var yyq329 [2]bool
+			_, _, _ = yysep329, yyq329, yy2arr329
+			const yyr329 bool = false
+			yyq329[0] = x.Name != ""
+			yyq329[1] = x.APIGroup != ""
+			if yyr329 || yy2arr329 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn317 int = 0
-				for _, b := range yyq317 {
+				var yynn329 int = 0
+				for _, b := range yyq329 {
 					if b {
-						yynn317++
+						yynn329++
 					}
 				}
-				r.EncodeMapStart(yynn317)
+				r.EncodeMapStart(yynn329)
 			}
-			if yyr317 || yy2arr317 {
-				if yyq317[0] {
-					yym319 := z.EncBinary()
-					_ = yym319
+			if yyr329 || yy2arr329 {
+				if yyq329[0] {
+					yym331 := z.EncBinary()
+					_ = yym331
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
@@ -3541,20 +3613,20 @@ func (x *APIVersion) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq317[0] {
+				if yyq329[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("name"))
-					yym320 := z.EncBinary()
-					_ = yym320
+					yym332 := z.EncBinary()
+					_ = yym332
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 					}
 				}
 			}
-			if yyr317 || yy2arr317 {
-				if yyq317[1] {
-					yym322 := z.EncBinary()
-					_ = yym322
+			if yyr329 || yy2arr329 {
+				if yyq329[1] {
+					yym334 := z.EncBinary()
+					_ = yym334
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIGroup))
@@ -3563,17 +3635,17 @@ func (x *APIVersion) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq317[1] {
+				if yyq329[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiGroup"))
-					yym323 := z.EncBinary()
-					_ = yym323
+					yym335 := z.EncBinary()
+					_ = yym335
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIGroup))
 					}
 				}
 			}
-			if yysep317 {
+			if yysep329 {
 				r.EncodeEnd()
 			}
 		}
@@ -3584,24 +3656,24 @@ func (x *APIVersion) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym324 := z.DecBinary()
-	_ = yym324
+	yym336 := z.DecBinary()
+	_ = yym336
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl325 := r.ReadMapStart()
-			if yyl325 == 0 {
+			yyl337 := r.ReadMapStart()
+			if yyl337 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl325, d)
+				x.codecDecodeSelfFromMap(yyl337, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl325 := r.ReadArrayStart()
-			if yyl325 == 0 {
+			yyl337 := r.ReadArrayStart()
+			if yyl337 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl325, d)
+				x.codecDecodeSelfFromArray(yyl337, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -3613,12 +3685,12 @@ func (x *APIVersion) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys326Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys326Slc
-	var yyhl326 bool = l >= 0
-	for yyj326 := 0; ; yyj326++ {
-		if yyhl326 {
-			if yyj326 >= l {
+	var yys338Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys338Slc
+	var yyhl338 bool = l >= 0
+	for yyj338 := 0; ; yyj338++ {
+		if yyhl338 {
+			if yyj338 >= l {
 				break
 			}
 		} else {
@@ -3626,9 +3698,9 @@ func (x *APIVersion) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys326Slc = r.DecodeBytes(yys326Slc, true, true)
-		yys326 := string(yys326Slc)
-		switch yys326 {
+		yys338Slc = r.DecodeBytes(yys338Slc, true, true)
+		yys338 := string(yys338Slc)
+		switch yys338 {
 		case "name":
 			if r.TryDecodeAsNil() {
 				x.Name = ""
@@ -3642,10 +3714,10 @@ func (x *APIVersion) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIGroup = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys326)
-		} // end switch yys326
-	} // end for yyj326
-	if !yyhl326 {
+			z.DecStructFieldNotFound(-1, yys338)
+		} // end switch yys338
+	} // end for yyj338
+	if !yyhl338 {
 		r.ReadEnd()
 	}
 }
@@ -3654,16 +3726,16 @@ func (x *APIVersion) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj329 int
-	var yyb329 bool
-	var yyhl329 bool = l >= 0
-	yyj329++
-	if yyhl329 {
-		yyb329 = yyj329 > l
+	var yyj341 int
+	var yyb341 bool
+	var yyhl341 bool = l >= 0
+	yyj341++
+	if yyhl341 {
+		yyb341 = yyj341 > l
 	} else {
-		yyb329 = r.CheckBreak()
+		yyb341 = r.CheckBreak()
 	}
-	if yyb329 {
+	if yyb341 {
 		r.ReadEnd()
 		return
 	}
@@ -3672,13 +3744,13 @@ func (x *APIVersion) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Name = string(r.DecodeString())
 	}
-	yyj329++
-	if yyhl329 {
-		yyb329 = yyj329 > l
+	yyj341++
+	if yyhl341 {
+		yyb341 = yyj341 > l
 	} else {
-		yyb329 = r.CheckBreak()
+		yyb341 = r.CheckBreak()
 	}
-	if yyb329 {
+	if yyb341 {
 		r.ReadEnd()
 		return
 	}
@@ -3688,16 +3760,16 @@ func (x *APIVersion) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIGroup = string(r.DecodeString())
 	}
 	for {
-		yyj329++
-		if yyhl329 {
-			yyb329 = yyj329 > l
+		yyj341++
+		if yyhl341 {
+			yyb341 = yyj341 > l
 		} else {
-			yyb329 = r.CheckBreak()
+			yyb341 = r.CheckBreak()
 		}
-		if yyb329 {
+		if yyb341 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj329-1, "")
+		z.DecStructFieldNotFound(yyj341-1, "")
 	}
 	r.ReadEnd()
 }
@@ -3709,35 +3781,35 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym332 := z.EncBinary()
-		_ = yym332
+		yym344 := z.EncBinary()
+		_ = yym344
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep333 := !z.EncBinary()
-			yy2arr333 := z.EncBasicHandle().StructToArray
-			var yyq333 [4]bool
-			_, _, _ = yysep333, yyq333, yy2arr333
-			const yyr333 bool = false
-			yyq333[0] = x.Kind != ""
-			yyq333[1] = x.APIVersion != ""
-			yyq333[2] = true
-			yyq333[3] = len(x.Data) != 0
-			if yyr333 || yy2arr333 {
+			yysep345 := !z.EncBinary()
+			yy2arr345 := z.EncBasicHandle().StructToArray
+			var yyq345 [4]bool
+			_, _, _ = yysep345, yyq345, yy2arr345
+			const yyr345 bool = false
+			yyq345[0] = x.Kind != ""
+			yyq345[1] = x.APIVersion != ""
+			yyq345[2] = true
+			yyq345[3] = len(x.Data) != 0
+			if yyr345 || yy2arr345 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn333 int = 0
-				for _, b := range yyq333 {
+				var yynn345 int = 0
+				for _, b := range yyq345 {
 					if b {
-						yynn333++
+						yynn345++
 					}
 				}
-				r.EncodeMapStart(yynn333)
+				r.EncodeMapStart(yynn345)
 			}
-			if yyr333 || yy2arr333 {
-				if yyq333[0] {
-					yym335 := z.EncBinary()
-					_ = yym335
+			if yyr345 || yy2arr345 {
+				if yyq345[0] {
+					yym347 := z.EncBinary()
+					_ = yym347
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -3746,20 +3818,20 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq333[0] {
+				if yyq345[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym336 := z.EncBinary()
-					_ = yym336
+					yym348 := z.EncBinary()
+					_ = yym348
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr333 || yy2arr333 {
-				if yyq333[1] {
-					yym338 := z.EncBinary()
-					_ = yym338
+			if yyr345 || yy2arr345 {
+				if yyq345[1] {
+					yym350 := z.EncBinary()
+					_ = yym350
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -3768,37 +3840,49 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq333[1] {
+				if yyq345[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym339 := z.EncBinary()
-					_ = yym339
+					yym351 := z.EncBinary()
+					_ = yym351
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr333 || yy2arr333 {
-				if yyq333[2] {
-					yy341 := &x.ObjectMeta
-					yy341.CodecEncodeSelf(e)
+			if yyr345 || yy2arr345 {
+				if yyq345[2] {
+					yy353 := &x.ObjectMeta
+					yym354 := z.EncBinary()
+					_ = yym354
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy353) {
+					} else {
+						z.EncFallback(yy353)
+					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq333[2] {
+				if yyq345[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy342 := &x.ObjectMeta
-					yy342.CodecEncodeSelf(e)
+					yy355 := &x.ObjectMeta
+					yym356 := z.EncBinary()
+					_ = yym356
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy355) {
+					} else {
+						z.EncFallback(yy355)
+					}
 				}
 			}
-			if yyr333 || yy2arr333 {
-				if yyq333[3] {
+			if yyr345 || yy2arr345 {
+				if yyq345[3] {
 					if x.Data == nil {
 						r.EncodeNil()
 					} else {
-						yym344 := z.EncBinary()
-						_ = yym344
+						yym358 := z.EncBinary()
+						_ = yym358
 						if false {
 						} else {
 							r.EncodeStringBytes(codecSelferC_RAW1234, []byte(x.Data))
@@ -3808,13 +3892,13 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq333[3] {
+				if yyq345[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("name"))
 					if x.Data == nil {
 						r.EncodeNil()
 					} else {
-						yym345 := z.EncBinary()
-						_ = yym345
+						yym359 := z.EncBinary()
+						_ = yym359
 						if false {
 						} else {
 							r.EncodeStringBytes(codecSelferC_RAW1234, []byte(x.Data))
@@ -3822,7 +3906,7 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep333 {
+			if yysep345 {
 				r.EncodeEnd()
 			}
 		}
@@ -3833,24 +3917,24 @@ func (x *ThirdPartyResourceData) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym346 := z.DecBinary()
-	_ = yym346
+	yym360 := z.DecBinary()
+	_ = yym360
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl347 := r.ReadMapStart()
-			if yyl347 == 0 {
+			yyl361 := r.ReadMapStart()
+			if yyl361 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl347, d)
+				x.codecDecodeSelfFromMap(yyl361, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl347 := r.ReadArrayStart()
-			if yyl347 == 0 {
+			yyl361 := r.ReadArrayStart()
+			if yyl361 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl347, d)
+				x.codecDecodeSelfFromArray(yyl361, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -3862,12 +3946,12 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys348Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys348Slc
-	var yyhl348 bool = l >= 0
-	for yyj348 := 0; ; yyj348++ {
-		if yyhl348 {
-			if yyj348 >= l {
+	var yys362Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys362Slc
+	var yyhl362 bool = l >= 0
+	for yyj362 := 0; ; yyj362++ {
+		if yyhl362 {
+			if yyj362 >= l {
 				break
 			}
 		} else {
@@ -3875,9 +3959,9 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				break
 			}
 		}
-		yys348Slc = r.DecodeBytes(yys348Slc, true, true)
-		yys348 := string(yys348Slc)
-		switch yys348 {
+		yys362Slc = r.DecodeBytes(yys362Slc, true, true)
+		yys362 := string(yys362Slc)
+		switch yys362 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -3894,26 +3978,32 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv351 := &x.ObjectMeta
-				yyv351.CodecDecodeSelf(d)
+				yyv365 := &x.ObjectMeta
+				yym366 := z.DecBinary()
+				_ = yym366
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv365) {
+				} else {
+					z.DecFallback(yyv365, false)
+				}
 			}
 		case "name":
 			if r.TryDecodeAsNil() {
 				x.Data = nil
 			} else {
-				yyv352 := &x.Data
-				yym353 := z.DecBinary()
-				_ = yym353
+				yyv367 := &x.Data
+				yym368 := z.DecBinary()
+				_ = yym368
 				if false {
 				} else {
-					*yyv352 = r.DecodeBytes(*(*[]byte)(yyv352), false, false)
+					*yyv367 = r.DecodeBytes(*(*[]byte)(yyv367), false, false)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys348)
-		} // end switch yys348
-	} // end for yyj348
-	if !yyhl348 {
+			z.DecStructFieldNotFound(-1, yys362)
+		} // end switch yys362
+	} // end for yyj362
+	if !yyhl362 {
 		r.ReadEnd()
 	}
 }
@@ -3922,16 +4012,16 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromArray(l int, d *codec1978.De
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj354 int
-	var yyb354 bool
-	var yyhl354 bool = l >= 0
-	yyj354++
-	if yyhl354 {
-		yyb354 = yyj354 > l
+	var yyj369 int
+	var yyb369 bool
+	var yyhl369 bool = l >= 0
+	yyj369++
+	if yyhl369 {
+		yyb369 = yyj369 > l
 	} else {
-		yyb354 = r.CheckBreak()
+		yyb369 = r.CheckBreak()
 	}
-	if yyb354 {
+	if yyb369 {
 		r.ReadEnd()
 		return
 	}
@@ -3940,13 +4030,13 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromArray(l int, d *codec1978.De
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj354++
-	if yyhl354 {
-		yyb354 = yyj354 > l
+	yyj369++
+	if yyhl369 {
+		yyb369 = yyj369 > l
 	} else {
-		yyb354 = r.CheckBreak()
+		yyb369 = r.CheckBreak()
 	}
-	if yyb354 {
+	if yyb369 {
 		r.ReadEnd()
 		return
 	}
@@ -3955,54 +4045,60 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromArray(l int, d *codec1978.De
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj354++
-	if yyhl354 {
-		yyb354 = yyj354 > l
+	yyj369++
+	if yyhl369 {
+		yyb369 = yyj369 > l
 	} else {
-		yyb354 = r.CheckBreak()
+		yyb369 = r.CheckBreak()
 	}
-	if yyb354 {
+	if yyb369 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv357 := &x.ObjectMeta
-		yyv357.CodecDecodeSelf(d)
+		yyv372 := &x.ObjectMeta
+		yym373 := z.DecBinary()
+		_ = yym373
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv372) {
+		} else {
+			z.DecFallback(yyv372, false)
+		}
 	}
-	yyj354++
-	if yyhl354 {
-		yyb354 = yyj354 > l
+	yyj369++
+	if yyhl369 {
+		yyb369 = yyj369 > l
 	} else {
-		yyb354 = r.CheckBreak()
+		yyb369 = r.CheckBreak()
 	}
-	if yyb354 {
+	if yyb369 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Data = nil
 	} else {
-		yyv358 := &x.Data
-		yym359 := z.DecBinary()
-		_ = yym359
+		yyv374 := &x.Data
+		yym375 := z.DecBinary()
+		_ = yym375
 		if false {
 		} else {
-			*yyv358 = r.DecodeBytes(*(*[]byte)(yyv358), false, false)
+			*yyv374 = r.DecodeBytes(*(*[]byte)(yyv374), false, false)
 		}
 	}
 	for {
-		yyj354++
-		if yyhl354 {
-			yyb354 = yyj354 > l
+		yyj369++
+		if yyhl369 {
+			yyb369 = yyj369 > l
 		} else {
-			yyb354 = r.CheckBreak()
+			yyb369 = r.CheckBreak()
 		}
-		if yyb354 {
+		if yyb369 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj354-1, "")
+		z.DecStructFieldNotFound(yyj369-1, "")
 	}
 	r.ReadEnd()
 }
@@ -4014,36 +4110,36 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym360 := z.EncBinary()
-		_ = yym360
+		yym376 := z.EncBinary()
+		_ = yym376
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep361 := !z.EncBinary()
-			yy2arr361 := z.EncBasicHandle().StructToArray
-			var yyq361 [5]bool
-			_, _, _ = yysep361, yyq361, yy2arr361
-			const yyr361 bool = false
-			yyq361[0] = x.Kind != ""
-			yyq361[1] = x.APIVersion != ""
-			yyq361[2] = true
-			yyq361[3] = true
-			yyq361[4] = true
-			if yyr361 || yy2arr361 {
+			yysep377 := !z.EncBinary()
+			yy2arr377 := z.EncBasicHandle().StructToArray
+			var yyq377 [5]bool
+			_, _, _ = yysep377, yyq377, yy2arr377
+			const yyr377 bool = false
+			yyq377[0] = x.Kind != ""
+			yyq377[1] = x.APIVersion != ""
+			yyq377[2] = true
+			yyq377[3] = true
+			yyq377[4] = true
+			if yyr377 || yy2arr377 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn361 int = 0
-				for _, b := range yyq361 {
+				var yynn377 int = 0
+				for _, b := range yyq377 {
 					if b {
-						yynn361++
+						yynn377++
 					}
 				}
-				r.EncodeMapStart(yynn361)
+				r.EncodeMapStart(yynn377)
 			}
-			if yyr361 || yy2arr361 {
-				if yyq361[0] {
-					yym363 := z.EncBinary()
-					_ = yym363
+			if yyr377 || yy2arr377 {
+				if yyq377[0] {
+					yym379 := z.EncBinary()
+					_ = yym379
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -4052,20 +4148,20 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq361[0] {
+				if yyq377[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym364 := z.EncBinary()
-					_ = yym364
+					yym380 := z.EncBinary()
+					_ = yym380
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr361 || yy2arr361 {
-				if yyq361[1] {
-					yym366 := z.EncBinary()
-					_ = yym366
+			if yyr377 || yy2arr377 {
+				if yyq377[1] {
+					yym382 := z.EncBinary()
+					_ = yym382
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -4074,59 +4170,71 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq361[1] {
+				if yyq377[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym367 := z.EncBinary()
-					_ = yym367
+					yym383 := z.EncBinary()
+					_ = yym383
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr361 || yy2arr361 {
-				if yyq361[2] {
-					yy369 := &x.ObjectMeta
-					yy369.CodecEncodeSelf(e)
+			if yyr377 || yy2arr377 {
+				if yyq377[2] {
+					yy385 := &x.ObjectMeta
+					yym386 := z.EncBinary()
+					_ = yym386
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy385) {
+					} else {
+						z.EncFallback(yy385)
+					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq361[2] {
+				if yyq377[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy370 := &x.ObjectMeta
-					yy370.CodecEncodeSelf(e)
+					yy387 := &x.ObjectMeta
+					yym388 := z.EncBinary()
+					_ = yym388
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy387) {
+					} else {
+						z.EncFallback(yy387)
+					}
 				}
 			}
-			if yyr361 || yy2arr361 {
-				if yyq361[3] {
-					yy372 := &x.Spec
-					yy372.CodecEncodeSelf(e)
+			if yyr377 || yy2arr377 {
+				if yyq377[3] {
+					yy390 := &x.Spec
+					yy390.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq361[3] {
+				if yyq377[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy373 := &x.Spec
-					yy373.CodecEncodeSelf(e)
+					yy391 := &x.Spec
+					yy391.CodecEncodeSelf(e)
 				}
 			}
-			if yyr361 || yy2arr361 {
-				if yyq361[4] {
-					yy375 := &x.Status
-					yy375.CodecEncodeSelf(e)
+			if yyr377 || yy2arr377 {
+				if yyq377[4] {
+					yy393 := &x.Status
+					yy393.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq361[4] {
+				if yyq377[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy376 := &x.Status
-					yy376.CodecEncodeSelf(e)
+					yy394 := &x.Status
+					yy394.CodecEncodeSelf(e)
 				}
 			}
-			if yysep361 {
+			if yysep377 {
 				r.EncodeEnd()
 			}
 		}
@@ -4137,24 +4245,24 @@ func (x *Deployment) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym377 := z.DecBinary()
-	_ = yym377
+	yym395 := z.DecBinary()
+	_ = yym395
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl378 := r.ReadMapStart()
-			if yyl378 == 0 {
+			yyl396 := r.ReadMapStart()
+			if yyl396 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl378, d)
+				x.codecDecodeSelfFromMap(yyl396, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl378 := r.ReadArrayStart()
-			if yyl378 == 0 {
+			yyl396 := r.ReadArrayStart()
+			if yyl396 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl378, d)
+				x.codecDecodeSelfFromArray(yyl396, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4166,12 +4274,12 @@ func (x *Deployment) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys379Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys379Slc
-	var yyhl379 bool = l >= 0
-	for yyj379 := 0; ; yyj379++ {
-		if yyhl379 {
-			if yyj379 >= l {
+	var yys397Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys397Slc
+	var yyhl397 bool = l >= 0
+	for yyj397 := 0; ; yyj397++ {
+		if yyhl397 {
+			if yyj397 >= l {
 				break
 			}
 		} else {
@@ -4179,9 +4287,9 @@ func (x *Deployment) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys379Slc = r.DecodeBytes(yys379Slc, true, true)
-		yys379 := string(yys379Slc)
-		switch yys379 {
+		yys397Slc = r.DecodeBytes(yys397Slc, true, true)
+		yys397 := string(yys397Slc)
+		switch yys397 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -4198,28 +4306,34 @@ func (x *Deployment) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv382 := &x.ObjectMeta
-				yyv382.CodecDecodeSelf(d)
+				yyv400 := &x.ObjectMeta
+				yym401 := z.DecBinary()
+				_ = yym401
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv400) {
+				} else {
+					z.DecFallback(yyv400, false)
+				}
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = DeploymentSpec{}
 			} else {
-				yyv383 := &x.Spec
-				yyv383.CodecDecodeSelf(d)
+				yyv402 := &x.Spec
+				yyv402.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = DeploymentStatus{}
 			} else {
-				yyv384 := &x.Status
-				yyv384.CodecDecodeSelf(d)
+				yyv403 := &x.Status
+				yyv403.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys379)
-		} // end switch yys379
-	} // end for yyj379
-	if !yyhl379 {
+			z.DecStructFieldNotFound(-1, yys397)
+		} // end switch yys397
+	} // end for yyj397
+	if !yyhl397 {
 		r.ReadEnd()
 	}
 }
@@ -4228,16 +4342,16 @@ func (x *Deployment) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj385 int
-	var yyb385 bool
-	var yyhl385 bool = l >= 0
-	yyj385++
-	if yyhl385 {
-		yyb385 = yyj385 > l
+	var yyj404 int
+	var yyb404 bool
+	var yyhl404 bool = l >= 0
+	yyj404++
+	if yyhl404 {
+		yyb404 = yyj404 > l
 	} else {
-		yyb385 = r.CheckBreak()
+		yyb404 = r.CheckBreak()
 	}
-	if yyb385 {
+	if yyb404 {
 		r.ReadEnd()
 		return
 	}
@@ -4246,13 +4360,13 @@ func (x *Deployment) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj385++
-	if yyhl385 {
-		yyb385 = yyj385 > l
+	yyj404++
+	if yyhl404 {
+		yyb404 = yyj404 > l
 	} else {
-		yyb385 = r.CheckBreak()
+		yyb404 = r.CheckBreak()
 	}
-	if yyb385 {
+	if yyb404 {
 		r.ReadEnd()
 		return
 	}
@@ -4261,65 +4375,71 @@ func (x *Deployment) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj385++
-	if yyhl385 {
-		yyb385 = yyj385 > l
+	yyj404++
+	if yyhl404 {
+		yyb404 = yyj404 > l
 	} else {
-		yyb385 = r.CheckBreak()
+		yyb404 = r.CheckBreak()
 	}
-	if yyb385 {
+	if yyb404 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv388 := &x.ObjectMeta
-		yyv388.CodecDecodeSelf(d)
+		yyv407 := &x.ObjectMeta
+		yym408 := z.DecBinary()
+		_ = yym408
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv407) {
+		} else {
+			z.DecFallback(yyv407, false)
+		}
 	}
-	yyj385++
-	if yyhl385 {
-		yyb385 = yyj385 > l
+	yyj404++
+	if yyhl404 {
+		yyb404 = yyj404 > l
 	} else {
-		yyb385 = r.CheckBreak()
+		yyb404 = r.CheckBreak()
 	}
-	if yyb385 {
+	if yyb404 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = DeploymentSpec{}
 	} else {
-		yyv389 := &x.Spec
-		yyv389.CodecDecodeSelf(d)
+		yyv409 := &x.Spec
+		yyv409.CodecDecodeSelf(d)
 	}
-	yyj385++
-	if yyhl385 {
-		yyb385 = yyj385 > l
+	yyj404++
+	if yyhl404 {
+		yyb404 = yyj404 > l
 	} else {
-		yyb385 = r.CheckBreak()
+		yyb404 = r.CheckBreak()
 	}
-	if yyb385 {
+	if yyb404 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = DeploymentStatus{}
 	} else {
-		yyv390 := &x.Status
-		yyv390.CodecDecodeSelf(d)
+		yyv410 := &x.Status
+		yyv410.CodecDecodeSelf(d)
 	}
 	for {
-		yyj385++
-		if yyhl385 {
-			yyb385 = yyj385 > l
+		yyj404++
+		if yyhl404 {
+			yyb404 = yyj404 > l
 		} else {
-			yyb385 = r.CheckBreak()
+			yyb404 = r.CheckBreak()
 		}
-		if yyb385 {
+		if yyb404 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj385-1, "")
+		z.DecStructFieldNotFound(yyj404-1, "")
 	}
 	r.ReadEnd()
 }
@@ -4331,36 +4451,36 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym391 := z.EncBinary()
-		_ = yym391
+		yym411 := z.EncBinary()
+		_ = yym411
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep392 := !z.EncBinary()
-			yy2arr392 := z.EncBasicHandle().StructToArray
-			var yyq392 [5]bool
-			_, _, _ = yysep392, yyq392, yy2arr392
-			const yyr392 bool = false
-			yyq392[0] = x.Replicas != 0
-			yyq392[1] = len(x.Selector) != 0
-			yyq392[2] = x.Template != nil
-			yyq392[3] = true
-			yyq392[4] = x.UniqueLabelKey != ""
-			if yyr392 || yy2arr392 {
+			yysep412 := !z.EncBinary()
+			yy2arr412 := z.EncBasicHandle().StructToArray
+			var yyq412 [5]bool
+			_, _, _ = yysep412, yyq412, yy2arr412
+			const yyr412 bool = false
+			yyq412[0] = x.Replicas != 0
+			yyq412[1] = len(x.Selector) != 0
+			yyq412[2] = x.Template != nil
+			yyq412[3] = true
+			yyq412[4] = x.UniqueLabelKey != ""
+			if yyr412 || yy2arr412 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn392 int = 0
-				for _, b := range yyq392 {
+				var yynn412 int = 0
+				for _, b := range yyq412 {
 					if b {
-						yynn392++
+						yynn412++
 					}
 				}
-				r.EncodeMapStart(yynn392)
+				r.EncodeMapStart(yynn412)
 			}
-			if yyr392 || yy2arr392 {
-				if yyq392[0] {
-					yym394 := z.EncBinary()
-					_ = yym394
+			if yyr412 || yy2arr412 {
+				if yyq412[0] {
+					yym414 := z.EncBinary()
+					_ = yym414
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Replicas))
@@ -4369,23 +4489,23 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq392[0] {
+				if yyq412[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("replicas"))
-					yym395 := z.EncBinary()
-					_ = yym395
+					yym415 := z.EncBinary()
+					_ = yym415
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Replicas))
 					}
 				}
 			}
-			if yyr392 || yy2arr392 {
-				if yyq392[1] {
+			if yyr412 || yy2arr412 {
+				if yyq412[1] {
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
-						yym397 := z.EncBinary()
-						_ = yym397
+						yym417 := z.EncBinary()
+						_ = yym417
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.Selector, false, e)
@@ -4395,13 +4515,13 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq392[1] {
+				if yyq412[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
-						yym398 := z.EncBinary()
-						_ = yym398
+						yym418 := z.EncBinary()
+						_ = yym418
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.Selector, false, e)
@@ -4409,44 +4529,56 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr392 || yy2arr392 {
-				if yyq392[2] {
+			if yyr412 || yy2arr412 {
+				if yyq412[2] {
 					if x.Template == nil {
 						r.EncodeNil()
 					} else {
-						x.Template.CodecEncodeSelf(e)
+						yym420 := z.EncBinary()
+						_ = yym420
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.Template) {
+						} else {
+							z.EncFallback(x.Template)
+						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq392[2] {
+				if yyq412[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("template"))
 					if x.Template == nil {
 						r.EncodeNil()
 					} else {
-						x.Template.CodecEncodeSelf(e)
+						yym421 := z.EncBinary()
+						_ = yym421
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.Template) {
+						} else {
+							z.EncFallback(x.Template)
+						}
 					}
 				}
 			}
-			if yyr392 || yy2arr392 {
-				if yyq392[3] {
-					yy401 := &x.Strategy
-					yy401.CodecEncodeSelf(e)
+			if yyr412 || yy2arr412 {
+				if yyq412[3] {
+					yy423 := &x.Strategy
+					yy423.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq392[3] {
+				if yyq412[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("strategy"))
-					yy402 := &x.Strategy
-					yy402.CodecEncodeSelf(e)
+					yy424 := &x.Strategy
+					yy424.CodecEncodeSelf(e)
 				}
 			}
-			if yyr392 || yy2arr392 {
-				if yyq392[4] {
-					yym404 := z.EncBinary()
-					_ = yym404
+			if yyr412 || yy2arr412 {
+				if yyq412[4] {
+					yym426 := z.EncBinary()
+					_ = yym426
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.UniqueLabelKey))
@@ -4455,17 +4587,17 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq392[4] {
+				if yyq412[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("uniqueLabelKey"))
-					yym405 := z.EncBinary()
-					_ = yym405
+					yym427 := z.EncBinary()
+					_ = yym427
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.UniqueLabelKey))
 					}
 				}
 			}
-			if yysep392 {
+			if yysep412 {
 				r.EncodeEnd()
 			}
 		}
@@ -4476,24 +4608,24 @@ func (x *DeploymentSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym406 := z.DecBinary()
-	_ = yym406
+	yym428 := z.DecBinary()
+	_ = yym428
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl407 := r.ReadMapStart()
-			if yyl407 == 0 {
+			yyl429 := r.ReadMapStart()
+			if yyl429 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl407, d)
+				x.codecDecodeSelfFromMap(yyl429, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl407 := r.ReadArrayStart()
-			if yyl407 == 0 {
+			yyl429 := r.ReadArrayStart()
+			if yyl429 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl407, d)
+				x.codecDecodeSelfFromArray(yyl429, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4505,12 +4637,12 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys408Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys408Slc
-	var yyhl408 bool = l >= 0
-	for yyj408 := 0; ; yyj408++ {
-		if yyhl408 {
-			if yyj408 >= l {
+	var yys430Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys430Slc
+	var yyhl430 bool = l >= 0
+	for yyj430 := 0; ; yyj430++ {
+		if yyhl430 {
+			if yyj430 >= l {
 				break
 			}
 		} else {
@@ -4518,9 +4650,9 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys408Slc = r.DecodeBytes(yys408Slc, true, true)
-		yys408 := string(yys408Slc)
-		switch yys408 {
+		yys430Slc = r.DecodeBytes(yys430Slc, true, true)
+		yys430 := string(yys430Slc)
+		switch yys430 {
 		case "replicas":
 			if r.TryDecodeAsNil() {
 				x.Replicas = 0
@@ -4531,12 +4663,12 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Selector = nil
 			} else {
-				yyv410 := &x.Selector
-				yym411 := z.DecBinary()
-				_ = yym411
+				yyv432 := &x.Selector
+				yym433 := z.DecBinary()
+				_ = yym433
 				if false {
 				} else {
-					z.F.DecMapStringStringX(yyv410, false, d)
+					z.F.DecMapStringStringX(yyv432, false, d)
 				}
 			}
 		case "template":
@@ -4548,14 +4680,20 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.Template == nil {
 					x.Template = new(pkg2_api.PodTemplateSpec)
 				}
-				x.Template.CodecDecodeSelf(d)
+				yym435 := z.DecBinary()
+				_ = yym435
+				if false {
+				} else if z.HasExtensions() && z.DecExt(x.Template) {
+				} else {
+					z.DecFallback(x.Template, false)
+				}
 			}
 		case "strategy":
 			if r.TryDecodeAsNil() {
 				x.Strategy = DeploymentStrategy{}
 			} else {
-				yyv413 := &x.Strategy
-				yyv413.CodecDecodeSelf(d)
+				yyv436 := &x.Strategy
+				yyv436.CodecDecodeSelf(d)
 			}
 		case "uniqueLabelKey":
 			if r.TryDecodeAsNil() {
@@ -4564,10 +4702,10 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.UniqueLabelKey = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys408)
-		} // end switch yys408
-	} // end for yyj408
-	if !yyhl408 {
+			z.DecStructFieldNotFound(-1, yys430)
+		} // end switch yys430
+	} // end for yyj430
+	if !yyhl430 {
 		r.ReadEnd()
 	}
 }
@@ -4576,16 +4714,16 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj415 int
-	var yyb415 bool
-	var yyhl415 bool = l >= 0
-	yyj415++
-	if yyhl415 {
-		yyb415 = yyj415 > l
+	var yyj438 int
+	var yyb438 bool
+	var yyhl438 bool = l >= 0
+	yyj438++
+	if yyhl438 {
+		yyb438 = yyj438 > l
 	} else {
-		yyb415 = r.CheckBreak()
+		yyb438 = r.CheckBreak()
 	}
-	if yyb415 {
+	if yyb438 {
 		r.ReadEnd()
 		return
 	}
@@ -4594,34 +4732,34 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Replicas = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj415++
-	if yyhl415 {
-		yyb415 = yyj415 > l
+	yyj438++
+	if yyhl438 {
+		yyb438 = yyj438 > l
 	} else {
-		yyb415 = r.CheckBreak()
+		yyb438 = r.CheckBreak()
 	}
-	if yyb415 {
+	if yyb438 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Selector = nil
 	} else {
-		yyv417 := &x.Selector
-		yym418 := z.DecBinary()
-		_ = yym418
+		yyv440 := &x.Selector
+		yym441 := z.DecBinary()
+		_ = yym441
 		if false {
 		} else {
-			z.F.DecMapStringStringX(yyv417, false, d)
+			z.F.DecMapStringStringX(yyv440, false, d)
 		}
 	}
-	yyj415++
-	if yyhl415 {
-		yyb415 = yyj415 > l
+	yyj438++
+	if yyhl438 {
+		yyb438 = yyj438 > l
 	} else {
-		yyb415 = r.CheckBreak()
+		yyb438 = r.CheckBreak()
 	}
-	if yyb415 {
+	if yyb438 {
 		r.ReadEnd()
 		return
 	}
@@ -4633,31 +4771,37 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.Template == nil {
 			x.Template = new(pkg2_api.PodTemplateSpec)
 		}
-		x.Template.CodecDecodeSelf(d)
+		yym443 := z.DecBinary()
+		_ = yym443
+		if false {
+		} else if z.HasExtensions() && z.DecExt(x.Template) {
+		} else {
+			z.DecFallback(x.Template, false)
+		}
 	}
-	yyj415++
-	if yyhl415 {
-		yyb415 = yyj415 > l
+	yyj438++
+	if yyhl438 {
+		yyb438 = yyj438 > l
 	} else {
-		yyb415 = r.CheckBreak()
+		yyb438 = r.CheckBreak()
 	}
-	if yyb415 {
+	if yyb438 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Strategy = DeploymentStrategy{}
 	} else {
-		yyv420 := &x.Strategy
-		yyv420.CodecDecodeSelf(d)
+		yyv444 := &x.Strategy
+		yyv444.CodecDecodeSelf(d)
 	}
-	yyj415++
-	if yyhl415 {
-		yyb415 = yyj415 > l
+	yyj438++
+	if yyhl438 {
+		yyb438 = yyj438 > l
 	} else {
-		yyb415 = r.CheckBreak()
+		yyb438 = r.CheckBreak()
 	}
-	if yyb415 {
+	if yyb438 {
 		r.ReadEnd()
 		return
 	}
@@ -4667,16 +4811,16 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.UniqueLabelKey = string(r.DecodeString())
 	}
 	for {
-		yyj415++
-		if yyhl415 {
-			yyb415 = yyj415 > l
+		yyj438++
+		if yyhl438 {
+			yyb438 = yyj438 > l
 		} else {
-			yyb415 = r.CheckBreak()
+			yyb438 = r.CheckBreak()
 		}
-		if yyb415 {
+		if yyb438 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj415-1, "")
+		z.DecStructFieldNotFound(yyj438-1, "")
 	}
 	r.ReadEnd()
 }
@@ -4688,43 +4832,43 @@ func (x *DeploymentStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym422 := z.EncBinary()
-		_ = yym422
+		yym446 := z.EncBinary()
+		_ = yym446
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep423 := !z.EncBinary()
-			yy2arr423 := z.EncBasicHandle().StructToArray
-			var yyq423 [2]bool
-			_, _, _ = yysep423, yyq423, yy2arr423
-			const yyr423 bool = false
-			yyq423[0] = x.Type != ""
-			yyq423[1] = x.RollingUpdate != nil
-			if yyr423 || yy2arr423 {
+			yysep447 := !z.EncBinary()
+			yy2arr447 := z.EncBasicHandle().StructToArray
+			var yyq447 [2]bool
+			_, _, _ = yysep447, yyq447, yy2arr447
+			const yyr447 bool = false
+			yyq447[0] = x.Type != ""
+			yyq447[1] = x.RollingUpdate != nil
+			if yyr447 || yy2arr447 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn423 int = 0
-				for _, b := range yyq423 {
+				var yynn447 int = 0
+				for _, b := range yyq447 {
 					if b {
-						yynn423++
+						yynn447++
 					}
 				}
-				r.EncodeMapStart(yynn423)
+				r.EncodeMapStart(yynn447)
 			}
-			if yyr423 || yy2arr423 {
-				if yyq423[0] {
+			if yyr447 || yy2arr447 {
+				if yyq447[0] {
 					x.Type.CodecEncodeSelf(e)
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq423[0] {
+				if yyq447[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("type"))
 					x.Type.CodecEncodeSelf(e)
 				}
 			}
-			if yyr423 || yy2arr423 {
-				if yyq423[1] {
+			if yyr447 || yy2arr447 {
+				if yyq447[1] {
 					if x.RollingUpdate == nil {
 						r.EncodeNil()
 					} else {
@@ -4734,7 +4878,7 @@ func (x *DeploymentStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq423[1] {
+				if yyq447[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("rollingUpdate"))
 					if x.RollingUpdate == nil {
 						r.EncodeNil()
@@ -4743,7 +4887,7 @@ func (x *DeploymentStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep423 {
+			if yysep447 {
 				r.EncodeEnd()
 			}
 		}
@@ -4754,24 +4898,24 @@ func (x *DeploymentStrategy) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym426 := z.DecBinary()
-	_ = yym426
+	yym450 := z.DecBinary()
+	_ = yym450
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl427 := r.ReadMapStart()
-			if yyl427 == 0 {
+			yyl451 := r.ReadMapStart()
+			if yyl451 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl427, d)
+				x.codecDecodeSelfFromMap(yyl451, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl427 := r.ReadArrayStart()
-			if yyl427 == 0 {
+			yyl451 := r.ReadArrayStart()
+			if yyl451 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl427, d)
+				x.codecDecodeSelfFromArray(yyl451, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4783,12 +4927,12 @@ func (x *DeploymentStrategy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys428Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys428Slc
-	var yyhl428 bool = l >= 0
-	for yyj428 := 0; ; yyj428++ {
-		if yyhl428 {
-			if yyj428 >= l {
+	var yys452Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys452Slc
+	var yyhl452 bool = l >= 0
+	for yyj452 := 0; ; yyj452++ {
+		if yyhl452 {
+			if yyj452 >= l {
 				break
 			}
 		} else {
@@ -4796,9 +4940,9 @@ func (x *DeploymentStrategy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
-		yys428Slc = r.DecodeBytes(yys428Slc, true, true)
-		yys428 := string(yys428Slc)
-		switch yys428 {
+		yys452Slc = r.DecodeBytes(yys452Slc, true, true)
+		yys452 := string(yys452Slc)
+		switch yys452 {
 		case "type":
 			if r.TryDecodeAsNil() {
 				x.Type = ""
@@ -4817,10 +4961,10 @@ func (x *DeploymentStrategy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				x.RollingUpdate.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys428)
-		} // end switch yys428
-	} // end for yyj428
-	if !yyhl428 {
+			z.DecStructFieldNotFound(-1, yys452)
+		} // end switch yys452
+	} // end for yyj452
+	if !yyhl452 {
 		r.ReadEnd()
 	}
 }
@@ -4829,16 +4973,16 @@ func (x *DeploymentStrategy) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj431 int
-	var yyb431 bool
-	var yyhl431 bool = l >= 0
-	yyj431++
-	if yyhl431 {
-		yyb431 = yyj431 > l
+	var yyj455 int
+	var yyb455 bool
+	var yyhl455 bool = l >= 0
+	yyj455++
+	if yyhl455 {
+		yyb455 = yyj455 > l
 	} else {
-		yyb431 = r.CheckBreak()
+		yyb455 = r.CheckBreak()
 	}
-	if yyb431 {
+	if yyb455 {
 		r.ReadEnd()
 		return
 	}
@@ -4847,13 +4991,13 @@ func (x *DeploymentStrategy) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.Type = DeploymentStrategyType(r.DecodeString())
 	}
-	yyj431++
-	if yyhl431 {
-		yyb431 = yyj431 > l
+	yyj455++
+	if yyhl455 {
+		yyb455 = yyj455 > l
 	} else {
-		yyb431 = r.CheckBreak()
+		yyb455 = r.CheckBreak()
 	}
-	if yyb431 {
+	if yyb455 {
 		r.ReadEnd()
 		return
 	}
@@ -4868,16 +5012,16 @@ func (x *DeploymentStrategy) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		x.RollingUpdate.CodecDecodeSelf(d)
 	}
 	for {
-		yyj431++
-		if yyhl431 {
-			yyb431 = yyj431 > l
+		yyj455++
+		if yyhl455 {
+			yyb455 = yyj455 > l
 		} else {
-			yyb431 = r.CheckBreak()
+			yyb455 = r.CheckBreak()
 		}
-		if yyb431 {
+		if yyb455 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj431-1, "")
+		z.DecStructFieldNotFound(yyj455-1, "")
 	}
 	r.ReadEnd()
 }
@@ -4886,8 +5030,8 @@ func (x DeploymentStrategyType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym434 := z.EncBinary()
-	_ = yym434
+	yym458 := z.EncBinary()
+	_ = yym458
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -4899,8 +5043,8 @@ func (x *DeploymentStrategyType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym435 := z.DecBinary()
-	_ = yym435
+	yym459 := z.DecBinary()
+	_ = yym459
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -4915,94 +5059,94 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym436 := z.EncBinary()
-		_ = yym436
+		yym460 := z.EncBinary()
+		_ = yym460
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep437 := !z.EncBinary()
-			yy2arr437 := z.EncBasicHandle().StructToArray
-			var yyq437 [3]bool
-			_, _, _ = yysep437, yyq437, yy2arr437
-			const yyr437 bool = false
-			yyq437[0] = true
-			yyq437[1] = true
-			yyq437[2] = x.MinReadySeconds != 0
-			if yyr437 || yy2arr437 {
+			yysep461 := !z.EncBinary()
+			yy2arr461 := z.EncBasicHandle().StructToArray
+			var yyq461 [3]bool
+			_, _, _ = yysep461, yyq461, yy2arr461
+			const yyr461 bool = false
+			yyq461[0] = true
+			yyq461[1] = true
+			yyq461[2] = x.MinReadySeconds != 0
+			if yyr461 || yy2arr461 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn437 int = 0
-				for _, b := range yyq437 {
+				var yynn461 int = 0
+				for _, b := range yyq461 {
 					if b {
-						yynn437++
+						yynn461++
 					}
 				}
-				r.EncodeMapStart(yynn437)
+				r.EncodeMapStart(yynn461)
 			}
-			if yyr437 || yy2arr437 {
-				if yyq437[0] {
-					yy439 := &x.MaxUnavailable
-					yym440 := z.EncBinary()
-					_ = yym440
+			if yyr461 || yy2arr461 {
+				if yyq461[0] {
+					yy463 := &x.MaxUnavailable
+					yym464 := z.EncBinary()
+					_ = yym464
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy439) {
-					} else if !yym440 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy439)
+					} else if z.HasExtensions() && z.EncExt(yy463) {
+					} else if !yym464 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy463)
 					} else {
-						z.EncFallback(yy439)
+						z.EncFallback(yy463)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq437[0] {
+				if yyq461[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("maxUnavailable"))
-					yy441 := &x.MaxUnavailable
-					yym442 := z.EncBinary()
-					_ = yym442
+					yy465 := &x.MaxUnavailable
+					yym466 := z.EncBinary()
+					_ = yym466
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy441) {
-					} else if !yym442 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy441)
+					} else if z.HasExtensions() && z.EncExt(yy465) {
+					} else if !yym466 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy465)
 					} else {
-						z.EncFallback(yy441)
+						z.EncFallback(yy465)
 					}
 				}
 			}
-			if yyr437 || yy2arr437 {
-				if yyq437[1] {
-					yy444 := &x.MaxSurge
-					yym445 := z.EncBinary()
-					_ = yym445
+			if yyr461 || yy2arr461 {
+				if yyq461[1] {
+					yy468 := &x.MaxSurge
+					yym469 := z.EncBinary()
+					_ = yym469
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy444) {
-					} else if !yym445 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy444)
+					} else if z.HasExtensions() && z.EncExt(yy468) {
+					} else if !yym469 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy468)
 					} else {
-						z.EncFallback(yy444)
+						z.EncFallback(yy468)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq437[1] {
+				if yyq461[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("maxSurge"))
-					yy446 := &x.MaxSurge
-					yym447 := z.EncBinary()
-					_ = yym447
+					yy470 := &x.MaxSurge
+					yym471 := z.EncBinary()
+					_ = yym471
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy446) {
-					} else if !yym447 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy446)
+					} else if z.HasExtensions() && z.EncExt(yy470) {
+					} else if !yym471 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy470)
 					} else {
-						z.EncFallback(yy446)
+						z.EncFallback(yy470)
 					}
 				}
 			}
-			if yyr437 || yy2arr437 {
-				if yyq437[2] {
-					yym449 := z.EncBinary()
-					_ = yym449
+			if yyr461 || yy2arr461 {
+				if yyq461[2] {
+					yym473 := z.EncBinary()
+					_ = yym473
 					if false {
 					} else {
 						r.EncodeInt(int64(x.MinReadySeconds))
@@ -5011,17 +5155,17 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq437[2] {
+				if yyq461[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("minReadySeconds"))
-					yym450 := z.EncBinary()
-					_ = yym450
+					yym474 := z.EncBinary()
+					_ = yym474
 					if false {
 					} else {
 						r.EncodeInt(int64(x.MinReadySeconds))
 					}
 				}
 			}
-			if yysep437 {
+			if yysep461 {
 				r.EncodeEnd()
 			}
 		}
@@ -5032,24 +5176,24 @@ func (x *RollingUpdateDeployment) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym451 := z.DecBinary()
-	_ = yym451
+	yym475 := z.DecBinary()
+	_ = yym475
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl452 := r.ReadMapStart()
-			if yyl452 == 0 {
+			yyl476 := r.ReadMapStart()
+			if yyl476 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl452, d)
+				x.codecDecodeSelfFromMap(yyl476, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl452 := r.ReadArrayStart()
-			if yyl452 == 0 {
+			yyl476 := r.ReadArrayStart()
+			if yyl476 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl452, d)
+				x.codecDecodeSelfFromArray(yyl476, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -5061,12 +5205,12 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys453Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys453Slc
-	var yyhl453 bool = l >= 0
-	for yyj453 := 0; ; yyj453++ {
-		if yyhl453 {
-			if yyj453 >= l {
+	var yys477Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys477Slc
+	var yyhl477 bool = l >= 0
+	for yyj477 := 0; ; yyj477++ {
+		if yyhl477 {
+			if yyj477 >= l {
 				break
 			}
 		} else {
@@ -5074,37 +5218,37 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				break
 			}
 		}
-		yys453Slc = r.DecodeBytes(yys453Slc, true, true)
-		yys453 := string(yys453Slc)
-		switch yys453 {
+		yys477Slc = r.DecodeBytes(yys477Slc, true, true)
+		yys477 := string(yys477Slc)
+		switch yys477 {
 		case "maxUnavailable":
 			if r.TryDecodeAsNil() {
 				x.MaxUnavailable = pkg6_util.IntOrString{}
 			} else {
-				yyv454 := &x.MaxUnavailable
-				yym455 := z.DecBinary()
-				_ = yym455
+				yyv478 := &x.MaxUnavailable
+				yym479 := z.DecBinary()
+				_ = yym479
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv454) {
-				} else if !yym455 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv454)
+				} else if z.HasExtensions() && z.DecExt(yyv478) {
+				} else if !yym479 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv478)
 				} else {
-					z.DecFallback(yyv454, false)
+					z.DecFallback(yyv478, false)
 				}
 			}
 		case "maxSurge":
 			if r.TryDecodeAsNil() {
 				x.MaxSurge = pkg6_util.IntOrString{}
 			} else {
-				yyv456 := &x.MaxSurge
-				yym457 := z.DecBinary()
-				_ = yym457
+				yyv480 := &x.MaxSurge
+				yym481 := z.DecBinary()
+				_ = yym481
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv456) {
-				} else if !yym457 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv456)
+				} else if z.HasExtensions() && z.DecExt(yyv480) {
+				} else if !yym481 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv480)
 				} else {
-					z.DecFallback(yyv456, false)
+					z.DecFallback(yyv480, false)
 				}
 			}
 		case "minReadySeconds":
@@ -5114,10 +5258,10 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				x.MinReadySeconds = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys453)
-		} // end switch yys453
-	} // end for yyj453
-	if !yyhl453 {
+			z.DecStructFieldNotFound(-1, yys477)
+		} // end switch yys477
+	} // end for yyj477
+	if !yyhl477 {
 		r.ReadEnd()
 	}
 }
@@ -5126,64 +5270,64 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromArray(l int, d *codec1978.D
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj459 int
-	var yyb459 bool
-	var yyhl459 bool = l >= 0
-	yyj459++
-	if yyhl459 {
-		yyb459 = yyj459 > l
+	var yyj483 int
+	var yyb483 bool
+	var yyhl483 bool = l >= 0
+	yyj483++
+	if yyhl483 {
+		yyb483 = yyj483 > l
 	} else {
-		yyb459 = r.CheckBreak()
+		yyb483 = r.CheckBreak()
 	}
-	if yyb459 {
+	if yyb483 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.MaxUnavailable = pkg6_util.IntOrString{}
 	} else {
-		yyv460 := &x.MaxUnavailable
-		yym461 := z.DecBinary()
-		_ = yym461
+		yyv484 := &x.MaxUnavailable
+		yym485 := z.DecBinary()
+		_ = yym485
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv460) {
-		} else if !yym461 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv460)
+		} else if z.HasExtensions() && z.DecExt(yyv484) {
+		} else if !yym485 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv484)
 		} else {
-			z.DecFallback(yyv460, false)
+			z.DecFallback(yyv484, false)
 		}
 	}
-	yyj459++
-	if yyhl459 {
-		yyb459 = yyj459 > l
+	yyj483++
+	if yyhl483 {
+		yyb483 = yyj483 > l
 	} else {
-		yyb459 = r.CheckBreak()
+		yyb483 = r.CheckBreak()
 	}
-	if yyb459 {
+	if yyb483 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.MaxSurge = pkg6_util.IntOrString{}
 	} else {
-		yyv462 := &x.MaxSurge
-		yym463 := z.DecBinary()
-		_ = yym463
+		yyv486 := &x.MaxSurge
+		yym487 := z.DecBinary()
+		_ = yym487
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv462) {
-		} else if !yym463 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv462)
+		} else if z.HasExtensions() && z.DecExt(yyv486) {
+		} else if !yym487 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv486)
 		} else {
-			z.DecFallback(yyv462, false)
+			z.DecFallback(yyv486, false)
 		}
 	}
-	yyj459++
-	if yyhl459 {
-		yyb459 = yyj459 > l
+	yyj483++
+	if yyhl483 {
+		yyb483 = yyj483 > l
 	} else {
-		yyb459 = r.CheckBreak()
+		yyb483 = r.CheckBreak()
 	}
-	if yyb459 {
+	if yyb483 {
 		r.ReadEnd()
 		return
 	}
@@ -5193,16 +5337,16 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromArray(l int, d *codec1978.D
 		x.MinReadySeconds = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj459++
-		if yyhl459 {
-			yyb459 = yyj459 > l
+		yyj483++
+		if yyhl483 {
+			yyb483 = yyj483 > l
 		} else {
-			yyb459 = r.CheckBreak()
+			yyb483 = r.CheckBreak()
 		}
-		if yyb459 {
+		if yyb483 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj459-1, "")
+		z.DecStructFieldNotFound(yyj483-1, "")
 	}
 	r.ReadEnd()
 }
@@ -5214,33 +5358,33 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym465 := z.EncBinary()
-		_ = yym465
+		yym489 := z.EncBinary()
+		_ = yym489
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep466 := !z.EncBinary()
-			yy2arr466 := z.EncBasicHandle().StructToArray
-			var yyq466 [2]bool
-			_, _, _ = yysep466, yyq466, yy2arr466
-			const yyr466 bool = false
-			yyq466[0] = x.Replicas != 0
-			yyq466[1] = x.UpdatedReplicas != 0
-			if yyr466 || yy2arr466 {
+			yysep490 := !z.EncBinary()
+			yy2arr490 := z.EncBasicHandle().StructToArray
+			var yyq490 [2]bool
+			_, _, _ = yysep490, yyq490, yy2arr490
+			const yyr490 bool = false
+			yyq490[0] = x.Replicas != 0
+			yyq490[1] = x.UpdatedReplicas != 0
+			if yyr490 || yy2arr490 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn466 int = 0
-				for _, b := range yyq466 {
+				var yynn490 int = 0
+				for _, b := range yyq490 {
 					if b {
-						yynn466++
+						yynn490++
 					}
 				}
-				r.EncodeMapStart(yynn466)
+				r.EncodeMapStart(yynn490)
 			}
-			if yyr466 || yy2arr466 {
-				if yyq466[0] {
-					yym468 := z.EncBinary()
-					_ = yym468
+			if yyr490 || yy2arr490 {
+				if yyq490[0] {
+					yym492 := z.EncBinary()
+					_ = yym492
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Replicas))
@@ -5249,20 +5393,20 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq466[0] {
+				if yyq490[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("replicas"))
-					yym469 := z.EncBinary()
-					_ = yym469
+					yym493 := z.EncBinary()
+					_ = yym493
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Replicas))
 					}
 				}
 			}
-			if yyr466 || yy2arr466 {
-				if yyq466[1] {
-					yym471 := z.EncBinary()
-					_ = yym471
+			if yyr490 || yy2arr490 {
+				if yyq490[1] {
+					yym495 := z.EncBinary()
+					_ = yym495
 					if false {
 					} else {
 						r.EncodeInt(int64(x.UpdatedReplicas))
@@ -5271,17 +5415,17 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq466[1] {
+				if yyq490[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("updatedReplicas"))
-					yym472 := z.EncBinary()
-					_ = yym472
+					yym496 := z.EncBinary()
+					_ = yym496
 					if false {
 					} else {
 						r.EncodeInt(int64(x.UpdatedReplicas))
 					}
 				}
 			}
-			if yysep466 {
+			if yysep490 {
 				r.EncodeEnd()
 			}
 		}
@@ -5289,260 +5433,6 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 }
 
 func (x *DeploymentStatus) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym473 := z.DecBinary()
-	_ = yym473
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl474 := r.ReadMapStart()
-			if yyl474 == 0 {
-				r.ReadEnd()
-			} else {
-				x.codecDecodeSelfFromMap(yyl474, d)
-			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl474 := r.ReadArrayStart()
-			if yyl474 == 0 {
-				r.ReadEnd()
-			} else {
-				x.codecDecodeSelfFromArray(yyl474, d)
-			}
-		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
-		}
-	}
-}
-
-func (x *DeploymentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yys475Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys475Slc
-	var yyhl475 bool = l >= 0
-	for yyj475 := 0; ; yyj475++ {
-		if yyhl475 {
-			if yyj475 >= l {
-				break
-			}
-		} else {
-			if r.CheckBreak() {
-				break
-			}
-		}
-		yys475Slc = r.DecodeBytes(yys475Slc, true, true)
-		yys475 := string(yys475Slc)
-		switch yys475 {
-		case "replicas":
-			if r.TryDecodeAsNil() {
-				x.Replicas = 0
-			} else {
-				x.Replicas = int(r.DecodeInt(codecSelferBitsize1234))
-			}
-		case "updatedReplicas":
-			if r.TryDecodeAsNil() {
-				x.UpdatedReplicas = 0
-			} else {
-				x.UpdatedReplicas = int(r.DecodeInt(codecSelferBitsize1234))
-			}
-		default:
-			z.DecStructFieldNotFound(-1, yys475)
-		} // end switch yys475
-	} // end for yyj475
-	if !yyhl475 {
-		r.ReadEnd()
-	}
-}
-
-func (x *DeploymentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yyj478 int
-	var yyb478 bool
-	var yyhl478 bool = l >= 0
-	yyj478++
-	if yyhl478 {
-		yyb478 = yyj478 > l
-	} else {
-		yyb478 = r.CheckBreak()
-	}
-	if yyb478 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.Replicas = 0
-	} else {
-		x.Replicas = int(r.DecodeInt(codecSelferBitsize1234))
-	}
-	yyj478++
-	if yyhl478 {
-		yyb478 = yyj478 > l
-	} else {
-		yyb478 = r.CheckBreak()
-	}
-	if yyb478 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.UpdatedReplicas = 0
-	} else {
-		x.UpdatedReplicas = int(r.DecodeInt(codecSelferBitsize1234))
-	}
-	for {
-		yyj478++
-		if yyhl478 {
-			yyb478 = yyj478 > l
-		} else {
-			yyb478 = r.CheckBreak()
-		}
-		if yyb478 {
-			break
-		}
-		z.DecStructFieldNotFound(yyj478-1, "")
-	}
-	r.ReadEnd()
-}
-
-func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	if x == nil {
-		r.EncodeNil()
-	} else {
-		yym481 := z.EncBinary()
-		_ = yym481
-		if false {
-		} else if z.HasExtensions() && z.EncExt(x) {
-		} else {
-			yysep482 := !z.EncBinary()
-			yy2arr482 := z.EncBasicHandle().StructToArray
-			var yyq482 [4]bool
-			_, _, _ = yysep482, yyq482, yy2arr482
-			const yyr482 bool = false
-			yyq482[0] = x.Kind != ""
-			yyq482[1] = x.APIVersion != ""
-			yyq482[2] = true
-			if yyr482 || yy2arr482 {
-				r.EncodeArrayStart(4)
-			} else {
-				var yynn482 int = 1
-				for _, b := range yyq482 {
-					if b {
-						yynn482++
-					}
-				}
-				r.EncodeMapStart(yynn482)
-			}
-			if yyr482 || yy2arr482 {
-				if yyq482[0] {
-					yym484 := z.EncBinary()
-					_ = yym484
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq482[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym485 := z.EncBinary()
-					_ = yym485
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr482 || yy2arr482 {
-				if yyq482[1] {
-					yym487 := z.EncBinary()
-					_ = yym487
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq482[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym488 := z.EncBinary()
-					_ = yym488
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr482 || yy2arr482 {
-				if yyq482[2] {
-					yy490 := &x.ListMeta
-					yym491 := z.EncBinary()
-					_ = yym491
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy490) {
-					} else {
-						z.EncFallback(yy490)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq482[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy492 := &x.ListMeta
-					yym493 := z.EncBinary()
-					_ = yym493
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy492) {
-					} else {
-						z.EncFallback(yy492)
-					}
-				}
-			}
-			if yyr482 || yy2arr482 {
-				if x.Items == nil {
-					r.EncodeNil()
-				} else {
-					yym495 := z.EncBinary()
-					_ = yym495
-					if false {
-					} else {
-						h.encSliceDeployment(([]Deployment)(x.Items), e)
-					}
-				}
-			} else {
-				r.EncodeString(codecSelferC_UTF81234, string("items"))
-				if x.Items == nil {
-					r.EncodeNil()
-				} else {
-					yym496 := z.EncBinary()
-					_ = yym496
-					if false {
-					} else {
-						h.encSliceDeployment(([]Deployment)(x.Items), e)
-					}
-				}
-			}
-			if yysep482 {
-				r.EncodeEnd()
-			}
-		}
-	}
-}
-
-func (x *DeploymentList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -5571,7 +5461,7 @@ func (x *DeploymentList) CodecDecodeSelf(d *codec1978.Decoder) {
 	}
 }
 
-func (x *DeploymentList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+func (x *DeploymentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -5591,6 +5481,260 @@ func (x *DeploymentList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 		yys499Slc = r.DecodeBytes(yys499Slc, true, true)
 		yys499 := string(yys499Slc)
 		switch yys499 {
+		case "replicas":
+			if r.TryDecodeAsNil() {
+				x.Replicas = 0
+			} else {
+				x.Replicas = int(r.DecodeInt(codecSelferBitsize1234))
+			}
+		case "updatedReplicas":
+			if r.TryDecodeAsNil() {
+				x.UpdatedReplicas = 0
+			} else {
+				x.UpdatedReplicas = int(r.DecodeInt(codecSelferBitsize1234))
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys499)
+		} // end switch yys499
+	} // end for yyj499
+	if !yyhl499 {
+		r.ReadEnd()
+	}
+}
+
+func (x *DeploymentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj502 int
+	var yyb502 bool
+	var yyhl502 bool = l >= 0
+	yyj502++
+	if yyhl502 {
+		yyb502 = yyj502 > l
+	} else {
+		yyb502 = r.CheckBreak()
+	}
+	if yyb502 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Replicas = 0
+	} else {
+		x.Replicas = int(r.DecodeInt(codecSelferBitsize1234))
+	}
+	yyj502++
+	if yyhl502 {
+		yyb502 = yyj502 > l
+	} else {
+		yyb502 = r.CheckBreak()
+	}
+	if yyb502 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.UpdatedReplicas = 0
+	} else {
+		x.UpdatedReplicas = int(r.DecodeInt(codecSelferBitsize1234))
+	}
+	for {
+		yyj502++
+		if yyhl502 {
+			yyb502 = yyj502 > l
+		} else {
+			yyb502 = r.CheckBreak()
+		}
+		if yyb502 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj502-1, "")
+	}
+	r.ReadEnd()
+}
+
+func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym505 := z.EncBinary()
+		_ = yym505
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep506 := !z.EncBinary()
+			yy2arr506 := z.EncBasicHandle().StructToArray
+			var yyq506 [4]bool
+			_, _, _ = yysep506, yyq506, yy2arr506
+			const yyr506 bool = false
+			yyq506[0] = x.Kind != ""
+			yyq506[1] = x.APIVersion != ""
+			yyq506[2] = true
+			if yyr506 || yy2arr506 {
+				r.EncodeArrayStart(4)
+			} else {
+				var yynn506 int = 1
+				for _, b := range yyq506 {
+					if b {
+						yynn506++
+					}
+				}
+				r.EncodeMapStart(yynn506)
+			}
+			if yyr506 || yy2arr506 {
+				if yyq506[0] {
+					yym508 := z.EncBinary()
+					_ = yym508
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq506[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym509 := z.EncBinary()
+					_ = yym509
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr506 || yy2arr506 {
+				if yyq506[1] {
+					yym511 := z.EncBinary()
+					_ = yym511
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq506[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym512 := z.EncBinary()
+					_ = yym512
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr506 || yy2arr506 {
+				if yyq506[2] {
+					yy514 := &x.ListMeta
+					yym515 := z.EncBinary()
+					_ = yym515
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy514) {
+					} else {
+						z.EncFallback(yy514)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq506[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy516 := &x.ListMeta
+					yym517 := z.EncBinary()
+					_ = yym517
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy516) {
+					} else {
+						z.EncFallback(yy516)
+					}
+				}
+			}
+			if yyr506 || yy2arr506 {
+				if x.Items == nil {
+					r.EncodeNil()
+				} else {
+					yym519 := z.EncBinary()
+					_ = yym519
+					if false {
+					} else {
+						h.encSliceDeployment(([]Deployment)(x.Items), e)
+					}
+				}
+			} else {
+				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				if x.Items == nil {
+					r.EncodeNil()
+				} else {
+					yym520 := z.EncBinary()
+					_ = yym520
+					if false {
+					} else {
+						h.encSliceDeployment(([]Deployment)(x.Items), e)
+					}
+				}
+			}
+			if yysep506 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *DeploymentList) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym521 := z.DecBinary()
+	_ = yym521
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl522 := r.ReadMapStart()
+			if yyl522 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl522, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl522 := r.ReadArrayStart()
+			if yyl522 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl522, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *DeploymentList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys523Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys523Slc
+	var yyhl523 bool = l >= 0
+	for yyj523 := 0; ; yyj523++ {
+		if yyhl523 {
+			if yyj523 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys523Slc = r.DecodeBytes(yys523Slc, true, true)
+		yys523 := string(yys523Slc)
+		switch yys523 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -5607,32 +5751,32 @@ func (x *DeploymentList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv502 := &x.ListMeta
-				yym503 := z.DecBinary()
-				_ = yym503
+				yyv526 := &x.ListMeta
+				yym527 := z.DecBinary()
+				_ = yym527
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv502) {
+				} else if z.HasExtensions() && z.DecExt(yyv526) {
 				} else {
-					z.DecFallback(yyv502, false)
+					z.DecFallback(yyv526, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv504 := &x.Items
-				yym505 := z.DecBinary()
-				_ = yym505
+				yyv528 := &x.Items
+				yym529 := z.DecBinary()
+				_ = yym529
 				if false {
 				} else {
-					h.decSliceDeployment((*[]Deployment)(yyv504), d)
+					h.decSliceDeployment((*[]Deployment)(yyv528), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys499)
-		} // end switch yys499
-	} // end for yyj499
-	if !yyhl499 {
+			z.DecStructFieldNotFound(-1, yys523)
+		} // end switch yys523
+	} // end for yyj523
+	if !yyhl523 {
 		r.ReadEnd()
 	}
 }
@@ -5641,16 +5785,16 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj506 int
-	var yyb506 bool
-	var yyhl506 bool = l >= 0
-	yyj506++
-	if yyhl506 {
-		yyb506 = yyj506 > l
+	var yyj530 int
+	var yyb530 bool
+	var yyhl530 bool = l >= 0
+	yyj530++
+	if yyhl530 {
+		yyb530 = yyj530 > l
 	} else {
-		yyb506 = r.CheckBreak()
+		yyb530 = r.CheckBreak()
 	}
-	if yyb506 {
+	if yyb530 {
 		r.ReadEnd()
 		return
 	}
@@ -5659,13 +5803,13 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj506++
-	if yyhl506 {
-		yyb506 = yyj506 > l
+	yyj530++
+	if yyhl530 {
+		yyb530 = yyj530 > l
 	} else {
-		yyb506 = r.CheckBreak()
+		yyb530 = r.CheckBreak()
 	}
-	if yyb506 {
+	if yyb530 {
 		r.ReadEnd()
 		return
 	}
@@ -5674,60 +5818,60 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj506++
-	if yyhl506 {
-		yyb506 = yyj506 > l
+	yyj530++
+	if yyhl530 {
+		yyb530 = yyj530 > l
 	} else {
-		yyb506 = r.CheckBreak()
+		yyb530 = r.CheckBreak()
 	}
-	if yyb506 {
+	if yyb530 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv509 := &x.ListMeta
-		yym510 := z.DecBinary()
-		_ = yym510
+		yyv533 := &x.ListMeta
+		yym534 := z.DecBinary()
+		_ = yym534
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv509) {
+		} else if z.HasExtensions() && z.DecExt(yyv533) {
 		} else {
-			z.DecFallback(yyv509, false)
+			z.DecFallback(yyv533, false)
 		}
 	}
-	yyj506++
-	if yyhl506 {
-		yyb506 = yyj506 > l
+	yyj530++
+	if yyhl530 {
+		yyb530 = yyj530 > l
 	} else {
-		yyb506 = r.CheckBreak()
+		yyb530 = r.CheckBreak()
 	}
-	if yyb506 {
+	if yyb530 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv511 := &x.Items
-		yym512 := z.DecBinary()
-		_ = yym512
+		yyv535 := &x.Items
+		yym536 := z.DecBinary()
+		_ = yym536
 		if false {
 		} else {
-			h.decSliceDeployment((*[]Deployment)(yyv511), d)
+			h.decSliceDeployment((*[]Deployment)(yyv535), d)
 		}
 	}
 	for {
-		yyj506++
-		if yyhl506 {
-			yyb506 = yyj506 > l
+		yyj530++
+		if yyhl530 {
+			yyb530 = yyj530 > l
 		} else {
-			yyb506 = r.CheckBreak()
+			yyb530 = r.CheckBreak()
 		}
-		if yyb506 {
+		if yyb530 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj506-1, "")
+		z.DecStructFieldNotFound(yyj530-1, "")
 	}
 	r.ReadEnd()
 }
@@ -5739,36 +5883,36 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym513 := z.EncBinary()
-		_ = yym513
+		yym537 := z.EncBinary()
+		_ = yym537
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep514 := !z.EncBinary()
-			yy2arr514 := z.EncBasicHandle().StructToArray
-			var yyq514 [2]bool
-			_, _, _ = yysep514, yyq514, yy2arr514
-			const yyr514 bool = false
-			yyq514[0] = len(x.Selector) != 0
-			yyq514[1] = x.Template != nil
-			if yyr514 || yy2arr514 {
+			yysep538 := !z.EncBinary()
+			yy2arr538 := z.EncBasicHandle().StructToArray
+			var yyq538 [2]bool
+			_, _, _ = yysep538, yyq538, yy2arr538
+			const yyr538 bool = false
+			yyq538[0] = len(x.Selector) != 0
+			yyq538[1] = x.Template != nil
+			if yyr538 || yy2arr538 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn514 int = 0
-				for _, b := range yyq514 {
+				var yynn538 int = 0
+				for _, b := range yyq538 {
 					if b {
-						yynn514++
+						yynn538++
 					}
 				}
-				r.EncodeMapStart(yynn514)
+				r.EncodeMapStart(yynn538)
 			}
-			if yyr514 || yy2arr514 {
-				if yyq514[0] {
+			if yyr538 || yy2arr538 {
+				if yyq538[0] {
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
-						yym516 := z.EncBinary()
-						_ = yym516
+						yym540 := z.EncBinary()
+						_ = yym540
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.Selector, false, e)
@@ -5778,13 +5922,13 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq514[0] {
+				if yyq538[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
-						yym517 := z.EncBinary()
-						_ = yym517
+						yym541 := z.EncBinary()
+						_ = yym541
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.Selector, false, e)
@@ -5792,27 +5936,39 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr514 || yy2arr514 {
-				if yyq514[1] {
+			if yyr538 || yy2arr538 {
+				if yyq538[1] {
 					if x.Template == nil {
 						r.EncodeNil()
 					} else {
-						x.Template.CodecEncodeSelf(e)
+						yym543 := z.EncBinary()
+						_ = yym543
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.Template) {
+						} else {
+							z.EncFallback(x.Template)
+						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq514[1] {
+				if yyq538[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("template"))
 					if x.Template == nil {
 						r.EncodeNil()
 					} else {
-						x.Template.CodecEncodeSelf(e)
+						yym544 := z.EncBinary()
+						_ = yym544
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.Template) {
+						} else {
+							z.EncFallback(x.Template)
+						}
 					}
 				}
 			}
-			if yysep514 {
+			if yysep538 {
 				r.EncodeEnd()
 			}
 		}
@@ -5823,24 +5979,24 @@ func (x *DaemonSetSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym519 := z.DecBinary()
-	_ = yym519
+	yym545 := z.DecBinary()
+	_ = yym545
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl520 := r.ReadMapStart()
-			if yyl520 == 0 {
+			yyl546 := r.ReadMapStart()
+			if yyl546 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl520, d)
+				x.codecDecodeSelfFromMap(yyl546, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl520 := r.ReadArrayStart()
-			if yyl520 == 0 {
+			yyl546 := r.ReadArrayStart()
+			if yyl546 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl520, d)
+				x.codecDecodeSelfFromArray(yyl546, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -5852,12 +6008,12 @@ func (x *DaemonSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys521Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys521Slc
-	var yyhl521 bool = l >= 0
-	for yyj521 := 0; ; yyj521++ {
-		if yyhl521 {
-			if yyj521 >= l {
+	var yys547Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys547Slc
+	var yyhl547 bool = l >= 0
+	for yyj547 := 0; ; yyj547++ {
+		if yyhl547 {
+			if yyj547 >= l {
 				break
 			}
 		} else {
@@ -5865,19 +6021,19 @@ func (x *DaemonSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys521Slc = r.DecodeBytes(yys521Slc, true, true)
-		yys521 := string(yys521Slc)
-		switch yys521 {
+		yys547Slc = r.DecodeBytes(yys547Slc, true, true)
+		yys547 := string(yys547Slc)
+		switch yys547 {
 		case "selector":
 			if r.TryDecodeAsNil() {
 				x.Selector = nil
 			} else {
-				yyv522 := &x.Selector
-				yym523 := z.DecBinary()
-				_ = yym523
+				yyv548 := &x.Selector
+				yym549 := z.DecBinary()
+				_ = yym549
 				if false {
 				} else {
-					z.F.DecMapStringStringX(yyv522, false, d)
+					z.F.DecMapStringStringX(yyv548, false, d)
 				}
 			}
 		case "template":
@@ -5889,13 +6045,19 @@ func (x *DaemonSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.Template == nil {
 					x.Template = new(pkg2_api.PodTemplateSpec)
 				}
-				x.Template.CodecDecodeSelf(d)
+				yym551 := z.DecBinary()
+				_ = yym551
+				if false {
+				} else if z.HasExtensions() && z.DecExt(x.Template) {
+				} else {
+					z.DecFallback(x.Template, false)
+				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys521)
-		} // end switch yys521
-	} // end for yyj521
-	if !yyhl521 {
+			z.DecStructFieldNotFound(-1, yys547)
+		} // end switch yys547
+	} // end for yyj547
+	if !yyhl547 {
 		r.ReadEnd()
 	}
 }
@@ -5904,37 +6066,37 @@ func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj525 int
-	var yyb525 bool
-	var yyhl525 bool = l >= 0
-	yyj525++
-	if yyhl525 {
-		yyb525 = yyj525 > l
+	var yyj552 int
+	var yyb552 bool
+	var yyhl552 bool = l >= 0
+	yyj552++
+	if yyhl552 {
+		yyb552 = yyj552 > l
 	} else {
-		yyb525 = r.CheckBreak()
+		yyb552 = r.CheckBreak()
 	}
-	if yyb525 {
+	if yyb552 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Selector = nil
 	} else {
-		yyv526 := &x.Selector
-		yym527 := z.DecBinary()
-		_ = yym527
+		yyv553 := &x.Selector
+		yym554 := z.DecBinary()
+		_ = yym554
 		if false {
 		} else {
-			z.F.DecMapStringStringX(yyv526, false, d)
+			z.F.DecMapStringStringX(yyv553, false, d)
 		}
 	}
-	yyj525++
-	if yyhl525 {
-		yyb525 = yyj525 > l
+	yyj552++
+	if yyhl552 {
+		yyb552 = yyj552 > l
 	} else {
-		yyb525 = r.CheckBreak()
+		yyb552 = r.CheckBreak()
 	}
-	if yyb525 {
+	if yyb552 {
 		r.ReadEnd()
 		return
 	}
@@ -5946,19 +6108,25 @@ func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.Template == nil {
 			x.Template = new(pkg2_api.PodTemplateSpec)
 		}
-		x.Template.CodecDecodeSelf(d)
+		yym556 := z.DecBinary()
+		_ = yym556
+		if false {
+		} else if z.HasExtensions() && z.DecExt(x.Template) {
+		} else {
+			z.DecFallback(x.Template, false)
+		}
 	}
 	for {
-		yyj525++
-		if yyhl525 {
-			yyb525 = yyj525 > l
+		yyj552++
+		if yyhl552 {
+			yyb552 = yyj552 > l
 		} else {
-			yyb525 = r.CheckBreak()
+			yyb552 = r.CheckBreak()
 		}
-		if yyb525 {
+		if yyb552 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj525-1, "")
+		z.DecStructFieldNotFound(yyj552-1, "")
 	}
 	r.ReadEnd()
 }
@@ -5970,76 +6138,76 @@ func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym529 := z.EncBinary()
-		_ = yym529
+		yym557 := z.EncBinary()
+		_ = yym557
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep530 := !z.EncBinary()
-			yy2arr530 := z.EncBasicHandle().StructToArray
-			var yyq530 [3]bool
-			_, _, _ = yysep530, yyq530, yy2arr530
-			const yyr530 bool = false
-			if yyr530 || yy2arr530 {
+			yysep558 := !z.EncBinary()
+			yy2arr558 := z.EncBasicHandle().StructToArray
+			var yyq558 [3]bool
+			_, _, _ = yysep558, yyq558, yy2arr558
+			const yyr558 bool = false
+			if yyr558 || yy2arr558 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn530 int = 3
-				for _, b := range yyq530 {
+				var yynn558 int = 3
+				for _, b := range yyq558 {
 					if b {
-						yynn530++
+						yynn558++
 					}
 				}
-				r.EncodeMapStart(yynn530)
+				r.EncodeMapStart(yynn558)
 			}
-			if yyr530 || yy2arr530 {
-				yym532 := z.EncBinary()
-				_ = yym532
+			if yyr558 || yy2arr558 {
+				yym560 := z.EncBinary()
+				_ = yym560
 				if false {
 				} else {
 					r.EncodeInt(int64(x.CurrentNumberScheduled))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("currentNumberScheduled"))
-				yym533 := z.EncBinary()
-				_ = yym533
+				yym561 := z.EncBinary()
+				_ = yym561
 				if false {
 				} else {
 					r.EncodeInt(int64(x.CurrentNumberScheduled))
 				}
 			}
-			if yyr530 || yy2arr530 {
-				yym535 := z.EncBinary()
-				_ = yym535
+			if yyr558 || yy2arr558 {
+				yym563 := z.EncBinary()
+				_ = yym563
 				if false {
 				} else {
 					r.EncodeInt(int64(x.NumberMisscheduled))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("numberMisscheduled"))
-				yym536 := z.EncBinary()
-				_ = yym536
+				yym564 := z.EncBinary()
+				_ = yym564
 				if false {
 				} else {
 					r.EncodeInt(int64(x.NumberMisscheduled))
 				}
 			}
-			if yyr530 || yy2arr530 {
-				yym538 := z.EncBinary()
-				_ = yym538
+			if yyr558 || yy2arr558 {
+				yym566 := z.EncBinary()
+				_ = yym566
 				if false {
 				} else {
 					r.EncodeInt(int64(x.DesiredNumberScheduled))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("desiredNumberScheduled"))
-				yym539 := z.EncBinary()
-				_ = yym539
+				yym567 := z.EncBinary()
+				_ = yym567
 				if false {
 				} else {
 					r.EncodeInt(int64(x.DesiredNumberScheduled))
 				}
 			}
-			if yysep530 {
+			if yysep558 {
 				r.EncodeEnd()
 			}
 		}
@@ -6050,24 +6218,24 @@ func (x *DaemonSetStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym540 := z.DecBinary()
-	_ = yym540
+	yym568 := z.DecBinary()
+	_ = yym568
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl541 := r.ReadMapStart()
-			if yyl541 == 0 {
+			yyl569 := r.ReadMapStart()
+			if yyl569 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl541, d)
+				x.codecDecodeSelfFromMap(yyl569, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl541 := r.ReadArrayStart()
-			if yyl541 == 0 {
+			yyl569 := r.ReadArrayStart()
+			if yyl569 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl541, d)
+				x.codecDecodeSelfFromArray(yyl569, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -6079,12 +6247,12 @@ func (x *DaemonSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys542Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys542Slc
-	var yyhl542 bool = l >= 0
-	for yyj542 := 0; ; yyj542++ {
-		if yyhl542 {
-			if yyj542 >= l {
+	var yys570Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys570Slc
+	var yyhl570 bool = l >= 0
+	for yyj570 := 0; ; yyj570++ {
+		if yyhl570 {
+			if yyj570 >= l {
 				break
 			}
 		} else {
@@ -6092,9 +6260,9 @@ func (x *DaemonSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys542Slc = r.DecodeBytes(yys542Slc, true, true)
-		yys542 := string(yys542Slc)
-		switch yys542 {
+		yys570Slc = r.DecodeBytes(yys570Slc, true, true)
+		yys570 := string(yys570Slc)
+		switch yys570 {
 		case "currentNumberScheduled":
 			if r.TryDecodeAsNil() {
 				x.CurrentNumberScheduled = 0
@@ -6114,10 +6282,10 @@ func (x *DaemonSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.DesiredNumberScheduled = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys542)
-		} // end switch yys542
-	} // end for yyj542
-	if !yyhl542 {
+			z.DecStructFieldNotFound(-1, yys570)
+		} // end switch yys570
+	} // end for yyj570
+	if !yyhl570 {
 		r.ReadEnd()
 	}
 }
@@ -6126,16 +6294,16 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj546 int
-	var yyb546 bool
-	var yyhl546 bool = l >= 0
-	yyj546++
-	if yyhl546 {
-		yyb546 = yyj546 > l
+	var yyj574 int
+	var yyb574 bool
+	var yyhl574 bool = l >= 0
+	yyj574++
+	if yyhl574 {
+		yyb574 = yyj574 > l
 	} else {
-		yyb546 = r.CheckBreak()
+		yyb574 = r.CheckBreak()
 	}
-	if yyb546 {
+	if yyb574 {
 		r.ReadEnd()
 		return
 	}
@@ -6144,13 +6312,13 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.CurrentNumberScheduled = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj546++
-	if yyhl546 {
-		yyb546 = yyj546 > l
+	yyj574++
+	if yyhl574 {
+		yyb574 = yyj574 > l
 	} else {
-		yyb546 = r.CheckBreak()
+		yyb574 = r.CheckBreak()
 	}
-	if yyb546 {
+	if yyb574 {
 		r.ReadEnd()
 		return
 	}
@@ -6159,13 +6327,13 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.NumberMisscheduled = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj546++
-	if yyhl546 {
-		yyb546 = yyj546 > l
+	yyj574++
+	if yyhl574 {
+		yyb574 = yyj574 > l
 	} else {
-		yyb546 = r.CheckBreak()
+		yyb574 = r.CheckBreak()
 	}
-	if yyb546 {
+	if yyb574 {
 		r.ReadEnd()
 		return
 	}
@@ -6175,16 +6343,16 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.DesiredNumberScheduled = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj546++
-		if yyhl546 {
-			yyb546 = yyj546 > l
+		yyj574++
+		if yyhl574 {
+			yyb574 = yyj574 > l
 		} else {
-			yyb546 = r.CheckBreak()
+			yyb574 = r.CheckBreak()
 		}
-		if yyb546 {
+		if yyb574 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj546-1, "")
+		z.DecStructFieldNotFound(yyj574-1, "")
 	}
 	r.ReadEnd()
 }
@@ -6196,36 +6364,36 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym550 := z.EncBinary()
-		_ = yym550
+		yym578 := z.EncBinary()
+		_ = yym578
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep551 := !z.EncBinary()
-			yy2arr551 := z.EncBasicHandle().StructToArray
-			var yyq551 [5]bool
-			_, _, _ = yysep551, yyq551, yy2arr551
-			const yyr551 bool = false
-			yyq551[0] = x.Kind != ""
-			yyq551[1] = x.APIVersion != ""
-			yyq551[2] = true
-			yyq551[3] = true
-			yyq551[4] = true
-			if yyr551 || yy2arr551 {
+			yysep579 := !z.EncBinary()
+			yy2arr579 := z.EncBasicHandle().StructToArray
+			var yyq579 [5]bool
+			_, _, _ = yysep579, yyq579, yy2arr579
+			const yyr579 bool = false
+			yyq579[0] = x.Kind != ""
+			yyq579[1] = x.APIVersion != ""
+			yyq579[2] = true
+			yyq579[3] = true
+			yyq579[4] = true
+			if yyr579 || yy2arr579 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn551 int = 0
-				for _, b := range yyq551 {
+				var yynn579 int = 0
+				for _, b := range yyq579 {
 					if b {
-						yynn551++
+						yynn579++
 					}
 				}
-				r.EncodeMapStart(yynn551)
+				r.EncodeMapStart(yynn579)
 			}
-			if yyr551 || yy2arr551 {
-				if yyq551[0] {
-					yym553 := z.EncBinary()
-					_ = yym553
+			if yyr579 || yy2arr579 {
+				if yyq579[0] {
+					yym581 := z.EncBinary()
+					_ = yym581
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -6234,20 +6402,20 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq551[0] {
+				if yyq579[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym554 := z.EncBinary()
-					_ = yym554
+					yym582 := z.EncBinary()
+					_ = yym582
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr551 || yy2arr551 {
-				if yyq551[1] {
-					yym556 := z.EncBinary()
-					_ = yym556
+			if yyr579 || yy2arr579 {
+				if yyq579[1] {
+					yym584 := z.EncBinary()
+					_ = yym584
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -6256,59 +6424,71 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq551[1] {
+				if yyq579[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym557 := z.EncBinary()
-					_ = yym557
+					yym585 := z.EncBinary()
+					_ = yym585
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr551 || yy2arr551 {
-				if yyq551[2] {
-					yy559 := &x.ObjectMeta
-					yy559.CodecEncodeSelf(e)
+			if yyr579 || yy2arr579 {
+				if yyq579[2] {
+					yy587 := &x.ObjectMeta
+					yym588 := z.EncBinary()
+					_ = yym588
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy587) {
+					} else {
+						z.EncFallback(yy587)
+					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq551[2] {
+				if yyq579[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy560 := &x.ObjectMeta
-					yy560.CodecEncodeSelf(e)
+					yy589 := &x.ObjectMeta
+					yym590 := z.EncBinary()
+					_ = yym590
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy589) {
+					} else {
+						z.EncFallback(yy589)
+					}
 				}
 			}
-			if yyr551 || yy2arr551 {
-				if yyq551[3] {
-					yy562 := &x.Spec
-					yy562.CodecEncodeSelf(e)
+			if yyr579 || yy2arr579 {
+				if yyq579[3] {
+					yy592 := &x.Spec
+					yy592.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq551[3] {
+				if yyq579[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy563 := &x.Spec
-					yy563.CodecEncodeSelf(e)
+					yy593 := &x.Spec
+					yy593.CodecEncodeSelf(e)
 				}
 			}
-			if yyr551 || yy2arr551 {
-				if yyq551[4] {
-					yy565 := &x.Status
-					yy565.CodecEncodeSelf(e)
+			if yyr579 || yy2arr579 {
+				if yyq579[4] {
+					yy595 := &x.Status
+					yy595.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq551[4] {
+				if yyq579[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy566 := &x.Status
-					yy566.CodecEncodeSelf(e)
+					yy596 := &x.Status
+					yy596.CodecEncodeSelf(e)
 				}
 			}
-			if yysep551 {
+			if yysep579 {
 				r.EncodeEnd()
 			}
 		}
@@ -6316,329 +6496,6 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 }
 
 func (x *DaemonSet) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	yym567 := z.DecBinary()
-	_ = yym567
-	if false {
-	} else if z.HasExtensions() && z.DecExt(x) {
-	} else {
-		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl568 := r.ReadMapStart()
-			if yyl568 == 0 {
-				r.ReadEnd()
-			} else {
-				x.codecDecodeSelfFromMap(yyl568, d)
-			}
-		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl568 := r.ReadArrayStart()
-			if yyl568 == 0 {
-				r.ReadEnd()
-			} else {
-				x.codecDecodeSelfFromArray(yyl568, d)
-			}
-		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
-		}
-	}
-}
-
-func (x *DaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yys569Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys569Slc
-	var yyhl569 bool = l >= 0
-	for yyj569 := 0; ; yyj569++ {
-		if yyhl569 {
-			if yyj569 >= l {
-				break
-			}
-		} else {
-			if r.CheckBreak() {
-				break
-			}
-		}
-		yys569Slc = r.DecodeBytes(yys569Slc, true, true)
-		yys569 := string(yys569Slc)
-		switch yys569 {
-		case "kind":
-			if r.TryDecodeAsNil() {
-				x.Kind = ""
-			} else {
-				x.Kind = string(r.DecodeString())
-			}
-		case "apiVersion":
-			if r.TryDecodeAsNil() {
-				x.APIVersion = ""
-			} else {
-				x.APIVersion = string(r.DecodeString())
-			}
-		case "metadata":
-			if r.TryDecodeAsNil() {
-				x.ObjectMeta = pkg2_api.ObjectMeta{}
-			} else {
-				yyv572 := &x.ObjectMeta
-				yyv572.CodecDecodeSelf(d)
-			}
-		case "spec":
-			if r.TryDecodeAsNil() {
-				x.Spec = DaemonSetSpec{}
-			} else {
-				yyv573 := &x.Spec
-				yyv573.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = DaemonSetStatus{}
-			} else {
-				yyv574 := &x.Status
-				yyv574.CodecDecodeSelf(d)
-			}
-		default:
-			z.DecStructFieldNotFound(-1, yys569)
-		} // end switch yys569
-	} // end for yyj569
-	if !yyhl569 {
-		r.ReadEnd()
-	}
-}
-
-func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperDecoder(d)
-	_, _, _ = h, z, r
-	var yyj575 int
-	var yyb575 bool
-	var yyhl575 bool = l >= 0
-	yyj575++
-	if yyhl575 {
-		yyb575 = yyj575 > l
-	} else {
-		yyb575 = r.CheckBreak()
-	}
-	if yyb575 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.Kind = ""
-	} else {
-		x.Kind = string(r.DecodeString())
-	}
-	yyj575++
-	if yyhl575 {
-		yyb575 = yyj575 > l
-	} else {
-		yyb575 = r.CheckBreak()
-	}
-	if yyb575 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.APIVersion = ""
-	} else {
-		x.APIVersion = string(r.DecodeString())
-	}
-	yyj575++
-	if yyhl575 {
-		yyb575 = yyj575 > l
-	} else {
-		yyb575 = r.CheckBreak()
-	}
-	if yyb575 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.ObjectMeta = pkg2_api.ObjectMeta{}
-	} else {
-		yyv578 := &x.ObjectMeta
-		yyv578.CodecDecodeSelf(d)
-	}
-	yyj575++
-	if yyhl575 {
-		yyb575 = yyj575 > l
-	} else {
-		yyb575 = r.CheckBreak()
-	}
-	if yyb575 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.Spec = DaemonSetSpec{}
-	} else {
-		yyv579 := &x.Spec
-		yyv579.CodecDecodeSelf(d)
-	}
-	yyj575++
-	if yyhl575 {
-		yyb575 = yyj575 > l
-	} else {
-		yyb575 = r.CheckBreak()
-	}
-	if yyb575 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.Status = DaemonSetStatus{}
-	} else {
-		yyv580 := &x.Status
-		yyv580.CodecDecodeSelf(d)
-	}
-	for {
-		yyj575++
-		if yyhl575 {
-			yyb575 = yyj575 > l
-		} else {
-			yyb575 = r.CheckBreak()
-		}
-		if yyb575 {
-			break
-		}
-		z.DecStructFieldNotFound(yyj575-1, "")
-	}
-	r.ReadEnd()
-}
-
-func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer1234
-	z, r := codec1978.GenHelperEncoder(e)
-	_, _, _ = h, z, r
-	if x == nil {
-		r.EncodeNil()
-	} else {
-		yym581 := z.EncBinary()
-		_ = yym581
-		if false {
-		} else if z.HasExtensions() && z.EncExt(x) {
-		} else {
-			yysep582 := !z.EncBinary()
-			yy2arr582 := z.EncBasicHandle().StructToArray
-			var yyq582 [4]bool
-			_, _, _ = yysep582, yyq582, yy2arr582
-			const yyr582 bool = false
-			yyq582[0] = x.Kind != ""
-			yyq582[1] = x.APIVersion != ""
-			yyq582[2] = true
-			if yyr582 || yy2arr582 {
-				r.EncodeArrayStart(4)
-			} else {
-				var yynn582 int = 1
-				for _, b := range yyq582 {
-					if b {
-						yynn582++
-					}
-				}
-				r.EncodeMapStart(yynn582)
-			}
-			if yyr582 || yy2arr582 {
-				if yyq582[0] {
-					yym584 := z.EncBinary()
-					_ = yym584
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq582[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym585 := z.EncBinary()
-					_ = yym585
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr582 || yy2arr582 {
-				if yyq582[1] {
-					yym587 := z.EncBinary()
-					_ = yym587
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq582[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym588 := z.EncBinary()
-					_ = yym588
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr582 || yy2arr582 {
-				if yyq582[2] {
-					yy590 := &x.ListMeta
-					yym591 := z.EncBinary()
-					_ = yym591
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy590) {
-					} else {
-						z.EncFallback(yy590)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq582[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy592 := &x.ListMeta
-					yym593 := z.EncBinary()
-					_ = yym593
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy592) {
-					} else {
-						z.EncFallback(yy592)
-					}
-				}
-			}
-			if yyr582 || yy2arr582 {
-				if x.Items == nil {
-					r.EncodeNil()
-				} else {
-					yym595 := z.EncBinary()
-					_ = yym595
-					if false {
-					} else {
-						h.encSliceDaemonSet(([]DaemonSet)(x.Items), e)
-					}
-				}
-			} else {
-				r.EncodeString(codecSelferC_UTF81234, string("items"))
-				if x.Items == nil {
-					r.EncodeNil()
-				} else {
-					yym596 := z.EncBinary()
-					_ = yym596
-					if false {
-					} else {
-						h.encSliceDaemonSet(([]DaemonSet)(x.Items), e)
-					}
-				}
-			}
-			if yysep582 {
-				r.EncodeEnd()
-			}
-		}
-	}
-}
-
-func (x *DaemonSetList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -6667,7 +6524,7 @@ func (x *DaemonSetList) CodecDecodeSelf(d *codec1978.Decoder) {
 	}
 }
 
-func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+func (x *DaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -6701,9 +6558,9 @@ func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		case "metadata":
 			if r.TryDecodeAsNil() {
-				x.ListMeta = pkg1_unversioned.ListMeta{}
+				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv602 := &x.ListMeta
+				yyv602 := &x.ObjectMeta
 				yym603 := z.DecBinary()
 				_ = yym603
 				if false {
@@ -6712,17 +6569,19 @@ func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 					z.DecFallback(yyv602, false)
 				}
 			}
-		case "items":
+		case "spec":
 			if r.TryDecodeAsNil() {
-				x.Items = nil
+				x.Spec = DaemonSetSpec{}
 			} else {
-				yyv604 := &x.Items
-				yym605 := z.DecBinary()
-				_ = yym605
-				if false {
-				} else {
-					h.decSliceDaemonSet((*[]DaemonSet)(yyv604), d)
-				}
+				yyv604 := &x.Spec
+				yyv604.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = DaemonSetStatus{}
+			} else {
+				yyv605 := &x.Status
+				yyv605.CodecDecodeSelf(d)
 			}
 		default:
 			z.DecStructFieldNotFound(-1, yys599)
@@ -6733,7 +6592,7 @@ func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	}
 }
 
-func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -6781,9 +6640,9 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		return
 	}
 	if r.TryDecodeAsNil() {
-		x.ListMeta = pkg1_unversioned.ListMeta{}
+		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv609 := &x.ListMeta
+		yyv609 := &x.ObjectMeta
 		yym610 := z.DecBinary()
 		_ = yym610
 		if false {
@@ -6803,15 +6662,26 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		return
 	}
 	if r.TryDecodeAsNil() {
-		x.Items = nil
+		x.Spec = DaemonSetSpec{}
 	} else {
-		yyv611 := &x.Items
-		yym612 := z.DecBinary()
-		_ = yym612
-		if false {
-		} else {
-			h.decSliceDaemonSet((*[]DaemonSet)(yyv611), d)
-		}
+		yyv611 := &x.Spec
+		yyv611.CodecDecodeSelf(d)
+	}
+	yyj606++
+	if yyhl606 {
+		yyb606 = yyj606 > l
+	} else {
+		yyb606 = r.CheckBreak()
+	}
+	if yyb606 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Status = DaemonSetStatus{}
+	} else {
+		yyv612 := &x.Status
+		yyv612.CodecDecodeSelf(d)
 	}
 	for {
 		yyj606++
@@ -6828,7 +6698,7 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	r.ReadEnd()
 }
 
-func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
+func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
@@ -6937,7 +6807,7 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym627
 					if false {
 					} else {
-						h.encSliceThirdPartyResourceData(([]ThirdPartyResourceData)(x.Items), e)
+						h.encSliceDaemonSet(([]DaemonSet)(x.Items), e)
 					}
 				}
 			} else {
@@ -6949,7 +6819,7 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym628
 					if false {
 					} else {
-						h.encSliceThirdPartyResourceData(([]ThirdPartyResourceData)(x.Items), e)
+						h.encSliceDaemonSet(([]DaemonSet)(x.Items), e)
 					}
 				}
 			}
@@ -6960,7 +6830,7 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 	}
 }
 
-func (x *ThirdPartyResourceDataList) CodecDecodeSelf(d *codec1978.Decoder) {
+func (x *DaemonSetList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -6989,7 +6859,7 @@ func (x *ThirdPartyResourceDataList) CodecDecodeSelf(d *codec1978.Decoder) {
 	}
 }
 
-func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -7043,7 +6913,7 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.
 				_ = yym637
 				if false {
 				} else {
-					h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv636), d)
+					h.decSliceDaemonSet((*[]DaemonSet)(yyv636), d)
 				}
 			}
 		default:
@@ -7055,7 +6925,7 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.
 	}
 }
 
-func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -7132,7 +7002,7 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 		_ = yym644
 		if false {
 		} else {
-			h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv643), d)
+			h.decSliceDaemonSet((*[]DaemonSet)(yyv643), d)
 		}
 	}
 	for {
@@ -7150,7 +7020,7 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 	r.ReadEnd()
 }
 
-func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
+func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
@@ -7164,18 +7034,16 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 		} else {
 			yysep646 := !z.EncBinary()
 			yy2arr646 := z.EncBasicHandle().StructToArray
-			var yyq646 [5]bool
+			var yyq646 [4]bool
 			_, _, _ = yysep646, yyq646, yy2arr646
 			const yyr646 bool = false
 			yyq646[0] = x.Kind != ""
 			yyq646[1] = x.APIVersion != ""
 			yyq646[2] = true
-			yyq646[3] = true
-			yyq646[4] = true
 			if yyr646 || yy2arr646 {
-				r.EncodeArrayStart(5)
+				r.EncodeArrayStart(4)
 			} else {
-				var yynn646 int = 0
+				var yynn646 int = 1
 				for _, b := range yyq646 {
 					if b {
 						yynn646++
@@ -7229,44 +7097,52 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr646 || yy2arr646 {
 				if yyq646[2] {
-					yy654 := &x.ObjectMeta
-					yy654.CodecEncodeSelf(e)
+					yy654 := &x.ListMeta
+					yym655 := z.EncBinary()
+					_ = yym655
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy654) {
+					} else {
+						z.EncFallback(yy654)
+					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
 				if yyq646[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy655 := &x.ObjectMeta
-					yy655.CodecEncodeSelf(e)
+					yy656 := &x.ListMeta
+					yym657 := z.EncBinary()
+					_ = yym657
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy656) {
+					} else {
+						z.EncFallback(yy656)
+					}
 				}
 			}
 			if yyr646 || yy2arr646 {
-				if yyq646[3] {
-					yy657 := &x.Spec
-					yy657.CodecEncodeSelf(e)
-				} else {
+				if x.Items == nil {
 					r.EncodeNil()
+				} else {
+					yym659 := z.EncBinary()
+					_ = yym659
+					if false {
+					} else {
+						h.encSliceThirdPartyResourceData(([]ThirdPartyResourceData)(x.Items), e)
+					}
 				}
 			} else {
-				if yyq646[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy658 := &x.Spec
-					yy658.CodecEncodeSelf(e)
-				}
-			}
-			if yyr646 || yy2arr646 {
-				if yyq646[4] {
-					yy660 := &x.Status
-					yy660.CodecEncodeSelf(e)
-				} else {
+				r.EncodeString(codecSelferC_UTF81234, string("items"))
+				if x.Items == nil {
 					r.EncodeNil()
-				}
-			} else {
-				if yyq646[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy661 := &x.Status
-					yy661.CodecEncodeSelf(e)
+				} else {
+					yym660 := z.EncBinary()
+					_ = yym660
+					if false {
+					} else {
+						h.encSliceThirdPartyResourceData(([]ThirdPartyResourceData)(x.Items), e)
+					}
 				}
 			}
 			if yysep646 {
@@ -7276,28 +7152,28 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 	}
 }
 
-func (x *Job) CodecDecodeSelf(d *codec1978.Decoder) {
+func (x *ThirdPartyResourceDataList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym662 := z.DecBinary()
-	_ = yym662
+	yym661 := z.DecBinary()
+	_ = yym661
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl663 := r.ReadMapStart()
-			if yyl663 == 0 {
+			yyl662 := r.ReadMapStart()
+			if yyl662 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl663, d)
+				x.codecDecodeSelfFromMap(yyl662, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl663 := r.ReadArrayStart()
-			if yyl663 == 0 {
+			yyl662 := r.ReadArrayStart()
+			if yyl662 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl663, d)
+				x.codecDecodeSelfFromArray(yyl662, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -7305,16 +7181,16 @@ func (x *Job) CodecDecodeSelf(d *codec1978.Decoder) {
 	}
 }
 
-func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys664Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys664Slc
-	var yyhl664 bool = l >= 0
-	for yyj664 := 0; ; yyj664++ {
-		if yyhl664 {
-			if yyj664 >= l {
+	var yys663Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys663Slc
+	var yyhl663 bool = l >= 0
+	for yyj663 := 0; ; yyj663++ {
+		if yyhl663 {
+			if yyj663 >= l {
 				break
 			}
 		} else {
@@ -7322,9 +7198,9 @@ func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys664Slc = r.DecodeBytes(yys664Slc, true, true)
-		yys664 := string(yys664Slc)
-		switch yys664 {
+		yys663Slc = r.DecodeBytes(yys663Slc, true, true)
+		yys663 := string(yys663Slc)
+		switch yys663 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -7339,35 +7215,39 @@ func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			}
 		case "metadata":
 			if r.TryDecodeAsNil() {
-				x.ObjectMeta = pkg2_api.ObjectMeta{}
+				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv667 := &x.ObjectMeta
-				yyv667.CodecDecodeSelf(d)
+				yyv666 := &x.ListMeta
+				yym667 := z.DecBinary()
+				_ = yym667
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv666) {
+				} else {
+					z.DecFallback(yyv666, false)
+				}
 			}
-		case "spec":
+		case "items":
 			if r.TryDecodeAsNil() {
-				x.Spec = JobSpec{}
+				x.Items = nil
 			} else {
-				yyv668 := &x.Spec
-				yyv668.CodecDecodeSelf(d)
-			}
-		case "status":
-			if r.TryDecodeAsNil() {
-				x.Status = JobStatus{}
-			} else {
-				yyv669 := &x.Status
-				yyv669.CodecDecodeSelf(d)
+				yyv668 := &x.Items
+				yym669 := z.DecBinary()
+				_ = yym669
+				if false {
+				} else {
+					h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv668), d)
+				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys664)
-		} // end switch yys664
-	} // end for yyj664
-	if !yyhl664 {
+			z.DecStructFieldNotFound(-1, yys663)
+		} // end switch yys663
+	} // end for yyj663
+	if !yyhl663 {
 		r.ReadEnd()
 	}
 }
 
-func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
@@ -7415,10 +7295,16 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		return
 	}
 	if r.TryDecodeAsNil() {
-		x.ObjectMeta = pkg2_api.ObjectMeta{}
+		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv673 := &x.ObjectMeta
-		yyv673.CodecDecodeSelf(d)
+		yyv673 := &x.ListMeta
+		yym674 := z.DecBinary()
+		_ = yym674
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv673) {
+		} else {
+			z.DecFallback(yyv673, false)
+		}
 	}
 	yyj670++
 	if yyhl670 {
@@ -7431,26 +7317,15 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		return
 	}
 	if r.TryDecodeAsNil() {
-		x.Spec = JobSpec{}
+		x.Items = nil
 	} else {
-		yyv674 := &x.Spec
-		yyv674.CodecDecodeSelf(d)
-	}
-	yyj670++
-	if yyhl670 {
-		yyb670 = yyj670 > l
-	} else {
-		yyb670 = r.CheckBreak()
-	}
-	if yyb670 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.Status = JobStatus{}
-	} else {
-		yyv675 := &x.Status
-		yyv675.CodecDecodeSelf(d)
+		yyv675 := &x.Items
+		yym676 := z.DecBinary()
+		_ = yym676
+		if false {
+		} else {
+			h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv675), d)
+		}
 	}
 	for {
 		yyj670++
@@ -7467,6 +7342,347 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	r.ReadEnd()
 }
 
+func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperEncoder(e)
+	_, _, _ = h, z, r
+	if x == nil {
+		r.EncodeNil()
+	} else {
+		yym677 := z.EncBinary()
+		_ = yym677
+		if false {
+		} else if z.HasExtensions() && z.EncExt(x) {
+		} else {
+			yysep678 := !z.EncBinary()
+			yy2arr678 := z.EncBasicHandle().StructToArray
+			var yyq678 [5]bool
+			_, _, _ = yysep678, yyq678, yy2arr678
+			const yyr678 bool = false
+			yyq678[0] = x.Kind != ""
+			yyq678[1] = x.APIVersion != ""
+			yyq678[2] = true
+			yyq678[3] = true
+			yyq678[4] = true
+			if yyr678 || yy2arr678 {
+				r.EncodeArrayStart(5)
+			} else {
+				var yynn678 int = 0
+				for _, b := range yyq678 {
+					if b {
+						yynn678++
+					}
+				}
+				r.EncodeMapStart(yynn678)
+			}
+			if yyr678 || yy2arr678 {
+				if yyq678[0] {
+					yym680 := z.EncBinary()
+					_ = yym680
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq678[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym681 := z.EncBinary()
+					_ = yym681
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr678 || yy2arr678 {
+				if yyq678[1] {
+					yym683 := z.EncBinary()
+					_ = yym683
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq678[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym684 := z.EncBinary()
+					_ = yym684
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr678 || yy2arr678 {
+				if yyq678[2] {
+					yy686 := &x.ObjectMeta
+					yym687 := z.EncBinary()
+					_ = yym687
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy686) {
+					} else {
+						z.EncFallback(yy686)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq678[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy688 := &x.ObjectMeta
+					yym689 := z.EncBinary()
+					_ = yym689
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy688) {
+					} else {
+						z.EncFallback(yy688)
+					}
+				}
+			}
+			if yyr678 || yy2arr678 {
+				if yyq678[3] {
+					yy691 := &x.Spec
+					yy691.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq678[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("spec"))
+					yy692 := &x.Spec
+					yy692.CodecEncodeSelf(e)
+				}
+			}
+			if yyr678 || yy2arr678 {
+				if yyq678[4] {
+					yy694 := &x.Status
+					yy694.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq678[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("status"))
+					yy695 := &x.Status
+					yy695.CodecEncodeSelf(e)
+				}
+			}
+			if yysep678 {
+				r.EncodeEnd()
+			}
+		}
+	}
+}
+
+func (x *Job) CodecDecodeSelf(d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	yym696 := z.DecBinary()
+	_ = yym696
+	if false {
+	} else if z.HasExtensions() && z.DecExt(x) {
+	} else {
+		if r.IsContainerType(codecSelferValueTypeMap1234) {
+			yyl697 := r.ReadMapStart()
+			if yyl697 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromMap(yyl697, d)
+			}
+		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
+			yyl697 := r.ReadArrayStart()
+			if yyl697 == 0 {
+				r.ReadEnd()
+			} else {
+				x.codecDecodeSelfFromArray(yyl697, d)
+			}
+		} else {
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
+		}
+	}
+}
+
+func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yys698Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys698Slc
+	var yyhl698 bool = l >= 0
+	for yyj698 := 0; ; yyj698++ {
+		if yyhl698 {
+			if yyj698 >= l {
+				break
+			}
+		} else {
+			if r.CheckBreak() {
+				break
+			}
+		}
+		yys698Slc = r.DecodeBytes(yys698Slc, true, true)
+		yys698 := string(yys698Slc)
+		switch yys698 {
+		case "kind":
+			if r.TryDecodeAsNil() {
+				x.Kind = ""
+			} else {
+				x.Kind = string(r.DecodeString())
+			}
+		case "apiVersion":
+			if r.TryDecodeAsNil() {
+				x.APIVersion = ""
+			} else {
+				x.APIVersion = string(r.DecodeString())
+			}
+		case "metadata":
+			if r.TryDecodeAsNil() {
+				x.ObjectMeta = pkg2_api.ObjectMeta{}
+			} else {
+				yyv701 := &x.ObjectMeta
+				yym702 := z.DecBinary()
+				_ = yym702
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv701) {
+				} else {
+					z.DecFallback(yyv701, false)
+				}
+			}
+		case "spec":
+			if r.TryDecodeAsNil() {
+				x.Spec = JobSpec{}
+			} else {
+				yyv703 := &x.Spec
+				yyv703.CodecDecodeSelf(d)
+			}
+		case "status":
+			if r.TryDecodeAsNil() {
+				x.Status = JobStatus{}
+			} else {
+				yyv704 := &x.Status
+				yyv704.CodecDecodeSelf(d)
+			}
+		default:
+			z.DecStructFieldNotFound(-1, yys698)
+		} // end switch yys698
+	} // end for yyj698
+	if !yyhl698 {
+		r.ReadEnd()
+	}
+}
+
+func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
+	var h codecSelfer1234
+	z, r := codec1978.GenHelperDecoder(d)
+	_, _, _ = h, z, r
+	var yyj705 int
+	var yyb705 bool
+	var yyhl705 bool = l >= 0
+	yyj705++
+	if yyhl705 {
+		yyb705 = yyj705 > l
+	} else {
+		yyb705 = r.CheckBreak()
+	}
+	if yyb705 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Kind = ""
+	} else {
+		x.Kind = string(r.DecodeString())
+	}
+	yyj705++
+	if yyhl705 {
+		yyb705 = yyj705 > l
+	} else {
+		yyb705 = r.CheckBreak()
+	}
+	if yyb705 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.APIVersion = ""
+	} else {
+		x.APIVersion = string(r.DecodeString())
+	}
+	yyj705++
+	if yyhl705 {
+		yyb705 = yyj705 > l
+	} else {
+		yyb705 = r.CheckBreak()
+	}
+	if yyb705 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.ObjectMeta = pkg2_api.ObjectMeta{}
+	} else {
+		yyv708 := &x.ObjectMeta
+		yym709 := z.DecBinary()
+		_ = yym709
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv708) {
+		} else {
+			z.DecFallback(yyv708, false)
+		}
+	}
+	yyj705++
+	if yyhl705 {
+		yyb705 = yyj705 > l
+	} else {
+		yyb705 = r.CheckBreak()
+	}
+	if yyb705 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Spec = JobSpec{}
+	} else {
+		yyv710 := &x.Spec
+		yyv710.CodecDecodeSelf(d)
+	}
+	yyj705++
+	if yyhl705 {
+		yyb705 = yyj705 > l
+	} else {
+		yyb705 = r.CheckBreak()
+	}
+	if yyb705 {
+		r.ReadEnd()
+		return
+	}
+	if r.TryDecodeAsNil() {
+		x.Status = JobStatus{}
+	} else {
+		yyv711 := &x.Status
+		yyv711.CodecDecodeSelf(d)
+	}
+	for {
+		yyj705++
+		if yyhl705 {
+			yyb705 = yyj705 > l
+		} else {
+			yyb705 = r.CheckBreak()
+		}
+		if yyb705 {
+			break
+		}
+		z.DecStructFieldNotFound(yyj705-1, "")
+	}
+	r.ReadEnd()
+}
+
 func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
@@ -7474,34 +7690,34 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym676 := z.EncBinary()
-		_ = yym676
+		yym712 := z.EncBinary()
+		_ = yym712
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep677 := !z.EncBinary()
-			yy2arr677 := z.EncBasicHandle().StructToArray
-			var yyq677 [4]bool
-			_, _, _ = yysep677, yyq677, yy2arr677
-			const yyr677 bool = false
-			yyq677[0] = x.Kind != ""
-			yyq677[1] = x.APIVersion != ""
-			yyq677[2] = true
-			if yyr677 || yy2arr677 {
+			yysep713 := !z.EncBinary()
+			yy2arr713 := z.EncBasicHandle().StructToArray
+			var yyq713 [4]bool
+			_, _, _ = yysep713, yyq713, yy2arr713
+			const yyr713 bool = false
+			yyq713[0] = x.Kind != ""
+			yyq713[1] = x.APIVersion != ""
+			yyq713[2] = true
+			if yyr713 || yy2arr713 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn677 int = 1
-				for _, b := range yyq677 {
+				var yynn713 int = 1
+				for _, b := range yyq713 {
 					if b {
-						yynn677++
+						yynn713++
 					}
 				}
-				r.EncodeMapStart(yynn677)
+				r.EncodeMapStart(yynn713)
 			}
-			if yyr677 || yy2arr677 {
-				if yyq677[0] {
-					yym679 := z.EncBinary()
-					_ = yym679
+			if yyr713 || yy2arr713 {
+				if yyq713[0] {
+					yym715 := z.EncBinary()
+					_ = yym715
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -7510,20 +7726,20 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq677[0] {
+				if yyq713[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym680 := z.EncBinary()
-					_ = yym680
+					yym716 := z.EncBinary()
+					_ = yym716
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr677 || yy2arr677 {
-				if yyq677[1] {
-					yym682 := z.EncBinary()
-					_ = yym682
+			if yyr713 || yy2arr713 {
+				if yyq713[1] {
+					yym718 := z.EncBinary()
+					_ = yym718
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -7532,48 +7748,48 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq677[1] {
+				if yyq713[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym683 := z.EncBinary()
-					_ = yym683
+					yym719 := z.EncBinary()
+					_ = yym719
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr677 || yy2arr677 {
-				if yyq677[2] {
-					yy685 := &x.ListMeta
-					yym686 := z.EncBinary()
-					_ = yym686
+			if yyr713 || yy2arr713 {
+				if yyq713[2] {
+					yy721 := &x.ListMeta
+					yym722 := z.EncBinary()
+					_ = yym722
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy685) {
+					} else if z.HasExtensions() && z.EncExt(yy721) {
 					} else {
-						z.EncFallback(yy685)
+						z.EncFallback(yy721)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq677[2] {
+				if yyq713[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy687 := &x.ListMeta
-					yym688 := z.EncBinary()
-					_ = yym688
+					yy723 := &x.ListMeta
+					yym724 := z.EncBinary()
+					_ = yym724
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy687) {
+					} else if z.HasExtensions() && z.EncExt(yy723) {
 					} else {
-						z.EncFallback(yy687)
+						z.EncFallback(yy723)
 					}
 				}
 			}
-			if yyr677 || yy2arr677 {
+			if yyr713 || yy2arr713 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym690 := z.EncBinary()
-					_ = yym690
+					yym726 := z.EncBinary()
+					_ = yym726
 					if false {
 					} else {
 						h.encSliceJob(([]Job)(x.Items), e)
@@ -7584,15 +7800,15 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym691 := z.EncBinary()
-					_ = yym691
+					yym727 := z.EncBinary()
+					_ = yym727
 					if false {
 					} else {
 						h.encSliceJob(([]Job)(x.Items), e)
 					}
 				}
 			}
-			if yysep677 {
+			if yysep713 {
 				r.EncodeEnd()
 			}
 		}
@@ -7603,24 +7819,24 @@ func (x *JobList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym692 := z.DecBinary()
-	_ = yym692
+	yym728 := z.DecBinary()
+	_ = yym728
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl693 := r.ReadMapStart()
-			if yyl693 == 0 {
+			yyl729 := r.ReadMapStart()
+			if yyl729 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl693, d)
+				x.codecDecodeSelfFromMap(yyl729, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl693 := r.ReadArrayStart()
-			if yyl693 == 0 {
+			yyl729 := r.ReadArrayStart()
+			if yyl729 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl693, d)
+				x.codecDecodeSelfFromArray(yyl729, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -7632,12 +7848,12 @@ func (x *JobList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys694Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys694Slc
-	var yyhl694 bool = l >= 0
-	for yyj694 := 0; ; yyj694++ {
-		if yyhl694 {
-			if yyj694 >= l {
+	var yys730Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys730Slc
+	var yyhl730 bool = l >= 0
+	for yyj730 := 0; ; yyj730++ {
+		if yyhl730 {
+			if yyj730 >= l {
 				break
 			}
 		} else {
@@ -7645,9 +7861,9 @@ func (x *JobList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys694Slc = r.DecodeBytes(yys694Slc, true, true)
-		yys694 := string(yys694Slc)
-		switch yys694 {
+		yys730Slc = r.DecodeBytes(yys730Slc, true, true)
+		yys730 := string(yys730Slc)
+		switch yys730 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -7664,32 +7880,32 @@ func (x *JobList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv697 := &x.ListMeta
-				yym698 := z.DecBinary()
-				_ = yym698
+				yyv733 := &x.ListMeta
+				yym734 := z.DecBinary()
+				_ = yym734
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv697) {
+				} else if z.HasExtensions() && z.DecExt(yyv733) {
 				} else {
-					z.DecFallback(yyv697, false)
+					z.DecFallback(yyv733, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv699 := &x.Items
-				yym700 := z.DecBinary()
-				_ = yym700
+				yyv735 := &x.Items
+				yym736 := z.DecBinary()
+				_ = yym736
 				if false {
 				} else {
-					h.decSliceJob((*[]Job)(yyv699), d)
+					h.decSliceJob((*[]Job)(yyv735), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys694)
-		} // end switch yys694
-	} // end for yyj694
-	if !yyhl694 {
+			z.DecStructFieldNotFound(-1, yys730)
+		} // end switch yys730
+	} // end for yyj730
+	if !yyhl730 {
 		r.ReadEnd()
 	}
 }
@@ -7698,16 +7914,16 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj701 int
-	var yyb701 bool
-	var yyhl701 bool = l >= 0
-	yyj701++
-	if yyhl701 {
-		yyb701 = yyj701 > l
+	var yyj737 int
+	var yyb737 bool
+	var yyhl737 bool = l >= 0
+	yyj737++
+	if yyhl737 {
+		yyb737 = yyj737 > l
 	} else {
-		yyb701 = r.CheckBreak()
+		yyb737 = r.CheckBreak()
 	}
-	if yyb701 {
+	if yyb737 {
 		r.ReadEnd()
 		return
 	}
@@ -7716,13 +7932,13 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj701++
-	if yyhl701 {
-		yyb701 = yyj701 > l
+	yyj737++
+	if yyhl737 {
+		yyb737 = yyj737 > l
 	} else {
-		yyb701 = r.CheckBreak()
+		yyb737 = r.CheckBreak()
 	}
-	if yyb701 {
+	if yyb737 {
 		r.ReadEnd()
 		return
 	}
@@ -7731,60 +7947,60 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj701++
-	if yyhl701 {
-		yyb701 = yyj701 > l
+	yyj737++
+	if yyhl737 {
+		yyb737 = yyj737 > l
 	} else {
-		yyb701 = r.CheckBreak()
+		yyb737 = r.CheckBreak()
 	}
-	if yyb701 {
+	if yyb737 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv704 := &x.ListMeta
-		yym705 := z.DecBinary()
-		_ = yym705
+		yyv740 := &x.ListMeta
+		yym741 := z.DecBinary()
+		_ = yym741
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv704) {
+		} else if z.HasExtensions() && z.DecExt(yyv740) {
 		} else {
-			z.DecFallback(yyv704, false)
+			z.DecFallback(yyv740, false)
 		}
 	}
-	yyj701++
-	if yyhl701 {
-		yyb701 = yyj701 > l
+	yyj737++
+	if yyhl737 {
+		yyb737 = yyj737 > l
 	} else {
-		yyb701 = r.CheckBreak()
+		yyb737 = r.CheckBreak()
 	}
-	if yyb701 {
+	if yyb737 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv706 := &x.Items
-		yym707 := z.DecBinary()
-		_ = yym707
+		yyv742 := &x.Items
+		yym743 := z.DecBinary()
+		_ = yym743
 		if false {
 		} else {
-			h.decSliceJob((*[]Job)(yyv706), d)
+			h.decSliceJob((*[]Job)(yyv742), d)
 		}
 	}
 	for {
-		yyj701++
-		if yyhl701 {
-			yyb701 = yyj701 > l
+		yyj737++
+		if yyhl737 {
+			yyb737 = yyj737 > l
 		} else {
-			yyb701 = r.CheckBreak()
+			yyb737 = r.CheckBreak()
 		}
-		if yyb701 {
+		if yyb737 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj701-1, "")
+		z.DecStructFieldNotFound(yyj737-1, "")
 	}
 	r.ReadEnd()
 }
@@ -7796,96 +8012,96 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym708 := z.EncBinary()
-		_ = yym708
+		yym744 := z.EncBinary()
+		_ = yym744
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep709 := !z.EncBinary()
-			yy2arr709 := z.EncBasicHandle().StructToArray
-			var yyq709 [4]bool
-			_, _, _ = yysep709, yyq709, yy2arr709
-			const yyr709 bool = false
-			yyq709[0] = x.Parallelism != nil
-			yyq709[1] = x.Completions != nil
-			yyq709[2] = x.Selector != nil
-			if yyr709 || yy2arr709 {
+			yysep745 := !z.EncBinary()
+			yy2arr745 := z.EncBasicHandle().StructToArray
+			var yyq745 [4]bool
+			_, _, _ = yysep745, yyq745, yy2arr745
+			const yyr745 bool = false
+			yyq745[0] = x.Parallelism != nil
+			yyq745[1] = x.Completions != nil
+			yyq745[2] = x.Selector != nil
+			if yyr745 || yy2arr745 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn709 int = 1
-				for _, b := range yyq709 {
+				var yynn745 int = 1
+				for _, b := range yyq745 {
 					if b {
-						yynn709++
+						yynn745++
 					}
 				}
-				r.EncodeMapStart(yynn709)
+				r.EncodeMapStart(yynn745)
 			}
-			if yyr709 || yy2arr709 {
-				if yyq709[0] {
+			if yyr745 || yy2arr745 {
+				if yyq745[0] {
 					if x.Parallelism == nil {
 						r.EncodeNil()
 					} else {
-						yy711 := *x.Parallelism
-						yym712 := z.EncBinary()
-						_ = yym712
+						yy747 := *x.Parallelism
+						yym748 := z.EncBinary()
+						_ = yym748
 						if false {
 						} else {
-							r.EncodeInt(int64(yy711))
+							r.EncodeInt(int64(yy747))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq709[0] {
+				if yyq745[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("parallelism"))
 					if x.Parallelism == nil {
 						r.EncodeNil()
 					} else {
-						yy713 := *x.Parallelism
-						yym714 := z.EncBinary()
-						_ = yym714
+						yy749 := *x.Parallelism
+						yym750 := z.EncBinary()
+						_ = yym750
 						if false {
 						} else {
-							r.EncodeInt(int64(yy713))
+							r.EncodeInt(int64(yy749))
 						}
 					}
 				}
 			}
-			if yyr709 || yy2arr709 {
-				if yyq709[1] {
+			if yyr745 || yy2arr745 {
+				if yyq745[1] {
 					if x.Completions == nil {
 						r.EncodeNil()
 					} else {
-						yy716 := *x.Completions
-						yym717 := z.EncBinary()
-						_ = yym717
+						yy752 := *x.Completions
+						yym753 := z.EncBinary()
+						_ = yym753
 						if false {
 						} else {
-							r.EncodeInt(int64(yy716))
+							r.EncodeInt(int64(yy752))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq709[1] {
+				if yyq745[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("completions"))
 					if x.Completions == nil {
 						r.EncodeNil()
 					} else {
-						yy718 := *x.Completions
-						yym719 := z.EncBinary()
-						_ = yym719
+						yy754 := *x.Completions
+						yym755 := z.EncBinary()
+						_ = yym755
 						if false {
 						} else {
-							r.EncodeInt(int64(yy718))
+							r.EncodeInt(int64(yy754))
 						}
 					}
 				}
 			}
-			if yyr709 || yy2arr709 {
-				if yyq709[2] {
+			if yyr745 || yy2arr745 {
+				if yyq745[2] {
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
@@ -7895,7 +8111,7 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq709[2] {
+				if yyq745[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
 					if x.Selector == nil {
 						r.EncodeNil()
@@ -7904,15 +8120,27 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr709 || yy2arr709 {
-				yy722 := &x.Template
-				yy722.CodecEncodeSelf(e)
+			if yyr745 || yy2arr745 {
+				yy758 := &x.Template
+				yym759 := z.EncBinary()
+				_ = yym759
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy758) {
+				} else {
+					z.EncFallback(yy758)
+				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("template"))
-				yy723 := &x.Template
-				yy723.CodecEncodeSelf(e)
+				yy760 := &x.Template
+				yym761 := z.EncBinary()
+				_ = yym761
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy760) {
+				} else {
+					z.EncFallback(yy760)
+				}
 			}
-			if yysep709 {
+			if yysep745 {
 				r.EncodeEnd()
 			}
 		}
@@ -7923,24 +8151,24 @@ func (x *JobSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym724 := z.DecBinary()
-	_ = yym724
+	yym762 := z.DecBinary()
+	_ = yym762
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl725 := r.ReadMapStart()
-			if yyl725 == 0 {
+			yyl763 := r.ReadMapStart()
+			if yyl763 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl725, d)
+				x.codecDecodeSelfFromMap(yyl763, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl725 := r.ReadArrayStart()
-			if yyl725 == 0 {
+			yyl763 := r.ReadArrayStart()
+			if yyl763 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl725, d)
+				x.codecDecodeSelfFromArray(yyl763, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -7952,12 +8180,12 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys726Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys726Slc
-	var yyhl726 bool = l >= 0
-	for yyj726 := 0; ; yyj726++ {
-		if yyhl726 {
-			if yyj726 >= l {
+	var yys764Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys764Slc
+	var yyhl764 bool = l >= 0
+	for yyj764 := 0; ; yyj764++ {
+		if yyhl764 {
+			if yyj764 >= l {
 				break
 			}
 		} else {
@@ -7965,9 +8193,9 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys726Slc = r.DecodeBytes(yys726Slc, true, true)
-		yys726 := string(yys726Slc)
-		switch yys726 {
+		yys764Slc = r.DecodeBytes(yys764Slc, true, true)
+		yys764 := string(yys764Slc)
+		switch yys764 {
 		case "parallelism":
 			if r.TryDecodeAsNil() {
 				if x.Parallelism != nil {
@@ -7977,8 +8205,8 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.Parallelism == nil {
 					x.Parallelism = new(int)
 				}
-				yym728 := z.DecBinary()
-				_ = yym728
+				yym766 := z.DecBinary()
+				_ = yym766
 				if false {
 				} else {
 					*((*int)(x.Parallelism)) = int(r.DecodeInt(codecSelferBitsize1234))
@@ -7993,8 +8221,8 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.Completions == nil {
 					x.Completions = new(int)
 				}
-				yym730 := z.DecBinary()
-				_ = yym730
+				yym768 := z.DecBinary()
+				_ = yym768
 				if false {
 				} else {
 					*((*int)(x.Completions)) = int(r.DecodeInt(codecSelferBitsize1234))
@@ -8015,14 +8243,20 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Template = pkg2_api.PodTemplateSpec{}
 			} else {
-				yyv732 := &x.Template
-				yyv732.CodecDecodeSelf(d)
+				yyv770 := &x.Template
+				yym771 := z.DecBinary()
+				_ = yym771
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv770) {
+				} else {
+					z.DecFallback(yyv770, false)
+				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys726)
-		} // end switch yys726
-	} // end for yyj726
-	if !yyhl726 {
+			z.DecStructFieldNotFound(-1, yys764)
+		} // end switch yys764
+	} // end for yyj764
+	if !yyhl764 {
 		r.ReadEnd()
 	}
 }
@@ -8031,16 +8265,16 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj733 int
-	var yyb733 bool
-	var yyhl733 bool = l >= 0
-	yyj733++
-	if yyhl733 {
-		yyb733 = yyj733 > l
+	var yyj772 int
+	var yyb772 bool
+	var yyhl772 bool = l >= 0
+	yyj772++
+	if yyhl772 {
+		yyb772 = yyj772 > l
 	} else {
-		yyb733 = r.CheckBreak()
+		yyb772 = r.CheckBreak()
 	}
-	if yyb733 {
+	if yyb772 {
 		r.ReadEnd()
 		return
 	}
@@ -8052,20 +8286,20 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.Parallelism == nil {
 			x.Parallelism = new(int)
 		}
-		yym735 := z.DecBinary()
-		_ = yym735
+		yym774 := z.DecBinary()
+		_ = yym774
 		if false {
 		} else {
 			*((*int)(x.Parallelism)) = int(r.DecodeInt(codecSelferBitsize1234))
 		}
 	}
-	yyj733++
-	if yyhl733 {
-		yyb733 = yyj733 > l
+	yyj772++
+	if yyhl772 {
+		yyb772 = yyj772 > l
 	} else {
-		yyb733 = r.CheckBreak()
+		yyb772 = r.CheckBreak()
 	}
-	if yyb733 {
+	if yyb772 {
 		r.ReadEnd()
 		return
 	}
@@ -8077,20 +8311,20 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.Completions == nil {
 			x.Completions = new(int)
 		}
-		yym737 := z.DecBinary()
-		_ = yym737
+		yym776 := z.DecBinary()
+		_ = yym776
 		if false {
 		} else {
 			*((*int)(x.Completions)) = int(r.DecodeInt(codecSelferBitsize1234))
 		}
 	}
-	yyj733++
-	if yyhl733 {
-		yyb733 = yyj733 > l
+	yyj772++
+	if yyhl772 {
+		yyb772 = yyj772 > l
 	} else {
-		yyb733 = r.CheckBreak()
+		yyb772 = r.CheckBreak()
 	}
-	if yyb733 {
+	if yyb772 {
 		r.ReadEnd()
 		return
 	}
@@ -8104,33 +8338,39 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.Selector.CodecDecodeSelf(d)
 	}
-	yyj733++
-	if yyhl733 {
-		yyb733 = yyj733 > l
+	yyj772++
+	if yyhl772 {
+		yyb772 = yyj772 > l
 	} else {
-		yyb733 = r.CheckBreak()
+		yyb772 = r.CheckBreak()
 	}
-	if yyb733 {
+	if yyb772 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Template = pkg2_api.PodTemplateSpec{}
 	} else {
-		yyv739 := &x.Template
-		yyv739.CodecDecodeSelf(d)
+		yyv778 := &x.Template
+		yym779 := z.DecBinary()
+		_ = yym779
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv778) {
+		} else {
+			z.DecFallback(yyv778, false)
+		}
 	}
 	for {
-		yyj733++
-		if yyhl733 {
-			yyb733 = yyj733 > l
+		yyj772++
+		if yyhl772 {
+			yyb772 = yyj772 > l
 		} else {
-			yyb733 = r.CheckBreak()
+			yyb772 = r.CheckBreak()
 		}
-		if yyb733 {
+		if yyb772 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj733-1, "")
+		z.DecStructFieldNotFound(yyj772-1, "")
 	}
 	r.ReadEnd()
 }
@@ -8142,40 +8382,40 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym740 := z.EncBinary()
-		_ = yym740
+		yym780 := z.EncBinary()
+		_ = yym780
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep741 := !z.EncBinary()
-			yy2arr741 := z.EncBasicHandle().StructToArray
-			var yyq741 [6]bool
-			_, _, _ = yysep741, yyq741, yy2arr741
-			const yyr741 bool = false
-			yyq741[0] = len(x.Conditions) != 0
-			yyq741[1] = x.StartTime != nil
-			yyq741[2] = x.CompletionTime != nil
-			yyq741[3] = x.Active != 0
-			yyq741[4] = x.Succeeded != 0
-			yyq741[5] = x.Failed != 0
-			if yyr741 || yy2arr741 {
+			yysep781 := !z.EncBinary()
+			yy2arr781 := z.EncBasicHandle().StructToArray
+			var yyq781 [6]bool
+			_, _, _ = yysep781, yyq781, yy2arr781
+			const yyr781 bool = false
+			yyq781[0] = len(x.Conditions) != 0
+			yyq781[1] = x.StartTime != nil
+			yyq781[2] = x.CompletionTime != nil
+			yyq781[3] = x.Active != 0
+			yyq781[4] = x.Succeeded != 0
+			yyq781[5] = x.Failed != 0
+			if yyr781 || yy2arr781 {
 				r.EncodeArrayStart(6)
 			} else {
-				var yynn741 int = 0
-				for _, b := range yyq741 {
+				var yynn781 int = 0
+				for _, b := range yyq781 {
 					if b {
-						yynn741++
+						yynn781++
 					}
 				}
-				r.EncodeMapStart(yynn741)
+				r.EncodeMapStart(yynn781)
 			}
-			if yyr741 || yy2arr741 {
-				if yyq741[0] {
+			if yyr781 || yy2arr781 {
+				if yyq781[0] {
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
-						yym743 := z.EncBinary()
-						_ = yym743
+						yym783 := z.EncBinary()
+						_ = yym783
 						if false {
 						} else {
 							h.encSliceJobCondition(([]JobCondition)(x.Conditions), e)
@@ -8185,13 +8425,13 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq741[0] {
+				if yyq781[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("conditions"))
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
-						yym744 := z.EncBinary()
-						_ = yym744
+						yym784 := z.EncBinary()
+						_ = yym784
 						if false {
 						} else {
 							h.encSliceJobCondition(([]JobCondition)(x.Conditions), e)
@@ -8199,18 +8439,18 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr741 || yy2arr741 {
-				if yyq741[1] {
+			if yyr781 || yy2arr781 {
+				if yyq781[1] {
 					if x.StartTime == nil {
 						r.EncodeNil()
 					} else {
-						yym746 := z.EncBinary()
-						_ = yym746
+						yym786 := z.EncBinary()
+						_ = yym786
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.StartTime) {
-						} else if yym746 {
+						} else if yym786 {
 							z.EncBinaryMarshal(x.StartTime)
-						} else if !yym746 && z.IsJSONHandle() {
+						} else if !yym786 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.StartTime)
 						} else {
 							z.EncFallback(x.StartTime)
@@ -8220,18 +8460,18 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq741[1] {
+				if yyq781[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("startTime"))
 					if x.StartTime == nil {
 						r.EncodeNil()
 					} else {
-						yym747 := z.EncBinary()
-						_ = yym747
+						yym787 := z.EncBinary()
+						_ = yym787
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.StartTime) {
-						} else if yym747 {
+						} else if yym787 {
 							z.EncBinaryMarshal(x.StartTime)
-						} else if !yym747 && z.IsJSONHandle() {
+						} else if !yym787 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.StartTime)
 						} else {
 							z.EncFallback(x.StartTime)
@@ -8239,18 +8479,18 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr741 || yy2arr741 {
-				if yyq741[2] {
+			if yyr781 || yy2arr781 {
+				if yyq781[2] {
 					if x.CompletionTime == nil {
 						r.EncodeNil()
 					} else {
-						yym749 := z.EncBinary()
-						_ = yym749
+						yym789 := z.EncBinary()
+						_ = yym789
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.CompletionTime) {
-						} else if yym749 {
+						} else if yym789 {
 							z.EncBinaryMarshal(x.CompletionTime)
-						} else if !yym749 && z.IsJSONHandle() {
+						} else if !yym789 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.CompletionTime)
 						} else {
 							z.EncFallback(x.CompletionTime)
@@ -8260,18 +8500,18 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq741[2] {
+				if yyq781[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("completionTime"))
 					if x.CompletionTime == nil {
 						r.EncodeNil()
 					} else {
-						yym750 := z.EncBinary()
-						_ = yym750
+						yym790 := z.EncBinary()
+						_ = yym790
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.CompletionTime) {
-						} else if yym750 {
+						} else if yym790 {
 							z.EncBinaryMarshal(x.CompletionTime)
-						} else if !yym750 && z.IsJSONHandle() {
+						} else if !yym790 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.CompletionTime)
 						} else {
 							z.EncFallback(x.CompletionTime)
@@ -8279,10 +8519,10 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr741 || yy2arr741 {
-				if yyq741[3] {
-					yym752 := z.EncBinary()
-					_ = yym752
+			if yyr781 || yy2arr781 {
+				if yyq781[3] {
+					yym792 := z.EncBinary()
+					_ = yym792
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Active))
@@ -8291,20 +8531,20 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq741[3] {
+				if yyq781[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("active"))
-					yym753 := z.EncBinary()
-					_ = yym753
+					yym793 := z.EncBinary()
+					_ = yym793
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Active))
 					}
 				}
 			}
-			if yyr741 || yy2arr741 {
-				if yyq741[4] {
-					yym755 := z.EncBinary()
-					_ = yym755
+			if yyr781 || yy2arr781 {
+				if yyq781[4] {
+					yym795 := z.EncBinary()
+					_ = yym795
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Succeeded))
@@ -8313,20 +8553,20 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq741[4] {
+				if yyq781[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("succeeded"))
-					yym756 := z.EncBinary()
-					_ = yym756
+					yym796 := z.EncBinary()
+					_ = yym796
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Succeeded))
 					}
 				}
 			}
-			if yyr741 || yy2arr741 {
-				if yyq741[5] {
-					yym758 := z.EncBinary()
-					_ = yym758
+			if yyr781 || yy2arr781 {
+				if yyq781[5] {
+					yym798 := z.EncBinary()
+					_ = yym798
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Failed))
@@ -8335,17 +8575,17 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq741[5] {
+				if yyq781[5] {
 					r.EncodeString(codecSelferC_UTF81234, string("failed"))
-					yym759 := z.EncBinary()
-					_ = yym759
+					yym799 := z.EncBinary()
+					_ = yym799
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Failed))
 					}
 				}
 			}
-			if yysep741 {
+			if yysep781 {
 				r.EncodeEnd()
 			}
 		}
@@ -8356,24 +8596,24 @@ func (x *JobStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym760 := z.DecBinary()
-	_ = yym760
+	yym800 := z.DecBinary()
+	_ = yym800
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl761 := r.ReadMapStart()
-			if yyl761 == 0 {
+			yyl801 := r.ReadMapStart()
+			if yyl801 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl761, d)
+				x.codecDecodeSelfFromMap(yyl801, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl761 := r.ReadArrayStart()
-			if yyl761 == 0 {
+			yyl801 := r.ReadArrayStart()
+			if yyl801 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl761, d)
+				x.codecDecodeSelfFromArray(yyl801, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -8385,12 +8625,12 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys762Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys762Slc
-	var yyhl762 bool = l >= 0
-	for yyj762 := 0; ; yyj762++ {
-		if yyhl762 {
-			if yyj762 >= l {
+	var yys802Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys802Slc
+	var yyhl802 bool = l >= 0
+	for yyj802 := 0; ; yyj802++ {
+		if yyhl802 {
+			if yyj802 >= l {
 				break
 			}
 		} else {
@@ -8398,19 +8638,19 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys762Slc = r.DecodeBytes(yys762Slc, true, true)
-		yys762 := string(yys762Slc)
-		switch yys762 {
+		yys802Slc = r.DecodeBytes(yys802Slc, true, true)
+		yys802 := string(yys802Slc)
+		switch yys802 {
 		case "conditions":
 			if r.TryDecodeAsNil() {
 				x.Conditions = nil
 			} else {
-				yyv763 := &x.Conditions
-				yym764 := z.DecBinary()
-				_ = yym764
+				yyv803 := &x.Conditions
+				yym804 := z.DecBinary()
+				_ = yym804
 				if false {
 				} else {
-					h.decSliceJobCondition((*[]JobCondition)(yyv763), d)
+					h.decSliceJobCondition((*[]JobCondition)(yyv803), d)
 				}
 			}
 		case "startTime":
@@ -8422,13 +8662,13 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.StartTime == nil {
 					x.StartTime = new(pkg1_unversioned.Time)
 				}
-				yym766 := z.DecBinary()
-				_ = yym766
+				yym806 := z.DecBinary()
+				_ = yym806
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.StartTime) {
-				} else if yym766 {
+				} else if yym806 {
 					z.DecBinaryUnmarshal(x.StartTime)
-				} else if !yym766 && z.IsJSONHandle() {
+				} else if !yym806 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.StartTime)
 				} else {
 					z.DecFallback(x.StartTime, false)
@@ -8443,13 +8683,13 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.CompletionTime == nil {
 					x.CompletionTime = new(pkg1_unversioned.Time)
 				}
-				yym768 := z.DecBinary()
-				_ = yym768
+				yym808 := z.DecBinary()
+				_ = yym808
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.CompletionTime) {
-				} else if yym768 {
+				} else if yym808 {
 					z.DecBinaryUnmarshal(x.CompletionTime)
-				} else if !yym768 && z.IsJSONHandle() {
+				} else if !yym808 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.CompletionTime)
 				} else {
 					z.DecFallback(x.CompletionTime, false)
@@ -8474,10 +8714,10 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Failed = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys762)
-		} // end switch yys762
-	} // end for yyj762
-	if !yyhl762 {
+			z.DecStructFieldNotFound(-1, yys802)
+		} // end switch yys802
+	} // end for yyj802
+	if !yyhl802 {
 		r.ReadEnd()
 	}
 }
@@ -8486,37 +8726,37 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj772 int
-	var yyb772 bool
-	var yyhl772 bool = l >= 0
-	yyj772++
-	if yyhl772 {
-		yyb772 = yyj772 > l
+	var yyj812 int
+	var yyb812 bool
+	var yyhl812 bool = l >= 0
+	yyj812++
+	if yyhl812 {
+		yyb812 = yyj812 > l
 	} else {
-		yyb772 = r.CheckBreak()
+		yyb812 = r.CheckBreak()
 	}
-	if yyb772 {
+	if yyb812 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Conditions = nil
 	} else {
-		yyv773 := &x.Conditions
-		yym774 := z.DecBinary()
-		_ = yym774
+		yyv813 := &x.Conditions
+		yym814 := z.DecBinary()
+		_ = yym814
 		if false {
 		} else {
-			h.decSliceJobCondition((*[]JobCondition)(yyv773), d)
+			h.decSliceJobCondition((*[]JobCondition)(yyv813), d)
 		}
 	}
-	yyj772++
-	if yyhl772 {
-		yyb772 = yyj772 > l
+	yyj812++
+	if yyhl812 {
+		yyb812 = yyj812 > l
 	} else {
-		yyb772 = r.CheckBreak()
+		yyb812 = r.CheckBreak()
 	}
-	if yyb772 {
+	if yyb812 {
 		r.ReadEnd()
 		return
 	}
@@ -8528,25 +8768,25 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.StartTime == nil {
 			x.StartTime = new(pkg1_unversioned.Time)
 		}
-		yym776 := z.DecBinary()
-		_ = yym776
+		yym816 := z.DecBinary()
+		_ = yym816
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.StartTime) {
-		} else if yym776 {
+		} else if yym816 {
 			z.DecBinaryUnmarshal(x.StartTime)
-		} else if !yym776 && z.IsJSONHandle() {
+		} else if !yym816 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.StartTime)
 		} else {
 			z.DecFallback(x.StartTime, false)
 		}
 	}
-	yyj772++
-	if yyhl772 {
-		yyb772 = yyj772 > l
+	yyj812++
+	if yyhl812 {
+		yyb812 = yyj812 > l
 	} else {
-		yyb772 = r.CheckBreak()
+		yyb812 = r.CheckBreak()
 	}
-	if yyb772 {
+	if yyb812 {
 		r.ReadEnd()
 		return
 	}
@@ -8558,25 +8798,25 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.CompletionTime == nil {
 			x.CompletionTime = new(pkg1_unversioned.Time)
 		}
-		yym778 := z.DecBinary()
-		_ = yym778
+		yym818 := z.DecBinary()
+		_ = yym818
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.CompletionTime) {
-		} else if yym778 {
+		} else if yym818 {
 			z.DecBinaryUnmarshal(x.CompletionTime)
-		} else if !yym778 && z.IsJSONHandle() {
+		} else if !yym818 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.CompletionTime)
 		} else {
 			z.DecFallback(x.CompletionTime, false)
 		}
 	}
-	yyj772++
-	if yyhl772 {
-		yyb772 = yyj772 > l
+	yyj812++
+	if yyhl812 {
+		yyb812 = yyj812 > l
 	} else {
-		yyb772 = r.CheckBreak()
+		yyb812 = r.CheckBreak()
 	}
-	if yyb772 {
+	if yyb812 {
 		r.ReadEnd()
 		return
 	}
@@ -8585,13 +8825,13 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Active = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj772++
-	if yyhl772 {
-		yyb772 = yyj772 > l
+	yyj812++
+	if yyhl812 {
+		yyb812 = yyj812 > l
 	} else {
-		yyb772 = r.CheckBreak()
+		yyb812 = r.CheckBreak()
 	}
-	if yyb772 {
+	if yyb812 {
 		r.ReadEnd()
 		return
 	}
@@ -8600,13 +8840,13 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Succeeded = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj772++
-	if yyhl772 {
-		yyb772 = yyj772 > l
+	yyj812++
+	if yyhl812 {
+		yyb812 = yyj812 > l
 	} else {
-		yyb772 = r.CheckBreak()
+		yyb812 = r.CheckBreak()
 	}
-	if yyb772 {
+	if yyb812 {
 		r.ReadEnd()
 		return
 	}
@@ -8616,16 +8856,16 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Failed = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj772++
-		if yyhl772 {
-			yyb772 = yyj772 > l
+		yyj812++
+		if yyhl812 {
+			yyb812 = yyj812 > l
 		} else {
-			yyb772 = r.CheckBreak()
+			yyb812 = r.CheckBreak()
 		}
-		if yyb772 {
+		if yyb812 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj772-1, "")
+		z.DecStructFieldNotFound(yyj812-1, "")
 	}
 	r.ReadEnd()
 }
@@ -8634,8 +8874,8 @@ func (x JobConditionType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym782 := z.EncBinary()
-	_ = yym782
+	yym822 := z.EncBinary()
+	_ = yym822
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -8647,8 +8887,8 @@ func (x *JobConditionType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym783 := z.DecBinary()
-	_ = yym783
+	yym823 := z.DecBinary()
+	_ = yym823
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -8663,40 +8903,40 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym784 := z.EncBinary()
-		_ = yym784
+		yym824 := z.EncBinary()
+		_ = yym824
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep785 := !z.EncBinary()
-			yy2arr785 := z.EncBasicHandle().StructToArray
-			var yyq785 [6]bool
-			_, _, _ = yysep785, yyq785, yy2arr785
-			const yyr785 bool = false
-			yyq785[2] = true
-			yyq785[3] = true
-			yyq785[4] = x.Reason != ""
-			yyq785[5] = x.Message != ""
-			if yyr785 || yy2arr785 {
+			yysep825 := !z.EncBinary()
+			yy2arr825 := z.EncBasicHandle().StructToArray
+			var yyq825 [6]bool
+			_, _, _ = yysep825, yyq825, yy2arr825
+			const yyr825 bool = false
+			yyq825[2] = true
+			yyq825[3] = true
+			yyq825[4] = x.Reason != ""
+			yyq825[5] = x.Message != ""
+			if yyr825 || yy2arr825 {
 				r.EncodeArrayStart(6)
 			} else {
-				var yynn785 int = 2
-				for _, b := range yyq785 {
+				var yynn825 int = 2
+				for _, b := range yyq825 {
 					if b {
-						yynn785++
+						yynn825++
 					}
 				}
-				r.EncodeMapStart(yynn785)
+				r.EncodeMapStart(yynn825)
 			}
-			if yyr785 || yy2arr785 {
+			if yyr825 || yy2arr825 {
 				x.Type.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("type"))
 				x.Type.CodecEncodeSelf(e)
 			}
-			if yyr785 || yy2arr785 {
-				yym788 := z.EncBinary()
-				_ = yym788
+			if yyr825 || yy2arr825 {
+				yym828 := z.EncBinary()
+				_ = yym828
 				if false {
 				} else if z.HasExtensions() && z.EncExt(x.Status) {
 				} else {
@@ -8704,86 +8944,86 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("status"))
-				yym789 := z.EncBinary()
-				_ = yym789
+				yym829 := z.EncBinary()
+				_ = yym829
 				if false {
 				} else if z.HasExtensions() && z.EncExt(x.Status) {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Status))
 				}
 			}
-			if yyr785 || yy2arr785 {
-				if yyq785[2] {
-					yy791 := &x.LastProbeTime
-					yym792 := z.EncBinary()
-					_ = yym792
+			if yyr825 || yy2arr825 {
+				if yyq825[2] {
+					yy831 := &x.LastProbeTime
+					yym832 := z.EncBinary()
+					_ = yym832
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy791) {
-					} else if yym792 {
-						z.EncBinaryMarshal(yy791)
-					} else if !yym792 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy791)
+					} else if z.HasExtensions() && z.EncExt(yy831) {
+					} else if yym832 {
+						z.EncBinaryMarshal(yy831)
+					} else if !yym832 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy831)
 					} else {
-						z.EncFallback(yy791)
+						z.EncFallback(yy831)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq785[2] {
+				if yyq825[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("lastProbeTime"))
-					yy793 := &x.LastProbeTime
-					yym794 := z.EncBinary()
-					_ = yym794
+					yy833 := &x.LastProbeTime
+					yym834 := z.EncBinary()
+					_ = yym834
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy793) {
-					} else if yym794 {
-						z.EncBinaryMarshal(yy793)
-					} else if !yym794 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy793)
+					} else if z.HasExtensions() && z.EncExt(yy833) {
+					} else if yym834 {
+						z.EncBinaryMarshal(yy833)
+					} else if !yym834 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy833)
 					} else {
-						z.EncFallback(yy793)
+						z.EncFallback(yy833)
 					}
 				}
 			}
-			if yyr785 || yy2arr785 {
-				if yyq785[3] {
-					yy796 := &x.LastTransitionTime
-					yym797 := z.EncBinary()
-					_ = yym797
+			if yyr825 || yy2arr825 {
+				if yyq825[3] {
+					yy836 := &x.LastTransitionTime
+					yym837 := z.EncBinary()
+					_ = yym837
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy796) {
-					} else if yym797 {
-						z.EncBinaryMarshal(yy796)
-					} else if !yym797 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy796)
+					} else if z.HasExtensions() && z.EncExt(yy836) {
+					} else if yym837 {
+						z.EncBinaryMarshal(yy836)
+					} else if !yym837 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy836)
 					} else {
-						z.EncFallback(yy796)
+						z.EncFallback(yy836)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq785[3] {
+				if yyq825[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("lastTransitionTime"))
-					yy798 := &x.LastTransitionTime
-					yym799 := z.EncBinary()
-					_ = yym799
+					yy838 := &x.LastTransitionTime
+					yym839 := z.EncBinary()
+					_ = yym839
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy798) {
-					} else if yym799 {
-						z.EncBinaryMarshal(yy798)
-					} else if !yym799 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy798)
+					} else if z.HasExtensions() && z.EncExt(yy838) {
+					} else if yym839 {
+						z.EncBinaryMarshal(yy838)
+					} else if !yym839 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy838)
 					} else {
-						z.EncFallback(yy798)
+						z.EncFallback(yy838)
 					}
 				}
 			}
-			if yyr785 || yy2arr785 {
-				if yyq785[4] {
-					yym801 := z.EncBinary()
-					_ = yym801
+			if yyr825 || yy2arr825 {
+				if yyq825[4] {
+					yym841 := z.EncBinary()
+					_ = yym841
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
@@ -8792,20 +9032,20 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq785[4] {
+				if yyq825[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("reason"))
-					yym802 := z.EncBinary()
-					_ = yym802
+					yym842 := z.EncBinary()
+					_ = yym842
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
 					}
 				}
 			}
-			if yyr785 || yy2arr785 {
-				if yyq785[5] {
-					yym804 := z.EncBinary()
-					_ = yym804
+			if yyr825 || yy2arr825 {
+				if yyq825[5] {
+					yym844 := z.EncBinary()
+					_ = yym844
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
@@ -8814,17 +9054,17 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq785[5] {
+				if yyq825[5] {
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
-					yym805 := z.EncBinary()
-					_ = yym805
+					yym845 := z.EncBinary()
+					_ = yym845
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
 					}
 				}
 			}
-			if yysep785 {
+			if yysep825 {
 				r.EncodeEnd()
 			}
 		}
@@ -8835,24 +9075,24 @@ func (x *JobCondition) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym806 := z.DecBinary()
-	_ = yym806
+	yym846 := z.DecBinary()
+	_ = yym846
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl807 := r.ReadMapStart()
-			if yyl807 == 0 {
+			yyl847 := r.ReadMapStart()
+			if yyl847 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl807, d)
+				x.codecDecodeSelfFromMap(yyl847, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl807 := r.ReadArrayStart()
-			if yyl807 == 0 {
+			yyl847 := r.ReadArrayStart()
+			if yyl847 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl807, d)
+				x.codecDecodeSelfFromArray(yyl847, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -8864,12 +9104,12 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys808Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys808Slc
-	var yyhl808 bool = l >= 0
-	for yyj808 := 0; ; yyj808++ {
-		if yyhl808 {
-			if yyj808 >= l {
+	var yys848Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys848Slc
+	var yyhl848 bool = l >= 0
+	for yyj848 := 0; ; yyj848++ {
+		if yyhl848 {
+			if yyj848 >= l {
 				break
 			}
 		} else {
@@ -8877,9 +9117,9 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys808Slc = r.DecodeBytes(yys808Slc, true, true)
-		yys808 := string(yys808Slc)
-		switch yys808 {
+		yys848Slc = r.DecodeBytes(yys848Slc, true, true)
+		yys848 := string(yys848Slc)
+		switch yys848 {
 		case "type":
 			if r.TryDecodeAsNil() {
 				x.Type = ""
@@ -8896,34 +9136,34 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.LastProbeTime = pkg1_unversioned.Time{}
 			} else {
-				yyv811 := &x.LastProbeTime
-				yym812 := z.DecBinary()
-				_ = yym812
+				yyv851 := &x.LastProbeTime
+				yym852 := z.DecBinary()
+				_ = yym852
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv811) {
-				} else if yym812 {
-					z.DecBinaryUnmarshal(yyv811)
-				} else if !yym812 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv811)
+				} else if z.HasExtensions() && z.DecExt(yyv851) {
+				} else if yym852 {
+					z.DecBinaryUnmarshal(yyv851)
+				} else if !yym852 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv851)
 				} else {
-					z.DecFallback(yyv811, false)
+					z.DecFallback(yyv851, false)
 				}
 			}
 		case "lastTransitionTime":
 			if r.TryDecodeAsNil() {
 				x.LastTransitionTime = pkg1_unversioned.Time{}
 			} else {
-				yyv813 := &x.LastTransitionTime
-				yym814 := z.DecBinary()
-				_ = yym814
+				yyv853 := &x.LastTransitionTime
+				yym854 := z.DecBinary()
+				_ = yym854
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv813) {
-				} else if yym814 {
-					z.DecBinaryUnmarshal(yyv813)
-				} else if !yym814 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv813)
+				} else if z.HasExtensions() && z.DecExt(yyv853) {
+				} else if yym854 {
+					z.DecBinaryUnmarshal(yyv853)
+				} else if !yym854 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv853)
 				} else {
-					z.DecFallback(yyv813, false)
+					z.DecFallback(yyv853, false)
 				}
 			}
 		case "reason":
@@ -8939,10 +9179,10 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Message = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys808)
-		} // end switch yys808
-	} // end for yyj808
-	if !yyhl808 {
+			z.DecStructFieldNotFound(-1, yys848)
+		} // end switch yys848
+	} // end for yyj848
+	if !yyhl848 {
 		r.ReadEnd()
 	}
 }
@@ -8951,16 +9191,16 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj817 int
-	var yyb817 bool
-	var yyhl817 bool = l >= 0
-	yyj817++
-	if yyhl817 {
-		yyb817 = yyj817 > l
+	var yyj857 int
+	var yyb857 bool
+	var yyhl857 bool = l >= 0
+	yyj857++
+	if yyhl857 {
+		yyb857 = yyj857 > l
 	} else {
-		yyb817 = r.CheckBreak()
+		yyb857 = r.CheckBreak()
 	}
-	if yyb817 {
+	if yyb857 {
 		r.ReadEnd()
 		return
 	}
@@ -8969,13 +9209,13 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Type = JobConditionType(r.DecodeString())
 	}
-	yyj817++
-	if yyhl817 {
-		yyb817 = yyj817 > l
+	yyj857++
+	if yyhl857 {
+		yyb857 = yyj857 > l
 	} else {
-		yyb817 = r.CheckBreak()
+		yyb857 = r.CheckBreak()
 	}
-	if yyb817 {
+	if yyb857 {
 		r.ReadEnd()
 		return
 	}
@@ -8984,65 +9224,65 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Status = pkg2_api.ConditionStatus(r.DecodeString())
 	}
-	yyj817++
-	if yyhl817 {
-		yyb817 = yyj817 > l
+	yyj857++
+	if yyhl857 {
+		yyb857 = yyj857 > l
 	} else {
-		yyb817 = r.CheckBreak()
+		yyb857 = r.CheckBreak()
 	}
-	if yyb817 {
+	if yyb857 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.LastProbeTime = pkg1_unversioned.Time{}
 	} else {
-		yyv820 := &x.LastProbeTime
-		yym821 := z.DecBinary()
-		_ = yym821
+		yyv860 := &x.LastProbeTime
+		yym861 := z.DecBinary()
+		_ = yym861
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv820) {
-		} else if yym821 {
-			z.DecBinaryUnmarshal(yyv820)
-		} else if !yym821 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv820)
+		} else if z.HasExtensions() && z.DecExt(yyv860) {
+		} else if yym861 {
+			z.DecBinaryUnmarshal(yyv860)
+		} else if !yym861 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv860)
 		} else {
-			z.DecFallback(yyv820, false)
+			z.DecFallback(yyv860, false)
 		}
 	}
-	yyj817++
-	if yyhl817 {
-		yyb817 = yyj817 > l
+	yyj857++
+	if yyhl857 {
+		yyb857 = yyj857 > l
 	} else {
-		yyb817 = r.CheckBreak()
+		yyb857 = r.CheckBreak()
 	}
-	if yyb817 {
+	if yyb857 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.LastTransitionTime = pkg1_unversioned.Time{}
 	} else {
-		yyv822 := &x.LastTransitionTime
-		yym823 := z.DecBinary()
-		_ = yym823
+		yyv862 := &x.LastTransitionTime
+		yym863 := z.DecBinary()
+		_ = yym863
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv822) {
-		} else if yym823 {
-			z.DecBinaryUnmarshal(yyv822)
-		} else if !yym823 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv822)
+		} else if z.HasExtensions() && z.DecExt(yyv862) {
+		} else if yym863 {
+			z.DecBinaryUnmarshal(yyv862)
+		} else if !yym863 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv862)
 		} else {
-			z.DecFallback(yyv822, false)
+			z.DecFallback(yyv862, false)
 		}
 	}
-	yyj817++
-	if yyhl817 {
-		yyb817 = yyj817 > l
+	yyj857++
+	if yyhl857 {
+		yyb857 = yyj857 > l
 	} else {
-		yyb817 = r.CheckBreak()
+		yyb857 = r.CheckBreak()
 	}
-	if yyb817 {
+	if yyb857 {
 		r.ReadEnd()
 		return
 	}
@@ -9051,13 +9291,13 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Reason = string(r.DecodeString())
 	}
-	yyj817++
-	if yyhl817 {
-		yyb817 = yyj817 > l
+	yyj857++
+	if yyhl857 {
+		yyb857 = yyj857 > l
 	} else {
-		yyb817 = r.CheckBreak()
+		yyb857 = r.CheckBreak()
 	}
-	if yyb817 {
+	if yyb857 {
 		r.ReadEnd()
 		return
 	}
@@ -9067,16 +9307,16 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Message = string(r.DecodeString())
 	}
 	for {
-		yyj817++
-		if yyhl817 {
-			yyb817 = yyj817 > l
+		yyj857++
+		if yyhl857 {
+			yyb857 = yyj857 > l
 		} else {
-			yyb817 = r.CheckBreak()
+			yyb857 = r.CheckBreak()
 		}
-		if yyb817 {
+		if yyb857 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj817-1, "")
+		z.DecStructFieldNotFound(yyj857-1, "")
 	}
 	r.ReadEnd()
 }
@@ -9088,36 +9328,36 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym826 := z.EncBinary()
-		_ = yym826
+		yym866 := z.EncBinary()
+		_ = yym866
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep827 := !z.EncBinary()
-			yy2arr827 := z.EncBasicHandle().StructToArray
-			var yyq827 [5]bool
-			_, _, _ = yysep827, yyq827, yy2arr827
-			const yyr827 bool = false
-			yyq827[0] = x.Kind != ""
-			yyq827[1] = x.APIVersion != ""
-			yyq827[2] = true
-			yyq827[3] = true
-			yyq827[4] = true
-			if yyr827 || yy2arr827 {
+			yysep867 := !z.EncBinary()
+			yy2arr867 := z.EncBasicHandle().StructToArray
+			var yyq867 [5]bool
+			_, _, _ = yysep867, yyq867, yy2arr867
+			const yyr867 bool = false
+			yyq867[0] = x.Kind != ""
+			yyq867[1] = x.APIVersion != ""
+			yyq867[2] = true
+			yyq867[3] = true
+			yyq867[4] = true
+			if yyr867 || yy2arr867 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn827 int = 0
-				for _, b := range yyq827 {
+				var yynn867 int = 0
+				for _, b := range yyq867 {
 					if b {
-						yynn827++
+						yynn867++
 					}
 				}
-				r.EncodeMapStart(yynn827)
+				r.EncodeMapStart(yynn867)
 			}
-			if yyr827 || yy2arr827 {
-				if yyq827[0] {
-					yym829 := z.EncBinary()
-					_ = yym829
+			if yyr867 || yy2arr867 {
+				if yyq867[0] {
+					yym869 := z.EncBinary()
+					_ = yym869
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -9126,20 +9366,20 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq827[0] {
+				if yyq867[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym830 := z.EncBinary()
-					_ = yym830
+					yym870 := z.EncBinary()
+					_ = yym870
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr827 || yy2arr827 {
-				if yyq827[1] {
-					yym832 := z.EncBinary()
-					_ = yym832
+			if yyr867 || yy2arr867 {
+				if yyq867[1] {
+					yym872 := z.EncBinary()
+					_ = yym872
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -9148,59 +9388,71 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq827[1] {
+				if yyq867[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym833 := z.EncBinary()
-					_ = yym833
+					yym873 := z.EncBinary()
+					_ = yym873
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr827 || yy2arr827 {
-				if yyq827[2] {
-					yy835 := &x.ObjectMeta
-					yy835.CodecEncodeSelf(e)
+			if yyr867 || yy2arr867 {
+				if yyq867[2] {
+					yy875 := &x.ObjectMeta
+					yym876 := z.EncBinary()
+					_ = yym876
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy875) {
+					} else {
+						z.EncFallback(yy875)
+					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq827[2] {
+				if yyq867[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy836 := &x.ObjectMeta
-					yy836.CodecEncodeSelf(e)
+					yy877 := &x.ObjectMeta
+					yym878 := z.EncBinary()
+					_ = yym878
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy877) {
+					} else {
+						z.EncFallback(yy877)
+					}
 				}
 			}
-			if yyr827 || yy2arr827 {
-				if yyq827[3] {
-					yy838 := &x.Spec
-					yy838.CodecEncodeSelf(e)
+			if yyr867 || yy2arr867 {
+				if yyq867[3] {
+					yy880 := &x.Spec
+					yy880.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq827[3] {
+				if yyq867[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy839 := &x.Spec
-					yy839.CodecEncodeSelf(e)
+					yy881 := &x.Spec
+					yy881.CodecEncodeSelf(e)
 				}
 			}
-			if yyr827 || yy2arr827 {
-				if yyq827[4] {
-					yy841 := &x.Status
-					yy841.CodecEncodeSelf(e)
+			if yyr867 || yy2arr867 {
+				if yyq867[4] {
+					yy883 := &x.Status
+					yy883.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq827[4] {
+				if yyq867[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy842 := &x.Status
-					yy842.CodecEncodeSelf(e)
+					yy884 := &x.Status
+					yy884.CodecEncodeSelf(e)
 				}
 			}
-			if yysep827 {
+			if yysep867 {
 				r.EncodeEnd()
 			}
 		}
@@ -9211,24 +9463,24 @@ func (x *Ingress) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym843 := z.DecBinary()
-	_ = yym843
+	yym885 := z.DecBinary()
+	_ = yym885
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl844 := r.ReadMapStart()
-			if yyl844 == 0 {
+			yyl886 := r.ReadMapStart()
+			if yyl886 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl844, d)
+				x.codecDecodeSelfFromMap(yyl886, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl844 := r.ReadArrayStart()
-			if yyl844 == 0 {
+			yyl886 := r.ReadArrayStart()
+			if yyl886 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl844, d)
+				x.codecDecodeSelfFromArray(yyl886, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -9240,12 +9492,12 @@ func (x *Ingress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys845Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys845Slc
-	var yyhl845 bool = l >= 0
-	for yyj845 := 0; ; yyj845++ {
-		if yyhl845 {
-			if yyj845 >= l {
+	var yys887Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys887Slc
+	var yyhl887 bool = l >= 0
+	for yyj887 := 0; ; yyj887++ {
+		if yyhl887 {
+			if yyj887 >= l {
 				break
 			}
 		} else {
@@ -9253,9 +9505,9 @@ func (x *Ingress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys845Slc = r.DecodeBytes(yys845Slc, true, true)
-		yys845 := string(yys845Slc)
-		switch yys845 {
+		yys887Slc = r.DecodeBytes(yys887Slc, true, true)
+		yys887 := string(yys887Slc)
+		switch yys887 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -9272,28 +9524,34 @@ func (x *Ingress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv848 := &x.ObjectMeta
-				yyv848.CodecDecodeSelf(d)
+				yyv890 := &x.ObjectMeta
+				yym891 := z.DecBinary()
+				_ = yym891
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv890) {
+				} else {
+					z.DecFallback(yyv890, false)
+				}
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = IngressSpec{}
 			} else {
-				yyv849 := &x.Spec
-				yyv849.CodecDecodeSelf(d)
+				yyv892 := &x.Spec
+				yyv892.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = IngressStatus{}
 			} else {
-				yyv850 := &x.Status
-				yyv850.CodecDecodeSelf(d)
+				yyv893 := &x.Status
+				yyv893.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys845)
-		} // end switch yys845
-	} // end for yyj845
-	if !yyhl845 {
+			z.DecStructFieldNotFound(-1, yys887)
+		} // end switch yys887
+	} // end for yyj887
+	if !yyhl887 {
 		r.ReadEnd()
 	}
 }
@@ -9302,16 +9560,16 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj851 int
-	var yyb851 bool
-	var yyhl851 bool = l >= 0
-	yyj851++
-	if yyhl851 {
-		yyb851 = yyj851 > l
+	var yyj894 int
+	var yyb894 bool
+	var yyhl894 bool = l >= 0
+	yyj894++
+	if yyhl894 {
+		yyb894 = yyj894 > l
 	} else {
-		yyb851 = r.CheckBreak()
+		yyb894 = r.CheckBreak()
 	}
-	if yyb851 {
+	if yyb894 {
 		r.ReadEnd()
 		return
 	}
@@ -9320,13 +9578,13 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj851++
-	if yyhl851 {
-		yyb851 = yyj851 > l
+	yyj894++
+	if yyhl894 {
+		yyb894 = yyj894 > l
 	} else {
-		yyb851 = r.CheckBreak()
+		yyb894 = r.CheckBreak()
 	}
-	if yyb851 {
+	if yyb894 {
 		r.ReadEnd()
 		return
 	}
@@ -9335,65 +9593,71 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj851++
-	if yyhl851 {
-		yyb851 = yyj851 > l
+	yyj894++
+	if yyhl894 {
+		yyb894 = yyj894 > l
 	} else {
-		yyb851 = r.CheckBreak()
+		yyb894 = r.CheckBreak()
 	}
-	if yyb851 {
+	if yyb894 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv854 := &x.ObjectMeta
-		yyv854.CodecDecodeSelf(d)
+		yyv897 := &x.ObjectMeta
+		yym898 := z.DecBinary()
+		_ = yym898
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv897) {
+		} else {
+			z.DecFallback(yyv897, false)
+		}
 	}
-	yyj851++
-	if yyhl851 {
-		yyb851 = yyj851 > l
+	yyj894++
+	if yyhl894 {
+		yyb894 = yyj894 > l
 	} else {
-		yyb851 = r.CheckBreak()
+		yyb894 = r.CheckBreak()
 	}
-	if yyb851 {
+	if yyb894 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = IngressSpec{}
 	} else {
-		yyv855 := &x.Spec
-		yyv855.CodecDecodeSelf(d)
+		yyv899 := &x.Spec
+		yyv899.CodecDecodeSelf(d)
 	}
-	yyj851++
-	if yyhl851 {
-		yyb851 = yyj851 > l
+	yyj894++
+	if yyhl894 {
+		yyb894 = yyj894 > l
 	} else {
-		yyb851 = r.CheckBreak()
+		yyb894 = r.CheckBreak()
 	}
-	if yyb851 {
+	if yyb894 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = IngressStatus{}
 	} else {
-		yyv856 := &x.Status
-		yyv856.CodecDecodeSelf(d)
+		yyv900 := &x.Status
+		yyv900.CodecDecodeSelf(d)
 	}
 	for {
-		yyj851++
-		if yyhl851 {
-			yyb851 = yyj851 > l
+		yyj894++
+		if yyhl894 {
+			yyb894 = yyj894 > l
 		} else {
-			yyb851 = r.CheckBreak()
+			yyb894 = r.CheckBreak()
 		}
-		if yyb851 {
+		if yyb894 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj851-1, "")
+		z.DecStructFieldNotFound(yyj894-1, "")
 	}
 	r.ReadEnd()
 }
@@ -9405,34 +9669,34 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym857 := z.EncBinary()
-		_ = yym857
+		yym901 := z.EncBinary()
+		_ = yym901
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep858 := !z.EncBinary()
-			yy2arr858 := z.EncBasicHandle().StructToArray
-			var yyq858 [4]bool
-			_, _, _ = yysep858, yyq858, yy2arr858
-			const yyr858 bool = false
-			yyq858[0] = x.Kind != ""
-			yyq858[1] = x.APIVersion != ""
-			yyq858[2] = true
-			if yyr858 || yy2arr858 {
+			yysep902 := !z.EncBinary()
+			yy2arr902 := z.EncBasicHandle().StructToArray
+			var yyq902 [4]bool
+			_, _, _ = yysep902, yyq902, yy2arr902
+			const yyr902 bool = false
+			yyq902[0] = x.Kind != ""
+			yyq902[1] = x.APIVersion != ""
+			yyq902[2] = true
+			if yyr902 || yy2arr902 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn858 int = 1
-				for _, b := range yyq858 {
+				var yynn902 int = 1
+				for _, b := range yyq902 {
 					if b {
-						yynn858++
+						yynn902++
 					}
 				}
-				r.EncodeMapStart(yynn858)
+				r.EncodeMapStart(yynn902)
 			}
-			if yyr858 || yy2arr858 {
-				if yyq858[0] {
-					yym860 := z.EncBinary()
-					_ = yym860
+			if yyr902 || yy2arr902 {
+				if yyq902[0] {
+					yym904 := z.EncBinary()
+					_ = yym904
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -9441,20 +9705,20 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq858[0] {
+				if yyq902[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym861 := z.EncBinary()
-					_ = yym861
+					yym905 := z.EncBinary()
+					_ = yym905
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr858 || yy2arr858 {
-				if yyq858[1] {
-					yym863 := z.EncBinary()
-					_ = yym863
+			if yyr902 || yy2arr902 {
+				if yyq902[1] {
+					yym907 := z.EncBinary()
+					_ = yym907
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -9463,48 +9727,48 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq858[1] {
+				if yyq902[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym864 := z.EncBinary()
-					_ = yym864
+					yym908 := z.EncBinary()
+					_ = yym908
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr858 || yy2arr858 {
-				if yyq858[2] {
-					yy866 := &x.ListMeta
-					yym867 := z.EncBinary()
-					_ = yym867
+			if yyr902 || yy2arr902 {
+				if yyq902[2] {
+					yy910 := &x.ListMeta
+					yym911 := z.EncBinary()
+					_ = yym911
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy866) {
+					} else if z.HasExtensions() && z.EncExt(yy910) {
 					} else {
-						z.EncFallback(yy866)
+						z.EncFallback(yy910)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq858[2] {
+				if yyq902[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy868 := &x.ListMeta
-					yym869 := z.EncBinary()
-					_ = yym869
+					yy912 := &x.ListMeta
+					yym913 := z.EncBinary()
+					_ = yym913
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy868) {
+					} else if z.HasExtensions() && z.EncExt(yy912) {
 					} else {
-						z.EncFallback(yy868)
+						z.EncFallback(yy912)
 					}
 				}
 			}
-			if yyr858 || yy2arr858 {
+			if yyr902 || yy2arr902 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym871 := z.EncBinary()
-					_ = yym871
+					yym915 := z.EncBinary()
+					_ = yym915
 					if false {
 					} else {
 						h.encSliceIngress(([]Ingress)(x.Items), e)
@@ -9515,15 +9779,15 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym872 := z.EncBinary()
-					_ = yym872
+					yym916 := z.EncBinary()
+					_ = yym916
 					if false {
 					} else {
 						h.encSliceIngress(([]Ingress)(x.Items), e)
 					}
 				}
 			}
-			if yysep858 {
+			if yysep902 {
 				r.EncodeEnd()
 			}
 		}
@@ -9534,24 +9798,24 @@ func (x *IngressList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym873 := z.DecBinary()
-	_ = yym873
+	yym917 := z.DecBinary()
+	_ = yym917
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl874 := r.ReadMapStart()
-			if yyl874 == 0 {
+			yyl918 := r.ReadMapStart()
+			if yyl918 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl874, d)
+				x.codecDecodeSelfFromMap(yyl918, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl874 := r.ReadArrayStart()
-			if yyl874 == 0 {
+			yyl918 := r.ReadArrayStart()
+			if yyl918 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl874, d)
+				x.codecDecodeSelfFromArray(yyl918, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -9563,12 +9827,12 @@ func (x *IngressList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys875Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys875Slc
-	var yyhl875 bool = l >= 0
-	for yyj875 := 0; ; yyj875++ {
-		if yyhl875 {
-			if yyj875 >= l {
+	var yys919Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys919Slc
+	var yyhl919 bool = l >= 0
+	for yyj919 := 0; ; yyj919++ {
+		if yyhl919 {
+			if yyj919 >= l {
 				break
 			}
 		} else {
@@ -9576,9 +9840,9 @@ func (x *IngressList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys875Slc = r.DecodeBytes(yys875Slc, true, true)
-		yys875 := string(yys875Slc)
-		switch yys875 {
+		yys919Slc = r.DecodeBytes(yys919Slc, true, true)
+		yys919 := string(yys919Slc)
+		switch yys919 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -9595,32 +9859,32 @@ func (x *IngressList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv878 := &x.ListMeta
-				yym879 := z.DecBinary()
-				_ = yym879
+				yyv922 := &x.ListMeta
+				yym923 := z.DecBinary()
+				_ = yym923
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv878) {
+				} else if z.HasExtensions() && z.DecExt(yyv922) {
 				} else {
-					z.DecFallback(yyv878, false)
+					z.DecFallback(yyv922, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv880 := &x.Items
-				yym881 := z.DecBinary()
-				_ = yym881
+				yyv924 := &x.Items
+				yym925 := z.DecBinary()
+				_ = yym925
 				if false {
 				} else {
-					h.decSliceIngress((*[]Ingress)(yyv880), d)
+					h.decSliceIngress((*[]Ingress)(yyv924), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys875)
-		} // end switch yys875
-	} // end for yyj875
-	if !yyhl875 {
+			z.DecStructFieldNotFound(-1, yys919)
+		} // end switch yys919
+	} // end for yyj919
+	if !yyhl919 {
 		r.ReadEnd()
 	}
 }
@@ -9629,16 +9893,16 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj882 int
-	var yyb882 bool
-	var yyhl882 bool = l >= 0
-	yyj882++
-	if yyhl882 {
-		yyb882 = yyj882 > l
+	var yyj926 int
+	var yyb926 bool
+	var yyhl926 bool = l >= 0
+	yyj926++
+	if yyhl926 {
+		yyb926 = yyj926 > l
 	} else {
-		yyb882 = r.CheckBreak()
+		yyb926 = r.CheckBreak()
 	}
-	if yyb882 {
+	if yyb926 {
 		r.ReadEnd()
 		return
 	}
@@ -9647,13 +9911,13 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj882++
-	if yyhl882 {
-		yyb882 = yyj882 > l
+	yyj926++
+	if yyhl926 {
+		yyb926 = yyj926 > l
 	} else {
-		yyb882 = r.CheckBreak()
+		yyb926 = r.CheckBreak()
 	}
-	if yyb882 {
+	if yyb926 {
 		r.ReadEnd()
 		return
 	}
@@ -9662,60 +9926,60 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj882++
-	if yyhl882 {
-		yyb882 = yyj882 > l
+	yyj926++
+	if yyhl926 {
+		yyb926 = yyj926 > l
 	} else {
-		yyb882 = r.CheckBreak()
+		yyb926 = r.CheckBreak()
 	}
-	if yyb882 {
+	if yyb926 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv885 := &x.ListMeta
-		yym886 := z.DecBinary()
-		_ = yym886
+		yyv929 := &x.ListMeta
+		yym930 := z.DecBinary()
+		_ = yym930
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv885) {
+		} else if z.HasExtensions() && z.DecExt(yyv929) {
 		} else {
-			z.DecFallback(yyv885, false)
+			z.DecFallback(yyv929, false)
 		}
 	}
-	yyj882++
-	if yyhl882 {
-		yyb882 = yyj882 > l
+	yyj926++
+	if yyhl926 {
+		yyb926 = yyj926 > l
 	} else {
-		yyb882 = r.CheckBreak()
+		yyb926 = r.CheckBreak()
 	}
-	if yyb882 {
+	if yyb926 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv887 := &x.Items
-		yym888 := z.DecBinary()
-		_ = yym888
+		yyv931 := &x.Items
+		yym932 := z.DecBinary()
+		_ = yym932
 		if false {
 		} else {
-			h.decSliceIngress((*[]Ingress)(yyv887), d)
+			h.decSliceIngress((*[]Ingress)(yyv931), d)
 		}
 	}
 	for {
-		yyj882++
-		if yyhl882 {
-			yyb882 = yyj882 > l
+		yyj926++
+		if yyhl926 {
+			yyb926 = yyj926 > l
 		} else {
-			yyb882 = r.CheckBreak()
+			yyb926 = r.CheckBreak()
 		}
-		if yyb882 {
+		if yyb926 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj882-1, "")
+		z.DecStructFieldNotFound(yyj926-1, "")
 	}
 	r.ReadEnd()
 }
@@ -9727,31 +9991,31 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym889 := z.EncBinary()
-		_ = yym889
+		yym933 := z.EncBinary()
+		_ = yym933
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep890 := !z.EncBinary()
-			yy2arr890 := z.EncBasicHandle().StructToArray
-			var yyq890 [2]bool
-			_, _, _ = yysep890, yyq890, yy2arr890
-			const yyr890 bool = false
-			yyq890[0] = x.Backend != nil
-			yyq890[1] = len(x.Rules) != 0
-			if yyr890 || yy2arr890 {
+			yysep934 := !z.EncBinary()
+			yy2arr934 := z.EncBasicHandle().StructToArray
+			var yyq934 [2]bool
+			_, _, _ = yysep934, yyq934, yy2arr934
+			const yyr934 bool = false
+			yyq934[0] = x.Backend != nil
+			yyq934[1] = len(x.Rules) != 0
+			if yyr934 || yy2arr934 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn890 int = 0
-				for _, b := range yyq890 {
+				var yynn934 int = 0
+				for _, b := range yyq934 {
 					if b {
-						yynn890++
+						yynn934++
 					}
 				}
-				r.EncodeMapStart(yynn890)
+				r.EncodeMapStart(yynn934)
 			}
-			if yyr890 || yy2arr890 {
-				if yyq890[0] {
+			if yyr934 || yy2arr934 {
+				if yyq934[0] {
 					if x.Backend == nil {
 						r.EncodeNil()
 					} else {
@@ -9761,7 +10025,7 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq890[0] {
+				if yyq934[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("backend"))
 					if x.Backend == nil {
 						r.EncodeNil()
@@ -9770,13 +10034,13 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr890 || yy2arr890 {
-				if yyq890[1] {
+			if yyr934 || yy2arr934 {
+				if yyq934[1] {
 					if x.Rules == nil {
 						r.EncodeNil()
 					} else {
-						yym893 := z.EncBinary()
-						_ = yym893
+						yym937 := z.EncBinary()
+						_ = yym937
 						if false {
 						} else {
 							h.encSliceIngressRule(([]IngressRule)(x.Rules), e)
@@ -9786,13 +10050,13 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq890[1] {
+				if yyq934[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("rules"))
 					if x.Rules == nil {
 						r.EncodeNil()
 					} else {
-						yym894 := z.EncBinary()
-						_ = yym894
+						yym938 := z.EncBinary()
+						_ = yym938
 						if false {
 						} else {
 							h.encSliceIngressRule(([]IngressRule)(x.Rules), e)
@@ -9800,7 +10064,7 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep890 {
+			if yysep934 {
 				r.EncodeEnd()
 			}
 		}
@@ -9811,24 +10075,24 @@ func (x *IngressSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym895 := z.DecBinary()
-	_ = yym895
+	yym939 := z.DecBinary()
+	_ = yym939
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl896 := r.ReadMapStart()
-			if yyl896 == 0 {
+			yyl940 := r.ReadMapStart()
+			if yyl940 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl896, d)
+				x.codecDecodeSelfFromMap(yyl940, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl896 := r.ReadArrayStart()
-			if yyl896 == 0 {
+			yyl940 := r.ReadArrayStart()
+			if yyl940 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl896, d)
+				x.codecDecodeSelfFromArray(yyl940, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -9840,12 +10104,12 @@ func (x *IngressSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys897Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys897Slc
-	var yyhl897 bool = l >= 0
-	for yyj897 := 0; ; yyj897++ {
-		if yyhl897 {
-			if yyj897 >= l {
+	var yys941Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys941Slc
+	var yyhl941 bool = l >= 0
+	for yyj941 := 0; ; yyj941++ {
+		if yyhl941 {
+			if yyj941 >= l {
 				break
 			}
 		} else {
@@ -9853,9 +10117,9 @@ func (x *IngressSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys897Slc = r.DecodeBytes(yys897Slc, true, true)
-		yys897 := string(yys897Slc)
-		switch yys897 {
+		yys941Slc = r.DecodeBytes(yys941Slc, true, true)
+		yys941 := string(yys941Slc)
+		switch yys941 {
 		case "backend":
 			if r.TryDecodeAsNil() {
 				if x.Backend != nil {
@@ -9871,19 +10135,19 @@ func (x *IngressSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Rules = nil
 			} else {
-				yyv899 := &x.Rules
-				yym900 := z.DecBinary()
-				_ = yym900
+				yyv943 := &x.Rules
+				yym944 := z.DecBinary()
+				_ = yym944
 				if false {
 				} else {
-					h.decSliceIngressRule((*[]IngressRule)(yyv899), d)
+					h.decSliceIngressRule((*[]IngressRule)(yyv943), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys897)
-		} // end switch yys897
-	} // end for yyj897
-	if !yyhl897 {
+			z.DecStructFieldNotFound(-1, yys941)
+		} // end switch yys941
+	} // end for yyj941
+	if !yyhl941 {
 		r.ReadEnd()
 	}
 }
@@ -9892,16 +10156,16 @@ func (x *IngressSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj901 int
-	var yyb901 bool
-	var yyhl901 bool = l >= 0
-	yyj901++
-	if yyhl901 {
-		yyb901 = yyj901 > l
+	var yyj945 int
+	var yyb945 bool
+	var yyhl945 bool = l >= 0
+	yyj945++
+	if yyhl945 {
+		yyb945 = yyj945 > l
 	} else {
-		yyb901 = r.CheckBreak()
+		yyb945 = r.CheckBreak()
 	}
-	if yyb901 {
+	if yyb945 {
 		r.ReadEnd()
 		return
 	}
@@ -9915,38 +10179,38 @@ func (x *IngressSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.Backend.CodecDecodeSelf(d)
 	}
-	yyj901++
-	if yyhl901 {
-		yyb901 = yyj901 > l
+	yyj945++
+	if yyhl945 {
+		yyb945 = yyj945 > l
 	} else {
-		yyb901 = r.CheckBreak()
+		yyb945 = r.CheckBreak()
 	}
-	if yyb901 {
+	if yyb945 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Rules = nil
 	} else {
-		yyv903 := &x.Rules
-		yym904 := z.DecBinary()
-		_ = yym904
+		yyv947 := &x.Rules
+		yym948 := z.DecBinary()
+		_ = yym948
 		if false {
 		} else {
-			h.decSliceIngressRule((*[]IngressRule)(yyv903), d)
+			h.decSliceIngressRule((*[]IngressRule)(yyv947), d)
 		}
 	}
 	for {
-		yyj901++
-		if yyhl901 {
-			yyb901 = yyj901 > l
+		yyj945++
+		if yyhl945 {
+			yyb945 = yyj945 > l
 		} else {
-			yyb901 = r.CheckBreak()
+			yyb945 = r.CheckBreak()
 		}
-		if yyb901 {
+		if yyb945 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj901-1, "")
+		z.DecStructFieldNotFound(yyj945-1, "")
 	}
 	r.ReadEnd()
 }
@@ -9958,43 +10222,55 @@ func (x *IngressStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym905 := z.EncBinary()
-		_ = yym905
+		yym949 := z.EncBinary()
+		_ = yym949
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep906 := !z.EncBinary()
-			yy2arr906 := z.EncBasicHandle().StructToArray
-			var yyq906 [1]bool
-			_, _, _ = yysep906, yyq906, yy2arr906
-			const yyr906 bool = false
-			yyq906[0] = true
-			if yyr906 || yy2arr906 {
+			yysep950 := !z.EncBinary()
+			yy2arr950 := z.EncBasicHandle().StructToArray
+			var yyq950 [1]bool
+			_, _, _ = yysep950, yyq950, yy2arr950
+			const yyr950 bool = false
+			yyq950[0] = true
+			if yyr950 || yy2arr950 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn906 int = 0
-				for _, b := range yyq906 {
+				var yynn950 int = 0
+				for _, b := range yyq950 {
 					if b {
-						yynn906++
+						yynn950++
 					}
 				}
-				r.EncodeMapStart(yynn906)
+				r.EncodeMapStart(yynn950)
 			}
-			if yyr906 || yy2arr906 {
-				if yyq906[0] {
-					yy908 := &x.LoadBalancer
-					yy908.CodecEncodeSelf(e)
+			if yyr950 || yy2arr950 {
+				if yyq950[0] {
+					yy952 := &x.LoadBalancer
+					yym953 := z.EncBinary()
+					_ = yym953
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy952) {
+					} else {
+						z.EncFallback(yy952)
+					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq906[0] {
+				if yyq950[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("loadBalancer"))
-					yy909 := &x.LoadBalancer
-					yy909.CodecEncodeSelf(e)
+					yy954 := &x.LoadBalancer
+					yym955 := z.EncBinary()
+					_ = yym955
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy954) {
+					} else {
+						z.EncFallback(yy954)
+					}
 				}
 			}
-			if yysep906 {
+			if yysep950 {
 				r.EncodeEnd()
 			}
 		}
@@ -10005,24 +10281,24 @@ func (x *IngressStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym910 := z.DecBinary()
-	_ = yym910
+	yym956 := z.DecBinary()
+	_ = yym956
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl911 := r.ReadMapStart()
-			if yyl911 == 0 {
+			yyl957 := r.ReadMapStart()
+			if yyl957 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl911, d)
+				x.codecDecodeSelfFromMap(yyl957, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl911 := r.ReadArrayStart()
-			if yyl911 == 0 {
+			yyl957 := r.ReadArrayStart()
+			if yyl957 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl911, d)
+				x.codecDecodeSelfFromArray(yyl957, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10034,12 +10310,12 @@ func (x *IngressStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys912Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys912Slc
-	var yyhl912 bool = l >= 0
-	for yyj912 := 0; ; yyj912++ {
-		if yyhl912 {
-			if yyj912 >= l {
+	var yys958Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys958Slc
+	var yyhl958 bool = l >= 0
+	for yyj958 := 0; ; yyj958++ {
+		if yyhl958 {
+			if yyj958 >= l {
 				break
 			}
 		} else {
@@ -10047,21 +10323,27 @@ func (x *IngressStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys912Slc = r.DecodeBytes(yys912Slc, true, true)
-		yys912 := string(yys912Slc)
-		switch yys912 {
+		yys958Slc = r.DecodeBytes(yys958Slc, true, true)
+		yys958 := string(yys958Slc)
+		switch yys958 {
 		case "loadBalancer":
 			if r.TryDecodeAsNil() {
 				x.LoadBalancer = pkg2_api.LoadBalancerStatus{}
 			} else {
-				yyv913 := &x.LoadBalancer
-				yyv913.CodecDecodeSelf(d)
+				yyv959 := &x.LoadBalancer
+				yym960 := z.DecBinary()
+				_ = yym960
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv959) {
+				} else {
+					z.DecFallback(yyv959, false)
+				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys912)
-		} // end switch yys912
-	} // end for yyj912
-	if !yyhl912 {
+			z.DecStructFieldNotFound(-1, yys958)
+		} // end switch yys958
+	} // end for yyj958
+	if !yyhl958 {
 		r.ReadEnd()
 	}
 }
@@ -10070,36 +10352,42 @@ func (x *IngressStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj914 int
-	var yyb914 bool
-	var yyhl914 bool = l >= 0
-	yyj914++
-	if yyhl914 {
-		yyb914 = yyj914 > l
+	var yyj961 int
+	var yyb961 bool
+	var yyhl961 bool = l >= 0
+	yyj961++
+	if yyhl961 {
+		yyb961 = yyj961 > l
 	} else {
-		yyb914 = r.CheckBreak()
+		yyb961 = r.CheckBreak()
 	}
-	if yyb914 {
+	if yyb961 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.LoadBalancer = pkg2_api.LoadBalancerStatus{}
 	} else {
-		yyv915 := &x.LoadBalancer
-		yyv915.CodecDecodeSelf(d)
+		yyv962 := &x.LoadBalancer
+		yym963 := z.DecBinary()
+		_ = yym963
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv962) {
+		} else {
+			z.DecFallback(yyv962, false)
+		}
 	}
 	for {
-		yyj914++
-		if yyhl914 {
-			yyb914 = yyj914 > l
+		yyj961++
+		if yyhl961 {
+			yyb961 = yyj961 > l
 		} else {
-			yyb914 = r.CheckBreak()
+			yyb961 = r.CheckBreak()
 		}
-		if yyb914 {
+		if yyb961 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj914-1, "")
+		z.DecStructFieldNotFound(yyj961-1, "")
 	}
 	r.ReadEnd()
 }
@@ -10111,33 +10399,33 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym916 := z.EncBinary()
-		_ = yym916
+		yym964 := z.EncBinary()
+		_ = yym964
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep917 := !z.EncBinary()
-			yy2arr917 := z.EncBasicHandle().StructToArray
-			var yyq917 [2]bool
-			_, _, _ = yysep917, yyq917, yy2arr917
-			const yyr917 bool = false
-			yyq917[0] = x.Host != ""
-			yyq917[1] = x.IngressRuleValue.HTTP != nil && x.HTTP != nil
-			if yyr917 || yy2arr917 {
+			yysep965 := !z.EncBinary()
+			yy2arr965 := z.EncBasicHandle().StructToArray
+			var yyq965 [2]bool
+			_, _, _ = yysep965, yyq965, yy2arr965
+			const yyr965 bool = false
+			yyq965[0] = x.Host != ""
+			yyq965[1] = x.IngressRuleValue.HTTP != nil && x.HTTP != nil
+			if yyr965 || yy2arr965 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn917 int = 0
-				for _, b := range yyq917 {
+				var yynn965 int = 0
+				for _, b := range yyq965 {
 					if b {
-						yynn917++
+						yynn965++
 					}
 				}
-				r.EncodeMapStart(yynn917)
+				r.EncodeMapStart(yynn965)
 			}
-			if yyr917 || yy2arr917 {
-				if yyq917[0] {
-					yym919 := z.EncBinary()
-					_ = yym919
+			if yyr965 || yy2arr965 {
+				if yyq965[0] {
+					yym967 := z.EncBinary()
+					_ = yym967
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Host))
@@ -10146,27 +10434,27 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq917[0] {
+				if yyq965[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("host"))
-					yym920 := z.EncBinary()
-					_ = yym920
+					yym968 := z.EncBinary()
+					_ = yym968
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Host))
 					}
 				}
 			}
-			var yyn921 bool
+			var yyn969 bool
 			if x.IngressRuleValue.HTTP == nil {
-				yyn921 = true
-				goto LABEL921
+				yyn969 = true
+				goto LABEL969
 			}
-		LABEL921:
-			if yyr917 || yy2arr917 {
-				if yyn921 {
+		LABEL969:
+			if yyr965 || yy2arr965 {
+				if yyn969 {
 					r.EncodeNil()
 				} else {
-					if yyq917[1] {
+					if yyq965[1] {
 						if x.HTTP == nil {
 							r.EncodeNil()
 						} else {
@@ -10177,9 +10465,9 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
-				if yyq917[1] {
+				if yyq965[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("http"))
-					if yyn921 {
+					if yyn969 {
 						r.EncodeNil()
 					} else {
 						if x.HTTP == nil {
@@ -10190,7 +10478,7 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep917 {
+			if yysep965 {
 				r.EncodeEnd()
 			}
 		}
@@ -10201,24 +10489,24 @@ func (x *IngressRule) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym922 := z.DecBinary()
-	_ = yym922
+	yym970 := z.DecBinary()
+	_ = yym970
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl923 := r.ReadMapStart()
-			if yyl923 == 0 {
+			yyl971 := r.ReadMapStart()
+			if yyl971 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl923, d)
+				x.codecDecodeSelfFromMap(yyl971, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl923 := r.ReadArrayStart()
-			if yyl923 == 0 {
+			yyl971 := r.ReadArrayStart()
+			if yyl971 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl923, d)
+				x.codecDecodeSelfFromArray(yyl971, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10230,12 +10518,12 @@ func (x *IngressRule) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys924Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys924Slc
-	var yyhl924 bool = l >= 0
-	for yyj924 := 0; ; yyj924++ {
-		if yyhl924 {
-			if yyj924 >= l {
+	var yys972Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys972Slc
+	var yyhl972 bool = l >= 0
+	for yyj972 := 0; ; yyj972++ {
+		if yyhl972 {
+			if yyj972 >= l {
 				break
 			}
 		} else {
@@ -10243,9 +10531,9 @@ func (x *IngressRule) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys924Slc = r.DecodeBytes(yys924Slc, true, true)
-		yys924 := string(yys924Slc)
-		switch yys924 {
+		yys972Slc = r.DecodeBytes(yys972Slc, true, true)
+		yys972 := string(yys972Slc)
+		switch yys972 {
 		case "host":
 			if r.TryDecodeAsNil() {
 				x.Host = ""
@@ -10267,10 +10555,10 @@ func (x *IngressRule) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.HTTP.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys924)
-		} // end switch yys924
-	} // end for yyj924
-	if !yyhl924 {
+			z.DecStructFieldNotFound(-1, yys972)
+		} // end switch yys972
+	} // end for yyj972
+	if !yyhl972 {
 		r.ReadEnd()
 	}
 }
@@ -10279,16 +10567,16 @@ func (x *IngressRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj927 int
-	var yyb927 bool
-	var yyhl927 bool = l >= 0
-	yyj927++
-	if yyhl927 {
-		yyb927 = yyj927 > l
+	var yyj975 int
+	var yyb975 bool
+	var yyhl975 bool = l >= 0
+	yyj975++
+	if yyhl975 {
+		yyb975 = yyj975 > l
 	} else {
-		yyb927 = r.CheckBreak()
+		yyb975 = r.CheckBreak()
 	}
-	if yyb927 {
+	if yyb975 {
 		r.ReadEnd()
 		return
 	}
@@ -10297,13 +10585,13 @@ func (x *IngressRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Host = string(r.DecodeString())
 	}
-	yyj927++
-	if yyhl927 {
-		yyb927 = yyj927 > l
+	yyj975++
+	if yyhl975 {
+		yyb975 = yyj975 > l
 	} else {
-		yyb927 = r.CheckBreak()
+		yyb975 = r.CheckBreak()
 	}
-	if yyb927 {
+	if yyb975 {
 		r.ReadEnd()
 		return
 	}
@@ -10318,16 +10606,16 @@ func (x *IngressRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.HTTP.CodecDecodeSelf(d)
 	}
 	for {
-		yyj927++
-		if yyhl927 {
-			yyb927 = yyj927 > l
+		yyj975++
+		if yyhl975 {
+			yyb975 = yyj975 > l
 		} else {
-			yyb927 = r.CheckBreak()
+			yyb975 = r.CheckBreak()
 		}
-		if yyb927 {
+		if yyb975 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj927-1, "")
+		z.DecStructFieldNotFound(yyj975-1, "")
 	}
 	r.ReadEnd()
 }
@@ -10339,30 +10627,30 @@ func (x *IngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym930 := z.EncBinary()
-		_ = yym930
+		yym978 := z.EncBinary()
+		_ = yym978
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep931 := !z.EncBinary()
-			yy2arr931 := z.EncBasicHandle().StructToArray
-			var yyq931 [1]bool
-			_, _, _ = yysep931, yyq931, yy2arr931
-			const yyr931 bool = false
-			yyq931[0] = x.HTTP != nil
-			if yyr931 || yy2arr931 {
+			yysep979 := !z.EncBinary()
+			yy2arr979 := z.EncBasicHandle().StructToArray
+			var yyq979 [1]bool
+			_, _, _ = yysep979, yyq979, yy2arr979
+			const yyr979 bool = false
+			yyq979[0] = x.HTTP != nil
+			if yyr979 || yy2arr979 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn931 int = 0
-				for _, b := range yyq931 {
+				var yynn979 int = 0
+				for _, b := range yyq979 {
 					if b {
-						yynn931++
+						yynn979++
 					}
 				}
-				r.EncodeMapStart(yynn931)
+				r.EncodeMapStart(yynn979)
 			}
-			if yyr931 || yy2arr931 {
-				if yyq931[0] {
+			if yyr979 || yy2arr979 {
+				if yyq979[0] {
 					if x.HTTP == nil {
 						r.EncodeNil()
 					} else {
@@ -10372,7 +10660,7 @@ func (x *IngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq931[0] {
+				if yyq979[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("http"))
 					if x.HTTP == nil {
 						r.EncodeNil()
@@ -10381,7 +10669,7 @@ func (x *IngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep931 {
+			if yysep979 {
 				r.EncodeEnd()
 			}
 		}
@@ -10392,24 +10680,24 @@ func (x *IngressRuleValue) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym933 := z.DecBinary()
-	_ = yym933
+	yym981 := z.DecBinary()
+	_ = yym981
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl934 := r.ReadMapStart()
-			if yyl934 == 0 {
+			yyl982 := r.ReadMapStart()
+			if yyl982 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl934, d)
+				x.codecDecodeSelfFromMap(yyl982, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl934 := r.ReadArrayStart()
-			if yyl934 == 0 {
+			yyl982 := r.ReadArrayStart()
+			if yyl982 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl934, d)
+				x.codecDecodeSelfFromArray(yyl982, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10421,12 +10709,12 @@ func (x *IngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys935Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys935Slc
-	var yyhl935 bool = l >= 0
-	for yyj935 := 0; ; yyj935++ {
-		if yyhl935 {
-			if yyj935 >= l {
+	var yys983Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys983Slc
+	var yyhl983 bool = l >= 0
+	for yyj983 := 0; ; yyj983++ {
+		if yyhl983 {
+			if yyj983 >= l {
 				break
 			}
 		} else {
@@ -10434,9 +10722,9 @@ func (x *IngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys935Slc = r.DecodeBytes(yys935Slc, true, true)
-		yys935 := string(yys935Slc)
-		switch yys935 {
+		yys983Slc = r.DecodeBytes(yys983Slc, true, true)
+		yys983 := string(yys983Slc)
+		switch yys983 {
 		case "http":
 			if r.TryDecodeAsNil() {
 				if x.HTTP != nil {
@@ -10449,10 +10737,10 @@ func (x *IngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.HTTP.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys935)
-		} // end switch yys935
-	} // end for yyj935
-	if !yyhl935 {
+			z.DecStructFieldNotFound(-1, yys983)
+		} // end switch yys983
+	} // end for yyj983
+	if !yyhl983 {
 		r.ReadEnd()
 	}
 }
@@ -10461,16 +10749,16 @@ func (x *IngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj937 int
-	var yyb937 bool
-	var yyhl937 bool = l >= 0
-	yyj937++
-	if yyhl937 {
-		yyb937 = yyj937 > l
+	var yyj985 int
+	var yyb985 bool
+	var yyhl985 bool = l >= 0
+	yyj985++
+	if yyhl985 {
+		yyb985 = yyj985 > l
 	} else {
-		yyb937 = r.CheckBreak()
+		yyb985 = r.CheckBreak()
 	}
-	if yyb937 {
+	if yyb985 {
 		r.ReadEnd()
 		return
 	}
@@ -10485,16 +10773,16 @@ func (x *IngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		x.HTTP.CodecDecodeSelf(d)
 	}
 	for {
-		yyj937++
-		if yyhl937 {
-			yyb937 = yyj937 > l
+		yyj985++
+		if yyhl985 {
+			yyb985 = yyj985 > l
 		} else {
-			yyb937 = r.CheckBreak()
+			yyb985 = r.CheckBreak()
 		}
-		if yyb937 {
+		if yyb985 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj937-1, "")
+		z.DecStructFieldNotFound(yyj985-1, "")
 	}
 	r.ReadEnd()
 }
@@ -10506,33 +10794,33 @@ func (x *HTTPIngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym939 := z.EncBinary()
-		_ = yym939
+		yym987 := z.EncBinary()
+		_ = yym987
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep940 := !z.EncBinary()
-			yy2arr940 := z.EncBasicHandle().StructToArray
-			var yyq940 [1]bool
-			_, _, _ = yysep940, yyq940, yy2arr940
-			const yyr940 bool = false
-			if yyr940 || yy2arr940 {
+			yysep988 := !z.EncBinary()
+			yy2arr988 := z.EncBasicHandle().StructToArray
+			var yyq988 [1]bool
+			_, _, _ = yysep988, yyq988, yy2arr988
+			const yyr988 bool = false
+			if yyr988 || yy2arr988 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn940 int = 1
-				for _, b := range yyq940 {
+				var yynn988 int = 1
+				for _, b := range yyq988 {
 					if b {
-						yynn940++
+						yynn988++
 					}
 				}
-				r.EncodeMapStart(yynn940)
+				r.EncodeMapStart(yynn988)
 			}
-			if yyr940 || yy2arr940 {
+			if yyr988 || yy2arr988 {
 				if x.Paths == nil {
 					r.EncodeNil()
 				} else {
-					yym942 := z.EncBinary()
-					_ = yym942
+					yym990 := z.EncBinary()
+					_ = yym990
 					if false {
 					} else {
 						h.encSliceHTTPIngressPath(([]HTTPIngressPath)(x.Paths), e)
@@ -10543,15 +10831,15 @@ func (x *HTTPIngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Paths == nil {
 					r.EncodeNil()
 				} else {
-					yym943 := z.EncBinary()
-					_ = yym943
+					yym991 := z.EncBinary()
+					_ = yym991
 					if false {
 					} else {
 						h.encSliceHTTPIngressPath(([]HTTPIngressPath)(x.Paths), e)
 					}
 				}
 			}
-			if yysep940 {
+			if yysep988 {
 				r.EncodeEnd()
 			}
 		}
@@ -10562,24 +10850,24 @@ func (x *HTTPIngressRuleValue) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym944 := z.DecBinary()
-	_ = yym944
+	yym992 := z.DecBinary()
+	_ = yym992
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl945 := r.ReadMapStart()
-			if yyl945 == 0 {
+			yyl993 := r.ReadMapStart()
+			if yyl993 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl945, d)
+				x.codecDecodeSelfFromMap(yyl993, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl945 := r.ReadArrayStart()
-			if yyl945 == 0 {
+			yyl993 := r.ReadArrayStart()
+			if yyl993 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl945, d)
+				x.codecDecodeSelfFromArray(yyl993, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10591,12 +10879,12 @@ func (x *HTTPIngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys946Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys946Slc
-	var yyhl946 bool = l >= 0
-	for yyj946 := 0; ; yyj946++ {
-		if yyhl946 {
-			if yyj946 >= l {
+	var yys994Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys994Slc
+	var yyhl994 bool = l >= 0
+	for yyj994 := 0; ; yyj994++ {
+		if yyhl994 {
+			if yyj994 >= l {
 				break
 			}
 		} else {
@@ -10604,26 +10892,26 @@ func (x *HTTPIngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
-		yys946Slc = r.DecodeBytes(yys946Slc, true, true)
-		yys946 := string(yys946Slc)
-		switch yys946 {
+		yys994Slc = r.DecodeBytes(yys994Slc, true, true)
+		yys994 := string(yys994Slc)
+		switch yys994 {
 		case "paths":
 			if r.TryDecodeAsNil() {
 				x.Paths = nil
 			} else {
-				yyv947 := &x.Paths
-				yym948 := z.DecBinary()
-				_ = yym948
+				yyv995 := &x.Paths
+				yym996 := z.DecBinary()
+				_ = yym996
 				if false {
 				} else {
-					h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv947), d)
+					h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv995), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys946)
-		} // end switch yys946
-	} // end for yyj946
-	if !yyhl946 {
+			z.DecStructFieldNotFound(-1, yys994)
+		} // end switch yys994
+	} // end for yyj994
+	if !yyhl994 {
 		r.ReadEnd()
 	}
 }
@@ -10632,41 +10920,41 @@ func (x *HTTPIngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj949 int
-	var yyb949 bool
-	var yyhl949 bool = l >= 0
-	yyj949++
-	if yyhl949 {
-		yyb949 = yyj949 > l
+	var yyj997 int
+	var yyb997 bool
+	var yyhl997 bool = l >= 0
+	yyj997++
+	if yyhl997 {
+		yyb997 = yyj997 > l
 	} else {
-		yyb949 = r.CheckBreak()
+		yyb997 = r.CheckBreak()
 	}
-	if yyb949 {
+	if yyb997 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Paths = nil
 	} else {
-		yyv950 := &x.Paths
-		yym951 := z.DecBinary()
-		_ = yym951
+		yyv998 := &x.Paths
+		yym999 := z.DecBinary()
+		_ = yym999
 		if false {
 		} else {
-			h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv950), d)
+			h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv998), d)
 		}
 	}
 	for {
-		yyj949++
-		if yyhl949 {
-			yyb949 = yyj949 > l
+		yyj997++
+		if yyhl997 {
+			yyb997 = yyj997 > l
 		} else {
-			yyb949 = r.CheckBreak()
+			yyb997 = r.CheckBreak()
 		}
-		if yyb949 {
+		if yyb997 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj949-1, "")
+		z.DecStructFieldNotFound(yyj997-1, "")
 	}
 	r.ReadEnd()
 }
@@ -10678,32 +10966,32 @@ func (x *HTTPIngressPath) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym952 := z.EncBinary()
-		_ = yym952
+		yym1000 := z.EncBinary()
+		_ = yym1000
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep953 := !z.EncBinary()
-			yy2arr953 := z.EncBasicHandle().StructToArray
-			var yyq953 [2]bool
-			_, _, _ = yysep953, yyq953, yy2arr953
-			const yyr953 bool = false
-			yyq953[0] = x.Path != ""
-			if yyr953 || yy2arr953 {
+			yysep1001 := !z.EncBinary()
+			yy2arr1001 := z.EncBasicHandle().StructToArray
+			var yyq1001 [2]bool
+			_, _, _ = yysep1001, yyq1001, yy2arr1001
+			const yyr1001 bool = false
+			yyq1001[0] = x.Path != ""
+			if yyr1001 || yy2arr1001 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn953 int = 1
-				for _, b := range yyq953 {
+				var yynn1001 int = 1
+				for _, b := range yyq1001 {
 					if b {
-						yynn953++
+						yynn1001++
 					}
 				}
-				r.EncodeMapStart(yynn953)
+				r.EncodeMapStart(yynn1001)
 			}
-			if yyr953 || yy2arr953 {
-				if yyq953[0] {
-					yym955 := z.EncBinary()
-					_ = yym955
+			if yyr1001 || yy2arr1001 {
+				if yyq1001[0] {
+					yym1003 := z.EncBinary()
+					_ = yym1003
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Path))
@@ -10712,25 +11000,25 @@ func (x *HTTPIngressPath) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq953[0] {
+				if yyq1001[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("path"))
-					yym956 := z.EncBinary()
-					_ = yym956
+					yym1004 := z.EncBinary()
+					_ = yym1004
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 					}
 				}
 			}
-			if yyr953 || yy2arr953 {
-				yy958 := &x.Backend
-				yy958.CodecEncodeSelf(e)
+			if yyr1001 || yy2arr1001 {
+				yy1006 := &x.Backend
+				yy1006.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("backend"))
-				yy959 := &x.Backend
-				yy959.CodecEncodeSelf(e)
+				yy1007 := &x.Backend
+				yy1007.CodecEncodeSelf(e)
 			}
-			if yysep953 {
+			if yysep1001 {
 				r.EncodeEnd()
 			}
 		}
@@ -10741,24 +11029,24 @@ func (x *HTTPIngressPath) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym960 := z.DecBinary()
-	_ = yym960
+	yym1008 := z.DecBinary()
+	_ = yym1008
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl961 := r.ReadMapStart()
-			if yyl961 == 0 {
+			yyl1009 := r.ReadMapStart()
+			if yyl1009 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl961, d)
+				x.codecDecodeSelfFromMap(yyl1009, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl961 := r.ReadArrayStart()
-			if yyl961 == 0 {
+			yyl1009 := r.ReadArrayStart()
+			if yyl1009 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl961, d)
+				x.codecDecodeSelfFromArray(yyl1009, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10770,12 +11058,12 @@ func (x *HTTPIngressPath) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys962Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys962Slc
-	var yyhl962 bool = l >= 0
-	for yyj962 := 0; ; yyj962++ {
-		if yyhl962 {
-			if yyj962 >= l {
+	var yys1010Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1010Slc
+	var yyhl1010 bool = l >= 0
+	for yyj1010 := 0; ; yyj1010++ {
+		if yyhl1010 {
+			if yyj1010 >= l {
 				break
 			}
 		} else {
@@ -10783,9 +11071,9 @@ func (x *HTTPIngressPath) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys962Slc = r.DecodeBytes(yys962Slc, true, true)
-		yys962 := string(yys962Slc)
-		switch yys962 {
+		yys1010Slc = r.DecodeBytes(yys1010Slc, true, true)
+		yys1010 := string(yys1010Slc)
+		switch yys1010 {
 		case "path":
 			if r.TryDecodeAsNil() {
 				x.Path = ""
@@ -10796,14 +11084,14 @@ func (x *HTTPIngressPath) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Backend = IngressBackend{}
 			} else {
-				yyv964 := &x.Backend
-				yyv964.CodecDecodeSelf(d)
+				yyv1012 := &x.Backend
+				yyv1012.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys962)
-		} // end switch yys962
-	} // end for yyj962
-	if !yyhl962 {
+			z.DecStructFieldNotFound(-1, yys1010)
+		} // end switch yys1010
+	} // end for yyj1010
+	if !yyhl1010 {
 		r.ReadEnd()
 	}
 }
@@ -10812,16 +11100,16 @@ func (x *HTTPIngressPath) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj965 int
-	var yyb965 bool
-	var yyhl965 bool = l >= 0
-	yyj965++
-	if yyhl965 {
-		yyb965 = yyj965 > l
+	var yyj1013 int
+	var yyb1013 bool
+	var yyhl1013 bool = l >= 0
+	yyj1013++
+	if yyhl1013 {
+		yyb1013 = yyj1013 > l
 	} else {
-		yyb965 = r.CheckBreak()
+		yyb1013 = r.CheckBreak()
 	}
-	if yyb965 {
+	if yyb1013 {
 		r.ReadEnd()
 		return
 	}
@@ -10830,33 +11118,33 @@ func (x *HTTPIngressPath) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Path = string(r.DecodeString())
 	}
-	yyj965++
-	if yyhl965 {
-		yyb965 = yyj965 > l
+	yyj1013++
+	if yyhl1013 {
+		yyb1013 = yyj1013 > l
 	} else {
-		yyb965 = r.CheckBreak()
+		yyb1013 = r.CheckBreak()
 	}
-	if yyb965 {
+	if yyb1013 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Backend = IngressBackend{}
 	} else {
-		yyv967 := &x.Backend
-		yyv967.CodecDecodeSelf(d)
+		yyv1015 := &x.Backend
+		yyv1015.CodecDecodeSelf(d)
 	}
 	for {
-		yyj965++
-		if yyhl965 {
-			yyb965 = yyj965 > l
+		yyj1013++
+		if yyhl1013 {
+			yyb1013 = yyj1013 > l
 		} else {
-			yyb965 = r.CheckBreak()
+			yyb1013 = r.CheckBreak()
 		}
-		if yyb965 {
+		if yyb1013 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj965-1, "")
+		z.DecStructFieldNotFound(yyj1013-1, "")
 	}
 	r.ReadEnd()
 }
@@ -10868,68 +11156,68 @@ func (x *IngressBackend) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym968 := z.EncBinary()
-		_ = yym968
+		yym1016 := z.EncBinary()
+		_ = yym1016
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep969 := !z.EncBinary()
-			yy2arr969 := z.EncBasicHandle().StructToArray
-			var yyq969 [2]bool
-			_, _, _ = yysep969, yyq969, yy2arr969
-			const yyr969 bool = false
-			if yyr969 || yy2arr969 {
+			yysep1017 := !z.EncBinary()
+			yy2arr1017 := z.EncBasicHandle().StructToArray
+			var yyq1017 [2]bool
+			_, _, _ = yysep1017, yyq1017, yy2arr1017
+			const yyr1017 bool = false
+			if yyr1017 || yy2arr1017 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn969 int = 2
-				for _, b := range yyq969 {
+				var yynn1017 int = 2
+				for _, b := range yyq1017 {
 					if b {
-						yynn969++
+						yynn1017++
 					}
 				}
-				r.EncodeMapStart(yynn969)
+				r.EncodeMapStart(yynn1017)
 			}
-			if yyr969 || yy2arr969 {
-				yym971 := z.EncBinary()
-				_ = yym971
+			if yyr1017 || yy2arr1017 {
+				yym1019 := z.EncBinary()
+				_ = yym1019
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ServiceName))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("serviceName"))
-				yym972 := z.EncBinary()
-				_ = yym972
+				yym1020 := z.EncBinary()
+				_ = yym1020
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ServiceName))
 				}
 			}
-			if yyr969 || yy2arr969 {
-				yy974 := &x.ServicePort
-				yym975 := z.EncBinary()
-				_ = yym975
+			if yyr1017 || yy2arr1017 {
+				yy1022 := &x.ServicePort
+				yym1023 := z.EncBinary()
+				_ = yym1023
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy974) {
-				} else if !yym975 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy974)
+				} else if z.HasExtensions() && z.EncExt(yy1022) {
+				} else if !yym1023 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy1022)
 				} else {
-					z.EncFallback(yy974)
+					z.EncFallback(yy1022)
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("servicePort"))
-				yy976 := &x.ServicePort
-				yym977 := z.EncBinary()
-				_ = yym977
+				yy1024 := &x.ServicePort
+				yym1025 := z.EncBinary()
+				_ = yym1025
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy976) {
-				} else if !yym977 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy976)
+				} else if z.HasExtensions() && z.EncExt(yy1024) {
+				} else if !yym1025 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy1024)
 				} else {
-					z.EncFallback(yy976)
+					z.EncFallback(yy1024)
 				}
 			}
-			if yysep969 {
+			if yysep1017 {
 				r.EncodeEnd()
 			}
 		}
@@ -10940,24 +11228,24 @@ func (x *IngressBackend) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym978 := z.DecBinary()
-	_ = yym978
+	yym1026 := z.DecBinary()
+	_ = yym1026
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl979 := r.ReadMapStart()
-			if yyl979 == 0 {
+			yyl1027 := r.ReadMapStart()
+			if yyl1027 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl979, d)
+				x.codecDecodeSelfFromMap(yyl1027, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl979 := r.ReadArrayStart()
-			if yyl979 == 0 {
+			yyl1027 := r.ReadArrayStart()
+			if yyl1027 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl979, d)
+				x.codecDecodeSelfFromArray(yyl1027, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10969,12 +11257,12 @@ func (x *IngressBackend) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys980Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys980Slc
-	var yyhl980 bool = l >= 0
-	for yyj980 := 0; ; yyj980++ {
-		if yyhl980 {
-			if yyj980 >= l {
+	var yys1028Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1028Slc
+	var yyhl1028 bool = l >= 0
+	for yyj1028 := 0; ; yyj1028++ {
+		if yyhl1028 {
+			if yyj1028 >= l {
 				break
 			}
 		} else {
@@ -10982,9 +11270,9 @@ func (x *IngressBackend) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys980Slc = r.DecodeBytes(yys980Slc, true, true)
-		yys980 := string(yys980Slc)
-		switch yys980 {
+		yys1028Slc = r.DecodeBytes(yys1028Slc, true, true)
+		yys1028 := string(yys1028Slc)
+		switch yys1028 {
 		case "serviceName":
 			if r.TryDecodeAsNil() {
 				x.ServiceName = ""
@@ -10995,22 +11283,22 @@ func (x *IngressBackend) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ServicePort = pkg6_util.IntOrString{}
 			} else {
-				yyv982 := &x.ServicePort
-				yym983 := z.DecBinary()
-				_ = yym983
+				yyv1030 := &x.ServicePort
+				yym1031 := z.DecBinary()
+				_ = yym1031
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv982) {
-				} else if !yym983 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv982)
+				} else if z.HasExtensions() && z.DecExt(yyv1030) {
+				} else if !yym1031 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv1030)
 				} else {
-					z.DecFallback(yyv982, false)
+					z.DecFallback(yyv1030, false)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys980)
-		} // end switch yys980
-	} // end for yyj980
-	if !yyhl980 {
+			z.DecStructFieldNotFound(-1, yys1028)
+		} // end switch yys1028
+	} // end for yyj1028
+	if !yyhl1028 {
 		r.ReadEnd()
 	}
 }
@@ -11019,16 +11307,16 @@ func (x *IngressBackend) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj984 int
-	var yyb984 bool
-	var yyhl984 bool = l >= 0
-	yyj984++
-	if yyhl984 {
-		yyb984 = yyj984 > l
+	var yyj1032 int
+	var yyb1032 bool
+	var yyhl1032 bool = l >= 0
+	yyj1032++
+	if yyhl1032 {
+		yyb1032 = yyj1032 > l
 	} else {
-		yyb984 = r.CheckBreak()
+		yyb1032 = r.CheckBreak()
 	}
-	if yyb984 {
+	if yyb1032 {
 		r.ReadEnd()
 		return
 	}
@@ -11037,41 +11325,41 @@ func (x *IngressBackend) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.ServiceName = string(r.DecodeString())
 	}
-	yyj984++
-	if yyhl984 {
-		yyb984 = yyj984 > l
+	yyj1032++
+	if yyhl1032 {
+		yyb1032 = yyj1032 > l
 	} else {
-		yyb984 = r.CheckBreak()
+		yyb1032 = r.CheckBreak()
 	}
-	if yyb984 {
+	if yyb1032 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ServicePort = pkg6_util.IntOrString{}
 	} else {
-		yyv986 := &x.ServicePort
-		yym987 := z.DecBinary()
-		_ = yym987
+		yyv1034 := &x.ServicePort
+		yym1035 := z.DecBinary()
+		_ = yym1035
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv986) {
-		} else if !yym987 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv986)
+		} else if z.HasExtensions() && z.DecExt(yyv1034) {
+		} else if !yym1035 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv1034)
 		} else {
-			z.DecFallback(yyv986, false)
+			z.DecFallback(yyv1034, false)
 		}
 	}
 	for {
-		yyj984++
-		if yyhl984 {
-			yyb984 = yyj984 > l
+		yyj1032++
+		if yyhl1032 {
+			yyb1032 = yyj1032 > l
 		} else {
-			yyb984 = r.CheckBreak()
+			yyb1032 = r.CheckBreak()
 		}
-		if yyb984 {
+		if yyb1032 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj984-1, "")
+		z.DecStructFieldNotFound(yyj1032-1, "")
 	}
 	r.ReadEnd()
 }
@@ -11080,8 +11368,8 @@ func (x NodeResource) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym988 := z.EncBinary()
-	_ = yym988
+	yym1036 := z.EncBinary()
+	_ = yym1036
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -11093,8 +11381,8 @@ func (x *NodeResource) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym989 := z.DecBinary()
-	_ = yym989
+	yym1037 := z.DecBinary()
+	_ = yym1037
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -11109,50 +11397,50 @@ func (x *NodeUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym990 := z.EncBinary()
-		_ = yym990
+		yym1038 := z.EncBinary()
+		_ = yym1038
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep991 := !z.EncBinary()
-			yy2arr991 := z.EncBasicHandle().StructToArray
-			var yyq991 [2]bool
-			_, _, _ = yysep991, yyq991, yy2arr991
-			const yyr991 bool = false
-			if yyr991 || yy2arr991 {
+			yysep1039 := !z.EncBinary()
+			yy2arr1039 := z.EncBasicHandle().StructToArray
+			var yyq1039 [2]bool
+			_, _, _ = yysep1039, yyq1039, yy2arr1039
+			const yyr1039 bool = false
+			if yyr1039 || yy2arr1039 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn991 int = 2
-				for _, b := range yyq991 {
+				var yynn1039 int = 2
+				for _, b := range yyq1039 {
 					if b {
-						yynn991++
+						yynn1039++
 					}
 				}
-				r.EncodeMapStart(yynn991)
+				r.EncodeMapStart(yynn1039)
 			}
-			if yyr991 || yy2arr991 {
+			if yyr1039 || yy2arr1039 {
 				x.Resource.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("resource"))
 				x.Resource.CodecEncodeSelf(e)
 			}
-			if yyr991 || yy2arr991 {
-				yym994 := z.EncBinary()
-				_ = yym994
+			if yyr1039 || yy2arr1039 {
+				yym1042 := z.EncBinary()
+				_ = yym1042
 				if false {
 				} else {
 					r.EncodeFloat64(float64(x.Value))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("value"))
-				yym995 := z.EncBinary()
-				_ = yym995
+				yym1043 := z.EncBinary()
+				_ = yym1043
 				if false {
 				} else {
 					r.EncodeFloat64(float64(x.Value))
 				}
 			}
-			if yysep991 {
+			if yysep1039 {
 				r.EncodeEnd()
 			}
 		}
@@ -11163,24 +11451,24 @@ func (x *NodeUtilization) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym996 := z.DecBinary()
-	_ = yym996
+	yym1044 := z.DecBinary()
+	_ = yym1044
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl997 := r.ReadMapStart()
-			if yyl997 == 0 {
+			yyl1045 := r.ReadMapStart()
+			if yyl1045 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl997, d)
+				x.codecDecodeSelfFromMap(yyl1045, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl997 := r.ReadArrayStart()
-			if yyl997 == 0 {
+			yyl1045 := r.ReadArrayStart()
+			if yyl1045 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl997, d)
+				x.codecDecodeSelfFromArray(yyl1045, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -11192,12 +11480,12 @@ func (x *NodeUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys998Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys998Slc
-	var yyhl998 bool = l >= 0
-	for yyj998 := 0; ; yyj998++ {
-		if yyhl998 {
-			if yyj998 >= l {
+	var yys1046Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1046Slc
+	var yyhl1046 bool = l >= 0
+	for yyj1046 := 0; ; yyj1046++ {
+		if yyhl1046 {
+			if yyj1046 >= l {
 				break
 			}
 		} else {
@@ -11205,9 +11493,9 @@ func (x *NodeUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys998Slc = r.DecodeBytes(yys998Slc, true, true)
-		yys998 := string(yys998Slc)
-		switch yys998 {
+		yys1046Slc = r.DecodeBytes(yys1046Slc, true, true)
+		yys1046 := string(yys1046Slc)
+		switch yys1046 {
 		case "resource":
 			if r.TryDecodeAsNil() {
 				x.Resource = ""
@@ -11221,10 +11509,10 @@ func (x *NodeUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Value = float64(r.DecodeFloat(false))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys998)
-		} // end switch yys998
-	} // end for yyj998
-	if !yyhl998 {
+			z.DecStructFieldNotFound(-1, yys1046)
+		} // end switch yys1046
+	} // end for yyj1046
+	if !yyhl1046 {
 		r.ReadEnd()
 	}
 }
@@ -11233,16 +11521,16 @@ func (x *NodeUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1001 int
-	var yyb1001 bool
-	var yyhl1001 bool = l >= 0
-	yyj1001++
-	if yyhl1001 {
-		yyb1001 = yyj1001 > l
+	var yyj1049 int
+	var yyb1049 bool
+	var yyhl1049 bool = l >= 0
+	yyj1049++
+	if yyhl1049 {
+		yyb1049 = yyj1049 > l
 	} else {
-		yyb1001 = r.CheckBreak()
+		yyb1049 = r.CheckBreak()
 	}
-	if yyb1001 {
+	if yyb1049 {
 		r.ReadEnd()
 		return
 	}
@@ -11251,13 +11539,13 @@ func (x *NodeUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Resource = NodeResource(r.DecodeString())
 	}
-	yyj1001++
-	if yyhl1001 {
-		yyb1001 = yyj1001 > l
+	yyj1049++
+	if yyhl1049 {
+		yyb1049 = yyj1049 > l
 	} else {
-		yyb1001 = r.CheckBreak()
+		yyb1049 = r.CheckBreak()
 	}
-	if yyb1001 {
+	if yyb1049 {
 		r.ReadEnd()
 		return
 	}
@@ -11267,16 +11555,16 @@ func (x *NodeUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.Value = float64(r.DecodeFloat(false))
 	}
 	for {
-		yyj1001++
-		if yyhl1001 {
-			yyb1001 = yyj1001 > l
+		yyj1049++
+		if yyhl1049 {
+			yyb1049 = yyj1049 > l
 		} else {
-			yyb1001 = r.CheckBreak()
+			yyb1049 = r.CheckBreak()
 		}
-		if yyb1001 {
+		if yyb1049 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1001-1, "")
+		z.DecStructFieldNotFound(yyj1049-1, "")
 	}
 	r.ReadEnd()
 }
@@ -11288,65 +11576,65 @@ func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1004 := z.EncBinary()
-		_ = yym1004
+		yym1052 := z.EncBinary()
+		_ = yym1052
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1005 := !z.EncBinary()
-			yy2arr1005 := z.EncBasicHandle().StructToArray
-			var yyq1005 [3]bool
-			_, _, _ = yysep1005, yyq1005, yy2arr1005
-			const yyr1005 bool = false
-			if yyr1005 || yy2arr1005 {
+			yysep1053 := !z.EncBinary()
+			yy2arr1053 := z.EncBasicHandle().StructToArray
+			var yyq1053 [3]bool
+			_, _, _ = yysep1053, yyq1053, yy2arr1053
+			const yyr1053 bool = false
+			if yyr1053 || yy2arr1053 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn1005 int = 3
-				for _, b := range yyq1005 {
+				var yynn1053 int = 3
+				for _, b := range yyq1053 {
 					if b {
-						yynn1005++
+						yynn1053++
 					}
 				}
-				r.EncodeMapStart(yynn1005)
+				r.EncodeMapStart(yynn1053)
 			}
-			if yyr1005 || yy2arr1005 {
-				yym1007 := z.EncBinary()
-				_ = yym1007
+			if yyr1053 || yy2arr1053 {
+				yym1055 := z.EncBinary()
+				_ = yym1055
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MinNodes))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("minNodes"))
-				yym1008 := z.EncBinary()
-				_ = yym1008
+				yym1056 := z.EncBinary()
+				_ = yym1056
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MinNodes))
 				}
 			}
-			if yyr1005 || yy2arr1005 {
-				yym1010 := z.EncBinary()
-				_ = yym1010
+			if yyr1053 || yy2arr1053 {
+				yym1058 := z.EncBinary()
+				_ = yym1058
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MaxNodes))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("maxNodes"))
-				yym1011 := z.EncBinary()
-				_ = yym1011
+				yym1059 := z.EncBinary()
+				_ = yym1059
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MaxNodes))
 				}
 			}
-			if yyr1005 || yy2arr1005 {
+			if yyr1053 || yy2arr1053 {
 				if x.TargetUtilization == nil {
 					r.EncodeNil()
 				} else {
-					yym1013 := z.EncBinary()
-					_ = yym1013
+					yym1061 := z.EncBinary()
+					_ = yym1061
 					if false {
 					} else {
 						h.encSliceNodeUtilization(([]NodeUtilization)(x.TargetUtilization), e)
@@ -11357,15 +11645,15 @@ func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.TargetUtilization == nil {
 					r.EncodeNil()
 				} else {
-					yym1014 := z.EncBinary()
-					_ = yym1014
+					yym1062 := z.EncBinary()
+					_ = yym1062
 					if false {
 					} else {
 						h.encSliceNodeUtilization(([]NodeUtilization)(x.TargetUtilization), e)
 					}
 				}
 			}
-			if yysep1005 {
+			if yysep1053 {
 				r.EncodeEnd()
 			}
 		}
@@ -11376,24 +11664,24 @@ func (x *ClusterAutoscalerSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1015 := z.DecBinary()
-	_ = yym1015
+	yym1063 := z.DecBinary()
+	_ = yym1063
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1016 := r.ReadMapStart()
-			if yyl1016 == 0 {
+			yyl1064 := r.ReadMapStart()
+			if yyl1064 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1016, d)
+				x.codecDecodeSelfFromMap(yyl1064, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1016 := r.ReadArrayStart()
-			if yyl1016 == 0 {
+			yyl1064 := r.ReadArrayStart()
+			if yyl1064 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1016, d)
+				x.codecDecodeSelfFromArray(yyl1064, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -11405,12 +11693,12 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1017Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1017Slc
-	var yyhl1017 bool = l >= 0
-	for yyj1017 := 0; ; yyj1017++ {
-		if yyhl1017 {
-			if yyj1017 >= l {
+	var yys1065Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1065Slc
+	var yyhl1065 bool = l >= 0
+	for yyj1065 := 0; ; yyj1065++ {
+		if yyhl1065 {
+			if yyj1065 >= l {
 				break
 			}
 		} else {
@@ -11418,9 +11706,9 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				break
 			}
 		}
-		yys1017Slc = r.DecodeBytes(yys1017Slc, true, true)
-		yys1017 := string(yys1017Slc)
-		switch yys1017 {
+		yys1065Slc = r.DecodeBytes(yys1065Slc, true, true)
+		yys1065 := string(yys1065Slc)
+		switch yys1065 {
 		case "minNodes":
 			if r.TryDecodeAsNil() {
 				x.MinNodes = 0
@@ -11437,19 +11725,19 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			if r.TryDecodeAsNil() {
 				x.TargetUtilization = nil
 			} else {
-				yyv1020 := &x.TargetUtilization
-				yym1021 := z.DecBinary()
-				_ = yym1021
+				yyv1068 := &x.TargetUtilization
+				yym1069 := z.DecBinary()
+				_ = yym1069
 				if false {
 				} else {
-					h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1020), d)
+					h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1068), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1017)
-		} // end switch yys1017
-	} // end for yyj1017
-	if !yyhl1017 {
+			z.DecStructFieldNotFound(-1, yys1065)
+		} // end switch yys1065
+	} // end for yyj1065
+	if !yyhl1065 {
 		r.ReadEnd()
 	}
 }
@@ -11458,16 +11746,16 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1022 int
-	var yyb1022 bool
-	var yyhl1022 bool = l >= 0
-	yyj1022++
-	if yyhl1022 {
-		yyb1022 = yyj1022 > l
+	var yyj1070 int
+	var yyb1070 bool
+	var yyhl1070 bool = l >= 0
+	yyj1070++
+	if yyhl1070 {
+		yyb1070 = yyj1070 > l
 	} else {
-		yyb1022 = r.CheckBreak()
+		yyb1070 = r.CheckBreak()
 	}
-	if yyb1022 {
+	if yyb1070 {
 		r.ReadEnd()
 		return
 	}
@@ -11476,13 +11764,13 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.MinNodes = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj1022++
-	if yyhl1022 {
-		yyb1022 = yyj1022 > l
+	yyj1070++
+	if yyhl1070 {
+		yyb1070 = yyj1070 > l
 	} else {
-		yyb1022 = r.CheckBreak()
+		yyb1070 = r.CheckBreak()
 	}
-	if yyb1022 {
+	if yyb1070 {
 		r.ReadEnd()
 		return
 	}
@@ -11491,38 +11779,38 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.MaxNodes = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj1022++
-	if yyhl1022 {
-		yyb1022 = yyj1022 > l
+	yyj1070++
+	if yyhl1070 {
+		yyb1070 = yyj1070 > l
 	} else {
-		yyb1022 = r.CheckBreak()
+		yyb1070 = r.CheckBreak()
 	}
-	if yyb1022 {
+	if yyb1070 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.TargetUtilization = nil
 	} else {
-		yyv1025 := &x.TargetUtilization
-		yym1026 := z.DecBinary()
-		_ = yym1026
+		yyv1073 := &x.TargetUtilization
+		yym1074 := z.DecBinary()
+		_ = yym1074
 		if false {
 		} else {
-			h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1025), d)
+			h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1073), d)
 		}
 	}
 	for {
-		yyj1022++
-		if yyhl1022 {
-			yyb1022 = yyj1022 > l
+		yyj1070++
+		if yyhl1070 {
+			yyb1070 = yyj1070 > l
 		} else {
-			yyb1022 = r.CheckBreak()
+			yyb1070 = r.CheckBreak()
 		}
-		if yyb1022 {
+		if yyb1070 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1022-1, "")
+		z.DecStructFieldNotFound(yyj1070-1, "")
 	}
 	r.ReadEnd()
 }
@@ -11534,35 +11822,35 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1027 := z.EncBinary()
-		_ = yym1027
+		yym1075 := z.EncBinary()
+		_ = yym1075
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1028 := !z.EncBinary()
-			yy2arr1028 := z.EncBasicHandle().StructToArray
-			var yyq1028 [4]bool
-			_, _, _ = yysep1028, yyq1028, yy2arr1028
-			const yyr1028 bool = false
-			yyq1028[0] = x.Kind != ""
-			yyq1028[1] = x.APIVersion != ""
-			yyq1028[2] = true
-			yyq1028[3] = true
-			if yyr1028 || yy2arr1028 {
+			yysep1076 := !z.EncBinary()
+			yy2arr1076 := z.EncBasicHandle().StructToArray
+			var yyq1076 [4]bool
+			_, _, _ = yysep1076, yyq1076, yy2arr1076
+			const yyr1076 bool = false
+			yyq1076[0] = x.Kind != ""
+			yyq1076[1] = x.APIVersion != ""
+			yyq1076[2] = true
+			yyq1076[3] = true
+			if yyr1076 || yy2arr1076 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1028 int = 0
-				for _, b := range yyq1028 {
+				var yynn1076 int = 0
+				for _, b := range yyq1076 {
 					if b {
-						yynn1028++
+						yynn1076++
 					}
 				}
-				r.EncodeMapStart(yynn1028)
+				r.EncodeMapStart(yynn1076)
 			}
-			if yyr1028 || yy2arr1028 {
-				if yyq1028[0] {
-					yym1030 := z.EncBinary()
-					_ = yym1030
+			if yyr1076 || yy2arr1076 {
+				if yyq1076[0] {
+					yym1078 := z.EncBinary()
+					_ = yym1078
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -11571,20 +11859,20 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1028[0] {
+				if yyq1076[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym1031 := z.EncBinary()
-					_ = yym1031
+					yym1079 := z.EncBinary()
+					_ = yym1079
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1028 || yy2arr1028 {
-				if yyq1028[1] {
-					yym1033 := z.EncBinary()
-					_ = yym1033
+			if yyr1076 || yy2arr1076 {
+				if yyq1076[1] {
+					yym1081 := z.EncBinary()
+					_ = yym1081
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -11593,45 +11881,57 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1028[1] {
+				if yyq1076[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym1034 := z.EncBinary()
-					_ = yym1034
+					yym1082 := z.EncBinary()
+					_ = yym1082
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1028 || yy2arr1028 {
-				if yyq1028[2] {
-					yy1036 := &x.ObjectMeta
-					yy1036.CodecEncodeSelf(e)
+			if yyr1076 || yy2arr1076 {
+				if yyq1076[2] {
+					yy1084 := &x.ObjectMeta
+					yym1085 := z.EncBinary()
+					_ = yym1085
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1084) {
+					} else {
+						z.EncFallback(yy1084)
+					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1028[2] {
+				if yyq1076[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy1037 := &x.ObjectMeta
-					yy1037.CodecEncodeSelf(e)
+					yy1086 := &x.ObjectMeta
+					yym1087 := z.EncBinary()
+					_ = yym1087
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1086) {
+					} else {
+						z.EncFallback(yy1086)
+					}
 				}
 			}
-			if yyr1028 || yy2arr1028 {
-				if yyq1028[3] {
-					yy1039 := &x.Spec
-					yy1039.CodecEncodeSelf(e)
+			if yyr1076 || yy2arr1076 {
+				if yyq1076[3] {
+					yy1089 := &x.Spec
+					yy1089.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1028[3] {
+				if yyq1076[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy1040 := &x.Spec
-					yy1040.CodecEncodeSelf(e)
+					yy1090 := &x.Spec
+					yy1090.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1028 {
+			if yysep1076 {
 				r.EncodeEnd()
 			}
 		}
@@ -11642,24 +11942,24 @@ func (x *ClusterAutoscaler) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1041 := z.DecBinary()
-	_ = yym1041
+	yym1091 := z.DecBinary()
+	_ = yym1091
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1042 := r.ReadMapStart()
-			if yyl1042 == 0 {
+			yyl1092 := r.ReadMapStart()
+			if yyl1092 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1042, d)
+				x.codecDecodeSelfFromMap(yyl1092, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1042 := r.ReadArrayStart()
-			if yyl1042 == 0 {
+			yyl1092 := r.ReadArrayStart()
+			if yyl1092 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1042, d)
+				x.codecDecodeSelfFromArray(yyl1092, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -11671,12 +11971,12 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1043Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1043Slc
-	var yyhl1043 bool = l >= 0
-	for yyj1043 := 0; ; yyj1043++ {
-		if yyhl1043 {
-			if yyj1043 >= l {
+	var yys1093Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1093Slc
+	var yyhl1093 bool = l >= 0
+	for yyj1093 := 0; ; yyj1093++ {
+		if yyhl1093 {
+			if yyj1093 >= l {
 				break
 			}
 		} else {
@@ -11684,9 +11984,9 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				break
 			}
 		}
-		yys1043Slc = r.DecodeBytes(yys1043Slc, true, true)
-		yys1043 := string(yys1043Slc)
-		switch yys1043 {
+		yys1093Slc = r.DecodeBytes(yys1093Slc, true, true)
+		yys1093 := string(yys1093Slc)
+		switch yys1093 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -11703,21 +12003,27 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv1046 := &x.ObjectMeta
-				yyv1046.CodecDecodeSelf(d)
+				yyv1096 := &x.ObjectMeta
+				yym1097 := z.DecBinary()
+				_ = yym1097
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv1096) {
+				} else {
+					z.DecFallback(yyv1096, false)
+				}
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = ClusterAutoscalerSpec{}
 			} else {
-				yyv1047 := &x.Spec
-				yyv1047.CodecDecodeSelf(d)
+				yyv1098 := &x.Spec
+				yyv1098.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1043)
-		} // end switch yys1043
-	} // end for yyj1043
-	if !yyhl1043 {
+			z.DecStructFieldNotFound(-1, yys1093)
+		} // end switch yys1093
+	} // end for yyj1093
+	if !yyhl1093 {
 		r.ReadEnd()
 	}
 }
@@ -11726,16 +12032,16 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1048 int
-	var yyb1048 bool
-	var yyhl1048 bool = l >= 0
-	yyj1048++
-	if yyhl1048 {
-		yyb1048 = yyj1048 > l
+	var yyj1099 int
+	var yyb1099 bool
+	var yyhl1099 bool = l >= 0
+	yyj1099++
+	if yyhl1099 {
+		yyb1099 = yyj1099 > l
 	} else {
-		yyb1048 = r.CheckBreak()
+		yyb1099 = r.CheckBreak()
 	}
-	if yyb1048 {
+	if yyb1099 {
 		r.ReadEnd()
 		return
 	}
@@ -11744,13 +12050,13 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1048++
-	if yyhl1048 {
-		yyb1048 = yyj1048 > l
+	yyj1099++
+	if yyhl1099 {
+		yyb1099 = yyj1099 > l
 	} else {
-		yyb1048 = r.CheckBreak()
+		yyb1099 = r.CheckBreak()
 	}
-	if yyb1048 {
+	if yyb1099 {
 		r.ReadEnd()
 		return
 	}
@@ -11759,49 +12065,55 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj1048++
-	if yyhl1048 {
-		yyb1048 = yyj1048 > l
+	yyj1099++
+	if yyhl1099 {
+		yyb1099 = yyj1099 > l
 	} else {
-		yyb1048 = r.CheckBreak()
+		yyb1099 = r.CheckBreak()
 	}
-	if yyb1048 {
+	if yyb1099 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv1051 := &x.ObjectMeta
-		yyv1051.CodecDecodeSelf(d)
+		yyv1102 := &x.ObjectMeta
+		yym1103 := z.DecBinary()
+		_ = yym1103
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv1102) {
+		} else {
+			z.DecFallback(yyv1102, false)
+		}
 	}
-	yyj1048++
-	if yyhl1048 {
-		yyb1048 = yyj1048 > l
+	yyj1099++
+	if yyhl1099 {
+		yyb1099 = yyj1099 > l
 	} else {
-		yyb1048 = r.CheckBreak()
+		yyb1099 = r.CheckBreak()
 	}
-	if yyb1048 {
+	if yyb1099 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = ClusterAutoscalerSpec{}
 	} else {
-		yyv1052 := &x.Spec
-		yyv1052.CodecDecodeSelf(d)
+		yyv1104 := &x.Spec
+		yyv1104.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1048++
-		if yyhl1048 {
-			yyb1048 = yyj1048 > l
+		yyj1099++
+		if yyhl1099 {
+			yyb1099 = yyj1099 > l
 		} else {
-			yyb1048 = r.CheckBreak()
+			yyb1099 = r.CheckBreak()
 		}
-		if yyb1048 {
+		if yyb1099 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1048-1, "")
+		z.DecStructFieldNotFound(yyj1099-1, "")
 	}
 	r.ReadEnd()
 }
@@ -11813,34 +12125,34 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1053 := z.EncBinary()
-		_ = yym1053
+		yym1105 := z.EncBinary()
+		_ = yym1105
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1054 := !z.EncBinary()
-			yy2arr1054 := z.EncBasicHandle().StructToArray
-			var yyq1054 [4]bool
-			_, _, _ = yysep1054, yyq1054, yy2arr1054
-			const yyr1054 bool = false
-			yyq1054[0] = x.Kind != ""
-			yyq1054[1] = x.APIVersion != ""
-			yyq1054[2] = true
-			if yyr1054 || yy2arr1054 {
+			yysep1106 := !z.EncBinary()
+			yy2arr1106 := z.EncBasicHandle().StructToArray
+			var yyq1106 [4]bool
+			_, _, _ = yysep1106, yyq1106, yy2arr1106
+			const yyr1106 bool = false
+			yyq1106[0] = x.Kind != ""
+			yyq1106[1] = x.APIVersion != ""
+			yyq1106[2] = true
+			if yyr1106 || yy2arr1106 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1054 int = 1
-				for _, b := range yyq1054 {
+				var yynn1106 int = 1
+				for _, b := range yyq1106 {
 					if b {
-						yynn1054++
+						yynn1106++
 					}
 				}
-				r.EncodeMapStart(yynn1054)
+				r.EncodeMapStart(yynn1106)
 			}
-			if yyr1054 || yy2arr1054 {
-				if yyq1054[0] {
-					yym1056 := z.EncBinary()
-					_ = yym1056
+			if yyr1106 || yy2arr1106 {
+				if yyq1106[0] {
+					yym1108 := z.EncBinary()
+					_ = yym1108
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -11849,20 +12161,20 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1054[0] {
+				if yyq1106[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym1057 := z.EncBinary()
-					_ = yym1057
+					yym1109 := z.EncBinary()
+					_ = yym1109
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1054 || yy2arr1054 {
-				if yyq1054[1] {
-					yym1059 := z.EncBinary()
-					_ = yym1059
+			if yyr1106 || yy2arr1106 {
+				if yyq1106[1] {
+					yym1111 := z.EncBinary()
+					_ = yym1111
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -11871,48 +12183,48 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1054[1] {
+				if yyq1106[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym1060 := z.EncBinary()
-					_ = yym1060
+					yym1112 := z.EncBinary()
+					_ = yym1112
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1054 || yy2arr1054 {
-				if yyq1054[2] {
-					yy1062 := &x.ListMeta
-					yym1063 := z.EncBinary()
-					_ = yym1063
+			if yyr1106 || yy2arr1106 {
+				if yyq1106[2] {
+					yy1114 := &x.ListMeta
+					yym1115 := z.EncBinary()
+					_ = yym1115
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1062) {
+					} else if z.HasExtensions() && z.EncExt(yy1114) {
 					} else {
-						z.EncFallback(yy1062)
+						z.EncFallback(yy1114)
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1054[2] {
+				if yyq1106[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy1064 := &x.ListMeta
-					yym1065 := z.EncBinary()
-					_ = yym1065
+					yy1116 := &x.ListMeta
+					yym1117 := z.EncBinary()
+					_ = yym1117
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1064) {
+					} else if z.HasExtensions() && z.EncExt(yy1116) {
 					} else {
-						z.EncFallback(yy1064)
+						z.EncFallback(yy1116)
 					}
 				}
 			}
-			if yyr1054 || yy2arr1054 {
+			if yyr1106 || yy2arr1106 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1067 := z.EncBinary()
-					_ = yym1067
+					yym1119 := z.EncBinary()
+					_ = yym1119
 					if false {
 					} else {
 						h.encSliceClusterAutoscaler(([]ClusterAutoscaler)(x.Items), e)
@@ -11923,15 +12235,15 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1068 := z.EncBinary()
-					_ = yym1068
+					yym1120 := z.EncBinary()
+					_ = yym1120
 					if false {
 					} else {
 						h.encSliceClusterAutoscaler(([]ClusterAutoscaler)(x.Items), e)
 					}
 				}
 			}
-			if yysep1054 {
+			if yysep1106 {
 				r.EncodeEnd()
 			}
 		}
@@ -11942,24 +12254,24 @@ func (x *ClusterAutoscalerList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1069 := z.DecBinary()
-	_ = yym1069
+	yym1121 := z.DecBinary()
+	_ = yym1121
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1070 := r.ReadMapStart()
-			if yyl1070 == 0 {
+			yyl1122 := r.ReadMapStart()
+			if yyl1122 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1070, d)
+				x.codecDecodeSelfFromMap(yyl1122, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1070 := r.ReadArrayStart()
-			if yyl1070 == 0 {
+			yyl1122 := r.ReadArrayStart()
+			if yyl1122 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1070, d)
+				x.codecDecodeSelfFromArray(yyl1122, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -11971,12 +12283,12 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1071Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1071Slc
-	var yyhl1071 bool = l >= 0
-	for yyj1071 := 0; ; yyj1071++ {
-		if yyhl1071 {
-			if yyj1071 >= l {
+	var yys1123Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1123Slc
+	var yyhl1123 bool = l >= 0
+	for yyj1123 := 0; ; yyj1123++ {
+		if yyhl1123 {
+			if yyj1123 >= l {
 				break
 			}
 		} else {
@@ -11984,9 +12296,9 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				break
 			}
 		}
-		yys1071Slc = r.DecodeBytes(yys1071Slc, true, true)
-		yys1071 := string(yys1071Slc)
-		switch yys1071 {
+		yys1123Slc = r.DecodeBytes(yys1123Slc, true, true)
+		yys1123 := string(yys1123Slc)
+		switch yys1123 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -12003,32 +12315,32 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv1074 := &x.ListMeta
-				yym1075 := z.DecBinary()
-				_ = yym1075
+				yyv1126 := &x.ListMeta
+				yym1127 := z.DecBinary()
+				_ = yym1127
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1074) {
+				} else if z.HasExtensions() && z.DecExt(yyv1126) {
 				} else {
-					z.DecFallback(yyv1074, false)
+					z.DecFallback(yyv1126, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv1076 := &x.Items
-				yym1077 := z.DecBinary()
-				_ = yym1077
+				yyv1128 := &x.Items
+				yym1129 := z.DecBinary()
+				_ = yym1129
 				if false {
 				} else {
-					h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1076), d)
+					h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1128), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1071)
-		} // end switch yys1071
-	} // end for yyj1071
-	if !yyhl1071 {
+			z.DecStructFieldNotFound(-1, yys1123)
+		} // end switch yys1123
+	} // end for yyj1123
+	if !yyhl1123 {
 		r.ReadEnd()
 	}
 }
@@ -12037,16 +12349,16 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1078 int
-	var yyb1078 bool
-	var yyhl1078 bool = l >= 0
-	yyj1078++
-	if yyhl1078 {
-		yyb1078 = yyj1078 > l
+	var yyj1130 int
+	var yyb1130 bool
+	var yyhl1130 bool = l >= 0
+	yyj1130++
+	if yyhl1130 {
+		yyb1130 = yyj1130 > l
 	} else {
-		yyb1078 = r.CheckBreak()
+		yyb1130 = r.CheckBreak()
 	}
-	if yyb1078 {
+	if yyb1130 {
 		r.ReadEnd()
 		return
 	}
@@ -12055,13 +12367,13 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1078++
-	if yyhl1078 {
-		yyb1078 = yyj1078 > l
+	yyj1130++
+	if yyhl1130 {
+		yyb1130 = yyj1130 > l
 	} else {
-		yyb1078 = r.CheckBreak()
+		yyb1130 = r.CheckBreak()
 	}
-	if yyb1078 {
+	if yyb1130 {
 		r.ReadEnd()
 		return
 	}
@@ -12070,60 +12382,60 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj1078++
-	if yyhl1078 {
-		yyb1078 = yyj1078 > l
+	yyj1130++
+	if yyhl1130 {
+		yyb1130 = yyj1130 > l
 	} else {
-		yyb1078 = r.CheckBreak()
+		yyb1130 = r.CheckBreak()
 	}
-	if yyb1078 {
+	if yyb1130 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv1081 := &x.ListMeta
-		yym1082 := z.DecBinary()
-		_ = yym1082
+		yyv1133 := &x.ListMeta
+		yym1134 := z.DecBinary()
+		_ = yym1134
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1081) {
+		} else if z.HasExtensions() && z.DecExt(yyv1133) {
 		} else {
-			z.DecFallback(yyv1081, false)
+			z.DecFallback(yyv1133, false)
 		}
 	}
-	yyj1078++
-	if yyhl1078 {
-		yyb1078 = yyj1078 > l
+	yyj1130++
+	if yyhl1130 {
+		yyb1130 = yyj1130 > l
 	} else {
-		yyb1078 = r.CheckBreak()
+		yyb1130 = r.CheckBreak()
 	}
-	if yyb1078 {
+	if yyb1130 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv1083 := &x.Items
-		yym1084 := z.DecBinary()
-		_ = yym1084
+		yyv1135 := &x.Items
+		yym1136 := z.DecBinary()
+		_ = yym1136
 		if false {
 		} else {
-			h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1083), d)
+			h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1135), d)
 		}
 	}
 	for {
-		yyj1078++
-		if yyhl1078 {
-			yyb1078 = yyj1078 > l
+		yyj1130++
+		if yyhl1130 {
+			yyb1130 = yyj1130 > l
 		} else {
-			yyb1078 = r.CheckBreak()
+			yyb1130 = r.CheckBreak()
 		}
-		if yyb1078 {
+		if yyb1130 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1078-1, "")
+		z.DecStructFieldNotFound(yyj1130-1, "")
 	}
 	r.ReadEnd()
 }
@@ -12135,36 +12447,36 @@ func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1085 := z.EncBinary()
-		_ = yym1085
+		yym1137 := z.EncBinary()
+		_ = yym1137
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1086 := !z.EncBinary()
-			yy2arr1086 := z.EncBasicHandle().StructToArray
-			var yyq1086 [2]bool
-			_, _, _ = yysep1086, yyq1086, yy2arr1086
-			const yyr1086 bool = false
-			yyq1086[0] = len(x.MatchLabels) != 0
-			yyq1086[1] = len(x.MatchExpressions) != 0
-			if yyr1086 || yy2arr1086 {
+			yysep1138 := !z.EncBinary()
+			yy2arr1138 := z.EncBasicHandle().StructToArray
+			var yyq1138 [2]bool
+			_, _, _ = yysep1138, yyq1138, yy2arr1138
+			const yyr1138 bool = false
+			yyq1138[0] = len(x.MatchLabels) != 0
+			yyq1138[1] = len(x.MatchExpressions) != 0
+			if yyr1138 || yy2arr1138 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn1086 int = 0
-				for _, b := range yyq1086 {
+				var yynn1138 int = 0
+				for _, b := range yyq1138 {
 					if b {
-						yynn1086++
+						yynn1138++
 					}
 				}
-				r.EncodeMapStart(yynn1086)
+				r.EncodeMapStart(yynn1138)
 			}
-			if yyr1086 || yy2arr1086 {
-				if yyq1086[0] {
+			if yyr1138 || yy2arr1138 {
+				if yyq1138[0] {
 					if x.MatchLabels == nil {
 						r.EncodeNil()
 					} else {
-						yym1088 := z.EncBinary()
-						_ = yym1088
+						yym1140 := z.EncBinary()
+						_ = yym1140
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.MatchLabels, false, e)
@@ -12174,13 +12486,13 @@ func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1086[0] {
+				if yyq1138[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("matchLabels"))
 					if x.MatchLabels == nil {
 						r.EncodeNil()
 					} else {
-						yym1089 := z.EncBinary()
-						_ = yym1089
+						yym1141 := z.EncBinary()
+						_ = yym1141
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.MatchLabels, false, e)
@@ -12188,13 +12500,13 @@ func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1086 || yy2arr1086 {
-				if yyq1086[1] {
+			if yyr1138 || yy2arr1138 {
+				if yyq1138[1] {
 					if x.MatchExpressions == nil {
 						r.EncodeNil()
 					} else {
-						yym1091 := z.EncBinary()
-						_ = yym1091
+						yym1143 := z.EncBinary()
+						_ = yym1143
 						if false {
 						} else {
 							h.encSlicePodSelectorRequirement(([]PodSelectorRequirement)(x.MatchExpressions), e)
@@ -12204,13 +12516,13 @@ func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1086[1] {
+				if yyq1138[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("matchExpressions"))
 					if x.MatchExpressions == nil {
 						r.EncodeNil()
 					} else {
-						yym1092 := z.EncBinary()
-						_ = yym1092
+						yym1144 := z.EncBinary()
+						_ = yym1144
 						if false {
 						} else {
 							h.encSlicePodSelectorRequirement(([]PodSelectorRequirement)(x.MatchExpressions), e)
@@ -12218,7 +12530,7 @@ func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1086 {
+			if yysep1138 {
 				r.EncodeEnd()
 			}
 		}
@@ -12229,24 +12541,24 @@ func (x *PodSelector) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1093 := z.DecBinary()
-	_ = yym1093
+	yym1145 := z.DecBinary()
+	_ = yym1145
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1094 := r.ReadMapStart()
-			if yyl1094 == 0 {
+			yyl1146 := r.ReadMapStart()
+			if yyl1146 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1094, d)
+				x.codecDecodeSelfFromMap(yyl1146, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1094 := r.ReadArrayStart()
-			if yyl1094 == 0 {
+			yyl1146 := r.ReadArrayStart()
+			if yyl1146 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1094, d)
+				x.codecDecodeSelfFromArray(yyl1146, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -12258,12 +12570,12 @@ func (x *PodSelector) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1095Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1095Slc
-	var yyhl1095 bool = l >= 0
-	for yyj1095 := 0; ; yyj1095++ {
-		if yyhl1095 {
-			if yyj1095 >= l {
+	var yys1147Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1147Slc
+	var yyhl1147 bool = l >= 0
+	for yyj1147 := 0; ; yyj1147++ {
+		if yyhl1147 {
+			if yyj1147 >= l {
 				break
 			}
 		} else {
@@ -12271,38 +12583,38 @@ func (x *PodSelector) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys1095Slc = r.DecodeBytes(yys1095Slc, true, true)
-		yys1095 := string(yys1095Slc)
-		switch yys1095 {
+		yys1147Slc = r.DecodeBytes(yys1147Slc, true, true)
+		yys1147 := string(yys1147Slc)
+		switch yys1147 {
 		case "matchLabels":
 			if r.TryDecodeAsNil() {
 				x.MatchLabels = nil
 			} else {
-				yyv1096 := &x.MatchLabels
-				yym1097 := z.DecBinary()
-				_ = yym1097
+				yyv1148 := &x.MatchLabels
+				yym1149 := z.DecBinary()
+				_ = yym1149
 				if false {
 				} else {
-					z.F.DecMapStringStringX(yyv1096, false, d)
+					z.F.DecMapStringStringX(yyv1148, false, d)
 				}
 			}
 		case "matchExpressions":
 			if r.TryDecodeAsNil() {
 				x.MatchExpressions = nil
 			} else {
-				yyv1098 := &x.MatchExpressions
-				yym1099 := z.DecBinary()
-				_ = yym1099
+				yyv1150 := &x.MatchExpressions
+				yym1151 := z.DecBinary()
+				_ = yym1151
 				if false {
 				} else {
-					h.decSlicePodSelectorRequirement((*[]PodSelectorRequirement)(yyv1098), d)
+					h.decSlicePodSelectorRequirement((*[]PodSelectorRequirement)(yyv1150), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1095)
-		} // end switch yys1095
-	} // end for yyj1095
-	if !yyhl1095 {
+			z.DecStructFieldNotFound(-1, yys1147)
+		} // end switch yys1147
+	} // end for yyj1147
+	if !yyhl1147 {
 		r.ReadEnd()
 	}
 }
@@ -12311,62 +12623,62 @@ func (x *PodSelector) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1100 int
-	var yyb1100 bool
-	var yyhl1100 bool = l >= 0
-	yyj1100++
-	if yyhl1100 {
-		yyb1100 = yyj1100 > l
+	var yyj1152 int
+	var yyb1152 bool
+	var yyhl1152 bool = l >= 0
+	yyj1152++
+	if yyhl1152 {
+		yyb1152 = yyj1152 > l
 	} else {
-		yyb1100 = r.CheckBreak()
+		yyb1152 = r.CheckBreak()
 	}
-	if yyb1100 {
+	if yyb1152 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.MatchLabels = nil
 	} else {
-		yyv1101 := &x.MatchLabels
-		yym1102 := z.DecBinary()
-		_ = yym1102
+		yyv1153 := &x.MatchLabels
+		yym1154 := z.DecBinary()
+		_ = yym1154
 		if false {
 		} else {
-			z.F.DecMapStringStringX(yyv1101, false, d)
+			z.F.DecMapStringStringX(yyv1153, false, d)
 		}
 	}
-	yyj1100++
-	if yyhl1100 {
-		yyb1100 = yyj1100 > l
+	yyj1152++
+	if yyhl1152 {
+		yyb1152 = yyj1152 > l
 	} else {
-		yyb1100 = r.CheckBreak()
+		yyb1152 = r.CheckBreak()
 	}
-	if yyb1100 {
+	if yyb1152 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.MatchExpressions = nil
 	} else {
-		yyv1103 := &x.MatchExpressions
-		yym1104 := z.DecBinary()
-		_ = yym1104
+		yyv1155 := &x.MatchExpressions
+		yym1156 := z.DecBinary()
+		_ = yym1156
 		if false {
 		} else {
-			h.decSlicePodSelectorRequirement((*[]PodSelectorRequirement)(yyv1103), d)
+			h.decSlicePodSelectorRequirement((*[]PodSelectorRequirement)(yyv1155), d)
 		}
 	}
 	for {
-		yyj1100++
-		if yyhl1100 {
-			yyb1100 = yyj1100 > l
+		yyj1152++
+		if yyhl1152 {
+			yyb1152 = yyj1152 > l
 		} else {
-			yyb1100 = r.CheckBreak()
+			yyb1152 = r.CheckBreak()
 		}
-		if yyb1100 {
+		if yyb1152 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1100-1, "")
+		z.DecStructFieldNotFound(yyj1152-1, "")
 	}
 	r.ReadEnd()
 }
@@ -12378,57 +12690,57 @@ func (x *PodSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1105 := z.EncBinary()
-		_ = yym1105
+		yym1157 := z.EncBinary()
+		_ = yym1157
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1106 := !z.EncBinary()
-			yy2arr1106 := z.EncBasicHandle().StructToArray
-			var yyq1106 [3]bool
-			_, _, _ = yysep1106, yyq1106, yy2arr1106
-			const yyr1106 bool = false
-			yyq1106[2] = len(x.Values) != 0
-			if yyr1106 || yy2arr1106 {
+			yysep1158 := !z.EncBinary()
+			yy2arr1158 := z.EncBasicHandle().StructToArray
+			var yyq1158 [3]bool
+			_, _, _ = yysep1158, yyq1158, yy2arr1158
+			const yyr1158 bool = false
+			yyq1158[2] = len(x.Values) != 0
+			if yyr1158 || yy2arr1158 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn1106 int = 2
-				for _, b := range yyq1106 {
+				var yynn1158 int = 2
+				for _, b := range yyq1158 {
 					if b {
-						yynn1106++
+						yynn1158++
 					}
 				}
-				r.EncodeMapStart(yynn1106)
+				r.EncodeMapStart(yynn1158)
 			}
-			if yyr1106 || yy2arr1106 {
-				yym1108 := z.EncBinary()
-				_ = yym1108
+			if yyr1158 || yy2arr1158 {
+				yym1160 := z.EncBinary()
+				_ = yym1160
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("key"))
-				yym1109 := z.EncBinary()
-				_ = yym1109
+				yym1161 := z.EncBinary()
+				_ = yym1161
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
 				}
 			}
-			if yyr1106 || yy2arr1106 {
+			if yyr1158 || yy2arr1158 {
 				x.Operator.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("operator"))
 				x.Operator.CodecEncodeSelf(e)
 			}
-			if yyr1106 || yy2arr1106 {
-				if yyq1106[2] {
+			if yyr1158 || yy2arr1158 {
+				if yyq1158[2] {
 					if x.Values == nil {
 						r.EncodeNil()
 					} else {
-						yym1112 := z.EncBinary()
-						_ = yym1112
+						yym1164 := z.EncBinary()
+						_ = yym1164
 						if false {
 						} else {
 							z.F.EncSliceStringV(x.Values, false, e)
@@ -12438,13 +12750,13 @@ func (x *PodSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1106[2] {
+				if yyq1158[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("values"))
 					if x.Values == nil {
 						r.EncodeNil()
 					} else {
-						yym1113 := z.EncBinary()
-						_ = yym1113
+						yym1165 := z.EncBinary()
+						_ = yym1165
 						if false {
 						} else {
 							z.F.EncSliceStringV(x.Values, false, e)
@@ -12452,7 +12764,7 @@ func (x *PodSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1106 {
+			if yysep1158 {
 				r.EncodeEnd()
 			}
 		}
@@ -12463,24 +12775,24 @@ func (x *PodSelectorRequirement) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1114 := z.DecBinary()
-	_ = yym1114
+	yym1166 := z.DecBinary()
+	_ = yym1166
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1115 := r.ReadMapStart()
-			if yyl1115 == 0 {
+			yyl1167 := r.ReadMapStart()
+			if yyl1167 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1115, d)
+				x.codecDecodeSelfFromMap(yyl1167, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1115 := r.ReadArrayStart()
-			if yyl1115 == 0 {
+			yyl1167 := r.ReadArrayStart()
+			if yyl1167 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1115, d)
+				x.codecDecodeSelfFromArray(yyl1167, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -12492,12 +12804,12 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1116Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1116Slc
-	var yyhl1116 bool = l >= 0
-	for yyj1116 := 0; ; yyj1116++ {
-		if yyhl1116 {
-			if yyj1116 >= l {
+	var yys1168Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1168Slc
+	var yyhl1168 bool = l >= 0
+	for yyj1168 := 0; ; yyj1168++ {
+		if yyhl1168 {
+			if yyj1168 >= l {
 				break
 			}
 		} else {
@@ -12505,9 +12817,9 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				break
 			}
 		}
-		yys1116Slc = r.DecodeBytes(yys1116Slc, true, true)
-		yys1116 := string(yys1116Slc)
-		switch yys1116 {
+		yys1168Slc = r.DecodeBytes(yys1168Slc, true, true)
+		yys1168 := string(yys1168Slc)
+		switch yys1168 {
 		case "key":
 			if r.TryDecodeAsNil() {
 				x.Key = ""
@@ -12524,19 +12836,19 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			if r.TryDecodeAsNil() {
 				x.Values = nil
 			} else {
-				yyv1119 := &x.Values
-				yym1120 := z.DecBinary()
-				_ = yym1120
+				yyv1171 := &x.Values
+				yym1172 := z.DecBinary()
+				_ = yym1172
 				if false {
 				} else {
-					z.F.DecSliceStringX(yyv1119, false, d)
+					z.F.DecSliceStringX(yyv1171, false, d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1116)
-		} // end switch yys1116
-	} // end for yyj1116
-	if !yyhl1116 {
+			z.DecStructFieldNotFound(-1, yys1168)
+		} // end switch yys1168
+	} // end for yyj1168
+	if !yyhl1168 {
 		r.ReadEnd()
 	}
 }
@@ -12545,16 +12857,16 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromArray(l int, d *codec1978.De
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1121 int
-	var yyb1121 bool
-	var yyhl1121 bool = l >= 0
-	yyj1121++
-	if yyhl1121 {
-		yyb1121 = yyj1121 > l
+	var yyj1173 int
+	var yyb1173 bool
+	var yyhl1173 bool = l >= 0
+	yyj1173++
+	if yyhl1173 {
+		yyb1173 = yyj1173 > l
 	} else {
-		yyb1121 = r.CheckBreak()
+		yyb1173 = r.CheckBreak()
 	}
-	if yyb1121 {
+	if yyb1173 {
 		r.ReadEnd()
 		return
 	}
@@ -12563,13 +12875,13 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromArray(l int, d *codec1978.De
 	} else {
 		x.Key = string(r.DecodeString())
 	}
-	yyj1121++
-	if yyhl1121 {
-		yyb1121 = yyj1121 > l
+	yyj1173++
+	if yyhl1173 {
+		yyb1173 = yyj1173 > l
 	} else {
-		yyb1121 = r.CheckBreak()
+		yyb1173 = r.CheckBreak()
 	}
-	if yyb1121 {
+	if yyb1173 {
 		r.ReadEnd()
 		return
 	}
@@ -12578,38 +12890,38 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromArray(l int, d *codec1978.De
 	} else {
 		x.Operator = PodSelectorOperator(r.DecodeString())
 	}
-	yyj1121++
-	if yyhl1121 {
-		yyb1121 = yyj1121 > l
+	yyj1173++
+	if yyhl1173 {
+		yyb1173 = yyj1173 > l
 	} else {
-		yyb1121 = r.CheckBreak()
+		yyb1173 = r.CheckBreak()
 	}
-	if yyb1121 {
+	if yyb1173 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Values = nil
 	} else {
-		yyv1124 := &x.Values
-		yym1125 := z.DecBinary()
-		_ = yym1125
+		yyv1176 := &x.Values
+		yym1177 := z.DecBinary()
+		_ = yym1177
 		if false {
 		} else {
-			z.F.DecSliceStringX(yyv1124, false, d)
+			z.F.DecSliceStringX(yyv1176, false, d)
 		}
 	}
 	for {
-		yyj1121++
-		if yyhl1121 {
-			yyb1121 = yyj1121 > l
+		yyj1173++
+		if yyhl1173 {
+			yyb1173 = yyj1173 > l
 		} else {
-			yyb1121 = r.CheckBreak()
+			yyb1173 = r.CheckBreak()
 		}
-		if yyb1121 {
+		if yyb1173 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1121-1, "")
+		z.DecStructFieldNotFound(yyj1173-1, "")
 	}
 	r.ReadEnd()
 }
@@ -12618,8 +12930,8 @@ func (x PodSelectorOperator) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym1126 := z.EncBinary()
-	_ = yym1126
+	yym1178 := z.EncBinary()
+	_ = yym1178
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -12631,8 +12943,8 @@ func (x *PodSelectorOperator) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1127 := z.DecBinary()
-	_ = yym1127
+	yym1179 := z.DecBinary()
+	_ = yym1179
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -12645,9 +12957,9 @@ func (x codecSelfer1234) encSliceHorizontalPodAutoscaler(v []HorizontalPodAutosc
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1128 := range v {
-		yy1129 := &yyv1128
-		yy1129.CodecEncodeSelf(e)
+	for _, yyv1180 := range v {
+		yy1181 := &yyv1180
+		yy1181.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -12657,75 +12969,75 @@ func (x codecSelfer1234) decSliceHorizontalPodAutoscaler(v *[]HorizontalPodAutos
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1130 := *v
-	yyh1130, yyl1130 := z.DecSliceHelperStart()
+	yyv1182 := *v
+	yyh1182, yyl1182 := z.DecSliceHelperStart()
 
-	var yyrr1130, yyrl1130 int
-	var yyc1130, yyrt1130 bool
-	_, _, _ = yyc1130, yyrt1130, yyrl1130
-	yyrr1130 = yyl1130
+	var yyrr1182, yyrl1182 int
+	var yyc1182, yyrt1182 bool
+	_, _, _ = yyc1182, yyrt1182, yyrl1182
+	yyrr1182 = yyl1182
 
-	if yyv1130 == nil {
-		if yyrl1130, yyrt1130 = z.DecInferLen(yyl1130, z.DecBasicHandle().MaxInitLen, 336); yyrt1130 {
-			yyrr1130 = yyrl1130
+	if yyv1182 == nil {
+		if yyrl1182, yyrt1182 = z.DecInferLen(yyl1182, z.DecBasicHandle().MaxInitLen, 336); yyrt1182 {
+			yyrr1182 = yyrl1182
 		}
-		yyv1130 = make([]HorizontalPodAutoscaler, yyrl1130)
-		yyc1130 = true
+		yyv1182 = make([]HorizontalPodAutoscaler, yyrl1182)
+		yyc1182 = true
 	}
 
-	if yyl1130 == 0 {
-		if len(yyv1130) != 0 {
-			yyv1130 = yyv1130[:0]
-			yyc1130 = true
+	if yyl1182 == 0 {
+		if len(yyv1182) != 0 {
+			yyv1182 = yyv1182[:0]
+			yyc1182 = true
 		}
-	} else if yyl1130 > 0 {
+	} else if yyl1182 > 0 {
 
-		if yyl1130 > cap(yyv1130) {
-			yyrl1130, yyrt1130 = z.DecInferLen(yyl1130, z.DecBasicHandle().MaxInitLen, 336)
-			yyv1130 = make([]HorizontalPodAutoscaler, yyrl1130)
-			yyc1130 = true
+		if yyl1182 > cap(yyv1182) {
+			yyrl1182, yyrt1182 = z.DecInferLen(yyl1182, z.DecBasicHandle().MaxInitLen, 336)
+			yyv1182 = make([]HorizontalPodAutoscaler, yyrl1182)
+			yyc1182 = true
 
-			yyrr1130 = len(yyv1130)
-		} else if yyl1130 != len(yyv1130) {
-			yyv1130 = yyv1130[:yyl1130]
-			yyc1130 = true
+			yyrr1182 = len(yyv1182)
+		} else if yyl1182 != len(yyv1182) {
+			yyv1182 = yyv1182[:yyl1182]
+			yyc1182 = true
 		}
-		yyj1130 := 0
-		for ; yyj1130 < yyrr1130; yyj1130++ {
+		yyj1182 := 0
+		for ; yyj1182 < yyrr1182; yyj1182++ {
 			if r.TryDecodeAsNil() {
-				yyv1130[yyj1130] = HorizontalPodAutoscaler{}
+				yyv1182[yyj1182] = HorizontalPodAutoscaler{}
 			} else {
-				yyv1131 := &yyv1130[yyj1130]
-				yyv1131.CodecDecodeSelf(d)
+				yyv1183 := &yyv1182[yyj1182]
+				yyv1183.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1130 {
-			for ; yyj1130 < yyl1130; yyj1130++ {
-				yyv1130 = append(yyv1130, HorizontalPodAutoscaler{})
+		if yyrt1182 {
+			for ; yyj1182 < yyl1182; yyj1182++ {
+				yyv1182 = append(yyv1182, HorizontalPodAutoscaler{})
 				if r.TryDecodeAsNil() {
-					yyv1130[yyj1130] = HorizontalPodAutoscaler{}
+					yyv1182[yyj1182] = HorizontalPodAutoscaler{}
 				} else {
-					yyv1132 := &yyv1130[yyj1130]
-					yyv1132.CodecDecodeSelf(d)
+					yyv1184 := &yyv1182[yyj1182]
+					yyv1184.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1130 := 0; !r.CheckBreak(); yyj1130++ {
-			if yyj1130 >= len(yyv1130) {
-				yyv1130 = append(yyv1130, HorizontalPodAutoscaler{}) // var yyz1130 HorizontalPodAutoscaler
-				yyc1130 = true
+		for yyj1182 := 0; !r.CheckBreak(); yyj1182++ {
+			if yyj1182 >= len(yyv1182) {
+				yyv1182 = append(yyv1182, HorizontalPodAutoscaler{}) // var yyz1182 HorizontalPodAutoscaler
+				yyc1182 = true
 			}
 
-			if yyj1130 < len(yyv1130) {
+			if yyj1182 < len(yyv1182) {
 				if r.TryDecodeAsNil() {
-					yyv1130[yyj1130] = HorizontalPodAutoscaler{}
+					yyv1182[yyj1182] = HorizontalPodAutoscaler{}
 				} else {
-					yyv1133 := &yyv1130[yyj1130]
-					yyv1133.CodecDecodeSelf(d)
+					yyv1185 := &yyv1182[yyj1182]
+					yyv1185.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -12733,10 +13045,10 @@ func (x codecSelfer1234) decSliceHorizontalPodAutoscaler(v *[]HorizontalPodAutos
 			}
 
 		}
-		yyh1130.End()
+		yyh1182.End()
 	}
-	if yyc1130 {
-		*v = yyv1130
+	if yyc1182 {
+		*v = yyv1182
 	}
 
 }
@@ -12746,9 +13058,9 @@ func (x codecSelfer1234) encSliceAPIVersion(v []APIVersion, e *codec1978.Encoder
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1134 := range v {
-		yy1135 := &yyv1134
-		yy1135.CodecEncodeSelf(e)
+	for _, yyv1186 := range v {
+		yy1187 := &yyv1186
+		yy1187.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -12758,75 +13070,75 @@ func (x codecSelfer1234) decSliceAPIVersion(v *[]APIVersion, d *codec1978.Decode
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1136 := *v
-	yyh1136, yyl1136 := z.DecSliceHelperStart()
+	yyv1188 := *v
+	yyh1188, yyl1188 := z.DecSliceHelperStart()
 
-	var yyrr1136, yyrl1136 int
-	var yyc1136, yyrt1136 bool
-	_, _, _ = yyc1136, yyrt1136, yyrl1136
-	yyrr1136 = yyl1136
+	var yyrr1188, yyrl1188 int
+	var yyc1188, yyrt1188 bool
+	_, _, _ = yyc1188, yyrt1188, yyrl1188
+	yyrr1188 = yyl1188
 
-	if yyv1136 == nil {
-		if yyrl1136, yyrt1136 = z.DecInferLen(yyl1136, z.DecBasicHandle().MaxInitLen, 32); yyrt1136 {
-			yyrr1136 = yyrl1136
+	if yyv1188 == nil {
+		if yyrl1188, yyrt1188 = z.DecInferLen(yyl1188, z.DecBasicHandle().MaxInitLen, 32); yyrt1188 {
+			yyrr1188 = yyrl1188
 		}
-		yyv1136 = make([]APIVersion, yyrl1136)
-		yyc1136 = true
+		yyv1188 = make([]APIVersion, yyrl1188)
+		yyc1188 = true
 	}
 
-	if yyl1136 == 0 {
-		if len(yyv1136) != 0 {
-			yyv1136 = yyv1136[:0]
-			yyc1136 = true
+	if yyl1188 == 0 {
+		if len(yyv1188) != 0 {
+			yyv1188 = yyv1188[:0]
+			yyc1188 = true
 		}
-	} else if yyl1136 > 0 {
+	} else if yyl1188 > 0 {
 
-		if yyl1136 > cap(yyv1136) {
-			yyrl1136, yyrt1136 = z.DecInferLen(yyl1136, z.DecBasicHandle().MaxInitLen, 32)
-			yyv1136 = make([]APIVersion, yyrl1136)
-			yyc1136 = true
+		if yyl1188 > cap(yyv1188) {
+			yyrl1188, yyrt1188 = z.DecInferLen(yyl1188, z.DecBasicHandle().MaxInitLen, 32)
+			yyv1188 = make([]APIVersion, yyrl1188)
+			yyc1188 = true
 
-			yyrr1136 = len(yyv1136)
-		} else if yyl1136 != len(yyv1136) {
-			yyv1136 = yyv1136[:yyl1136]
-			yyc1136 = true
+			yyrr1188 = len(yyv1188)
+		} else if yyl1188 != len(yyv1188) {
+			yyv1188 = yyv1188[:yyl1188]
+			yyc1188 = true
 		}
-		yyj1136 := 0
-		for ; yyj1136 < yyrr1136; yyj1136++ {
+		yyj1188 := 0
+		for ; yyj1188 < yyrr1188; yyj1188++ {
 			if r.TryDecodeAsNil() {
-				yyv1136[yyj1136] = APIVersion{}
+				yyv1188[yyj1188] = APIVersion{}
 			} else {
-				yyv1137 := &yyv1136[yyj1136]
-				yyv1137.CodecDecodeSelf(d)
+				yyv1189 := &yyv1188[yyj1188]
+				yyv1189.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1136 {
-			for ; yyj1136 < yyl1136; yyj1136++ {
-				yyv1136 = append(yyv1136, APIVersion{})
+		if yyrt1188 {
+			for ; yyj1188 < yyl1188; yyj1188++ {
+				yyv1188 = append(yyv1188, APIVersion{})
 				if r.TryDecodeAsNil() {
-					yyv1136[yyj1136] = APIVersion{}
+					yyv1188[yyj1188] = APIVersion{}
 				} else {
-					yyv1138 := &yyv1136[yyj1136]
-					yyv1138.CodecDecodeSelf(d)
+					yyv1190 := &yyv1188[yyj1188]
+					yyv1190.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1136 := 0; !r.CheckBreak(); yyj1136++ {
-			if yyj1136 >= len(yyv1136) {
-				yyv1136 = append(yyv1136, APIVersion{}) // var yyz1136 APIVersion
-				yyc1136 = true
+		for yyj1188 := 0; !r.CheckBreak(); yyj1188++ {
+			if yyj1188 >= len(yyv1188) {
+				yyv1188 = append(yyv1188, APIVersion{}) // var yyz1188 APIVersion
+				yyc1188 = true
 			}
 
-			if yyj1136 < len(yyv1136) {
+			if yyj1188 < len(yyv1188) {
 				if r.TryDecodeAsNil() {
-					yyv1136[yyj1136] = APIVersion{}
+					yyv1188[yyj1188] = APIVersion{}
 				} else {
-					yyv1139 := &yyv1136[yyj1136]
-					yyv1139.CodecDecodeSelf(d)
+					yyv1191 := &yyv1188[yyj1188]
+					yyv1191.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -12834,10 +13146,10 @@ func (x codecSelfer1234) decSliceAPIVersion(v *[]APIVersion, d *codec1978.Decode
 			}
 
 		}
-		yyh1136.End()
+		yyh1188.End()
 	}
-	if yyc1136 {
-		*v = yyv1136
+	if yyc1188 {
+		*v = yyv1188
 	}
 
 }
@@ -12847,9 +13159,9 @@ func (x codecSelfer1234) encSliceThirdPartyResource(v []ThirdPartyResource, e *c
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1140 := range v {
-		yy1141 := &yyv1140
-		yy1141.CodecEncodeSelf(e)
+	for _, yyv1192 := range v {
+		yy1193 := &yyv1192
+		yy1193.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -12859,75 +13171,75 @@ func (x codecSelfer1234) decSliceThirdPartyResource(v *[]ThirdPartyResource, d *
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1142 := *v
-	yyh1142, yyl1142 := z.DecSliceHelperStart()
+	yyv1194 := *v
+	yyh1194, yyl1194 := z.DecSliceHelperStart()
 
-	var yyrr1142, yyrl1142 int
-	var yyc1142, yyrt1142 bool
-	_, _, _ = yyc1142, yyrt1142, yyrl1142
-	yyrr1142 = yyl1142
+	var yyrr1194, yyrl1194 int
+	var yyc1194, yyrt1194 bool
+	_, _, _ = yyc1194, yyrt1194, yyrl1194
+	yyrr1194 = yyl1194
 
-	if yyv1142 == nil {
-		if yyrl1142, yyrt1142 = z.DecInferLen(yyl1142, z.DecBasicHandle().MaxInitLen, 232); yyrt1142 {
-			yyrr1142 = yyrl1142
+	if yyv1194 == nil {
+		if yyrl1194, yyrt1194 = z.DecInferLen(yyl1194, z.DecBasicHandle().MaxInitLen, 232); yyrt1194 {
+			yyrr1194 = yyrl1194
 		}
-		yyv1142 = make([]ThirdPartyResource, yyrl1142)
-		yyc1142 = true
+		yyv1194 = make([]ThirdPartyResource, yyrl1194)
+		yyc1194 = true
 	}
 
-	if yyl1142 == 0 {
-		if len(yyv1142) != 0 {
-			yyv1142 = yyv1142[:0]
-			yyc1142 = true
+	if yyl1194 == 0 {
+		if len(yyv1194) != 0 {
+			yyv1194 = yyv1194[:0]
+			yyc1194 = true
 		}
-	} else if yyl1142 > 0 {
+	} else if yyl1194 > 0 {
 
-		if yyl1142 > cap(yyv1142) {
-			yyrl1142, yyrt1142 = z.DecInferLen(yyl1142, z.DecBasicHandle().MaxInitLen, 232)
-			yyv1142 = make([]ThirdPartyResource, yyrl1142)
-			yyc1142 = true
+		if yyl1194 > cap(yyv1194) {
+			yyrl1194, yyrt1194 = z.DecInferLen(yyl1194, z.DecBasicHandle().MaxInitLen, 232)
+			yyv1194 = make([]ThirdPartyResource, yyrl1194)
+			yyc1194 = true
 
-			yyrr1142 = len(yyv1142)
-		} else if yyl1142 != len(yyv1142) {
-			yyv1142 = yyv1142[:yyl1142]
-			yyc1142 = true
+			yyrr1194 = len(yyv1194)
+		} else if yyl1194 != len(yyv1194) {
+			yyv1194 = yyv1194[:yyl1194]
+			yyc1194 = true
 		}
-		yyj1142 := 0
-		for ; yyj1142 < yyrr1142; yyj1142++ {
+		yyj1194 := 0
+		for ; yyj1194 < yyrr1194; yyj1194++ {
 			if r.TryDecodeAsNil() {
-				yyv1142[yyj1142] = ThirdPartyResource{}
+				yyv1194[yyj1194] = ThirdPartyResource{}
 			} else {
-				yyv1143 := &yyv1142[yyj1142]
-				yyv1143.CodecDecodeSelf(d)
+				yyv1195 := &yyv1194[yyj1194]
+				yyv1195.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1142 {
-			for ; yyj1142 < yyl1142; yyj1142++ {
-				yyv1142 = append(yyv1142, ThirdPartyResource{})
+		if yyrt1194 {
+			for ; yyj1194 < yyl1194; yyj1194++ {
+				yyv1194 = append(yyv1194, ThirdPartyResource{})
 				if r.TryDecodeAsNil() {
-					yyv1142[yyj1142] = ThirdPartyResource{}
+					yyv1194[yyj1194] = ThirdPartyResource{}
 				} else {
-					yyv1144 := &yyv1142[yyj1142]
-					yyv1144.CodecDecodeSelf(d)
+					yyv1196 := &yyv1194[yyj1194]
+					yyv1196.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1142 := 0; !r.CheckBreak(); yyj1142++ {
-			if yyj1142 >= len(yyv1142) {
-				yyv1142 = append(yyv1142, ThirdPartyResource{}) // var yyz1142 ThirdPartyResource
-				yyc1142 = true
+		for yyj1194 := 0; !r.CheckBreak(); yyj1194++ {
+			if yyj1194 >= len(yyv1194) {
+				yyv1194 = append(yyv1194, ThirdPartyResource{}) // var yyz1194 ThirdPartyResource
+				yyc1194 = true
 			}
 
-			if yyj1142 < len(yyv1142) {
+			if yyj1194 < len(yyv1194) {
 				if r.TryDecodeAsNil() {
-					yyv1142[yyj1142] = ThirdPartyResource{}
+					yyv1194[yyj1194] = ThirdPartyResource{}
 				} else {
-					yyv1145 := &yyv1142[yyj1142]
-					yyv1145.CodecDecodeSelf(d)
+					yyv1197 := &yyv1194[yyj1194]
+					yyv1197.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -12935,10 +13247,10 @@ func (x codecSelfer1234) decSliceThirdPartyResource(v *[]ThirdPartyResource, d *
 			}
 
 		}
-		yyh1142.End()
+		yyh1194.End()
 	}
-	if yyc1142 {
-		*v = yyv1142
+	if yyc1194 {
+		*v = yyv1194
 	}
 
 }
@@ -12948,9 +13260,9 @@ func (x codecSelfer1234) encSliceDeployment(v []Deployment, e *codec1978.Encoder
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1146 := range v {
-		yy1147 := &yyv1146
-		yy1147.CodecEncodeSelf(e)
+	for _, yyv1198 := range v {
+		yy1199 := &yyv1198
+		yy1199.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -12960,75 +13272,75 @@ func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decode
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1148 := *v
-	yyh1148, yyl1148 := z.DecSliceHelperStart()
+	yyv1200 := *v
+	yyh1200, yyl1200 := z.DecSliceHelperStart()
 
-	var yyrr1148, yyrl1148 int
-	var yyc1148, yyrt1148 bool
-	_, _, _ = yyc1148, yyrt1148, yyrl1148
-	yyrr1148 = yyl1148
+	var yyrr1200, yyrl1200 int
+	var yyc1200, yyrt1200 bool
+	_, _, _ = yyc1200, yyrt1200, yyrl1200
+	yyrr1200 = yyl1200
 
-	if yyv1148 == nil {
-		if yyrl1148, yyrt1148 = z.DecInferLen(yyl1148, z.DecBasicHandle().MaxInitLen, 272); yyrt1148 {
-			yyrr1148 = yyrl1148
+	if yyv1200 == nil {
+		if yyrl1200, yyrt1200 = z.DecInferLen(yyl1200, z.DecBasicHandle().MaxInitLen, 272); yyrt1200 {
+			yyrr1200 = yyrl1200
 		}
-		yyv1148 = make([]Deployment, yyrl1148)
-		yyc1148 = true
+		yyv1200 = make([]Deployment, yyrl1200)
+		yyc1200 = true
 	}
 
-	if yyl1148 == 0 {
-		if len(yyv1148) != 0 {
-			yyv1148 = yyv1148[:0]
-			yyc1148 = true
+	if yyl1200 == 0 {
+		if len(yyv1200) != 0 {
+			yyv1200 = yyv1200[:0]
+			yyc1200 = true
 		}
-	} else if yyl1148 > 0 {
+	} else if yyl1200 > 0 {
 
-		if yyl1148 > cap(yyv1148) {
-			yyrl1148, yyrt1148 = z.DecInferLen(yyl1148, z.DecBasicHandle().MaxInitLen, 272)
-			yyv1148 = make([]Deployment, yyrl1148)
-			yyc1148 = true
+		if yyl1200 > cap(yyv1200) {
+			yyrl1200, yyrt1200 = z.DecInferLen(yyl1200, z.DecBasicHandle().MaxInitLen, 272)
+			yyv1200 = make([]Deployment, yyrl1200)
+			yyc1200 = true
 
-			yyrr1148 = len(yyv1148)
-		} else if yyl1148 != len(yyv1148) {
-			yyv1148 = yyv1148[:yyl1148]
-			yyc1148 = true
+			yyrr1200 = len(yyv1200)
+		} else if yyl1200 != len(yyv1200) {
+			yyv1200 = yyv1200[:yyl1200]
+			yyc1200 = true
 		}
-		yyj1148 := 0
-		for ; yyj1148 < yyrr1148; yyj1148++ {
+		yyj1200 := 0
+		for ; yyj1200 < yyrr1200; yyj1200++ {
 			if r.TryDecodeAsNil() {
-				yyv1148[yyj1148] = Deployment{}
+				yyv1200[yyj1200] = Deployment{}
 			} else {
-				yyv1149 := &yyv1148[yyj1148]
-				yyv1149.CodecDecodeSelf(d)
+				yyv1201 := &yyv1200[yyj1200]
+				yyv1201.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1148 {
-			for ; yyj1148 < yyl1148; yyj1148++ {
-				yyv1148 = append(yyv1148, Deployment{})
+		if yyrt1200 {
+			for ; yyj1200 < yyl1200; yyj1200++ {
+				yyv1200 = append(yyv1200, Deployment{})
 				if r.TryDecodeAsNil() {
-					yyv1148[yyj1148] = Deployment{}
+					yyv1200[yyj1200] = Deployment{}
 				} else {
-					yyv1150 := &yyv1148[yyj1148]
-					yyv1150.CodecDecodeSelf(d)
+					yyv1202 := &yyv1200[yyj1200]
+					yyv1202.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1148 := 0; !r.CheckBreak(); yyj1148++ {
-			if yyj1148 >= len(yyv1148) {
-				yyv1148 = append(yyv1148, Deployment{}) // var yyz1148 Deployment
-				yyc1148 = true
+		for yyj1200 := 0; !r.CheckBreak(); yyj1200++ {
+			if yyj1200 >= len(yyv1200) {
+				yyv1200 = append(yyv1200, Deployment{}) // var yyz1200 Deployment
+				yyc1200 = true
 			}
 
-			if yyj1148 < len(yyv1148) {
+			if yyj1200 < len(yyv1200) {
 				if r.TryDecodeAsNil() {
-					yyv1148[yyj1148] = Deployment{}
+					yyv1200[yyj1200] = Deployment{}
 				} else {
-					yyv1151 := &yyv1148[yyj1148]
-					yyv1151.CodecDecodeSelf(d)
+					yyv1203 := &yyv1200[yyj1200]
+					yyv1203.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13036,10 +13348,10 @@ func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decode
 			}
 
 		}
-		yyh1148.End()
+		yyh1200.End()
 	}
-	if yyc1148 {
-		*v = yyv1148
+	if yyc1200 {
+		*v = yyv1200
 	}
 
 }
@@ -13049,9 +13361,9 @@ func (x codecSelfer1234) encSliceDaemonSet(v []DaemonSet, e *codec1978.Encoder) 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1152 := range v {
-		yy1153 := &yyv1152
-		yy1153.CodecEncodeSelf(e)
+	for _, yyv1204 := range v {
+		yy1205 := &yyv1204
+		yy1205.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13061,75 +13373,75 @@ func (x codecSelfer1234) decSliceDaemonSet(v *[]DaemonSet, d *codec1978.Decoder)
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1154 := *v
-	yyh1154, yyl1154 := z.DecSliceHelperStart()
+	yyv1206 := *v
+	yyh1206, yyl1206 := z.DecSliceHelperStart()
 
-	var yyrr1154, yyrl1154 int
-	var yyc1154, yyrt1154 bool
-	_, _, _ = yyc1154, yyrt1154, yyrl1154
-	yyrr1154 = yyl1154
+	var yyrr1206, yyrl1206 int
+	var yyc1206, yyrt1206 bool
+	_, _, _ = yyc1206, yyrt1206, yyrl1206
+	yyrr1206 = yyl1206
 
-	if yyv1154 == nil {
-		if yyrl1154, yyrt1154 = z.DecInferLen(yyl1154, z.DecBasicHandle().MaxInitLen, 232); yyrt1154 {
-			yyrr1154 = yyrl1154
+	if yyv1206 == nil {
+		if yyrl1206, yyrt1206 = z.DecInferLen(yyl1206, z.DecBasicHandle().MaxInitLen, 232); yyrt1206 {
+			yyrr1206 = yyrl1206
 		}
-		yyv1154 = make([]DaemonSet, yyrl1154)
-		yyc1154 = true
+		yyv1206 = make([]DaemonSet, yyrl1206)
+		yyc1206 = true
 	}
 
-	if yyl1154 == 0 {
-		if len(yyv1154) != 0 {
-			yyv1154 = yyv1154[:0]
-			yyc1154 = true
+	if yyl1206 == 0 {
+		if len(yyv1206) != 0 {
+			yyv1206 = yyv1206[:0]
+			yyc1206 = true
 		}
-	} else if yyl1154 > 0 {
+	} else if yyl1206 > 0 {
 
-		if yyl1154 > cap(yyv1154) {
-			yyrl1154, yyrt1154 = z.DecInferLen(yyl1154, z.DecBasicHandle().MaxInitLen, 232)
-			yyv1154 = make([]DaemonSet, yyrl1154)
-			yyc1154 = true
+		if yyl1206 > cap(yyv1206) {
+			yyrl1206, yyrt1206 = z.DecInferLen(yyl1206, z.DecBasicHandle().MaxInitLen, 232)
+			yyv1206 = make([]DaemonSet, yyrl1206)
+			yyc1206 = true
 
-			yyrr1154 = len(yyv1154)
-		} else if yyl1154 != len(yyv1154) {
-			yyv1154 = yyv1154[:yyl1154]
-			yyc1154 = true
+			yyrr1206 = len(yyv1206)
+		} else if yyl1206 != len(yyv1206) {
+			yyv1206 = yyv1206[:yyl1206]
+			yyc1206 = true
 		}
-		yyj1154 := 0
-		for ; yyj1154 < yyrr1154; yyj1154++ {
+		yyj1206 := 0
+		for ; yyj1206 < yyrr1206; yyj1206++ {
 			if r.TryDecodeAsNil() {
-				yyv1154[yyj1154] = DaemonSet{}
+				yyv1206[yyj1206] = DaemonSet{}
 			} else {
-				yyv1155 := &yyv1154[yyj1154]
-				yyv1155.CodecDecodeSelf(d)
+				yyv1207 := &yyv1206[yyj1206]
+				yyv1207.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1154 {
-			for ; yyj1154 < yyl1154; yyj1154++ {
-				yyv1154 = append(yyv1154, DaemonSet{})
+		if yyrt1206 {
+			for ; yyj1206 < yyl1206; yyj1206++ {
+				yyv1206 = append(yyv1206, DaemonSet{})
 				if r.TryDecodeAsNil() {
-					yyv1154[yyj1154] = DaemonSet{}
+					yyv1206[yyj1206] = DaemonSet{}
 				} else {
-					yyv1156 := &yyv1154[yyj1154]
-					yyv1156.CodecDecodeSelf(d)
+					yyv1208 := &yyv1206[yyj1206]
+					yyv1208.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1154 := 0; !r.CheckBreak(); yyj1154++ {
-			if yyj1154 >= len(yyv1154) {
-				yyv1154 = append(yyv1154, DaemonSet{}) // var yyz1154 DaemonSet
-				yyc1154 = true
+		for yyj1206 := 0; !r.CheckBreak(); yyj1206++ {
+			if yyj1206 >= len(yyv1206) {
+				yyv1206 = append(yyv1206, DaemonSet{}) // var yyz1206 DaemonSet
+				yyc1206 = true
 			}
 
-			if yyj1154 < len(yyv1154) {
+			if yyj1206 < len(yyv1206) {
 				if r.TryDecodeAsNil() {
-					yyv1154[yyj1154] = DaemonSet{}
+					yyv1206[yyj1206] = DaemonSet{}
 				} else {
-					yyv1157 := &yyv1154[yyj1154]
-					yyv1157.CodecDecodeSelf(d)
+					yyv1209 := &yyv1206[yyj1206]
+					yyv1209.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13137,10 +13449,10 @@ func (x codecSelfer1234) decSliceDaemonSet(v *[]DaemonSet, d *codec1978.Decoder)
 			}
 
 		}
-		yyh1154.End()
+		yyh1206.End()
 	}
-	if yyc1154 {
-		*v = yyv1154
+	if yyc1206 {
+		*v = yyv1206
 	}
 
 }
@@ -13150,9 +13462,9 @@ func (x codecSelfer1234) encSliceThirdPartyResourceData(v []ThirdPartyResourceDa
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1158 := range v {
-		yy1159 := &yyv1158
-		yy1159.CodecEncodeSelf(e)
+	for _, yyv1210 := range v {
+		yy1211 := &yyv1210
+		yy1211.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13162,75 +13474,75 @@ func (x codecSelfer1234) decSliceThirdPartyResourceData(v *[]ThirdPartyResourceD
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1160 := *v
-	yyh1160, yyl1160 := z.DecSliceHelperStart()
+	yyv1212 := *v
+	yyh1212, yyl1212 := z.DecSliceHelperStart()
 
-	var yyrr1160, yyrl1160 int
-	var yyc1160, yyrt1160 bool
-	_, _, _ = yyc1160, yyrt1160, yyrl1160
-	yyrr1160 = yyl1160
+	var yyrr1212, yyrl1212 int
+	var yyc1212, yyrt1212 bool
+	_, _, _ = yyc1212, yyrt1212, yyrl1212
+	yyrr1212 = yyl1212
 
-	if yyv1160 == nil {
-		if yyrl1160, yyrt1160 = z.DecInferLen(yyl1160, z.DecBasicHandle().MaxInitLen, 216); yyrt1160 {
-			yyrr1160 = yyrl1160
+	if yyv1212 == nil {
+		if yyrl1212, yyrt1212 = z.DecInferLen(yyl1212, z.DecBasicHandle().MaxInitLen, 216); yyrt1212 {
+			yyrr1212 = yyrl1212
 		}
-		yyv1160 = make([]ThirdPartyResourceData, yyrl1160)
-		yyc1160 = true
+		yyv1212 = make([]ThirdPartyResourceData, yyrl1212)
+		yyc1212 = true
 	}
 
-	if yyl1160 == 0 {
-		if len(yyv1160) != 0 {
-			yyv1160 = yyv1160[:0]
-			yyc1160 = true
+	if yyl1212 == 0 {
+		if len(yyv1212) != 0 {
+			yyv1212 = yyv1212[:0]
+			yyc1212 = true
 		}
-	} else if yyl1160 > 0 {
+	} else if yyl1212 > 0 {
 
-		if yyl1160 > cap(yyv1160) {
-			yyrl1160, yyrt1160 = z.DecInferLen(yyl1160, z.DecBasicHandle().MaxInitLen, 216)
-			yyv1160 = make([]ThirdPartyResourceData, yyrl1160)
-			yyc1160 = true
+		if yyl1212 > cap(yyv1212) {
+			yyrl1212, yyrt1212 = z.DecInferLen(yyl1212, z.DecBasicHandle().MaxInitLen, 216)
+			yyv1212 = make([]ThirdPartyResourceData, yyrl1212)
+			yyc1212 = true
 
-			yyrr1160 = len(yyv1160)
-		} else if yyl1160 != len(yyv1160) {
-			yyv1160 = yyv1160[:yyl1160]
-			yyc1160 = true
+			yyrr1212 = len(yyv1212)
+		} else if yyl1212 != len(yyv1212) {
+			yyv1212 = yyv1212[:yyl1212]
+			yyc1212 = true
 		}
-		yyj1160 := 0
-		for ; yyj1160 < yyrr1160; yyj1160++ {
+		yyj1212 := 0
+		for ; yyj1212 < yyrr1212; yyj1212++ {
 			if r.TryDecodeAsNil() {
-				yyv1160[yyj1160] = ThirdPartyResourceData{}
+				yyv1212[yyj1212] = ThirdPartyResourceData{}
 			} else {
-				yyv1161 := &yyv1160[yyj1160]
-				yyv1161.CodecDecodeSelf(d)
+				yyv1213 := &yyv1212[yyj1212]
+				yyv1213.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1160 {
-			for ; yyj1160 < yyl1160; yyj1160++ {
-				yyv1160 = append(yyv1160, ThirdPartyResourceData{})
+		if yyrt1212 {
+			for ; yyj1212 < yyl1212; yyj1212++ {
+				yyv1212 = append(yyv1212, ThirdPartyResourceData{})
 				if r.TryDecodeAsNil() {
-					yyv1160[yyj1160] = ThirdPartyResourceData{}
+					yyv1212[yyj1212] = ThirdPartyResourceData{}
 				} else {
-					yyv1162 := &yyv1160[yyj1160]
-					yyv1162.CodecDecodeSelf(d)
+					yyv1214 := &yyv1212[yyj1212]
+					yyv1214.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1160 := 0; !r.CheckBreak(); yyj1160++ {
-			if yyj1160 >= len(yyv1160) {
-				yyv1160 = append(yyv1160, ThirdPartyResourceData{}) // var yyz1160 ThirdPartyResourceData
-				yyc1160 = true
+		for yyj1212 := 0; !r.CheckBreak(); yyj1212++ {
+			if yyj1212 >= len(yyv1212) {
+				yyv1212 = append(yyv1212, ThirdPartyResourceData{}) // var yyz1212 ThirdPartyResourceData
+				yyc1212 = true
 			}
 
-			if yyj1160 < len(yyv1160) {
+			if yyj1212 < len(yyv1212) {
 				if r.TryDecodeAsNil() {
-					yyv1160[yyj1160] = ThirdPartyResourceData{}
+					yyv1212[yyj1212] = ThirdPartyResourceData{}
 				} else {
-					yyv1163 := &yyv1160[yyj1160]
-					yyv1163.CodecDecodeSelf(d)
+					yyv1215 := &yyv1212[yyj1212]
+					yyv1215.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13238,10 +13550,10 @@ func (x codecSelfer1234) decSliceThirdPartyResourceData(v *[]ThirdPartyResourceD
 			}
 
 		}
-		yyh1160.End()
+		yyh1212.End()
 	}
-	if yyc1160 {
-		*v = yyv1160
+	if yyc1212 {
+		*v = yyv1212
 	}
 
 }
@@ -13251,9 +13563,9 @@ func (x codecSelfer1234) encSliceJob(v []Job, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1164 := range v {
-		yy1165 := &yyv1164
-		yy1165.CodecEncodeSelf(e)
+	for _, yyv1216 := range v {
+		yy1217 := &yyv1216
+		yy1217.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13263,75 +13575,75 @@ func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1166 := *v
-	yyh1166, yyl1166 := z.DecSliceHelperStart()
+	yyv1218 := *v
+	yyh1218, yyl1218 := z.DecSliceHelperStart()
 
-	var yyrr1166, yyrl1166 int
-	var yyc1166, yyrt1166 bool
-	_, _, _ = yyc1166, yyrt1166, yyrl1166
-	yyrr1166 = yyl1166
+	var yyrr1218, yyrl1218 int
+	var yyc1218, yyrt1218 bool
+	_, _, _ = yyc1218, yyrt1218, yyrl1218
+	yyrr1218 = yyl1218
 
-	if yyv1166 == nil {
-		if yyrl1166, yyrt1166 = z.DecInferLen(yyl1166, z.DecBasicHandle().MaxInitLen, 608); yyrt1166 {
-			yyrr1166 = yyrl1166
+	if yyv1218 == nil {
+		if yyrl1218, yyrt1218 = z.DecInferLen(yyl1218, z.DecBasicHandle().MaxInitLen, 608); yyrt1218 {
+			yyrr1218 = yyrl1218
 		}
-		yyv1166 = make([]Job, yyrl1166)
-		yyc1166 = true
+		yyv1218 = make([]Job, yyrl1218)
+		yyc1218 = true
 	}
 
-	if yyl1166 == 0 {
-		if len(yyv1166) != 0 {
-			yyv1166 = yyv1166[:0]
-			yyc1166 = true
+	if yyl1218 == 0 {
+		if len(yyv1218) != 0 {
+			yyv1218 = yyv1218[:0]
+			yyc1218 = true
 		}
-	} else if yyl1166 > 0 {
+	} else if yyl1218 > 0 {
 
-		if yyl1166 > cap(yyv1166) {
-			yyrl1166, yyrt1166 = z.DecInferLen(yyl1166, z.DecBasicHandle().MaxInitLen, 608)
-			yyv1166 = make([]Job, yyrl1166)
-			yyc1166 = true
+		if yyl1218 > cap(yyv1218) {
+			yyrl1218, yyrt1218 = z.DecInferLen(yyl1218, z.DecBasicHandle().MaxInitLen, 608)
+			yyv1218 = make([]Job, yyrl1218)
+			yyc1218 = true
 
-			yyrr1166 = len(yyv1166)
-		} else if yyl1166 != len(yyv1166) {
-			yyv1166 = yyv1166[:yyl1166]
-			yyc1166 = true
+			yyrr1218 = len(yyv1218)
+		} else if yyl1218 != len(yyv1218) {
+			yyv1218 = yyv1218[:yyl1218]
+			yyc1218 = true
 		}
-		yyj1166 := 0
-		for ; yyj1166 < yyrr1166; yyj1166++ {
+		yyj1218 := 0
+		for ; yyj1218 < yyrr1218; yyj1218++ {
 			if r.TryDecodeAsNil() {
-				yyv1166[yyj1166] = Job{}
+				yyv1218[yyj1218] = Job{}
 			} else {
-				yyv1167 := &yyv1166[yyj1166]
-				yyv1167.CodecDecodeSelf(d)
+				yyv1219 := &yyv1218[yyj1218]
+				yyv1219.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1166 {
-			for ; yyj1166 < yyl1166; yyj1166++ {
-				yyv1166 = append(yyv1166, Job{})
+		if yyrt1218 {
+			for ; yyj1218 < yyl1218; yyj1218++ {
+				yyv1218 = append(yyv1218, Job{})
 				if r.TryDecodeAsNil() {
-					yyv1166[yyj1166] = Job{}
+					yyv1218[yyj1218] = Job{}
 				} else {
-					yyv1168 := &yyv1166[yyj1166]
-					yyv1168.CodecDecodeSelf(d)
+					yyv1220 := &yyv1218[yyj1218]
+					yyv1220.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1166 := 0; !r.CheckBreak(); yyj1166++ {
-			if yyj1166 >= len(yyv1166) {
-				yyv1166 = append(yyv1166, Job{}) // var yyz1166 Job
-				yyc1166 = true
+		for yyj1218 := 0; !r.CheckBreak(); yyj1218++ {
+			if yyj1218 >= len(yyv1218) {
+				yyv1218 = append(yyv1218, Job{}) // var yyz1218 Job
+				yyc1218 = true
 			}
 
-			if yyj1166 < len(yyv1166) {
+			if yyj1218 < len(yyv1218) {
 				if r.TryDecodeAsNil() {
-					yyv1166[yyj1166] = Job{}
+					yyv1218[yyj1218] = Job{}
 				} else {
-					yyv1169 := &yyv1166[yyj1166]
-					yyv1169.CodecDecodeSelf(d)
+					yyv1221 := &yyv1218[yyj1218]
+					yyv1221.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13339,10 +13651,10 @@ func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh1166.End()
+		yyh1218.End()
 	}
-	if yyc1166 {
-		*v = yyv1166
+	if yyc1218 {
+		*v = yyv1218
 	}
 
 }
@@ -13352,9 +13664,9 @@ func (x codecSelfer1234) encSliceJobCondition(v []JobCondition, e *codec1978.Enc
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1170 := range v {
-		yy1171 := &yyv1170
-		yy1171.CodecEncodeSelf(e)
+	for _, yyv1222 := range v {
+		yy1223 := &yyv1222
+		yy1223.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13364,75 +13676,75 @@ func (x codecSelfer1234) decSliceJobCondition(v *[]JobCondition, d *codec1978.De
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1172 := *v
-	yyh1172, yyl1172 := z.DecSliceHelperStart()
+	yyv1224 := *v
+	yyh1224, yyl1224 := z.DecSliceHelperStart()
 
-	var yyrr1172, yyrl1172 int
-	var yyc1172, yyrt1172 bool
-	_, _, _ = yyc1172, yyrt1172, yyrl1172
-	yyrr1172 = yyl1172
+	var yyrr1224, yyrl1224 int
+	var yyc1224, yyrt1224 bool
+	_, _, _ = yyc1224, yyrt1224, yyrl1224
+	yyrr1224 = yyl1224
 
-	if yyv1172 == nil {
-		if yyrl1172, yyrt1172 = z.DecInferLen(yyl1172, z.DecBasicHandle().MaxInitLen, 112); yyrt1172 {
-			yyrr1172 = yyrl1172
+	if yyv1224 == nil {
+		if yyrl1224, yyrt1224 = z.DecInferLen(yyl1224, z.DecBasicHandle().MaxInitLen, 112); yyrt1224 {
+			yyrr1224 = yyrl1224
 		}
-		yyv1172 = make([]JobCondition, yyrl1172)
-		yyc1172 = true
+		yyv1224 = make([]JobCondition, yyrl1224)
+		yyc1224 = true
 	}
 
-	if yyl1172 == 0 {
-		if len(yyv1172) != 0 {
-			yyv1172 = yyv1172[:0]
-			yyc1172 = true
+	if yyl1224 == 0 {
+		if len(yyv1224) != 0 {
+			yyv1224 = yyv1224[:0]
+			yyc1224 = true
 		}
-	} else if yyl1172 > 0 {
+	} else if yyl1224 > 0 {
 
-		if yyl1172 > cap(yyv1172) {
-			yyrl1172, yyrt1172 = z.DecInferLen(yyl1172, z.DecBasicHandle().MaxInitLen, 112)
-			yyv1172 = make([]JobCondition, yyrl1172)
-			yyc1172 = true
+		if yyl1224 > cap(yyv1224) {
+			yyrl1224, yyrt1224 = z.DecInferLen(yyl1224, z.DecBasicHandle().MaxInitLen, 112)
+			yyv1224 = make([]JobCondition, yyrl1224)
+			yyc1224 = true
 
-			yyrr1172 = len(yyv1172)
-		} else if yyl1172 != len(yyv1172) {
-			yyv1172 = yyv1172[:yyl1172]
-			yyc1172 = true
+			yyrr1224 = len(yyv1224)
+		} else if yyl1224 != len(yyv1224) {
+			yyv1224 = yyv1224[:yyl1224]
+			yyc1224 = true
 		}
-		yyj1172 := 0
-		for ; yyj1172 < yyrr1172; yyj1172++ {
+		yyj1224 := 0
+		for ; yyj1224 < yyrr1224; yyj1224++ {
 			if r.TryDecodeAsNil() {
-				yyv1172[yyj1172] = JobCondition{}
+				yyv1224[yyj1224] = JobCondition{}
 			} else {
-				yyv1173 := &yyv1172[yyj1172]
-				yyv1173.CodecDecodeSelf(d)
+				yyv1225 := &yyv1224[yyj1224]
+				yyv1225.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1172 {
-			for ; yyj1172 < yyl1172; yyj1172++ {
-				yyv1172 = append(yyv1172, JobCondition{})
+		if yyrt1224 {
+			for ; yyj1224 < yyl1224; yyj1224++ {
+				yyv1224 = append(yyv1224, JobCondition{})
 				if r.TryDecodeAsNil() {
-					yyv1172[yyj1172] = JobCondition{}
+					yyv1224[yyj1224] = JobCondition{}
 				} else {
-					yyv1174 := &yyv1172[yyj1172]
-					yyv1174.CodecDecodeSelf(d)
+					yyv1226 := &yyv1224[yyj1224]
+					yyv1226.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1172 := 0; !r.CheckBreak(); yyj1172++ {
-			if yyj1172 >= len(yyv1172) {
-				yyv1172 = append(yyv1172, JobCondition{}) // var yyz1172 JobCondition
-				yyc1172 = true
+		for yyj1224 := 0; !r.CheckBreak(); yyj1224++ {
+			if yyj1224 >= len(yyv1224) {
+				yyv1224 = append(yyv1224, JobCondition{}) // var yyz1224 JobCondition
+				yyc1224 = true
 			}
 
-			if yyj1172 < len(yyv1172) {
+			if yyj1224 < len(yyv1224) {
 				if r.TryDecodeAsNil() {
-					yyv1172[yyj1172] = JobCondition{}
+					yyv1224[yyj1224] = JobCondition{}
 				} else {
-					yyv1175 := &yyv1172[yyj1172]
-					yyv1175.CodecDecodeSelf(d)
+					yyv1227 := &yyv1224[yyj1224]
+					yyv1227.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13440,10 +13752,10 @@ func (x codecSelfer1234) decSliceJobCondition(v *[]JobCondition, d *codec1978.De
 			}
 
 		}
-		yyh1172.End()
+		yyh1224.End()
 	}
-	if yyc1172 {
-		*v = yyv1172
+	if yyc1224 {
+		*v = yyv1224
 	}
 
 }
@@ -13453,9 +13765,9 @@ func (x codecSelfer1234) encSliceIngress(v []Ingress, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1176 := range v {
-		yy1177 := &yyv1176
-		yy1177.CodecEncodeSelf(e)
+	for _, yyv1228 := range v {
+		yy1229 := &yyv1228
+		yy1229.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13465,75 +13777,75 @@ func (x codecSelfer1234) decSliceIngress(v *[]Ingress, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1178 := *v
-	yyh1178, yyl1178 := z.DecSliceHelperStart()
+	yyv1230 := *v
+	yyh1230, yyl1230 := z.DecSliceHelperStart()
 
-	var yyrr1178, yyrl1178 int
-	var yyc1178, yyrt1178 bool
-	_, _, _ = yyc1178, yyrt1178, yyrl1178
-	yyrr1178 = yyl1178
+	var yyrr1230, yyrl1230 int
+	var yyc1230, yyrt1230 bool
+	_, _, _ = yyc1230, yyrt1230, yyrl1230
+	yyrr1230 = yyl1230
 
-	if yyv1178 == nil {
-		if yyrl1178, yyrt1178 = z.DecInferLen(yyl1178, z.DecBasicHandle().MaxInitLen, 248); yyrt1178 {
-			yyrr1178 = yyrl1178
+	if yyv1230 == nil {
+		if yyrl1230, yyrt1230 = z.DecInferLen(yyl1230, z.DecBasicHandle().MaxInitLen, 248); yyrt1230 {
+			yyrr1230 = yyrl1230
 		}
-		yyv1178 = make([]Ingress, yyrl1178)
-		yyc1178 = true
+		yyv1230 = make([]Ingress, yyrl1230)
+		yyc1230 = true
 	}
 
-	if yyl1178 == 0 {
-		if len(yyv1178) != 0 {
-			yyv1178 = yyv1178[:0]
-			yyc1178 = true
+	if yyl1230 == 0 {
+		if len(yyv1230) != 0 {
+			yyv1230 = yyv1230[:0]
+			yyc1230 = true
 		}
-	} else if yyl1178 > 0 {
+	} else if yyl1230 > 0 {
 
-		if yyl1178 > cap(yyv1178) {
-			yyrl1178, yyrt1178 = z.DecInferLen(yyl1178, z.DecBasicHandle().MaxInitLen, 248)
-			yyv1178 = make([]Ingress, yyrl1178)
-			yyc1178 = true
+		if yyl1230 > cap(yyv1230) {
+			yyrl1230, yyrt1230 = z.DecInferLen(yyl1230, z.DecBasicHandle().MaxInitLen, 248)
+			yyv1230 = make([]Ingress, yyrl1230)
+			yyc1230 = true
 
-			yyrr1178 = len(yyv1178)
-		} else if yyl1178 != len(yyv1178) {
-			yyv1178 = yyv1178[:yyl1178]
-			yyc1178 = true
+			yyrr1230 = len(yyv1230)
+		} else if yyl1230 != len(yyv1230) {
+			yyv1230 = yyv1230[:yyl1230]
+			yyc1230 = true
 		}
-		yyj1178 := 0
-		for ; yyj1178 < yyrr1178; yyj1178++ {
+		yyj1230 := 0
+		for ; yyj1230 < yyrr1230; yyj1230++ {
 			if r.TryDecodeAsNil() {
-				yyv1178[yyj1178] = Ingress{}
+				yyv1230[yyj1230] = Ingress{}
 			} else {
-				yyv1179 := &yyv1178[yyj1178]
-				yyv1179.CodecDecodeSelf(d)
+				yyv1231 := &yyv1230[yyj1230]
+				yyv1231.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1178 {
-			for ; yyj1178 < yyl1178; yyj1178++ {
-				yyv1178 = append(yyv1178, Ingress{})
+		if yyrt1230 {
+			for ; yyj1230 < yyl1230; yyj1230++ {
+				yyv1230 = append(yyv1230, Ingress{})
 				if r.TryDecodeAsNil() {
-					yyv1178[yyj1178] = Ingress{}
+					yyv1230[yyj1230] = Ingress{}
 				} else {
-					yyv1180 := &yyv1178[yyj1178]
-					yyv1180.CodecDecodeSelf(d)
+					yyv1232 := &yyv1230[yyj1230]
+					yyv1232.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1178 := 0; !r.CheckBreak(); yyj1178++ {
-			if yyj1178 >= len(yyv1178) {
-				yyv1178 = append(yyv1178, Ingress{}) // var yyz1178 Ingress
-				yyc1178 = true
+		for yyj1230 := 0; !r.CheckBreak(); yyj1230++ {
+			if yyj1230 >= len(yyv1230) {
+				yyv1230 = append(yyv1230, Ingress{}) // var yyz1230 Ingress
+				yyc1230 = true
 			}
 
-			if yyj1178 < len(yyv1178) {
+			if yyj1230 < len(yyv1230) {
 				if r.TryDecodeAsNil() {
-					yyv1178[yyj1178] = Ingress{}
+					yyv1230[yyj1230] = Ingress{}
 				} else {
-					yyv1181 := &yyv1178[yyj1178]
-					yyv1181.CodecDecodeSelf(d)
+					yyv1233 := &yyv1230[yyj1230]
+					yyv1233.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13541,10 +13853,10 @@ func (x codecSelfer1234) decSliceIngress(v *[]Ingress, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh1178.End()
+		yyh1230.End()
 	}
-	if yyc1178 {
-		*v = yyv1178
+	if yyc1230 {
+		*v = yyv1230
 	}
 
 }
@@ -13554,9 +13866,9 @@ func (x codecSelfer1234) encSliceIngressRule(v []IngressRule, e *codec1978.Encod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1182 := range v {
-		yy1183 := &yyv1182
-		yy1183.CodecEncodeSelf(e)
+	for _, yyv1234 := range v {
+		yy1235 := &yyv1234
+		yy1235.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13566,75 +13878,75 @@ func (x codecSelfer1234) decSliceIngressRule(v *[]IngressRule, d *codec1978.Deco
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1184 := *v
-	yyh1184, yyl1184 := z.DecSliceHelperStart()
+	yyv1236 := *v
+	yyh1236, yyl1236 := z.DecSliceHelperStart()
 
-	var yyrr1184, yyrl1184 int
-	var yyc1184, yyrt1184 bool
-	_, _, _ = yyc1184, yyrt1184, yyrl1184
-	yyrr1184 = yyl1184
+	var yyrr1236, yyrl1236 int
+	var yyc1236, yyrt1236 bool
+	_, _, _ = yyc1236, yyrt1236, yyrl1236
+	yyrr1236 = yyl1236
 
-	if yyv1184 == nil {
-		if yyrl1184, yyrt1184 = z.DecInferLen(yyl1184, z.DecBasicHandle().MaxInitLen, 24); yyrt1184 {
-			yyrr1184 = yyrl1184
+	if yyv1236 == nil {
+		if yyrl1236, yyrt1236 = z.DecInferLen(yyl1236, z.DecBasicHandle().MaxInitLen, 24); yyrt1236 {
+			yyrr1236 = yyrl1236
 		}
-		yyv1184 = make([]IngressRule, yyrl1184)
-		yyc1184 = true
+		yyv1236 = make([]IngressRule, yyrl1236)
+		yyc1236 = true
 	}
 
-	if yyl1184 == 0 {
-		if len(yyv1184) != 0 {
-			yyv1184 = yyv1184[:0]
-			yyc1184 = true
+	if yyl1236 == 0 {
+		if len(yyv1236) != 0 {
+			yyv1236 = yyv1236[:0]
+			yyc1236 = true
 		}
-	} else if yyl1184 > 0 {
+	} else if yyl1236 > 0 {
 
-		if yyl1184 > cap(yyv1184) {
-			yyrl1184, yyrt1184 = z.DecInferLen(yyl1184, z.DecBasicHandle().MaxInitLen, 24)
-			yyv1184 = make([]IngressRule, yyrl1184)
-			yyc1184 = true
+		if yyl1236 > cap(yyv1236) {
+			yyrl1236, yyrt1236 = z.DecInferLen(yyl1236, z.DecBasicHandle().MaxInitLen, 24)
+			yyv1236 = make([]IngressRule, yyrl1236)
+			yyc1236 = true
 
-			yyrr1184 = len(yyv1184)
-		} else if yyl1184 != len(yyv1184) {
-			yyv1184 = yyv1184[:yyl1184]
-			yyc1184 = true
+			yyrr1236 = len(yyv1236)
+		} else if yyl1236 != len(yyv1236) {
+			yyv1236 = yyv1236[:yyl1236]
+			yyc1236 = true
 		}
-		yyj1184 := 0
-		for ; yyj1184 < yyrr1184; yyj1184++ {
+		yyj1236 := 0
+		for ; yyj1236 < yyrr1236; yyj1236++ {
 			if r.TryDecodeAsNil() {
-				yyv1184[yyj1184] = IngressRule{}
+				yyv1236[yyj1236] = IngressRule{}
 			} else {
-				yyv1185 := &yyv1184[yyj1184]
-				yyv1185.CodecDecodeSelf(d)
+				yyv1237 := &yyv1236[yyj1236]
+				yyv1237.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1184 {
-			for ; yyj1184 < yyl1184; yyj1184++ {
-				yyv1184 = append(yyv1184, IngressRule{})
+		if yyrt1236 {
+			for ; yyj1236 < yyl1236; yyj1236++ {
+				yyv1236 = append(yyv1236, IngressRule{})
 				if r.TryDecodeAsNil() {
-					yyv1184[yyj1184] = IngressRule{}
+					yyv1236[yyj1236] = IngressRule{}
 				} else {
-					yyv1186 := &yyv1184[yyj1184]
-					yyv1186.CodecDecodeSelf(d)
+					yyv1238 := &yyv1236[yyj1236]
+					yyv1238.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1184 := 0; !r.CheckBreak(); yyj1184++ {
-			if yyj1184 >= len(yyv1184) {
-				yyv1184 = append(yyv1184, IngressRule{}) // var yyz1184 IngressRule
-				yyc1184 = true
+		for yyj1236 := 0; !r.CheckBreak(); yyj1236++ {
+			if yyj1236 >= len(yyv1236) {
+				yyv1236 = append(yyv1236, IngressRule{}) // var yyz1236 IngressRule
+				yyc1236 = true
 			}
 
-			if yyj1184 < len(yyv1184) {
+			if yyj1236 < len(yyv1236) {
 				if r.TryDecodeAsNil() {
-					yyv1184[yyj1184] = IngressRule{}
+					yyv1236[yyj1236] = IngressRule{}
 				} else {
-					yyv1187 := &yyv1184[yyj1184]
-					yyv1187.CodecDecodeSelf(d)
+					yyv1239 := &yyv1236[yyj1236]
+					yyv1239.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13642,10 +13954,10 @@ func (x codecSelfer1234) decSliceIngressRule(v *[]IngressRule, d *codec1978.Deco
 			}
 
 		}
-		yyh1184.End()
+		yyh1236.End()
 	}
-	if yyc1184 {
-		*v = yyv1184
+	if yyc1236 {
+		*v = yyv1236
 	}
 
 }
@@ -13655,9 +13967,9 @@ func (x codecSelfer1234) encSliceHTTPIngressPath(v []HTTPIngressPath, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1188 := range v {
-		yy1189 := &yyv1188
-		yy1189.CodecEncodeSelf(e)
+	for _, yyv1240 := range v {
+		yy1241 := &yyv1240
+		yy1241.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13667,75 +13979,75 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1190 := *v
-	yyh1190, yyl1190 := z.DecSliceHelperStart()
+	yyv1242 := *v
+	yyh1242, yyl1242 := z.DecSliceHelperStart()
 
-	var yyrr1190, yyrl1190 int
-	var yyc1190, yyrt1190 bool
-	_, _, _ = yyc1190, yyrt1190, yyrl1190
-	yyrr1190 = yyl1190
+	var yyrr1242, yyrl1242 int
+	var yyc1242, yyrt1242 bool
+	_, _, _ = yyc1242, yyrt1242, yyrl1242
+	yyrr1242 = yyl1242
 
-	if yyv1190 == nil {
-		if yyrl1190, yyrt1190 = z.DecInferLen(yyl1190, z.DecBasicHandle().MaxInitLen, 64); yyrt1190 {
-			yyrr1190 = yyrl1190
+	if yyv1242 == nil {
+		if yyrl1242, yyrt1242 = z.DecInferLen(yyl1242, z.DecBasicHandle().MaxInitLen, 64); yyrt1242 {
+			yyrr1242 = yyrl1242
 		}
-		yyv1190 = make([]HTTPIngressPath, yyrl1190)
-		yyc1190 = true
+		yyv1242 = make([]HTTPIngressPath, yyrl1242)
+		yyc1242 = true
 	}
 
-	if yyl1190 == 0 {
-		if len(yyv1190) != 0 {
-			yyv1190 = yyv1190[:0]
-			yyc1190 = true
+	if yyl1242 == 0 {
+		if len(yyv1242) != 0 {
+			yyv1242 = yyv1242[:0]
+			yyc1242 = true
 		}
-	} else if yyl1190 > 0 {
+	} else if yyl1242 > 0 {
 
-		if yyl1190 > cap(yyv1190) {
-			yyrl1190, yyrt1190 = z.DecInferLen(yyl1190, z.DecBasicHandle().MaxInitLen, 64)
-			yyv1190 = make([]HTTPIngressPath, yyrl1190)
-			yyc1190 = true
+		if yyl1242 > cap(yyv1242) {
+			yyrl1242, yyrt1242 = z.DecInferLen(yyl1242, z.DecBasicHandle().MaxInitLen, 64)
+			yyv1242 = make([]HTTPIngressPath, yyrl1242)
+			yyc1242 = true
 
-			yyrr1190 = len(yyv1190)
-		} else if yyl1190 != len(yyv1190) {
-			yyv1190 = yyv1190[:yyl1190]
-			yyc1190 = true
+			yyrr1242 = len(yyv1242)
+		} else if yyl1242 != len(yyv1242) {
+			yyv1242 = yyv1242[:yyl1242]
+			yyc1242 = true
 		}
-		yyj1190 := 0
-		for ; yyj1190 < yyrr1190; yyj1190++ {
+		yyj1242 := 0
+		for ; yyj1242 < yyrr1242; yyj1242++ {
 			if r.TryDecodeAsNil() {
-				yyv1190[yyj1190] = HTTPIngressPath{}
+				yyv1242[yyj1242] = HTTPIngressPath{}
 			} else {
-				yyv1191 := &yyv1190[yyj1190]
-				yyv1191.CodecDecodeSelf(d)
+				yyv1243 := &yyv1242[yyj1242]
+				yyv1243.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1190 {
-			for ; yyj1190 < yyl1190; yyj1190++ {
-				yyv1190 = append(yyv1190, HTTPIngressPath{})
+		if yyrt1242 {
+			for ; yyj1242 < yyl1242; yyj1242++ {
+				yyv1242 = append(yyv1242, HTTPIngressPath{})
 				if r.TryDecodeAsNil() {
-					yyv1190[yyj1190] = HTTPIngressPath{}
+					yyv1242[yyj1242] = HTTPIngressPath{}
 				} else {
-					yyv1192 := &yyv1190[yyj1190]
-					yyv1192.CodecDecodeSelf(d)
+					yyv1244 := &yyv1242[yyj1242]
+					yyv1244.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1190 := 0; !r.CheckBreak(); yyj1190++ {
-			if yyj1190 >= len(yyv1190) {
-				yyv1190 = append(yyv1190, HTTPIngressPath{}) // var yyz1190 HTTPIngressPath
-				yyc1190 = true
+		for yyj1242 := 0; !r.CheckBreak(); yyj1242++ {
+			if yyj1242 >= len(yyv1242) {
+				yyv1242 = append(yyv1242, HTTPIngressPath{}) // var yyz1242 HTTPIngressPath
+				yyc1242 = true
 			}
 
-			if yyj1190 < len(yyv1190) {
+			if yyj1242 < len(yyv1242) {
 				if r.TryDecodeAsNil() {
-					yyv1190[yyj1190] = HTTPIngressPath{}
+					yyv1242[yyj1242] = HTTPIngressPath{}
 				} else {
-					yyv1193 := &yyv1190[yyj1190]
-					yyv1193.CodecDecodeSelf(d)
+					yyv1245 := &yyv1242[yyj1242]
+					yyv1245.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13743,10 +14055,10 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 			}
 
 		}
-		yyh1190.End()
+		yyh1242.End()
 	}
-	if yyc1190 {
-		*v = yyv1190
+	if yyc1242 {
+		*v = yyv1242
 	}
 
 }
@@ -13756,9 +14068,9 @@ func (x codecSelfer1234) encSliceNodeUtilization(v []NodeUtilization, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1194 := range v {
-		yy1195 := &yyv1194
-		yy1195.CodecEncodeSelf(e)
+	for _, yyv1246 := range v {
+		yy1247 := &yyv1246
+		yy1247.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13768,75 +14080,75 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1196 := *v
-	yyh1196, yyl1196 := z.DecSliceHelperStart()
+	yyv1248 := *v
+	yyh1248, yyl1248 := z.DecSliceHelperStart()
 
-	var yyrr1196, yyrl1196 int
-	var yyc1196, yyrt1196 bool
-	_, _, _ = yyc1196, yyrt1196, yyrl1196
-	yyrr1196 = yyl1196
+	var yyrr1248, yyrl1248 int
+	var yyc1248, yyrt1248 bool
+	_, _, _ = yyc1248, yyrt1248, yyrl1248
+	yyrr1248 = yyl1248
 
-	if yyv1196 == nil {
-		if yyrl1196, yyrt1196 = z.DecInferLen(yyl1196, z.DecBasicHandle().MaxInitLen, 24); yyrt1196 {
-			yyrr1196 = yyrl1196
+	if yyv1248 == nil {
+		if yyrl1248, yyrt1248 = z.DecInferLen(yyl1248, z.DecBasicHandle().MaxInitLen, 24); yyrt1248 {
+			yyrr1248 = yyrl1248
 		}
-		yyv1196 = make([]NodeUtilization, yyrl1196)
-		yyc1196 = true
+		yyv1248 = make([]NodeUtilization, yyrl1248)
+		yyc1248 = true
 	}
 
-	if yyl1196 == 0 {
-		if len(yyv1196) != 0 {
-			yyv1196 = yyv1196[:0]
-			yyc1196 = true
+	if yyl1248 == 0 {
+		if len(yyv1248) != 0 {
+			yyv1248 = yyv1248[:0]
+			yyc1248 = true
 		}
-	} else if yyl1196 > 0 {
+	} else if yyl1248 > 0 {
 
-		if yyl1196 > cap(yyv1196) {
-			yyrl1196, yyrt1196 = z.DecInferLen(yyl1196, z.DecBasicHandle().MaxInitLen, 24)
-			yyv1196 = make([]NodeUtilization, yyrl1196)
-			yyc1196 = true
+		if yyl1248 > cap(yyv1248) {
+			yyrl1248, yyrt1248 = z.DecInferLen(yyl1248, z.DecBasicHandle().MaxInitLen, 24)
+			yyv1248 = make([]NodeUtilization, yyrl1248)
+			yyc1248 = true
 
-			yyrr1196 = len(yyv1196)
-		} else if yyl1196 != len(yyv1196) {
-			yyv1196 = yyv1196[:yyl1196]
-			yyc1196 = true
+			yyrr1248 = len(yyv1248)
+		} else if yyl1248 != len(yyv1248) {
+			yyv1248 = yyv1248[:yyl1248]
+			yyc1248 = true
 		}
-		yyj1196 := 0
-		for ; yyj1196 < yyrr1196; yyj1196++ {
+		yyj1248 := 0
+		for ; yyj1248 < yyrr1248; yyj1248++ {
 			if r.TryDecodeAsNil() {
-				yyv1196[yyj1196] = NodeUtilization{}
+				yyv1248[yyj1248] = NodeUtilization{}
 			} else {
-				yyv1197 := &yyv1196[yyj1196]
-				yyv1197.CodecDecodeSelf(d)
+				yyv1249 := &yyv1248[yyj1248]
+				yyv1249.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1196 {
-			for ; yyj1196 < yyl1196; yyj1196++ {
-				yyv1196 = append(yyv1196, NodeUtilization{})
+		if yyrt1248 {
+			for ; yyj1248 < yyl1248; yyj1248++ {
+				yyv1248 = append(yyv1248, NodeUtilization{})
 				if r.TryDecodeAsNil() {
-					yyv1196[yyj1196] = NodeUtilization{}
+					yyv1248[yyj1248] = NodeUtilization{}
 				} else {
-					yyv1198 := &yyv1196[yyj1196]
-					yyv1198.CodecDecodeSelf(d)
+					yyv1250 := &yyv1248[yyj1248]
+					yyv1250.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1196 := 0; !r.CheckBreak(); yyj1196++ {
-			if yyj1196 >= len(yyv1196) {
-				yyv1196 = append(yyv1196, NodeUtilization{}) // var yyz1196 NodeUtilization
-				yyc1196 = true
+		for yyj1248 := 0; !r.CheckBreak(); yyj1248++ {
+			if yyj1248 >= len(yyv1248) {
+				yyv1248 = append(yyv1248, NodeUtilization{}) // var yyz1248 NodeUtilization
+				yyc1248 = true
 			}
 
-			if yyj1196 < len(yyv1196) {
+			if yyj1248 < len(yyv1248) {
 				if r.TryDecodeAsNil() {
-					yyv1196[yyj1196] = NodeUtilization{}
+					yyv1248[yyj1248] = NodeUtilization{}
 				} else {
-					yyv1199 := &yyv1196[yyj1196]
-					yyv1199.CodecDecodeSelf(d)
+					yyv1251 := &yyv1248[yyj1248]
+					yyv1251.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13844,10 +14156,10 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 			}
 
 		}
-		yyh1196.End()
+		yyh1248.End()
 	}
-	if yyc1196 {
-		*v = yyv1196
+	if yyc1248 {
+		*v = yyv1248
 	}
 
 }
@@ -13857,9 +14169,9 @@ func (x codecSelfer1234) encSliceClusterAutoscaler(v []ClusterAutoscaler, e *cod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1200 := range v {
-		yy1201 := &yyv1200
-		yy1201.CodecEncodeSelf(e)
+	for _, yyv1252 := range v {
+		yy1253 := &yyv1252
+		yy1253.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13869,75 +14181,75 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1202 := *v
-	yyh1202, yyl1202 := z.DecSliceHelperStart()
+	yyv1254 := *v
+	yyh1254, yyl1254 := z.DecSliceHelperStart()
 
-	var yyrr1202, yyrl1202 int
-	var yyc1202, yyrt1202 bool
-	_, _, _ = yyc1202, yyrt1202, yyrl1202
-	yyrr1202 = yyl1202
+	var yyrr1254, yyrl1254 int
+	var yyc1254, yyrt1254 bool
+	_, _, _ = yyc1254, yyrt1254, yyrl1254
+	yyrr1254 = yyl1254
 
-	if yyv1202 == nil {
-		if yyrl1202, yyrt1202 = z.DecInferLen(yyl1202, z.DecBasicHandle().MaxInitLen, 232); yyrt1202 {
-			yyrr1202 = yyrl1202
+	if yyv1254 == nil {
+		if yyrl1254, yyrt1254 = z.DecInferLen(yyl1254, z.DecBasicHandle().MaxInitLen, 232); yyrt1254 {
+			yyrr1254 = yyrl1254
 		}
-		yyv1202 = make([]ClusterAutoscaler, yyrl1202)
-		yyc1202 = true
+		yyv1254 = make([]ClusterAutoscaler, yyrl1254)
+		yyc1254 = true
 	}
 
-	if yyl1202 == 0 {
-		if len(yyv1202) != 0 {
-			yyv1202 = yyv1202[:0]
-			yyc1202 = true
+	if yyl1254 == 0 {
+		if len(yyv1254) != 0 {
+			yyv1254 = yyv1254[:0]
+			yyc1254 = true
 		}
-	} else if yyl1202 > 0 {
+	} else if yyl1254 > 0 {
 
-		if yyl1202 > cap(yyv1202) {
-			yyrl1202, yyrt1202 = z.DecInferLen(yyl1202, z.DecBasicHandle().MaxInitLen, 232)
-			yyv1202 = make([]ClusterAutoscaler, yyrl1202)
-			yyc1202 = true
+		if yyl1254 > cap(yyv1254) {
+			yyrl1254, yyrt1254 = z.DecInferLen(yyl1254, z.DecBasicHandle().MaxInitLen, 232)
+			yyv1254 = make([]ClusterAutoscaler, yyrl1254)
+			yyc1254 = true
 
-			yyrr1202 = len(yyv1202)
-		} else if yyl1202 != len(yyv1202) {
-			yyv1202 = yyv1202[:yyl1202]
-			yyc1202 = true
+			yyrr1254 = len(yyv1254)
+		} else if yyl1254 != len(yyv1254) {
+			yyv1254 = yyv1254[:yyl1254]
+			yyc1254 = true
 		}
-		yyj1202 := 0
-		for ; yyj1202 < yyrr1202; yyj1202++ {
+		yyj1254 := 0
+		for ; yyj1254 < yyrr1254; yyj1254++ {
 			if r.TryDecodeAsNil() {
-				yyv1202[yyj1202] = ClusterAutoscaler{}
+				yyv1254[yyj1254] = ClusterAutoscaler{}
 			} else {
-				yyv1203 := &yyv1202[yyj1202]
-				yyv1203.CodecDecodeSelf(d)
+				yyv1255 := &yyv1254[yyj1254]
+				yyv1255.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1202 {
-			for ; yyj1202 < yyl1202; yyj1202++ {
-				yyv1202 = append(yyv1202, ClusterAutoscaler{})
+		if yyrt1254 {
+			for ; yyj1254 < yyl1254; yyj1254++ {
+				yyv1254 = append(yyv1254, ClusterAutoscaler{})
 				if r.TryDecodeAsNil() {
-					yyv1202[yyj1202] = ClusterAutoscaler{}
+					yyv1254[yyj1254] = ClusterAutoscaler{}
 				} else {
-					yyv1204 := &yyv1202[yyj1202]
-					yyv1204.CodecDecodeSelf(d)
+					yyv1256 := &yyv1254[yyj1254]
+					yyv1256.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1202 := 0; !r.CheckBreak(); yyj1202++ {
-			if yyj1202 >= len(yyv1202) {
-				yyv1202 = append(yyv1202, ClusterAutoscaler{}) // var yyz1202 ClusterAutoscaler
-				yyc1202 = true
+		for yyj1254 := 0; !r.CheckBreak(); yyj1254++ {
+			if yyj1254 >= len(yyv1254) {
+				yyv1254 = append(yyv1254, ClusterAutoscaler{}) // var yyz1254 ClusterAutoscaler
+				yyc1254 = true
 			}
 
-			if yyj1202 < len(yyv1202) {
+			if yyj1254 < len(yyv1254) {
 				if r.TryDecodeAsNil() {
-					yyv1202[yyj1202] = ClusterAutoscaler{}
+					yyv1254[yyj1254] = ClusterAutoscaler{}
 				} else {
-					yyv1205 := &yyv1202[yyj1202]
-					yyv1205.CodecDecodeSelf(d)
+					yyv1257 := &yyv1254[yyj1254]
+					yyv1257.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13945,10 +14257,10 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 			}
 
 		}
-		yyh1202.End()
+		yyh1254.End()
 	}
-	if yyc1202 {
-		*v = yyv1202
+	if yyc1254 {
+		*v = yyv1254
 	}
 
 }
@@ -13958,9 +14270,9 @@ func (x codecSelfer1234) encSlicePodSelectorRequirement(v []PodSelectorRequireme
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1206 := range v {
-		yy1207 := &yyv1206
-		yy1207.CodecEncodeSelf(e)
+	for _, yyv1258 := range v {
+		yy1259 := &yyv1258
+		yy1259.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13970,75 +14282,75 @@ func (x codecSelfer1234) decSlicePodSelectorRequirement(v *[]PodSelectorRequirem
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1208 := *v
-	yyh1208, yyl1208 := z.DecSliceHelperStart()
+	yyv1260 := *v
+	yyh1260, yyl1260 := z.DecSliceHelperStart()
 
-	var yyrr1208, yyrl1208 int
-	var yyc1208, yyrt1208 bool
-	_, _, _ = yyc1208, yyrt1208, yyrl1208
-	yyrr1208 = yyl1208
+	var yyrr1260, yyrl1260 int
+	var yyc1260, yyrt1260 bool
+	_, _, _ = yyc1260, yyrt1260, yyrl1260
+	yyrr1260 = yyl1260
 
-	if yyv1208 == nil {
-		if yyrl1208, yyrt1208 = z.DecInferLen(yyl1208, z.DecBasicHandle().MaxInitLen, 56); yyrt1208 {
-			yyrr1208 = yyrl1208
+	if yyv1260 == nil {
+		if yyrl1260, yyrt1260 = z.DecInferLen(yyl1260, z.DecBasicHandle().MaxInitLen, 56); yyrt1260 {
+			yyrr1260 = yyrl1260
 		}
-		yyv1208 = make([]PodSelectorRequirement, yyrl1208)
-		yyc1208 = true
+		yyv1260 = make([]PodSelectorRequirement, yyrl1260)
+		yyc1260 = true
 	}
 
-	if yyl1208 == 0 {
-		if len(yyv1208) != 0 {
-			yyv1208 = yyv1208[:0]
-			yyc1208 = true
+	if yyl1260 == 0 {
+		if len(yyv1260) != 0 {
+			yyv1260 = yyv1260[:0]
+			yyc1260 = true
 		}
-	} else if yyl1208 > 0 {
+	} else if yyl1260 > 0 {
 
-		if yyl1208 > cap(yyv1208) {
-			yyrl1208, yyrt1208 = z.DecInferLen(yyl1208, z.DecBasicHandle().MaxInitLen, 56)
-			yyv1208 = make([]PodSelectorRequirement, yyrl1208)
-			yyc1208 = true
+		if yyl1260 > cap(yyv1260) {
+			yyrl1260, yyrt1260 = z.DecInferLen(yyl1260, z.DecBasicHandle().MaxInitLen, 56)
+			yyv1260 = make([]PodSelectorRequirement, yyrl1260)
+			yyc1260 = true
 
-			yyrr1208 = len(yyv1208)
-		} else if yyl1208 != len(yyv1208) {
-			yyv1208 = yyv1208[:yyl1208]
-			yyc1208 = true
+			yyrr1260 = len(yyv1260)
+		} else if yyl1260 != len(yyv1260) {
+			yyv1260 = yyv1260[:yyl1260]
+			yyc1260 = true
 		}
-		yyj1208 := 0
-		for ; yyj1208 < yyrr1208; yyj1208++ {
+		yyj1260 := 0
+		for ; yyj1260 < yyrr1260; yyj1260++ {
 			if r.TryDecodeAsNil() {
-				yyv1208[yyj1208] = PodSelectorRequirement{}
+				yyv1260[yyj1260] = PodSelectorRequirement{}
 			} else {
-				yyv1209 := &yyv1208[yyj1208]
-				yyv1209.CodecDecodeSelf(d)
+				yyv1261 := &yyv1260[yyj1260]
+				yyv1261.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1208 {
-			for ; yyj1208 < yyl1208; yyj1208++ {
-				yyv1208 = append(yyv1208, PodSelectorRequirement{})
+		if yyrt1260 {
+			for ; yyj1260 < yyl1260; yyj1260++ {
+				yyv1260 = append(yyv1260, PodSelectorRequirement{})
 				if r.TryDecodeAsNil() {
-					yyv1208[yyj1208] = PodSelectorRequirement{}
+					yyv1260[yyj1260] = PodSelectorRequirement{}
 				} else {
-					yyv1210 := &yyv1208[yyj1208]
-					yyv1210.CodecDecodeSelf(d)
+					yyv1262 := &yyv1260[yyj1260]
+					yyv1262.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1208 := 0; !r.CheckBreak(); yyj1208++ {
-			if yyj1208 >= len(yyv1208) {
-				yyv1208 = append(yyv1208, PodSelectorRequirement{}) // var yyz1208 PodSelectorRequirement
-				yyc1208 = true
+		for yyj1260 := 0; !r.CheckBreak(); yyj1260++ {
+			if yyj1260 >= len(yyv1260) {
+				yyv1260 = append(yyv1260, PodSelectorRequirement{}) // var yyz1260 PodSelectorRequirement
+				yyc1260 = true
 			}
 
-			if yyj1208 < len(yyv1208) {
+			if yyj1260 < len(yyv1260) {
 				if r.TryDecodeAsNil() {
-					yyv1208[yyj1208] = PodSelectorRequirement{}
+					yyv1260[yyj1260] = PodSelectorRequirement{}
 				} else {
-					yyv1211 := &yyv1208[yyj1208]
-					yyv1211.CodecDecodeSelf(d)
+					yyv1263 := &yyv1260[yyj1260]
+					yyv1263.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -14046,10 +14358,10 @@ func (x codecSelfer1234) decSlicePodSelectorRequirement(v *[]PodSelectorRequirem
 			}
 
 		}
-		yyh1208.End()
+		yyh1260.End()
 	}
-	if yyc1208 {
-		*v = yyv1208
+	if yyc1260 {
+		*v = yyv1260
 	}
 
 }

--- a/pkg/apiserver/testing/types.generated.go
+++ b/pkg/apiserver/testing/types.generated.go
@@ -141,16 +141,28 @@ func (x *Simple) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				yy10 := &x.ObjectMeta
-				yy10.CodecEncodeSelf(e)
+				yym11 := z.EncBinary()
+				_ = yym11
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy10) {
+				} else {
+					z.EncFallback(yy10)
+				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-				yy11 := &x.ObjectMeta
-				yy11.CodecEncodeSelf(e)
+				yy12 := &x.ObjectMeta
+				yym13 := z.EncBinary()
+				_ = yym13
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy12) {
+				} else {
+					z.EncFallback(yy12)
+				}
 			}
 			if yyr2 || yy2arr2 {
 				if yyq2[3] {
-					yym13 := z.EncBinary()
-					_ = yym13
+					yym15 := z.EncBinary()
+					_ = yym15
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Other))
@@ -161,8 +173,8 @@ func (x *Simple) CodecEncodeSelf(e *codec1978.Encoder) {
 			} else {
 				if yyq2[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("other"))
-					yym14 := z.EncBinary()
-					_ = yym14
+					yym16 := z.EncBinary()
+					_ = yym16
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Other))
@@ -174,8 +186,8 @@ func (x *Simple) CodecEncodeSelf(e *codec1978.Encoder) {
 					if x.Labels == nil {
 						r.EncodeNil()
 					} else {
-						yym16 := z.EncBinary()
-						_ = yym16
+						yym18 := z.EncBinary()
+						_ = yym18
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.Labels, false, e)
@@ -190,8 +202,8 @@ func (x *Simple) CodecEncodeSelf(e *codec1978.Encoder) {
 					if x.Labels == nil {
 						r.EncodeNil()
 					} else {
-						yym17 := z.EncBinary()
-						_ = yym17
+						yym19 := z.EncBinary()
+						_ = yym19
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.Labels, false, e)
@@ -210,24 +222,24 @@ func (x *Simple) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym18 := z.DecBinary()
-	_ = yym18
+	yym20 := z.DecBinary()
+	_ = yym20
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl19 := r.ReadMapStart()
-			if yyl19 == 0 {
+			yyl21 := r.ReadMapStart()
+			if yyl21 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl19, d)
+				x.codecDecodeSelfFromMap(yyl21, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl19 := r.ReadArrayStart()
-			if yyl19 == 0 {
+			yyl21 := r.ReadArrayStart()
+			if yyl21 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl19, d)
+				x.codecDecodeSelfFromArray(yyl21, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -239,12 +251,12 @@ func (x *Simple) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys20Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys20Slc
-	var yyhl20 bool = l >= 0
-	for yyj20 := 0; ; yyj20++ {
-		if yyhl20 {
-			if yyj20 >= l {
+	var yys22Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys22Slc
+	var yyhl22 bool = l >= 0
+	for yyj22 := 0; ; yyj22++ {
+		if yyhl22 {
+			if yyj22 >= l {
 				break
 			}
 		} else {
@@ -252,9 +264,9 @@ func (x *Simple) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys20Slc = r.DecodeBytes(yys20Slc, true, true)
-		yys20 := string(yys20Slc)
-		switch yys20 {
+		yys22Slc = r.DecodeBytes(yys22Slc, true, true)
+		yys22 := string(yys22Slc)
+		switch yys22 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -271,8 +283,14 @@ func (x *Simple) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv23 := &x.ObjectMeta
-				yyv23.CodecDecodeSelf(d)
+				yyv25 := &x.ObjectMeta
+				yym26 := z.DecBinary()
+				_ = yym26
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv25) {
+				} else {
+					z.DecFallback(yyv25, false)
+				}
 			}
 		case "other":
 			if r.TryDecodeAsNil() {
@@ -284,19 +302,19 @@ func (x *Simple) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Labels = nil
 			} else {
-				yyv25 := &x.Labels
-				yym26 := z.DecBinary()
-				_ = yym26
+				yyv28 := &x.Labels
+				yym29 := z.DecBinary()
+				_ = yym29
 				if false {
 				} else {
-					z.F.DecMapStringStringX(yyv25, false, d)
+					z.F.DecMapStringStringX(yyv28, false, d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys20)
-		} // end switch yys20
-	} // end for yyj20
-	if !yyhl20 {
+			z.DecStructFieldNotFound(-1, yys22)
+		} // end switch yys22
+	} // end for yyj22
+	if !yyhl22 {
 		r.ReadEnd()
 	}
 }
@@ -305,16 +323,16 @@ func (x *Simple) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj27 int
-	var yyb27 bool
-	var yyhl27 bool = l >= 0
-	yyj27++
-	if yyhl27 {
-		yyb27 = yyj27 > l
+	var yyj30 int
+	var yyb30 bool
+	var yyhl30 bool = l >= 0
+	yyj30++
+	if yyhl30 {
+		yyb30 = yyj30 > l
 	} else {
-		yyb27 = r.CheckBreak()
+		yyb30 = r.CheckBreak()
 	}
-	if yyb27 {
+	if yyb30 {
 		r.ReadEnd()
 		return
 	}
@@ -323,13 +341,13 @@ func (x *Simple) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj27++
-	if yyhl27 {
-		yyb27 = yyj27 > l
+	yyj30++
+	if yyhl30 {
+		yyb30 = yyj30 > l
 	} else {
-		yyb27 = r.CheckBreak()
+		yyb30 = r.CheckBreak()
 	}
-	if yyb27 {
+	if yyb30 {
 		r.ReadEnd()
 		return
 	}
@@ -338,29 +356,35 @@ func (x *Simple) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj27++
-	if yyhl27 {
-		yyb27 = yyj27 > l
+	yyj30++
+	if yyhl30 {
+		yyb30 = yyj30 > l
 	} else {
-		yyb27 = r.CheckBreak()
+		yyb30 = r.CheckBreak()
 	}
-	if yyb27 {
+	if yyb30 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv30 := &x.ObjectMeta
-		yyv30.CodecDecodeSelf(d)
+		yyv33 := &x.ObjectMeta
+		yym34 := z.DecBinary()
+		_ = yym34
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv33) {
+		} else {
+			z.DecFallback(yyv33, false)
+		}
 	}
-	yyj27++
-	if yyhl27 {
-		yyb27 = yyj27 > l
+	yyj30++
+	if yyhl30 {
+		yyb30 = yyj30 > l
 	} else {
-		yyb27 = r.CheckBreak()
+		yyb30 = r.CheckBreak()
 	}
-	if yyb27 {
+	if yyb30 {
 		r.ReadEnd()
 		return
 	}
@@ -369,38 +393,38 @@ func (x *Simple) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Other = string(r.DecodeString())
 	}
-	yyj27++
-	if yyhl27 {
-		yyb27 = yyj27 > l
+	yyj30++
+	if yyhl30 {
+		yyb30 = yyj30 > l
 	} else {
-		yyb27 = r.CheckBreak()
+		yyb30 = r.CheckBreak()
 	}
-	if yyb27 {
+	if yyb30 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Labels = nil
 	} else {
-		yyv32 := &x.Labels
-		yym33 := z.DecBinary()
-		_ = yym33
+		yyv36 := &x.Labels
+		yym37 := z.DecBinary()
+		_ = yym37
 		if false {
 		} else {
-			z.F.DecMapStringStringX(yyv32, false, d)
+			z.F.DecMapStringStringX(yyv36, false, d)
 		}
 	}
 	for {
-		yyj27++
-		if yyhl27 {
-			yyb27 = yyj27 > l
+		yyj30++
+		if yyhl30 {
+			yyb30 = yyj30 > l
 		} else {
-			yyb27 = r.CheckBreak()
+			yyb30 = r.CheckBreak()
 		}
-		if yyb27 {
+		if yyb30 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj27-1, "")
+		z.DecStructFieldNotFound(yyj30-1, "")
 	}
 	r.ReadEnd()
 }
@@ -412,87 +436,99 @@ func (x *SimpleRoot) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym34 := z.EncBinary()
-		_ = yym34
+		yym38 := z.EncBinary()
+		_ = yym38
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep35 := !z.EncBinary()
-			yy2arr35 := z.EncBasicHandle().StructToArray
-			var yyq35 [5]bool
-			_, _, _ = yysep35, yyq35, yy2arr35
-			const yyr35 bool = false
-			yyq35[0] = x.Kind != ""
-			yyq35[1] = x.APIVersion != ""
-			yyq35[3] = x.Other != ""
-			yyq35[4] = len(x.Labels) != 0
-			if yyr35 || yy2arr35 {
+			yysep39 := !z.EncBinary()
+			yy2arr39 := z.EncBasicHandle().StructToArray
+			var yyq39 [5]bool
+			_, _, _ = yysep39, yyq39, yy2arr39
+			const yyr39 bool = false
+			yyq39[0] = x.Kind != ""
+			yyq39[1] = x.APIVersion != ""
+			yyq39[3] = x.Other != ""
+			yyq39[4] = len(x.Labels) != 0
+			if yyr39 || yy2arr39 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn35 int = 1
-				for _, b := range yyq35 {
+				var yynn39 int = 1
+				for _, b := range yyq39 {
 					if b {
-						yynn35++
+						yynn39++
 					}
 				}
-				r.EncodeMapStart(yynn35)
+				r.EncodeMapStart(yynn39)
 			}
-			if yyr35 || yy2arr35 {
-				if yyq35[0] {
-					yym37 := z.EncBinary()
-					_ = yym37
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq35[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym38 := z.EncBinary()
-					_ = yym38
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
-					}
-				}
-			}
-			if yyr35 || yy2arr35 {
-				if yyq35[1] {
-					yym40 := z.EncBinary()
-					_ = yym40
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq35[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+			if yyr39 || yy2arr39 {
+				if yyq39[0] {
 					yym41 := z.EncBinary()
 					_ = yym41
 					if false {
 					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq39[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("kind"))
+					yym42 := z.EncBinary()
+					_ = yym42
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
+					}
+				}
+			}
+			if yyr39 || yy2arr39 {
+				if yyq39[1] {
+					yym44 := z.EncBinary()
+					_ = yym44
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq39[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym45 := z.EncBinary()
+					_ = yym45
+					if false {
+					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr35 || yy2arr35 {
-				yy43 := &x.ObjectMeta
-				yy43.CodecEncodeSelf(e)
+			if yyr39 || yy2arr39 {
+				yy47 := &x.ObjectMeta
+				yym48 := z.EncBinary()
+				_ = yym48
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy47) {
+				} else {
+					z.EncFallback(yy47)
+				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-				yy44 := &x.ObjectMeta
-				yy44.CodecEncodeSelf(e)
+				yy49 := &x.ObjectMeta
+				yym50 := z.EncBinary()
+				_ = yym50
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy49) {
+				} else {
+					z.EncFallback(yy49)
+				}
 			}
-			if yyr35 || yy2arr35 {
-				if yyq35[3] {
-					yym46 := z.EncBinary()
-					_ = yym46
+			if yyr39 || yy2arr39 {
+				if yyq39[3] {
+					yym52 := z.EncBinary()
+					_ = yym52
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Other))
@@ -501,23 +537,23 @@ func (x *SimpleRoot) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq35[3] {
+				if yyq39[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("other"))
-					yym47 := z.EncBinary()
-					_ = yym47
+					yym53 := z.EncBinary()
+					_ = yym53
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Other))
 					}
 				}
 			}
-			if yyr35 || yy2arr35 {
-				if yyq35[4] {
+			if yyr39 || yy2arr39 {
+				if yyq39[4] {
 					if x.Labels == nil {
 						r.EncodeNil()
 					} else {
-						yym49 := z.EncBinary()
-						_ = yym49
+						yym55 := z.EncBinary()
+						_ = yym55
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.Labels, false, e)
@@ -527,13 +563,13 @@ func (x *SimpleRoot) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq35[4] {
+				if yyq39[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("labels"))
 					if x.Labels == nil {
 						r.EncodeNil()
 					} else {
-						yym50 := z.EncBinary()
-						_ = yym50
+						yym56 := z.EncBinary()
+						_ = yym56
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.Labels, false, e)
@@ -541,7 +577,7 @@ func (x *SimpleRoot) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep35 {
+			if yysep39 {
 				r.EncodeEnd()
 			}
 		}
@@ -552,24 +588,24 @@ func (x *SimpleRoot) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym51 := z.DecBinary()
-	_ = yym51
+	yym57 := z.DecBinary()
+	_ = yym57
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl52 := r.ReadMapStart()
-			if yyl52 == 0 {
+			yyl58 := r.ReadMapStart()
+			if yyl58 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl52, d)
+				x.codecDecodeSelfFromMap(yyl58, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl52 := r.ReadArrayStart()
-			if yyl52 == 0 {
+			yyl58 := r.ReadArrayStart()
+			if yyl58 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl52, d)
+				x.codecDecodeSelfFromArray(yyl58, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -581,12 +617,12 @@ func (x *SimpleRoot) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys53Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys53Slc
-	var yyhl53 bool = l >= 0
-	for yyj53 := 0; ; yyj53++ {
-		if yyhl53 {
-			if yyj53 >= l {
+	var yys59Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys59Slc
+	var yyhl59 bool = l >= 0
+	for yyj59 := 0; ; yyj59++ {
+		if yyhl59 {
+			if yyj59 >= l {
 				break
 			}
 		} else {
@@ -594,9 +630,9 @@ func (x *SimpleRoot) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys53Slc = r.DecodeBytes(yys53Slc, true, true)
-		yys53 := string(yys53Slc)
-		switch yys53 {
+		yys59Slc = r.DecodeBytes(yys59Slc, true, true)
+		yys59 := string(yys59Slc)
+		switch yys59 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -613,8 +649,14 @@ func (x *SimpleRoot) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv56 := &x.ObjectMeta
-				yyv56.CodecDecodeSelf(d)
+				yyv62 := &x.ObjectMeta
+				yym63 := z.DecBinary()
+				_ = yym63
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv62) {
+				} else {
+					z.DecFallback(yyv62, false)
+				}
 			}
 		case "other":
 			if r.TryDecodeAsNil() {
@@ -626,19 +668,19 @@ func (x *SimpleRoot) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Labels = nil
 			} else {
-				yyv58 := &x.Labels
-				yym59 := z.DecBinary()
-				_ = yym59
+				yyv65 := &x.Labels
+				yym66 := z.DecBinary()
+				_ = yym66
 				if false {
 				} else {
-					z.F.DecMapStringStringX(yyv58, false, d)
+					z.F.DecMapStringStringX(yyv65, false, d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys53)
-		} // end switch yys53
-	} // end for yyj53
-	if !yyhl53 {
+			z.DecStructFieldNotFound(-1, yys59)
+		} // end switch yys59
+	} // end for yyj59
+	if !yyhl59 {
 		r.ReadEnd()
 	}
 }
@@ -647,16 +689,16 @@ func (x *SimpleRoot) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj60 int
-	var yyb60 bool
-	var yyhl60 bool = l >= 0
-	yyj60++
-	if yyhl60 {
-		yyb60 = yyj60 > l
+	var yyj67 int
+	var yyb67 bool
+	var yyhl67 bool = l >= 0
+	yyj67++
+	if yyhl67 {
+		yyb67 = yyj67 > l
 	} else {
-		yyb60 = r.CheckBreak()
+		yyb67 = r.CheckBreak()
 	}
-	if yyb60 {
+	if yyb67 {
 		r.ReadEnd()
 		return
 	}
@@ -665,13 +707,13 @@ func (x *SimpleRoot) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj60++
-	if yyhl60 {
-		yyb60 = yyj60 > l
+	yyj67++
+	if yyhl67 {
+		yyb67 = yyj67 > l
 	} else {
-		yyb60 = r.CheckBreak()
+		yyb67 = r.CheckBreak()
 	}
-	if yyb60 {
+	if yyb67 {
 		r.ReadEnd()
 		return
 	}
@@ -680,29 +722,35 @@ func (x *SimpleRoot) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj60++
-	if yyhl60 {
-		yyb60 = yyj60 > l
+	yyj67++
+	if yyhl67 {
+		yyb67 = yyj67 > l
 	} else {
-		yyb60 = r.CheckBreak()
+		yyb67 = r.CheckBreak()
 	}
-	if yyb60 {
+	if yyb67 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv63 := &x.ObjectMeta
-		yyv63.CodecDecodeSelf(d)
+		yyv70 := &x.ObjectMeta
+		yym71 := z.DecBinary()
+		_ = yym71
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv70) {
+		} else {
+			z.DecFallback(yyv70, false)
+		}
 	}
-	yyj60++
-	if yyhl60 {
-		yyb60 = yyj60 > l
+	yyj67++
+	if yyhl67 {
+		yyb67 = yyj67 > l
 	} else {
-		yyb60 = r.CheckBreak()
+		yyb67 = r.CheckBreak()
 	}
-	if yyb60 {
+	if yyb67 {
 		r.ReadEnd()
 		return
 	}
@@ -711,38 +759,38 @@ func (x *SimpleRoot) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Other = string(r.DecodeString())
 	}
-	yyj60++
-	if yyhl60 {
-		yyb60 = yyj60 > l
+	yyj67++
+	if yyhl67 {
+		yyb67 = yyj67 > l
 	} else {
-		yyb60 = r.CheckBreak()
+		yyb67 = r.CheckBreak()
 	}
-	if yyb60 {
+	if yyb67 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Labels = nil
 	} else {
-		yyv65 := &x.Labels
-		yym66 := z.DecBinary()
-		_ = yym66
+		yyv73 := &x.Labels
+		yym74 := z.DecBinary()
+		_ = yym74
 		if false {
 		} else {
-			z.F.DecMapStringStringX(yyv65, false, d)
+			z.F.DecMapStringStringX(yyv73, false, d)
 		}
 	}
 	for {
-		yyj60++
-		if yyhl60 {
-			yyb60 = yyj60 > l
+		yyj67++
+		if yyhl67 {
+			yyb67 = yyj67 > l
 		} else {
-			yyb60 = r.CheckBreak()
+			yyb67 = r.CheckBreak()
 		}
-		if yyb60 {
+		if yyb67 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj60-1, "")
+		z.DecStructFieldNotFound(yyj67-1, "")
 	}
 	r.ReadEnd()
 }
@@ -754,33 +802,33 @@ func (x *SimpleGetOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym67 := z.EncBinary()
-		_ = yym67
+		yym75 := z.EncBinary()
+		_ = yym75
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep68 := !z.EncBinary()
-			yy2arr68 := z.EncBasicHandle().StructToArray
-			var yyq68 [5]bool
-			_, _, _ = yysep68, yyq68, yy2arr68
-			const yyr68 bool = false
-			yyq68[0] = x.Kind != ""
-			yyq68[1] = x.APIVersion != ""
-			if yyr68 || yy2arr68 {
+			yysep76 := !z.EncBinary()
+			yy2arr76 := z.EncBasicHandle().StructToArray
+			var yyq76 [5]bool
+			_, _, _ = yysep76, yyq76, yy2arr76
+			const yyr76 bool = false
+			yyq76[0] = x.Kind != ""
+			yyq76[1] = x.APIVersion != ""
+			if yyr76 || yy2arr76 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn68 int = 3
-				for _, b := range yyq68 {
+				var yynn76 int = 3
+				for _, b := range yyq76 {
 					if b {
-						yynn68++
+						yynn76++
 					}
 				}
-				r.EncodeMapStart(yynn68)
+				r.EncodeMapStart(yynn76)
 			}
-			if yyr68 || yy2arr68 {
-				if yyq68[0] {
-					yym70 := z.EncBinary()
-					_ = yym70
+			if yyr76 || yy2arr76 {
+				if yyq76[0] {
+					yym78 := z.EncBinary()
+					_ = yym78
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -789,20 +837,20 @@ func (x *SimpleGetOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq68[0] {
+				if yyq76[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym71 := z.EncBinary()
-					_ = yym71
+					yym79 := z.EncBinary()
+					_ = yym79
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr68 || yy2arr68 {
-				if yyq68[1] {
-					yym73 := z.EncBinary()
-					_ = yym73
+			if yyr76 || yy2arr76 {
+				if yyq76[1] {
+					yym81 := z.EncBinary()
+					_ = yym81
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -811,65 +859,65 @@ func (x *SimpleGetOptions) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq68[1] {
+				if yyq76[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym74 := z.EncBinary()
-					_ = yym74
+					yym82 := z.EncBinary()
+					_ = yym82
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr68 || yy2arr68 {
-				yym76 := z.EncBinary()
-				_ = yym76
+			if yyr76 || yy2arr76 {
+				yym84 := z.EncBinary()
+				_ = yym84
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Param1))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("param1"))
-				yym77 := z.EncBinary()
-				_ = yym77
+				yym85 := z.EncBinary()
+				_ = yym85
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Param1))
 				}
 			}
-			if yyr68 || yy2arr68 {
-				yym79 := z.EncBinary()
-				_ = yym79
+			if yyr76 || yy2arr76 {
+				yym87 := z.EncBinary()
+				_ = yym87
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Param2))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("param2"))
-				yym80 := z.EncBinary()
-				_ = yym80
+				yym88 := z.EncBinary()
+				_ = yym88
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Param2))
 				}
 			}
-			if yyr68 || yy2arr68 {
-				yym82 := z.EncBinary()
-				_ = yym82
+			if yyr76 || yy2arr76 {
+				yym90 := z.EncBinary()
+				_ = yym90
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("atAPath"))
-				yym83 := z.EncBinary()
-				_ = yym83
+				yym91 := z.EncBinary()
+				_ = yym91
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 				}
 			}
-			if yysep68 {
+			if yysep76 {
 				r.EncodeEnd()
 			}
 		}
@@ -880,24 +928,24 @@ func (x *SimpleGetOptions) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym84 := z.DecBinary()
-	_ = yym84
+	yym92 := z.DecBinary()
+	_ = yym92
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl85 := r.ReadMapStart()
-			if yyl85 == 0 {
+			yyl93 := r.ReadMapStart()
+			if yyl93 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl85, d)
+				x.codecDecodeSelfFromMap(yyl93, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl85 := r.ReadArrayStart()
-			if yyl85 == 0 {
+			yyl93 := r.ReadArrayStart()
+			if yyl93 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl85, d)
+				x.codecDecodeSelfFromArray(yyl93, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -909,12 +957,12 @@ func (x *SimpleGetOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys86Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys86Slc
-	var yyhl86 bool = l >= 0
-	for yyj86 := 0; ; yyj86++ {
-		if yyhl86 {
-			if yyj86 >= l {
+	var yys94Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys94Slc
+	var yyhl94 bool = l >= 0
+	for yyj94 := 0; ; yyj94++ {
+		if yyhl94 {
+			if yyj94 >= l {
 				break
 			}
 		} else {
@@ -922,9 +970,9 @@ func (x *SimpleGetOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys86Slc = r.DecodeBytes(yys86Slc, true, true)
-		yys86 := string(yys86Slc)
-		switch yys86 {
+		yys94Slc = r.DecodeBytes(yys94Slc, true, true)
+		yys94 := string(yys94Slc)
+		switch yys94 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -956,10 +1004,10 @@ func (x *SimpleGetOptions) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Path = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys86)
-		} // end switch yys86
-	} // end for yyj86
-	if !yyhl86 {
+			z.DecStructFieldNotFound(-1, yys94)
+		} // end switch yys94
+	} // end for yyj94
+	if !yyhl94 {
 		r.ReadEnd()
 	}
 }
@@ -968,16 +1016,16 @@ func (x *SimpleGetOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj92 int
-	var yyb92 bool
-	var yyhl92 bool = l >= 0
-	yyj92++
-	if yyhl92 {
-		yyb92 = yyj92 > l
+	var yyj100 int
+	var yyb100 bool
+	var yyhl100 bool = l >= 0
+	yyj100++
+	if yyhl100 {
+		yyb100 = yyj100 > l
 	} else {
-		yyb92 = r.CheckBreak()
+		yyb100 = r.CheckBreak()
 	}
-	if yyb92 {
+	if yyb100 {
 		r.ReadEnd()
 		return
 	}
@@ -986,13 +1034,13 @@ func (x *SimpleGetOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj92++
-	if yyhl92 {
-		yyb92 = yyj92 > l
+	yyj100++
+	if yyhl100 {
+		yyb100 = yyj100 > l
 	} else {
-		yyb92 = r.CheckBreak()
+		yyb100 = r.CheckBreak()
 	}
-	if yyb92 {
+	if yyb100 {
 		r.ReadEnd()
 		return
 	}
@@ -1001,13 +1049,13 @@ func (x *SimpleGetOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj92++
-	if yyhl92 {
-		yyb92 = yyj92 > l
+	yyj100++
+	if yyhl100 {
+		yyb100 = yyj100 > l
 	} else {
-		yyb92 = r.CheckBreak()
+		yyb100 = r.CheckBreak()
 	}
-	if yyb92 {
+	if yyb100 {
 		r.ReadEnd()
 		return
 	}
@@ -1016,13 +1064,13 @@ func (x *SimpleGetOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.Param1 = string(r.DecodeString())
 	}
-	yyj92++
-	if yyhl92 {
-		yyb92 = yyj92 > l
+	yyj100++
+	if yyhl100 {
+		yyb100 = yyj100 > l
 	} else {
-		yyb92 = r.CheckBreak()
+		yyb100 = r.CheckBreak()
 	}
-	if yyb92 {
+	if yyb100 {
 		r.ReadEnd()
 		return
 	}
@@ -1031,13 +1079,13 @@ func (x *SimpleGetOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.Param2 = string(r.DecodeString())
 	}
-	yyj92++
-	if yyhl92 {
-		yyb92 = yyj92 > l
+	yyj100++
+	if yyhl100 {
+		yyb100 = yyj100 > l
 	} else {
-		yyb92 = r.CheckBreak()
+		yyb100 = r.CheckBreak()
 	}
-	if yyb92 {
+	if yyb100 {
 		r.ReadEnd()
 		return
 	}
@@ -1047,16 +1095,16 @@ func (x *SimpleGetOptions) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		x.Path = string(r.DecodeString())
 	}
 	for {
-		yyj92++
-		if yyhl92 {
-			yyb92 = yyj92 > l
+		yyj100++
+		if yyhl100 {
+			yyb100 = yyj100 > l
 		} else {
-			yyb92 = r.CheckBreak()
+			yyb100 = r.CheckBreak()
 		}
-		if yyb92 {
+		if yyb100 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj92-1, "")
+		z.DecStructFieldNotFound(yyj100-1, "")
 	}
 	r.ReadEnd()
 }
@@ -1068,34 +1116,34 @@ func (x *SimpleList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym98 := z.EncBinary()
-		_ = yym98
+		yym106 := z.EncBinary()
+		_ = yym106
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep99 := !z.EncBinary()
-			yy2arr99 := z.EncBasicHandle().StructToArray
-			var yyq99 [4]bool
-			_, _, _ = yysep99, yyq99, yy2arr99
-			const yyr99 bool = false
-			yyq99[0] = x.Kind != ""
-			yyq99[1] = x.APIVersion != ""
-			yyq99[3] = len(x.Items) != 0
-			if yyr99 || yy2arr99 {
+			yysep107 := !z.EncBinary()
+			yy2arr107 := z.EncBasicHandle().StructToArray
+			var yyq107 [4]bool
+			_, _, _ = yysep107, yyq107, yy2arr107
+			const yyr107 bool = false
+			yyq107[0] = x.Kind != ""
+			yyq107[1] = x.APIVersion != ""
+			yyq107[3] = len(x.Items) != 0
+			if yyr107 || yy2arr107 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn99 int = 1
-				for _, b := range yyq99 {
+				var yynn107 int = 1
+				for _, b := range yyq107 {
 					if b {
-						yynn99++
+						yynn107++
 					}
 				}
-				r.EncodeMapStart(yynn99)
+				r.EncodeMapStart(yynn107)
 			}
-			if yyr99 || yy2arr99 {
-				if yyq99[0] {
-					yym101 := z.EncBinary()
-					_ = yym101
+			if yyr107 || yy2arr107 {
+				if yyq107[0] {
+					yym109 := z.EncBinary()
+					_ = yym109
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -1104,20 +1152,20 @@ func (x *SimpleList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq99[0] {
+				if yyq107[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym102 := z.EncBinary()
-					_ = yym102
+					yym110 := z.EncBinary()
+					_ = yym110
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr99 || yy2arr99 {
-				if yyq99[1] {
-					yym104 := z.EncBinary()
-					_ = yym104
+			if yyr107 || yy2arr107 {
+				if yyq107[1] {
+					yym112 := z.EncBinary()
+					_ = yym112
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -1126,43 +1174,43 @@ func (x *SimpleList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq99[1] {
+				if yyq107[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym105 := z.EncBinary()
-					_ = yym105
+					yym113 := z.EncBinary()
+					_ = yym113
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr99 || yy2arr99 {
-				yy107 := &x.ListMeta
-				yym108 := z.EncBinary()
-				_ = yym108
+			if yyr107 || yy2arr107 {
+				yy115 := &x.ListMeta
+				yym116 := z.EncBinary()
+				_ = yym116
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy107) {
+				} else if z.HasExtensions() && z.EncExt(yy115) {
 				} else {
-					z.EncFallback(yy107)
+					z.EncFallback(yy115)
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-				yy109 := &x.ListMeta
-				yym110 := z.EncBinary()
-				_ = yym110
+				yy117 := &x.ListMeta
+				yym118 := z.EncBinary()
+				_ = yym118
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy109) {
+				} else if z.HasExtensions() && z.EncExt(yy117) {
 				} else {
-					z.EncFallback(yy109)
+					z.EncFallback(yy117)
 				}
 			}
-			if yyr99 || yy2arr99 {
-				if yyq99[3] {
+			if yyr107 || yy2arr107 {
+				if yyq107[3] {
 					if x.Items == nil {
 						r.EncodeNil()
 					} else {
-						yym112 := z.EncBinary()
-						_ = yym112
+						yym120 := z.EncBinary()
+						_ = yym120
 						if false {
 						} else {
 							h.encSliceSimple(([]Simple)(x.Items), e)
@@ -1172,13 +1220,13 @@ func (x *SimpleList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq99[3] {
+				if yyq107[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("items"))
 					if x.Items == nil {
 						r.EncodeNil()
 					} else {
-						yym113 := z.EncBinary()
-						_ = yym113
+						yym121 := z.EncBinary()
+						_ = yym121
 						if false {
 						} else {
 							h.encSliceSimple(([]Simple)(x.Items), e)
@@ -1186,7 +1234,7 @@ func (x *SimpleList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep99 {
+			if yysep107 {
 				r.EncodeEnd()
 			}
 		}
@@ -1197,24 +1245,24 @@ func (x *SimpleList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym114 := z.DecBinary()
-	_ = yym114
+	yym122 := z.DecBinary()
+	_ = yym122
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl115 := r.ReadMapStart()
-			if yyl115 == 0 {
+			yyl123 := r.ReadMapStart()
+			if yyl123 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl115, d)
+				x.codecDecodeSelfFromMap(yyl123, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl115 := r.ReadArrayStart()
-			if yyl115 == 0 {
+			yyl123 := r.ReadArrayStart()
+			if yyl123 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl115, d)
+				x.codecDecodeSelfFromArray(yyl123, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -1226,12 +1274,12 @@ func (x *SimpleList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys116Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys116Slc
-	var yyhl116 bool = l >= 0
-	for yyj116 := 0; ; yyj116++ {
-		if yyhl116 {
-			if yyj116 >= l {
+	var yys124Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys124Slc
+	var yyhl124 bool = l >= 0
+	for yyj124 := 0; ; yyj124++ {
+		if yyhl124 {
+			if yyj124 >= l {
 				break
 			}
 		} else {
@@ -1239,9 +1287,9 @@ func (x *SimpleList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys116Slc = r.DecodeBytes(yys116Slc, true, true)
-		yys116 := string(yys116Slc)
-		switch yys116 {
+		yys124Slc = r.DecodeBytes(yys124Slc, true, true)
+		yys124 := string(yys124Slc)
+		switch yys124 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -1258,32 +1306,32 @@ func (x *SimpleList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv119 := &x.ListMeta
-				yym120 := z.DecBinary()
-				_ = yym120
+				yyv127 := &x.ListMeta
+				yym128 := z.DecBinary()
+				_ = yym128
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv119) {
+				} else if z.HasExtensions() && z.DecExt(yyv127) {
 				} else {
-					z.DecFallback(yyv119, false)
+					z.DecFallback(yyv127, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv121 := &x.Items
-				yym122 := z.DecBinary()
-				_ = yym122
+				yyv129 := &x.Items
+				yym130 := z.DecBinary()
+				_ = yym130
 				if false {
 				} else {
-					h.decSliceSimple((*[]Simple)(yyv121), d)
+					h.decSliceSimple((*[]Simple)(yyv129), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys116)
-		} // end switch yys116
-	} // end for yyj116
-	if !yyhl116 {
+			z.DecStructFieldNotFound(-1, yys124)
+		} // end switch yys124
+	} // end for yyj124
+	if !yyhl124 {
 		r.ReadEnd()
 	}
 }
@@ -1292,16 +1340,16 @@ func (x *SimpleList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj123 int
-	var yyb123 bool
-	var yyhl123 bool = l >= 0
-	yyj123++
-	if yyhl123 {
-		yyb123 = yyj123 > l
+	var yyj131 int
+	var yyb131 bool
+	var yyhl131 bool = l >= 0
+	yyj131++
+	if yyhl131 {
+		yyb131 = yyj131 > l
 	} else {
-		yyb123 = r.CheckBreak()
+		yyb131 = r.CheckBreak()
 	}
-	if yyb123 {
+	if yyb131 {
 		r.ReadEnd()
 		return
 	}
@@ -1310,13 +1358,13 @@ func (x *SimpleList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj123++
-	if yyhl123 {
-		yyb123 = yyj123 > l
+	yyj131++
+	if yyhl131 {
+		yyb131 = yyj131 > l
 	} else {
-		yyb123 = r.CheckBreak()
+		yyb131 = r.CheckBreak()
 	}
-	if yyb123 {
+	if yyb131 {
 		r.ReadEnd()
 		return
 	}
@@ -1325,60 +1373,60 @@ func (x *SimpleList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj123++
-	if yyhl123 {
-		yyb123 = yyj123 > l
+	yyj131++
+	if yyhl131 {
+		yyb131 = yyj131 > l
 	} else {
-		yyb123 = r.CheckBreak()
+		yyb131 = r.CheckBreak()
 	}
-	if yyb123 {
+	if yyb131 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv126 := &x.ListMeta
-		yym127 := z.DecBinary()
-		_ = yym127
+		yyv134 := &x.ListMeta
+		yym135 := z.DecBinary()
+		_ = yym135
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv126) {
+		} else if z.HasExtensions() && z.DecExt(yyv134) {
 		} else {
-			z.DecFallback(yyv126, false)
+			z.DecFallback(yyv134, false)
 		}
 	}
-	yyj123++
-	if yyhl123 {
-		yyb123 = yyj123 > l
+	yyj131++
+	if yyhl131 {
+		yyb131 = yyj131 > l
 	} else {
-		yyb123 = r.CheckBreak()
+		yyb131 = r.CheckBreak()
 	}
-	if yyb123 {
+	if yyb131 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv128 := &x.Items
-		yym129 := z.DecBinary()
-		_ = yym129
+		yyv136 := &x.Items
+		yym137 := z.DecBinary()
+		_ = yym137
 		if false {
 		} else {
-			h.decSliceSimple((*[]Simple)(yyv128), d)
+			h.decSliceSimple((*[]Simple)(yyv136), d)
 		}
 	}
 	for {
-		yyj123++
-		if yyhl123 {
-			yyb123 = yyj123 > l
+		yyj131++
+		if yyhl131 {
+			yyb131 = yyj131 > l
 		} else {
-			yyb123 = r.CheckBreak()
+			yyb131 = r.CheckBreak()
 		}
-		if yyb123 {
+		if yyb131 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj123-1, "")
+		z.DecStructFieldNotFound(yyj131-1, "")
 	}
 	r.ReadEnd()
 }
@@ -1388,9 +1436,9 @@ func (x codecSelfer1234) encSliceSimple(v []Simple, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv130 := range v {
-		yy131 := &yyv130
-		yy131.CodecEncodeSelf(e)
+	for _, yyv138 := range v {
+		yy139 := &yyv138
+		yy139.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -1400,75 +1448,75 @@ func (x codecSelfer1234) decSliceSimple(v *[]Simple, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv132 := *v
-	yyh132, yyl132 := z.DecSliceHelperStart()
+	yyv140 := *v
+	yyh140, yyl140 := z.DecSliceHelperStart()
 
-	var yyrr132, yyrl132 int
-	var yyc132, yyrt132 bool
-	_, _, _ = yyc132, yyrt132, yyrl132
-	yyrr132 = yyl132
+	var yyrr140, yyrl140 int
+	var yyc140, yyrt140 bool
+	_, _, _ = yyc140, yyrt140, yyrl140
+	yyrr140 = yyl140
 
-	if yyv132 == nil {
-		if yyrl132, yyrt132 = z.DecInferLen(yyl132, z.DecBasicHandle().MaxInitLen, 216); yyrt132 {
-			yyrr132 = yyrl132
+	if yyv140 == nil {
+		if yyrl140, yyrt140 = z.DecInferLen(yyl140, z.DecBasicHandle().MaxInitLen, 216); yyrt140 {
+			yyrr140 = yyrl140
 		}
-		yyv132 = make([]Simple, yyrl132)
-		yyc132 = true
+		yyv140 = make([]Simple, yyrl140)
+		yyc140 = true
 	}
 
-	if yyl132 == 0 {
-		if len(yyv132) != 0 {
-			yyv132 = yyv132[:0]
-			yyc132 = true
+	if yyl140 == 0 {
+		if len(yyv140) != 0 {
+			yyv140 = yyv140[:0]
+			yyc140 = true
 		}
-	} else if yyl132 > 0 {
+	} else if yyl140 > 0 {
 
-		if yyl132 > cap(yyv132) {
-			yyrl132, yyrt132 = z.DecInferLen(yyl132, z.DecBasicHandle().MaxInitLen, 216)
-			yyv132 = make([]Simple, yyrl132)
-			yyc132 = true
+		if yyl140 > cap(yyv140) {
+			yyrl140, yyrt140 = z.DecInferLen(yyl140, z.DecBasicHandle().MaxInitLen, 216)
+			yyv140 = make([]Simple, yyrl140)
+			yyc140 = true
 
-			yyrr132 = len(yyv132)
-		} else if yyl132 != len(yyv132) {
-			yyv132 = yyv132[:yyl132]
-			yyc132 = true
+			yyrr140 = len(yyv140)
+		} else if yyl140 != len(yyv140) {
+			yyv140 = yyv140[:yyl140]
+			yyc140 = true
 		}
-		yyj132 := 0
-		for ; yyj132 < yyrr132; yyj132++ {
+		yyj140 := 0
+		for ; yyj140 < yyrr140; yyj140++ {
 			if r.TryDecodeAsNil() {
-				yyv132[yyj132] = Simple{}
+				yyv140[yyj140] = Simple{}
 			} else {
-				yyv133 := &yyv132[yyj132]
-				yyv133.CodecDecodeSelf(d)
+				yyv141 := &yyv140[yyj140]
+				yyv141.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt132 {
-			for ; yyj132 < yyl132; yyj132++ {
-				yyv132 = append(yyv132, Simple{})
+		if yyrt140 {
+			for ; yyj140 < yyl140; yyj140++ {
+				yyv140 = append(yyv140, Simple{})
 				if r.TryDecodeAsNil() {
-					yyv132[yyj132] = Simple{}
+					yyv140[yyj140] = Simple{}
 				} else {
-					yyv134 := &yyv132[yyj132]
-					yyv134.CodecDecodeSelf(d)
+					yyv142 := &yyv140[yyj140]
+					yyv142.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj132 := 0; !r.CheckBreak(); yyj132++ {
-			if yyj132 >= len(yyv132) {
-				yyv132 = append(yyv132, Simple{}) // var yyz132 Simple
-				yyc132 = true
+		for yyj140 := 0; !r.CheckBreak(); yyj140++ {
+			if yyj140 >= len(yyv140) {
+				yyv140 = append(yyv140, Simple{}) // var yyz140 Simple
+				yyc140 = true
 			}
 
-			if yyj132 < len(yyv132) {
+			if yyj140 < len(yyv140) {
 				if r.TryDecodeAsNil() {
-					yyv132[yyj132] = Simple{}
+					yyv140[yyj140] = Simple{}
 				} else {
-					yyv135 := &yyv132[yyj132]
-					yyv135.CodecDecodeSelf(d)
+					yyv143 := &yyv140[yyj140]
+					yyv143.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -1476,10 +1524,10 @@ func (x codecSelfer1234) decSliceSimple(v *[]Simple, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh132.End()
+		yyh140.End()
 	}
-	if yyc132 {
-		*v = yyv132
+	if yyc140 {
+		*v = yyv140
 	}
 
 }

--- a/pkg/kubectl/testing/types.generated.go
+++ b/pkg/kubectl/testing/types.generated.go
@@ -141,28 +141,40 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2 || yy2arr2 {
 				if yyq2[2] {
 					yy10 := &x.ObjectMeta
-					yy10.CodecEncodeSelf(e)
+					yym11 := z.EncBinary()
+					_ = yym11
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy10) {
+					} else {
+						z.EncFallback(yy10)
+					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
 				if yyq2[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy11 := &x.ObjectMeta
-					yy11.CodecEncodeSelf(e)
+					yy12 := &x.ObjectMeta
+					yym13 := z.EncBinary()
+					_ = yym13
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy12) {
+					} else {
+						z.EncFallback(yy12)
+					}
 				}
 			}
 			if yyr2 || yy2arr2 {
-				yym13 := z.EncBinary()
-				_ = yym13
+				yym15 := z.EncBinary()
+				_ = yym15
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("Key"))
-				yym14 := z.EncBinary()
-				_ = yym14
+				yym16 := z.EncBinary()
+				_ = yym16
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
@@ -172,8 +184,8 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Map == nil {
 					r.EncodeNil()
 				} else {
-					yym16 := z.EncBinary()
-					_ = yym16
+					yym18 := z.EncBinary()
+					_ = yym18
 					if false {
 					} else {
 						z.F.EncMapStringIntV(x.Map, false, e)
@@ -184,8 +196,8 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Map == nil {
 					r.EncodeNil()
 				} else {
-					yym17 := z.EncBinary()
-					_ = yym17
+					yym19 := z.EncBinary()
+					_ = yym19
 					if false {
 					} else {
 						z.F.EncMapStringIntV(x.Map, false, e)
@@ -196,8 +208,8 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.StringList == nil {
 					r.EncodeNil()
 				} else {
-					yym19 := z.EncBinary()
-					_ = yym19
+					yym21 := z.EncBinary()
+					_ = yym21
 					if false {
 					} else {
 						z.F.EncSliceStringV(x.StringList, false, e)
@@ -208,8 +220,8 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.StringList == nil {
 					r.EncodeNil()
 				} else {
-					yym20 := z.EncBinary()
-					_ = yym20
+					yym22 := z.EncBinary()
+					_ = yym22
 					if false {
 					} else {
 						z.F.EncSliceStringV(x.StringList, false, e)
@@ -220,8 +232,8 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.IntList == nil {
 					r.EncodeNil()
 				} else {
-					yym22 := z.EncBinary()
-					_ = yym22
+					yym24 := z.EncBinary()
+					_ = yym24
 					if false {
 					} else {
 						z.F.EncSliceIntV(x.IntList, false, e)
@@ -232,8 +244,8 @@ func (x *TestStruct) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.IntList == nil {
 					r.EncodeNil()
 				} else {
-					yym23 := z.EncBinary()
-					_ = yym23
+					yym25 := z.EncBinary()
+					_ = yym25
 					if false {
 					} else {
 						z.F.EncSliceIntV(x.IntList, false, e)
@@ -251,24 +263,24 @@ func (x *TestStruct) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym24 := z.DecBinary()
-	_ = yym24
+	yym26 := z.DecBinary()
+	_ = yym26
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl25 := r.ReadMapStart()
-			if yyl25 == 0 {
+			yyl27 := r.ReadMapStart()
+			if yyl27 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl25, d)
+				x.codecDecodeSelfFromMap(yyl27, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl25 := r.ReadArrayStart()
-			if yyl25 == 0 {
+			yyl27 := r.ReadArrayStart()
+			if yyl27 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl25, d)
+				x.codecDecodeSelfFromArray(yyl27, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -280,12 +292,12 @@ func (x *TestStruct) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys26Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys26Slc
-	var yyhl26 bool = l >= 0
-	for yyj26 := 0; ; yyj26++ {
-		if yyhl26 {
-			if yyj26 >= l {
+	var yys28Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys28Slc
+	var yyhl28 bool = l >= 0
+	for yyj28 := 0; ; yyj28++ {
+		if yyhl28 {
+			if yyj28 >= l {
 				break
 			}
 		} else {
@@ -293,9 +305,9 @@ func (x *TestStruct) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys26Slc = r.DecodeBytes(yys26Slc, true, true)
-		yys26 := string(yys26Slc)
-		switch yys26 {
+		yys28Slc = r.DecodeBytes(yys28Slc, true, true)
+		yys28 := string(yys28Slc)
+		switch yys28 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -312,8 +324,14 @@ func (x *TestStruct) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv29 := &x.ObjectMeta
-				yyv29.CodecDecodeSelf(d)
+				yyv31 := &x.ObjectMeta
+				yym32 := z.DecBinary()
+				_ = yym32
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv31) {
+				} else {
+					z.DecFallback(yyv31, false)
+				}
 			}
 		case "Key":
 			if r.TryDecodeAsNil() {
@@ -325,43 +343,43 @@ func (x *TestStruct) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Map = nil
 			} else {
-				yyv31 := &x.Map
-				yym32 := z.DecBinary()
-				_ = yym32
+				yyv34 := &x.Map
+				yym35 := z.DecBinary()
+				_ = yym35
 				if false {
 				} else {
-					z.F.DecMapStringIntX(yyv31, false, d)
+					z.F.DecMapStringIntX(yyv34, false, d)
 				}
 			}
 		case "StringList":
 			if r.TryDecodeAsNil() {
 				x.StringList = nil
 			} else {
-				yyv33 := &x.StringList
-				yym34 := z.DecBinary()
-				_ = yym34
+				yyv36 := &x.StringList
+				yym37 := z.DecBinary()
+				_ = yym37
 				if false {
 				} else {
-					z.F.DecSliceStringX(yyv33, false, d)
+					z.F.DecSliceStringX(yyv36, false, d)
 				}
 			}
 		case "IntList":
 			if r.TryDecodeAsNil() {
 				x.IntList = nil
 			} else {
-				yyv35 := &x.IntList
-				yym36 := z.DecBinary()
-				_ = yym36
+				yyv38 := &x.IntList
+				yym39 := z.DecBinary()
+				_ = yym39
 				if false {
 				} else {
-					z.F.DecSliceIntX(yyv35, false, d)
+					z.F.DecSliceIntX(yyv38, false, d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys26)
-		} // end switch yys26
-	} // end for yyj26
-	if !yyhl26 {
+			z.DecStructFieldNotFound(-1, yys28)
+		} // end switch yys28
+	} // end for yyj28
+	if !yyhl28 {
 		r.ReadEnd()
 	}
 }
@@ -370,16 +388,16 @@ func (x *TestStruct) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj37 int
-	var yyb37 bool
-	var yyhl37 bool = l >= 0
-	yyj37++
-	if yyhl37 {
-		yyb37 = yyj37 > l
+	var yyj40 int
+	var yyb40 bool
+	var yyhl40 bool = l >= 0
+	yyj40++
+	if yyhl40 {
+		yyb40 = yyj40 > l
 	} else {
-		yyb37 = r.CheckBreak()
+		yyb40 = r.CheckBreak()
 	}
-	if yyb37 {
+	if yyb40 {
 		r.ReadEnd()
 		return
 	}
@@ -388,13 +406,13 @@ func (x *TestStruct) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj37++
-	if yyhl37 {
-		yyb37 = yyj37 > l
+	yyj40++
+	if yyhl40 {
+		yyb40 = yyj40 > l
 	} else {
-		yyb37 = r.CheckBreak()
+		yyb40 = r.CheckBreak()
 	}
-	if yyb37 {
+	if yyb40 {
 		r.ReadEnd()
 		return
 	}
@@ -403,29 +421,35 @@ func (x *TestStruct) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj37++
-	if yyhl37 {
-		yyb37 = yyj37 > l
+	yyj40++
+	if yyhl40 {
+		yyb40 = yyj40 > l
 	} else {
-		yyb37 = r.CheckBreak()
+		yyb40 = r.CheckBreak()
 	}
-	if yyb37 {
+	if yyb40 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv40 := &x.ObjectMeta
-		yyv40.CodecDecodeSelf(d)
+		yyv43 := &x.ObjectMeta
+		yym44 := z.DecBinary()
+		_ = yym44
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv43) {
+		} else {
+			z.DecFallback(yyv43, false)
+		}
 	}
-	yyj37++
-	if yyhl37 {
-		yyb37 = yyj37 > l
+	yyj40++
+	if yyhl40 {
+		yyb40 = yyj40 > l
 	} else {
-		yyb37 = r.CheckBreak()
+		yyb40 = r.CheckBreak()
 	}
-	if yyb37 {
+	if yyb40 {
 		r.ReadEnd()
 		return
 	}
@@ -434,80 +458,80 @@ func (x *TestStruct) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Key = string(r.DecodeString())
 	}
-	yyj37++
-	if yyhl37 {
-		yyb37 = yyj37 > l
+	yyj40++
+	if yyhl40 {
+		yyb40 = yyj40 > l
 	} else {
-		yyb37 = r.CheckBreak()
+		yyb40 = r.CheckBreak()
 	}
-	if yyb37 {
+	if yyb40 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Map = nil
 	} else {
-		yyv42 := &x.Map
-		yym43 := z.DecBinary()
-		_ = yym43
+		yyv46 := &x.Map
+		yym47 := z.DecBinary()
+		_ = yym47
 		if false {
 		} else {
-			z.F.DecMapStringIntX(yyv42, false, d)
+			z.F.DecMapStringIntX(yyv46, false, d)
 		}
 	}
-	yyj37++
-	if yyhl37 {
-		yyb37 = yyj37 > l
+	yyj40++
+	if yyhl40 {
+		yyb40 = yyj40 > l
 	} else {
-		yyb37 = r.CheckBreak()
+		yyb40 = r.CheckBreak()
 	}
-	if yyb37 {
+	if yyb40 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.StringList = nil
 	} else {
-		yyv44 := &x.StringList
-		yym45 := z.DecBinary()
-		_ = yym45
+		yyv48 := &x.StringList
+		yym49 := z.DecBinary()
+		_ = yym49
 		if false {
 		} else {
-			z.F.DecSliceStringX(yyv44, false, d)
+			z.F.DecSliceStringX(yyv48, false, d)
 		}
 	}
-	yyj37++
-	if yyhl37 {
-		yyb37 = yyj37 > l
+	yyj40++
+	if yyhl40 {
+		yyb40 = yyj40 > l
 	} else {
-		yyb37 = r.CheckBreak()
+		yyb40 = r.CheckBreak()
 	}
-	if yyb37 {
+	if yyb40 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.IntList = nil
 	} else {
-		yyv46 := &x.IntList
-		yym47 := z.DecBinary()
-		_ = yym47
+		yyv50 := &x.IntList
+		yym51 := z.DecBinary()
+		_ = yym51
 		if false {
 		} else {
-			z.F.DecSliceIntX(yyv46, false, d)
+			z.F.DecSliceIntX(yyv50, false, d)
 		}
 	}
 	for {
-		yyj37++
-		if yyhl37 {
-			yyb37 = yyj37 > l
+		yyj40++
+		if yyhl40 {
+			yyb40 = yyj40 > l
 		} else {
-			yyb37 = r.CheckBreak()
+			yyb40 = r.CheckBreak()
 		}
-		if yyb37 {
+		if yyb40 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj37-1, "")
+		z.DecStructFieldNotFound(yyj40-1, "")
 	}
 	r.ReadEnd()
 }

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2387,6 +2387,33 @@ func (kl *Kubelet) syncNetworkStatus() {
 	kl.networkConfigured = networkConfigured
 }
 
+func (kl *Kubelet) getNodeAddress(ip net.IP) ([]api.NodeAddress, error) {
+	var addresses []api.NodeAddress
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return []api.NodeAddress{}, err
+	}
+FIND:
+	for _, i := range ifaces {
+		addrs, err := i.Addrs()
+		if err == nil {
+			for _, addr := range addrs {
+				if addrOri, ok := addr.(*net.IPNet); ok {
+					if addrOri.IP.Equal(ip) {
+						addresses = []api.NodeAddress{
+							api.NodeAddress{api.NodeLegacyHostIP, addrOri.String()},
+							api.NodeAddress{api.NodeInternalIP, addrOri.String()},
+						}
+						break FIND
+					}
+				}
+			}
+		}
+	}
+
+	return addresses, nil
+}
+
 // setNodeStatus fills in the Status fields of the given Node, overwriting
 // any fields that are currently set.
 // TODO(madhusudancs): Simplify the logic for setting node conditions and
@@ -2408,47 +2435,38 @@ func (kl *Kubelet) setNodeStatus(node *api.Node) error {
 		node.Status.Addresses = nodeAddresses
 	} else {
 		addr := net.ParseIP(kl.hostname)
-		if addr != nil {
-			node.Status.Addresses = []api.NodeAddress{
-				{Type: api.NodeLegacyHostIP, Address: addr.String()},
-				{Type: api.NodeInternalIP, Address: addr.String()},
-			}
-		} else {
+		if addr == nil {
 			addrs, err := net.LookupIP(node.Name)
 			if err != nil {
 				return fmt.Errorf("can't get ip address of node %s: %v", node.Name, err)
 			} else if len(addrs) == 0 {
 				return fmt.Errorf("no ip address for node %v", node.Name)
-			} else {
-				// check all ip addresses for this node.Name and try to find the first non-loopback IPv4 address.
-				// If no match is found, it uses the IP of the interface with gateway on it.
-				for _, ip := range addrs {
-					if ip.IsLoopback() {
-						continue
-					}
-
-					if ip.To4() != nil {
-						node.Status.Addresses = []api.NodeAddress{
-							{Type: api.NodeLegacyHostIP, Address: ip.String()},
-							{Type: api.NodeInternalIP, Address: ip.String()},
-						}
-						break
-					}
+			}
+			// check all ip addresses for this node.Name and try to find the first non-loopback IPv4 address.
+			// If no match is found, it uses the IP of the interface with gateway on it.
+			for _, ip := range addrs {
+				if ip.IsLoopback() {
+					continue
 				}
 
-				if len(node.Status.Addresses) == 0 {
-					ip, err := util.ChooseHostInterface()
-					if err != nil {
-						return err
-					}
-
-					node.Status.Addresses = []api.NodeAddress{
-						{Type: api.NodeLegacyHostIP, Address: ip.String()},
-						{Type: api.NodeInternalIP, Address: ip.String()},
-					}
+				if ip.To4() != nil {
+					addr = ip
+					break
 				}
 			}
+			if addr == nil {
+				ip, err := util.ChooseHostInterface()
+				if err != nil {
+					return err
+				}
+				addr = ip
+			}
 		}
+		addresses, err := kl.getNodeAddress(addr)
+		if err != nil || len(addresses) == 0 {
+			return fmt.Errorf("can't get ip network of node %s", node.Name)
+		}
+		node.Status.Addresses = addresses
 	}
 
 	// TODO: Post NotReady if we cannot get MachineInfo from cAdvisor. This needs to start

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2398,11 +2398,9 @@ FIND:
 		addrs, err := i.Addrs()
 		if err == nil {
 			for _, addr := range addrs {
-				if addrOri, ok := addr.(*net.IPNet); ok {
-					if addrOri.IP.Equal(ip) {
-						network = addrOri.String()
-						break FIND
-					}
+				if addrOri, ok := addr.(*net.IPNet); ok && addrOri.IP.Equal(ip) {
+					network = addrOri.String()
+					break FIND
 				}
 			}
 		}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2401,8 +2401,8 @@ FIND:
 				if addrOri, ok := addr.(*net.IPNet); ok {
 					if addrOri.IP.Equal(ip) {
 						addresses = []api.NodeAddress{
-							api.NodeAddress{api.NodeLegacyHostIP, addrOri.String()},
-							api.NodeAddress{api.NodeInternalIP, addrOri.String()},
+							{api.NodeLegacyHostIP, addrOri.String()},
+							{api.NodeInternalIP, addrOri.String()},
 						}
 						break FIND
 					}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2387,11 +2387,11 @@ func (kl *Kubelet) syncNetworkStatus() {
 	kl.networkConfigured = networkConfigured
 }
 
-func (kl *Kubelet) getNodeAddress(ip net.IP) ([]api.NodeAddress, error) {
-	var addresses []api.NodeAddress
+func (kl *Kubelet) getNodeAddress(ip net.IP) (string, error) {
+	var network string
 	ifaces, err := net.Interfaces()
 	if err != nil {
-		return []api.NodeAddress{}, err
+		return "", err
 	}
 FIND:
 	for _, i := range ifaces {
@@ -2400,10 +2400,7 @@ FIND:
 			for _, addr := range addrs {
 				if addrOri, ok := addr.(*net.IPNet); ok {
 					if addrOri.IP.Equal(ip) {
-						addresses = []api.NodeAddress{
-							{api.NodeLegacyHostIP, addrOri.String()},
-							{api.NodeInternalIP, addrOri.String()},
-						}
+						network = addrOri.String()
 						break FIND
 					}
 				}
@@ -2411,7 +2408,7 @@ FIND:
 		}
 	}
 
-	return addresses, nil
+	return network, nil
 }
 
 // setNodeStatus fills in the Status fields of the given Node, overwriting
@@ -2462,11 +2459,14 @@ func (kl *Kubelet) setNodeStatus(node *api.Node) error {
 				addr = ip
 			}
 		}
-		addresses, err := kl.getNodeAddress(addr)
-		if err != nil || len(addresses) == 0 {
+		network, err := kl.getNodeAddress(addr)
+		if err != nil || len(network) == 0 {
 			return fmt.Errorf("can't get ip network of node %s", node.Name)
 		}
-		node.Status.Addresses = addresses
+		node.Status.Addresses = []api.NodeAddress{
+			{Type: api.NodeLegacyHostIP, Address: addr.String(), Subnet: network},
+			{Type: api.NodeInternalIP, Address: addr.String(), Subnet: network},
+		}
 	}
 
 	// TODO: Post NotReady if we cannot get MachineInfo from cAdvisor. This needs to start

--- a/pkg/storage/testing/types.generated.go
+++ b/pkg/storage/testing/types.generated.go
@@ -139,23 +139,35 @@ func (x *TestResource) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				yy10 := &x.ObjectMeta
-				yy10.CodecEncodeSelf(e)
+				yym11 := z.EncBinary()
+				_ = yym11
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy10) {
+				} else {
+					z.EncFallback(yy10)
+				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-				yy11 := &x.ObjectMeta
-				yy11.CodecEncodeSelf(e)
-			}
-			if yyr2 || yy2arr2 {
+				yy12 := &x.ObjectMeta
 				yym13 := z.EncBinary()
 				_ = yym13
+				if false {
+				} else if z.HasExtensions() && z.EncExt(yy12) {
+				} else {
+					z.EncFallback(yy12)
+				}
+			}
+			if yyr2 || yy2arr2 {
+				yym15 := z.EncBinary()
+				_ = yym15
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Value))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("value"))
-				yym14 := z.EncBinary()
-				_ = yym14
+				yym16 := z.EncBinary()
+				_ = yym16
 				if false {
 				} else {
 					r.EncodeInt(int64(x.Value))
@@ -172,24 +184,24 @@ func (x *TestResource) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym15 := z.DecBinary()
-	_ = yym15
+	yym17 := z.DecBinary()
+	_ = yym17
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl16 := r.ReadMapStart()
-			if yyl16 == 0 {
+			yyl18 := r.ReadMapStart()
+			if yyl18 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl16, d)
+				x.codecDecodeSelfFromMap(yyl18, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl16 := r.ReadArrayStart()
-			if yyl16 == 0 {
+			yyl18 := r.ReadArrayStart()
+			if yyl18 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl16, d)
+				x.codecDecodeSelfFromArray(yyl18, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -201,12 +213,12 @@ func (x *TestResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys17Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys17Slc
-	var yyhl17 bool = l >= 0
-	for yyj17 := 0; ; yyj17++ {
-		if yyhl17 {
-			if yyj17 >= l {
+	var yys19Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys19Slc
+	var yyhl19 bool = l >= 0
+	for yyj19 := 0; ; yyj19++ {
+		if yyhl19 {
+			if yyj19 >= l {
 				break
 			}
 		} else {
@@ -214,9 +226,9 @@ func (x *TestResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys17Slc = r.DecodeBytes(yys17Slc, true, true)
-		yys17 := string(yys17Slc)
-		switch yys17 {
+		yys19Slc = r.DecodeBytes(yys19Slc, true, true)
+		yys19 := string(yys19Slc)
+		switch yys19 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -233,8 +245,14 @@ func (x *TestResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv20 := &x.ObjectMeta
-				yyv20.CodecDecodeSelf(d)
+				yyv22 := &x.ObjectMeta
+				yym23 := z.DecBinary()
+				_ = yym23
+				if false {
+				} else if z.HasExtensions() && z.DecExt(yyv22) {
+				} else {
+					z.DecFallback(yyv22, false)
+				}
 			}
 		case "value":
 			if r.TryDecodeAsNil() {
@@ -243,10 +261,10 @@ func (x *TestResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Value = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys17)
-		} // end switch yys17
-	} // end for yyj17
-	if !yyhl17 {
+			z.DecStructFieldNotFound(-1, yys19)
+		} // end switch yys19
+	} // end for yyj19
+	if !yyhl19 {
 		r.ReadEnd()
 	}
 }
@@ -255,16 +273,16 @@ func (x *TestResource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj22 int
-	var yyb22 bool
-	var yyhl22 bool = l >= 0
-	yyj22++
-	if yyhl22 {
-		yyb22 = yyj22 > l
+	var yyj25 int
+	var yyb25 bool
+	var yyhl25 bool = l >= 0
+	yyj25++
+	if yyhl25 {
+		yyb25 = yyj25 > l
 	} else {
-		yyb22 = r.CheckBreak()
+		yyb25 = r.CheckBreak()
 	}
-	if yyb22 {
+	if yyb25 {
 		r.ReadEnd()
 		return
 	}
@@ -273,13 +291,13 @@ func (x *TestResource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj22++
-	if yyhl22 {
-		yyb22 = yyj22 > l
+	yyj25++
+	if yyhl25 {
+		yyb25 = yyj25 > l
 	} else {
-		yyb22 = r.CheckBreak()
+		yyb25 = r.CheckBreak()
 	}
-	if yyb22 {
+	if yyb25 {
 		r.ReadEnd()
 		return
 	}
@@ -288,29 +306,35 @@ func (x *TestResource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj22++
-	if yyhl22 {
-		yyb22 = yyj22 > l
+	yyj25++
+	if yyhl25 {
+		yyb25 = yyj25 > l
 	} else {
-		yyb22 = r.CheckBreak()
+		yyb25 = r.CheckBreak()
 	}
-	if yyb22 {
+	if yyb25 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv25 := &x.ObjectMeta
-		yyv25.CodecDecodeSelf(d)
+		yyv28 := &x.ObjectMeta
+		yym29 := z.DecBinary()
+		_ = yym29
+		if false {
+		} else if z.HasExtensions() && z.DecExt(yyv28) {
+		} else {
+			z.DecFallback(yyv28, false)
+		}
 	}
-	yyj22++
-	if yyhl22 {
-		yyb22 = yyj22 > l
+	yyj25++
+	if yyhl25 {
+		yyb25 = yyj25 > l
 	} else {
-		yyb22 = r.CheckBreak()
+		yyb25 = r.CheckBreak()
 	}
-	if yyb22 {
+	if yyb25 {
 		r.ReadEnd()
 		return
 	}
@@ -320,16 +344,16 @@ func (x *TestResource) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Value = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj22++
-		if yyhl22 {
-			yyb22 = yyj22 > l
+		yyj25++
+		if yyhl25 {
+			yyb25 = yyj25 > l
 		} else {
-			yyb22 = r.CheckBreak()
+			yyb25 = r.CheckBreak()
 		}
-		if yyb22 {
+		if yyb25 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj22-1, "")
+		z.DecStructFieldNotFound(yyj25-1, "")
 	}
 	r.ReadEnd()
 }


### PR DESCRIPTION
Add subnet key in struct NodeAddress, so that kubelet can report ipnetwork to the key, This can help scheduler to deploy pods among different subnets, because of most IDC production env get each switch has a individual subnet, This priority can make less pods down when a switch down.
