### PR TITLE
Pass runtime.Object to Helper.Create/Replace

### DIFF
--- a/pkg/kubectl/cmd/autoscale.go
+++ b/pkg/kubectl/cmd/autoscale.go
@@ -140,12 +140,7 @@ func RunAutoscale(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []
 		return err
 	}
 
-	// Serialize the object with the annotation applied.
-	data, err := hpa.Mapping.Codec.Encode(object)
-	if err != nil {
-		return err
-	}
-	object, err = resource.NewHelper(hpa.Client, hpa.Mapping).Create(namespace, false, data)
+	object, err = resource.NewHelper(hpa.Client, hpa.Mapping).Create(namespace, false, object)
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -112,13 +112,7 @@ func RunCreate(f *cmdutil.Factory, cmd *cobra.Command, out io.Writer, options *C
 			return cmdutil.AddSourceToErr("creating", info.Source, err)
 		}
 
-		// Serialize the object with the annotation applied.
-		data, err := info.Mapping.Codec.Encode(info.Object)
-		if err != nil {
-			return cmdutil.AddSourceToErr("creating", info.Source, err)
-		}
-
-		obj, err := resource.NewHelper(info.Client, info.Mapping).Create(info.Namespace, true, data)
+		obj, err := resource.NewHelper(info.Client, info.Mapping).Create(info.Namespace, true, info.Object)
 		if err != nil {
 			return cmdutil.AddSourceToErr("creating", info.Source, err)
 		}

--- a/pkg/kubectl/cmd/expose.go
+++ b/pkg/kubectl/cmd/expose.go
@@ -207,11 +207,7 @@ func RunExpose(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []str
 	}
 
 	// Serialize the object with the annotation applied.
-	data, err := info.Mapping.Codec.Encode(object)
-	if err != nil {
-		return err
-	}
-	object, err = resource.NewHelper(info.Client, info.Mapping).Create(namespace, false, data)
+	object, err = resource.NewHelper(info.Client, info.Mapping).Create(namespace, false, object)
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/replace.go
+++ b/pkg/kubectl/cmd/replace.go
@@ -134,12 +134,7 @@ func RunReplace(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []st
 		}
 
 		// Serialize the object with the annotation applied.
-		data, err := info.Mapping.Codec.Encode(info.Object)
-		if err != nil {
-			return cmdutil.AddSourceToErr("replacing", info.Source, err)
-		}
-
-		obj, err := resource.NewHelper(info.Client, info.Mapping).Replace(info.Namespace, info.Name, true, data)
+		obj, err := resource.NewHelper(info.Client, info.Mapping).Replace(info.Namespace, info.Name, true, info.Object)
 		if err != nil {
 			return cmdutil.AddSourceToErr("replacing", info.Source, err)
 		}
@@ -226,13 +221,7 @@ func forceReplace(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []
 			return err
 		}
 
-		// Serialize the object with the annotation applied.
-		data, err := info.Mapping.Codec.Encode(info.Object)
-		if err != nil {
-			return err
-		}
-
-		obj, err := resource.NewHelper(info.Client, info.Mapping).Create(info.Namespace, true, data)
+		obj, err := resource.NewHelper(info.Client, info.Mapping).Create(info.Namespace, true, info.Object)
 		if err != nil {
 			return err
 		}

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -376,13 +376,7 @@ func createGeneratedObject(f *cmdutil.Factory, cmd *cobra.Command, generator kub
 			return nil, "", nil, nil, err
 		}
 
-		// Serialize the object with the annotation applied.
-		data, err := mapping.Codec.Encode(info.Object)
-		if err != nil {
-			return nil, "", nil, nil, err
-		}
-
-		obj, err = resource.NewHelper(client, mapping).Create(namespace, false, data)
+		obj, err = resource.NewHelper(client, mapping).Create(namespace, false, info.Object)
 		if err != nil {
 			return nil, "", nil, nil, err
 		}

--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -414,12 +414,7 @@ func UpdateObject(info *resource.Info, updateFn func(runtime.Object) error) (run
 		return nil, err
 	}
 
-	data, err := helper.Codec.Encode(info.Object)
-	if err != nil {
-		return nil, err
-	}
-
-	if _, err := helper.Replace(info.Namespace, info.Name, true, data); err != nil {
+	if _, err := helper.Replace(info.Namespace, info.Name, true, info.Object); err != nil {
 		return nil, err
 	}
 

--- a/pkg/kubectl/resource/helper_test.go
+++ b/pkg/kubectl/resource/helper_test.go
@@ -170,7 +170,10 @@ func TestHelperCreate(t *testing.T) {
 		},
 		{
 			Modify: true,
-			Object: &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "10"}},
+			Object: &api.Pod{
+				ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "10"},
+				Spec:       apitesting.DeepEqualSafePodSpec(),
+			},
 			ExpectObject: &api.Pod{
 				ObjectMeta: api.ObjectMeta{Name: "foo"},
 				Spec:       apitesting.DeepEqualSafePodSpec(),
@@ -194,11 +197,7 @@ func TestHelperCreate(t *testing.T) {
 			Versioner:       testapi.Default.MetadataAccessor(),
 			NamespaceScoped: true,
 		}
-		data := []byte{}
-		if test.Object != nil {
-			data = []byte(runtime.EncodeOrDie(testapi.Default.Codec(), test.Object))
-		}
-		_, err := modifier.Create("bar", test.Modify, data)
+		_, err := modifier.Create("bar", test.Modify, test.Object)
 		if (err != nil) != test.Err {
 			t.Errorf("%d: unexpected error: %t %v", i, test.Err, err)
 		}
@@ -218,7 +217,7 @@ func TestHelperCreate(t *testing.T) {
 			expect = []byte(runtime.EncodeOrDie(testapi.Default.Codec(), test.ExpectObject))
 		}
 		if !reflect.DeepEqual(expect, body) {
-			t.Errorf("%d: unexpected body: %s", i, string(body))
+			t.Errorf("%d: unexpected body: %s (expected %s)", i, string(body), string(expect))
 		}
 
 	}
@@ -413,7 +412,10 @@ func TestHelperReplace(t *testing.T) {
 			Req: expectPut,
 		},
 		{
-			Object: &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}},
+			Object: &api.Pod{
+				ObjectMeta: api.ObjectMeta{Name: "foo"},
+				Spec:       apitesting.DeepEqualSafePodSpec(),
+			},
 			ExpectObject: &api.Pod{
 				ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "10"},
 				Spec:       apitesting.DeepEqualSafePodSpec(),
@@ -449,11 +451,7 @@ func TestHelperReplace(t *testing.T) {
 			Versioner:       testapi.Default.MetadataAccessor(),
 			NamespaceScoped: true,
 		}
-		data := []byte{}
-		if test.Object != nil {
-			data = []byte(runtime.EncodeOrDie(testapi.Default.Codec(), test.Object))
-		}
-		_, err := modifier.Replace("bar", "foo", test.Overwrite, data)
+		_, err := modifier.Replace("bar", "foo", test.Overwrite, test.Object)
 		if (err != nil) != test.Err {
 			t.Errorf("%d: unexpected error: %t %v", i, test.Err, err)
 		}


### PR DESCRIPTION
kubectl commands were serializing using the info.Mapping.Codec, rather than letting the RESTClient serialize the object using the Codec for the version it expected to speak to the server with.

This also meant that in `modify` cases, the object would get encoded, decoded, and re-encoded, which would apply defaulting client-side, which is not ideal.
