### PR TITLE
Switch from gcr.io/_b_ prefix to b.gcr.io/ to designate bring-your-ow…

### DIFF
--- a/test/e2e/rc.go
+++ b/test/e2e/rc.go
@@ -43,7 +43,7 @@ var _ = Describe("ReplicationController", func() {
 		// requires private images
 		SkipUnlessProviderIs("gce", "gke")
 
-		ServeImageOrFail(framework, "private", "gcr.io/_b_k8s_authenticated_test/serve_hostname:1.1")
+		ServeImageOrFail(framework, "private", "b.gcr.io/k8s_authenticated_test/serve_hostname:1.1")
 	})
 })
 


### PR DESCRIPTION
…n-bucket pulls

cherry-pick of #13747
should help for #14674, though it's not obvious for me if we should cherry-pick test changes to 1.0

cc @brendandburns @davidopp @fgrzadkowski @gmarek @ihmccreery @mikedanese 
