### PR TITLE
Manually removing raw=true at one place to debug

### DIFF
--- a/_v1.1/docs/user-guide/simple-yaml.md
+++ b/_v1.1/docs/user-guide/simple-yaml.md
@@ -44,7 +44,7 @@ spec:
 {% endraw %}
 {% endhighlight %}
 
-[Download example](pod.yaml?raw=true)
+[Download example](pod.yaml)
 <!-- END MUNGE: EXAMPLE pod.yaml -->
 
 You can see your cluster's pods:


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/issues/16393

Manually removing raw=true at one place to verify that the link works fine without it.
Will add a munger to do this if it works fine.

cc @bgrant0607 
