### PR TITLE
Fixed flakiness of resize nodes test.

### DIFF
--- a/test/e2e/resize_nodes.go
+++ b/test/e2e/resize_nodes.go
@@ -88,7 +88,8 @@ func groupSize() (int, error) {
 }
 
 func waitForGroupSize(size int) error {
-	for start := time.Now(); time.Since(start) < 4*time.Minute; time.Sleep(5 * time.Second) {
+	timeout := 10 * time.Minute
+	for start := time.Now(); time.Since(start) < timeout; time.Sleep(5 * time.Second) {
 		currentSize, err := groupSize()
 		if err != nil {
 			Logf("Failed to get node instance group size: %v", err)


### PR DESCRIPTION
Fixed flakiness of resize nodes test by increasing timeout for waiting for change of size of managed instance group with nodes. Fixes #11442.

Cherry pick of #12138
part of #14674
