### PR TITLE
Display controllers along with type when describing a pod

### DIFF
--- a/hack/test-cmd.sh
+++ b/hack/test-cmd.sh
@@ -276,9 +276,9 @@ runTests() {
   kube::test::get_object_jsonpath_assert 'pod/valid-pod' "{$id_field}" 'valid-pod'
   kube::test::get_object_jsonpath_assert 'pods/valid-pod' "{$id_field}" 'valid-pod'
   # Describe command should print detailed information
-  kube::test::describe_object_assert pods 'valid-pod' "Name:" "Image(s):" "Node:" "Labels:" "Status:" "Replication Controllers"
+  kube::test::describe_object_assert pods 'valid-pod' "Name:" "Image(s):" "Node:" "Labels:" "Status:" "Controllers"
   # Describe command (resource only) should print detailed information
-  kube::test::describe_resource_assert pods "Name:" "Image(s):" "Node:" "Labels:" "Status:" "Replication Controllers"
+  kube::test::describe_resource_assert pods "Name:" "Image(s):" "Node:" "Labels:" "Status:" "Controllers"
 
   ### Dump current valid-pod POD
   output_pod=$(kubectl get pod valid-pod -o yaml --output-version=v1 "${kube_flags[@]}")

--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -18,6 +18,7 @@ package kubectl
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"reflect"
@@ -483,7 +484,7 @@ func describePod(pod *api.Pod, rcs []api.ReplicationController, events *api.Even
 		for _, rc := range rcs {
 			matchingRCs = append(matchingRCs, &rc)
 		}
-		fmt.Fprintf(out, "Replication Controllers:\t%s\n", printReplicationControllersByLabels(matchingRCs))
+		fmt.Fprintf(out, "Controllers:\t%s\n", printControllers(pod.Annotations))
 		fmt.Fprintf(out, "Containers:\n")
 		describeContainers(pod, out)
 		if len(pod.Status.Conditions) > 0 {
@@ -500,6 +501,18 @@ func describePod(pod *api.Pod, rcs []api.ReplicationController, events *api.Even
 		}
 		return nil
 	})
+}
+
+func printControllers(annotation map[string]string) string {
+	value, ok := annotation["kubernetes.io/created-by"]
+	if ok {
+		var r api.SerializedReference
+		err := json.Unmarshal([]byte(value), &r)
+		if err == nil {
+			return fmt.Sprintf("%s/%s", r.Reference.Kind, r.Reference.Name)
+		}
+	}
+	return "<none>"
 }
 
 func describeVolumes(volumes []api.Volume, out io.Writer) {

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -505,7 +505,7 @@ var _ = Describe("Kubectl client", func() {
 					{"Reason:"},
 					{"Message:"},
 					{"IP:"},
-					{"Replication Controllers:", "redis-master"}}
+					{"Controllers:", "ReplicationController/redis-master"}}
 				checkOutput(output, requiredStrings)
 			})
 


### PR DESCRIPTION
Fixes: #14304

There're more controllers than replication controller, the patch
displays annotation item with key "kuberntetes.io/created-by" in
the form of "Controllers: type/name".
