### PR TITLE
Fix PD leak in release-1.0 e2e tests

### DIFF
--- a/test/e2e/pd.go
+++ b/test/e2e/pd.go
@@ -283,7 +283,7 @@ func deletePD(pdName string) error {
 		zone := testContext.CloudConfig.Zone
 
 		// TODO: make this hit the compute API directly.
-		cmd := exec.Command("gcloud", "compute", "--project="+testContext.CloudConfig.ProjectID, "disks", "delete", "--zone="+zone, pdName)
+		cmd := exec.Command("gcloud", "compute", "--project="+testContext.CloudConfig.ProjectID, "disks", "delete", "--zone="+zone, "--quiet", pdName)
 		data, err := cmd.CombinedOutput()
 		if err != nil {
 			Logf("Error deleting PD: %s (%v)", string(data), err)


### PR DESCRIPTION
seeing some of this and volumes don't get cleaned up

```
INFO: Couldn't delete PD "k-2-0b641e39-7ddf-11e5-9aed-8cdcd43413f0". Sleeping 5 seconds (exit status 1)
INFO: Error deleting PD: The following disks will be deleted. Deleting a disk is irreversible 
and any data on the disk will be lost.
 - [k-2-0b641e39-7ddf-11e5-9aed-8cdcd43413f0] in [us-central1-b]

Do you want to continue (Y/n)?  
ERROR: (gcloud.compute.disks.delete) Some requests did not succeed:
 - The disk resource 'k-2-0b641e39-7ddf-11e5-9aed-8cdcd43413f0' is already being used by 'k-2-minion-k6o2'

 (exit status 1)
INFO: Couldn't delete PD "k-2-0b641e39-7ddf-11e5-9aed-8cdcd43413f0". Sleeping 5 seconds (exit status 1)
INFO: Error deleting PD: The following disks will be deleted. Deleting a disk is irreversible 
and any data on the disk will be lost.
 - [k-2-0b641e39-7ddf-11e5-9aed-8cdcd43413f0] in [us-central1-b]

Do you want to continue (Y/n)?  
ERROR: (gcloud.compute.disks.delete) Some requests did not succeed:
 - The disk resource 'k-2-0b641e39-7ddf-11e5-9aed-8cdcd43413f0' is already being used by 'k-2-minion-k6o2'

 (exit status 1)
INFO: Couldn't delete PD "k-2-0b641e39-7ddf-11e5-9aed-8cdcd43413f0". Sleeping 5 seconds (exit status 1)
INFO: Error deleting PD: The following disks will be deleted. Deleting a disk is irreversible 
and any data on the disk will be lost.
 - [k-2-0b641e39-7ddf-11e5-9aed-8cdcd43413f0] in [us-central1-b]

Do you want to continue (Y/n)?  
ERROR: (gcloud.compute.disks.delete) Some requests did not succeed:
 - The disk resource 'k-2-0b641e39-7ddf-11e5-9aed-8cdcd43413f0' is already being used by 'k-2-minion-k6o2'

 (exit status 1)
INFO: Couldn't delete PD "k-2-0b641e39-7ddf-11e5-9aed-8cdcd43413f0". Sleeping 5 seconds (exit status 1)
INFO: Error deleting PD: The following disks will be deleted. Deleting a disk is irreversible 
and any data on the disk will be lost.
 - [k-2-0b641e39-7ddf-11e5-9aed-8cdcd43413f0] in [us-central1-b]

Do you want to continue (Y/n)?  
ERROR: (gcloud.compute.disks.delete) Some requests did not succeed:
 - The disk resource 'k-2-0b641e39-7ddf-11e5-9aed-8cdcd43413f0' is already being used by 'k-2-minion-k6o2'

 (exit status 1)
INFO: Couldn't delete PD "k-2-0b641e39-7ddf-11e5-9aed-8cdcd43413f0". Sleeping 5 seconds (exit status 1)
INFO: Error deleting PD: The following disks will be deleted. Deleting a disk is irreversible 
and any data on the disk will be lost.
 - [k-2-0b641e39-7ddf-11e5-9aed-8cdcd43413f0] in [us-central1-b]

Do you want to continue (Y/n)?  
ERROR: (gcloud.compute.disks.delete) Some requests did not succeed:
 - The disk resource 'k-2-0b641e39-7ddf-11e5-9aed-8cdcd43413f0' is already being used by 'k-2-minion-k6o2'

 (exit status 1)
INFO: Couldn't delete PD "k-2-0b641e39-7ddf-11e5-9aed-8cdcd43413f0". Sleeping 5 seconds (exit status 1)
INFO: Error deleting PD: The following disks will be deleted. Deleting a disk is irreversible 
and any data on the disk will be lost.
 - [k-2-0b641e39-7ddf-11e5-9aed-8cdcd43413f0] in [us-central1-b]

Do you want to continue (Y/n)?  
ERROR: (gcloud.compute.disks.delete) Some requests did not succeed:
 - The disk resource 'k-2-0b641e39-7ddf-11e5-9aed-8cdcd43413f0' is already being used by 'k-2-minion-k6o2'

 (exit status 1)
INFO: Couldn't delete PD "k-2-0b641e39-7ddf-11e5-9aed-8cdcd43413f0". Sleeping 5 seconds (exit status 1)
INFO: Deleted PD k-2-0b641e39-7ddf-11e5-9aed-8cdcd43413f0
STEP: cleaning up PD-RO test environment
INFO: Error deleting PD: The following disks will be deleted. Deleting a disk is irreversible 
and any data on the disk will be lost.
 - [k-2-0b641e39-7ddf-11e5-9aed-8cdcd43413f0] in [us-central1-b]

```
