### PR TITLE
Defer GinkgoRecover call in e2e runKubectlWithTimeout to handle panics

### DIFF
--- a/test/e2e/portforward.go
+++ b/test/e2e/portforward.go
@@ -115,6 +115,7 @@ func runPortForward(ns, podName string, port int) (*exec.Cmd, int) {
 func runKubectlWithTimeout(timeout time.Duration, args ...string) string {
 	logOutput := make(chan string)
 	go func() {
+		defer GinkgoRecover()
 		logOutput <- runKubectl(args...)
 	}()
 	select {


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/16467
