### PR TITLE
Fixing a bug in FixDownloadLinks munger

### DIFF
--- a/_tools/release_docs/main.go
+++ b/_tools/release_docs/main.go
@@ -253,8 +253,8 @@ var (
 // to
 // "[Download example](pod.yaml)"
 func rewriteDownloadLinks(fileBytes []byte) []byte {
-	return downloadLinkRE.ReplaceAllFunc(fileBytes, func([]byte) []byte {
-		matches := downloadLinkRE.FindSubmatch(fileBytes)
+	return downloadLinkRE.ReplaceAllFunc(fileBytes, func(in []byte) []byte {
+		matches := downloadLinkRE.FindSubmatch(in)
 		fileName := string(matches[1])
 		extension := string(matches[2])
 		newLink := "[Download example](" + fileName + extension + ")"


### PR DESCRIPTION
Fixing a bug where the first Download example link in a file was used everywhere in that file.

Verified that this fixes the bug by running the munger again: https://github.com/nikhiljindal/kubernetes/commit/48fce163d14b60f099e05a75620869f981f1f04f

cc @bgrant0607 
