### PR TITLE
Enable cacher for all resources.

### DIFF
--- a/pkg/controller/serviceaccount/tokengetter.go
+++ b/pkg/controller/serviceaccount/tokengetter.go
@@ -73,9 +73,9 @@ func (r *registryGetter) GetSecret(namespace, name string) (*api.Secret, error) 
 
 // NewGetterFromStorageInterface returns a ServiceAccountTokenGetter that
 // uses the specified storage to retrieve service accounts and secrets.
-func NewGetterFromStorageInterface(storage storage.Interface) ServiceAccountTokenGetter {
+func NewGetterFromStorageInterface(s storage.Interface) ServiceAccountTokenGetter {
 	return NewGetterFromRegistries(
-		serviceaccount.NewRegistry(serviceaccountetcd.NewREST(storage)),
-		secret.NewRegistry(secretetcd.NewREST(storage)),
+		serviceaccount.NewRegistry(serviceaccountetcd.NewREST(s, storage.NoDecoration)),
+		secret.NewRegistry(secretetcd.NewREST(s, storage.NoDecoration)),
 	)
 }

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -268,6 +268,13 @@ type Config struct {
 	KubernetesServiceNodePort int
 }
 
+func (c *Config) storageFactory() storage.StorageFactory {
+	if c.EnableWatchCache {
+		return storage.NewCacher
+	}
+	return storage.NoDecoration
+}
+
 type InstallSSHKey func(user string, data []byte) error
 
 // Master contains state for a Kubernetes cluster master/api server.
@@ -535,27 +542,22 @@ func (m *Master) init(c *Config) {
 
 	healthzChecks := []healthz.HealthzChecker{}
 
-	var storageFactory storage.StorageFactory
-	if c.EnableWatchCache {
-		storageFactory = storage.NewCacher
-	} else {
-		storageFactory = storage.NoDecoration
-	}
+	storageFactory := c.storageFactory()
 	dbClient := func(resource string) storage.Interface { return c.StorageDestinations.get("", resource) }
 	podStorage := podetcd.NewStorage(dbClient("pods"), storageFactory, c.KubeletClient, m.proxyTransport)
 
-	podTemplateStorage := podtemplateetcd.NewREST(dbClient("podTemplates"))
+	podTemplateStorage := podtemplateetcd.NewREST(dbClient("podTemplates"), storageFactory)
 
-	eventStorage := eventetcd.NewREST(dbClient("events"), uint64(c.EventTTL.Seconds()))
-	limitRangeStorage := limitrangeetcd.NewREST(dbClient("limitRanges"))
+	eventStorage := eventetcd.NewREST(dbClient("events"), storageFactory, uint64(c.EventTTL.Seconds()))
+	limitRangeStorage := limitrangeetcd.NewREST(dbClient("limitRanges"), storageFactory)
 
-	resourceQuotaStorage, resourceQuotaStatusStorage := resourcequotaetcd.NewREST(dbClient("resourceQuotas"))
-	secretStorage := secretetcd.NewREST(dbClient("secrets"))
-	serviceAccountStorage := serviceaccountetcd.NewREST(dbClient("serviceAccounts"))
-	persistentVolumeStorage, persistentVolumeStatusStorage := pvetcd.NewREST(dbClient("persistentVolumes"))
-	persistentVolumeClaimStorage, persistentVolumeClaimStatusStorage := pvcetcd.NewREST(dbClient("persistentVolumeClaims"))
+	resourceQuotaStorage, resourceQuotaStatusStorage := resourcequotaetcd.NewREST(dbClient("resourceQuotas"), storageFactory)
+	secretStorage := secretetcd.NewREST(dbClient("secrets"), storageFactory)
+	serviceAccountStorage := serviceaccountetcd.NewREST(dbClient("serviceAccounts"), storageFactory)
+	persistentVolumeStorage, persistentVolumeStatusStorage := pvetcd.NewREST(dbClient("persistentVolumes"), storageFactory)
+	persistentVolumeClaimStorage, persistentVolumeClaimStatusStorage := pvcetcd.NewREST(dbClient("persistentVolumeClaims"), storageFactory)
 
-	namespaceStorage, namespaceStatusStorage, namespaceFinalizeStorage := namespaceetcd.NewREST(dbClient("namespaces"))
+	namespaceStorage, namespaceStatusStorage, namespaceFinalizeStorage := namespaceetcd.NewREST(dbClient("namespaces"), storageFactory)
 	m.namespaceRegistry = namespace.NewRegistry(namespaceStorage)
 
 	endpointsStorage := endpointsetcd.NewREST(dbClient("endpoints"), storageFactory)
@@ -564,7 +566,7 @@ func (m *Master) init(c *Config) {
 	nodeStorage, nodeStatusStorage := nodeetcd.NewREST(dbClient("nodes"), storageFactory, c.KubeletClient, m.proxyTransport)
 	m.nodeRegistry = node.NewRegistry(nodeStorage)
 
-	serviceStorage := serviceetcd.NewREST(dbClient("services"))
+	serviceStorage := serviceetcd.NewREST(dbClient("services"), storageFactory)
 	m.serviceRegistry = service.NewRegistry(serviceStorage)
 
 	var serviceClusterIPRegistry service.RangeRegistry
@@ -585,7 +587,7 @@ func (m *Master) init(c *Config) {
 	})
 	m.serviceNodePortAllocator = serviceNodePortRegistry
 
-	controllerStorage, controllerStatusStorage := controlleretcd.NewREST(dbClient("replicationControllers"))
+	controllerStorage, controllerStatusStorage := controlleretcd.NewREST(dbClient("replicationControllers"), storageFactory)
 
 	// TODO: Factor out the core API registration
 	m.storage = map[string]rest.Storage{
@@ -1005,7 +1007,7 @@ func (m *Master) InstallThirdPartyResource(rsrc *expapi.ThirdPartyResource) erro
 }
 
 func (m *Master) thirdpartyapi(group, kind, version string) *apiserver.APIGroupVersion {
-	resourceStorage := thirdpartyresourcedataetcd.NewREST(m.thirdPartyStorage, group, kind)
+	resourceStorage := thirdpartyresourcedataetcd.NewREST(m.thirdPartyStorage, storage.NoDecoration, group, kind)
 
 	apiRoot := makeThirdPartyPath("")
 
@@ -1047,21 +1049,22 @@ func (m *Master) experimental(c *Config) *apiserver.APIGroupVersion {
 		}
 		return enabled
 	}
+	storageFactory := c.storageFactory()
 	dbClient := func(resource string) storage.Interface {
 		return c.StorageDestinations.get("extensions", resource)
 	}
 
 	storage := map[string]rest.Storage{}
 	if isEnabled("horizontalpodautoscalers") {
-		autoscalerStorage, autoscalerStatusStorage := horizontalpodautoscaleretcd.NewREST(dbClient("horizontalpodautoscalers"))
+		autoscalerStorage, autoscalerStatusStorage := horizontalpodautoscaleretcd.NewREST(dbClient("horizontalpodautoscalers"), storageFactory)
 		storage["horizontalpodautoscalers"] = autoscalerStorage
 		storage["horizontalpodautoscalers/status"] = autoscalerStatusStorage
-		controllerStorage := expcontrolleretcd.NewStorage(c.StorageDestinations.get("", "replicationControllers"))
+		controllerStorage := expcontrolleretcd.NewStorage(c.StorageDestinations.get("", "replicationControllers"), storageFactory)
 		storage["replicationcontrollers"] = controllerStorage.ReplicationController
 		storage["replicationcontrollers/scale"] = controllerStorage.Scale
 	}
 	if isEnabled("thirdpartyresources") {
-		thirdPartyResourceStorage := thirdpartyresourceetcd.NewREST(dbClient("thirdpartyresources"))
+		thirdPartyResourceStorage := thirdpartyresourceetcd.NewREST(dbClient("thirdpartyresources"), storageFactory)
 		thirdPartyControl := ThirdPartyController{
 			master: m,
 			thirdPartyResourceRegistry: thirdPartyResourceStorage,
@@ -1078,23 +1081,23 @@ func (m *Master) experimental(c *Config) *apiserver.APIGroupVersion {
 	}
 
 	if isEnabled("daemonsets") {
-		daemonSetStorage, daemonSetStatusStorage := daemonetcd.NewREST(dbClient("daemonsets"))
+		daemonSetStorage, daemonSetStatusStorage := daemonetcd.NewREST(dbClient("daemonsets"), storageFactory)
 		storage["daemonsets"] = daemonSetStorage
 		storage["daemonsets/status"] = daemonSetStatusStorage
 	}
 	if isEnabled("deployments") {
-		deploymentStorage := deploymentetcd.NewStorage(dbClient("deployments"))
+		deploymentStorage := deploymentetcd.NewStorage(dbClient("deployments"), storageFactory)
 		storage["deployments"] = deploymentStorage.Deployment
 		storage["deployments/status"] = deploymentStorage.Status
 		storage["deployments/scale"] = deploymentStorage.Scale
 	}
 	if isEnabled("jobs") {
-		jobStorage, jobStatusStorage := jobetcd.NewREST(dbClient("jobs"))
+		jobStorage, jobStatusStorage := jobetcd.NewREST(dbClient("jobs"), storageFactory)
 		storage["jobs"] = jobStorage
 		storage["jobs/status"] = jobStatusStorage
 	}
 	if isEnabled("ingresses") {
-		ingressStorage, ingressStatusStorage := ingressetcd.NewREST(dbClient("ingresses"))
+		ingressStorage, ingressStatusStorage := ingressetcd.NewREST(dbClient("ingresses"), storageFactory)
 		storage["ingresses"] = ingressStorage
 		storage["ingresses/status"] = ingressStatusStorage
 	}

--- a/pkg/registry/controller/etcd/etcd.go
+++ b/pkg/registry/controller/etcd/etcd.go
@@ -32,13 +32,18 @@ type REST struct {
 }
 
 // NewREST returns a RESTStorage object that will work against replication controllers.
-func NewREST(s storage.Interface) (*REST, *StatusREST) {
+func NewREST(s storage.Interface, storageFactory storage.StorageFactory) (*REST, *StatusREST) {
 	prefix := "/controllers"
+
+	newListFunc := func() runtime.Object { return &api.ReplicationControllerList{} }
+	storageInterface := storageFactory(
+		s, 100, nil, &api.ReplicationController{}, prefix, true, newListFunc)
+
 	store := &etcdgeneric.Etcd{
 		NewFunc: func() runtime.Object { return &api.ReplicationController{} },
 
 		// NewListFunc returns an object capable of storing results of an etcd list.
-		NewListFunc: func() runtime.Object { return &api.ReplicationControllerList{} },
+		NewListFunc: newListFunc,
 		// Produces a path that etcd understands, to the root of the resource
 		// by combining the namespace in the context with the given prefix
 		KeyRootFunc: func(ctx api.Context) string {
@@ -65,7 +70,7 @@ func NewREST(s storage.Interface) (*REST, *StatusREST) {
 		// Used to validate controller updates
 		UpdateStrategy: controller.Strategy,
 
-		Storage: s,
+		Storage: storageInterface,
 	}
 	statusStore := *store
 	statusStore.UpdateStrategy = controller.StatusStrategy

--- a/pkg/registry/controller/etcd/etcd_test.go
+++ b/pkg/registry/controller/etcd/etcd_test.go
@@ -24,13 +24,14 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 	"k8s.io/kubernetes/pkg/tools"
 )
 
 func newStorage(t *testing.T) (*REST, *StatusREST, *tools.FakeEtcdClient) {
 	etcdStorage, fakeClient := registrytest.NewEtcdStorage(t, "")
-	storage, statusStorage := NewREST(etcdStorage)
-	return storage, statusStorage, fakeClient
+	controllerStorage, statusStorage := NewREST(etcdStorage, storage.NoDecoration)
+	return controllerStorage, statusStorage, fakeClient
 }
 
 // createController is a helper function that returns a controller with the updated resource version.

--- a/pkg/registry/daemonset/etcd/etcd.go
+++ b/pkg/registry/daemonset/etcd/etcd.go
@@ -33,25 +33,28 @@ type REST struct {
 	*etcdgeneric.Etcd
 }
 
-// daemonPrefix is the location for daemons in etcd
-var daemonPrefix = "/daemonsets"
-
 // NewREST returns a RESTStorage object that will work against DaemonSets.
-func NewREST(s storage.Interface) (*REST, *StatusREST) {
+func NewREST(s storage.Interface, storageFactory storage.StorageFactory) (*REST, *StatusREST) {
+	prefix := "/daemonsets"
+
+	newListFunc := func() runtime.Object { return &extensions.DaemonSetList{} }
+	storageInterface := storageFactory(
+		s, 100, nil, &extensions.DaemonSet{}, prefix, false, newListFunc)
+
 	store := &etcdgeneric.Etcd{
 		NewFunc: func() runtime.Object { return &extensions.DaemonSet{} },
 
 		// NewListFunc returns an object capable of storing results of an etcd list.
-		NewListFunc: func() runtime.Object { return &extensions.DaemonSetList{} },
+		NewListFunc: newListFunc,
 		// Produces a path that etcd understands, to the root of the resource
 		// by combining the namespace in the context with the given prefix
 		KeyRootFunc: func(ctx api.Context) string {
-			return etcdgeneric.NamespaceKeyRootFunc(ctx, daemonPrefix)
+			return etcdgeneric.NamespaceKeyRootFunc(ctx, prefix)
 		},
 		// Produces a path that etcd understands, to the resource by combining
 		// the namespace in the context with the given prefix
 		KeyFunc: func(ctx api.Context, name string) (string, error) {
-			return etcdgeneric.NamespaceKeyFunc(ctx, daemonPrefix, name)
+			return etcdgeneric.NamespaceKeyFunc(ctx, prefix, name)
 		},
 		// Retrieve the name field of a daemon set
 		ObjectNameFunc: func(obj runtime.Object) (string, error) {
@@ -69,7 +72,7 @@ func NewREST(s storage.Interface) (*REST, *StatusREST) {
 		// Used to validate daemon set updates
 		UpdateStrategy: daemonset.Strategy,
 
-		Storage: s,
+		Storage: storageInterface,
 	}
 	statusStore := *store
 	statusStore.UpdateStrategy = daemonset.StatusStrategy

--- a/pkg/registry/daemonset/etcd/etcd_test.go
+++ b/pkg/registry/daemonset/etcd/etcd_test.go
@@ -25,13 +25,14 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 	"k8s.io/kubernetes/pkg/tools"
 )
 
 func newStorage(t *testing.T) (*REST, *StatusREST, *tools.FakeEtcdClient) {
 	etcdStorage, fakeClient := registrytest.NewEtcdStorage(t, "extensions")
-	storage, statusStorage := NewREST(etcdStorage)
-	return storage, statusStorage, fakeClient
+	daemonSetStorage, statusStorage := NewREST(etcdStorage, storage.NoDecoration)
+	return daemonSetStorage, statusStorage, fakeClient
 }
 
 func newValidDaemonSet() *extensions.DaemonSet {

--- a/pkg/registry/deployment/etcd/etcd_test.go
+++ b/pkg/registry/deployment/etcd/etcd_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 	"k8s.io/kubernetes/pkg/tools"
 	"k8s.io/kubernetes/pkg/tools/etcdtest"
 	"k8s.io/kubernetes/pkg/util"
@@ -33,7 +34,7 @@ import (
 
 func newStorage(t *testing.T) (*DeploymentStorage, *tools.FakeEtcdClient) {
 	etcdStorage, fakeClient := registrytest.NewEtcdStorage(t, "extensions")
-	deploymentStorage := NewStorage(etcdStorage)
+	deploymentStorage := NewStorage(etcdStorage, storage.NoDecoration)
 	return &deploymentStorage, fakeClient
 }
 

--- a/pkg/registry/event/etcd/etcd.go
+++ b/pkg/registry/event/etcd/etcd.go
@@ -32,8 +32,13 @@ type REST struct {
 }
 
 // NewREST returns a RESTStorage object that will work against events.
-func NewREST(s storage.Interface, ttl uint64) *REST {
+func NewREST(s storage.Interface, storageFactory storage.StorageFactory, ttl uint64) *REST {
 	prefix := "/events"
+
+	// We explicitly do NOT do any decoration here - switching on Cacher
+	// for events will lead to too high memory consumption.
+	storageInterface := s
+
 	store := &etcdgeneric.Etcd{
 		NewFunc:     func() runtime.Object { return &api.Event{} },
 		NewListFunc: func() runtime.Object { return &api.EventList{} },
@@ -57,7 +62,7 @@ func NewREST(s storage.Interface, ttl uint64) *REST {
 		CreateStrategy: event.Strategy,
 		UpdateStrategy: event.Strategy,
 
-		Storage: s,
+		Storage: storageInterface,
 	}
 	return &REST{store}
 }

--- a/pkg/registry/event/etcd/etcd_test.go
+++ b/pkg/registry/event/etcd/etcd_test.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 	"k8s.io/kubernetes/pkg/tools"
 )
 
@@ -30,7 +31,7 @@ var testTTL uint64 = 60
 func newStorage(t *testing.T) (*REST, *tools.FakeEtcdClient) {
 	etcdStorage, fakeClient := registrytest.NewEtcdStorage(t, "")
 	fakeClient.HideExpires = true
-	return NewREST(etcdStorage, testTTL), fakeClient
+	return NewREST(etcdStorage, storage.NoDecoration, testTTL), fakeClient
 }
 
 func validNewEvent(namespace string) *api.Event {

--- a/pkg/registry/experimental/controller/etcd/etcd.go
+++ b/pkg/registry/experimental/controller/etcd/etcd.go
@@ -37,9 +37,9 @@ type ContainerStorage struct {
 	Scale                 *ScaleREST
 }
 
-func NewStorage(s storage.Interface) ContainerStorage {
+func NewStorage(s storage.Interface, storageFactory storage.StorageFactory) ContainerStorage {
 	// scale does not set status, only updates spec so we ignore the status
-	controllerREST, _ := etcd.NewREST(s)
+	controllerREST, _ := etcd.NewREST(s, storageFactory)
 	rcRegistry := controller.NewRegistry(controllerREST)
 
 	return ContainerStorage{

--- a/pkg/registry/experimental/controller/etcd/etcd_test.go
+++ b/pkg/registry/experimental/controller/etcd/etcd_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 	"k8s.io/kubernetes/pkg/tools"
 	"k8s.io/kubernetes/pkg/tools/etcdtest"
 	"k8s.io/kubernetes/pkg/util"
@@ -31,7 +32,7 @@ import (
 
 func newStorage(t *testing.T) (*ScaleREST, *tools.FakeEtcdClient) {
 	etcdStorage, fakeClient := registrytest.NewEtcdStorage(t, "")
-	return NewStorage(etcdStorage).Scale, fakeClient
+	return NewStorage(etcdStorage, storage.NoDecoration).Scale, fakeClient
 }
 
 var validPodTemplate = api.PodTemplate{

--- a/pkg/registry/horizontalpodautoscaler/etcd/etcd.go
+++ b/pkg/registry/horizontalpodautoscaler/etcd/etcd.go
@@ -33,12 +33,17 @@ type REST struct {
 }
 
 // NewREST returns a RESTStorage object that will work against horizontal pod autoscalers.
-func NewREST(s storage.Interface) (*REST, *StatusREST) {
+func NewREST(s storage.Interface, storageFactory storage.StorageFactory) (*REST, *StatusREST) {
 	prefix := "/horizontalpodautoscalers"
+
+	newListFunc := func() runtime.Object { return &extensions.HorizontalPodAutoscalerList{} }
+	storageInterface := storageFactory(
+		s, 100, nil, &extensions.HorizontalPodAutoscaler{}, prefix, false, newListFunc)
+
 	store := &etcdgeneric.Etcd{
 		NewFunc: func() runtime.Object { return &extensions.HorizontalPodAutoscaler{} },
 		// NewListFunc returns an object capable of storing results of an etcd list.
-		NewListFunc: func() runtime.Object { return &extensions.HorizontalPodAutoscalerList{} },
+		NewListFunc: newListFunc,
 		// Produces a path that etcd understands, to the root of the resource
 		// by combining the namespace in the context with the given prefix
 		KeyRootFunc: func(ctx api.Context) string {
@@ -65,7 +70,7 @@ func NewREST(s storage.Interface) (*REST, *StatusREST) {
 		// Used to validate autoscaler updates
 		UpdateStrategy: horizontalpodautoscaler.Strategy,
 
-		Storage: s,
+		Storage: storageInterface,
 	}
 	statusStore := *store
 	statusStore.UpdateStrategy = horizontalpodautoscaler.StatusStrategy

--- a/pkg/registry/horizontalpodautoscaler/etcd/etcd_test.go
+++ b/pkg/registry/horizontalpodautoscaler/etcd/etcd_test.go
@@ -27,13 +27,14 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 	"k8s.io/kubernetes/pkg/tools"
 )
 
 func newStorage(t *testing.T) (*REST, *StatusREST, *tools.FakeEtcdClient) {
 	etcdStorage, fakeClient := registrytest.NewEtcdStorage(t, "extensions")
-	storage, statusStorage := NewREST(etcdStorage)
-	return storage, statusStorage, fakeClient
+	horizontalPodAutoscalerStorage, statusStorage := NewREST(etcdStorage, storage.NoDecoration)
+	return horizontalPodAutoscalerStorage, statusStorage, fakeClient
 }
 
 func validNewHorizontalPodAutoscaler(name string) *extensions.HorizontalPodAutoscaler {

--- a/pkg/registry/ingress/etcd/etcd_test.go
+++ b/pkg/registry/ingress/etcd/etcd_test.go
@@ -25,13 +25,14 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 	"k8s.io/kubernetes/pkg/tools"
 	"k8s.io/kubernetes/pkg/util"
 )
 
 func newStorage(t *testing.T) (*REST, *StatusREST, *tools.FakeEtcdClient) {
 	etcdStorage, fakeClient := registrytest.NewEtcdStorage(t, "extensions")
-	ingressStorage, statusStorage := NewREST(etcdStorage)
+	ingressStorage, statusStorage := NewREST(etcdStorage, storage.NoDecoration)
 	return ingressStorage, statusStorage, fakeClient
 }
 

--- a/pkg/registry/job/etcd/etcd_test.go
+++ b/pkg/registry/job/etcd/etcd_test.go
@@ -27,13 +27,14 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 	"k8s.io/kubernetes/pkg/tools"
 )
 
 func newStorage(t *testing.T) (*REST, *StatusREST, *tools.FakeEtcdClient) {
 	etcdStorage, fakeClient := registrytest.NewEtcdStorage(t, "extensions")
-	storage, statusStorage := NewREST(etcdStorage)
-	return storage, statusStorage, fakeClient
+	jobStorage, statusStorage := NewREST(etcdStorage, storage.NoDecoration)
+	return jobStorage, statusStorage, fakeClient
 }
 
 func validNewJob() *extensions.Job {

--- a/pkg/registry/limitrange/etcd/etcd_test.go
+++ b/pkg/registry/limitrange/etcd/etcd_test.go
@@ -25,12 +25,13 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 	"k8s.io/kubernetes/pkg/tools"
 )
 
 func newStorage(t *testing.T) (*REST, *tools.FakeEtcdClient) {
 	etcdStorage, fakeClient := registrytest.NewEtcdStorage(t, "")
-	return NewREST(etcdStorage), fakeClient
+	return NewREST(etcdStorage, storage.NoDecoration), fakeClient
 }
 
 func validNewLimitRange() *api.LimitRange {

--- a/pkg/registry/namespace/etcd/etcd_test.go
+++ b/pkg/registry/namespace/etcd/etcd_test.go
@@ -26,14 +26,15 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 	"k8s.io/kubernetes/pkg/tools"
 	"k8s.io/kubernetes/pkg/tools/etcdtest"
 )
 
 func newStorage(t *testing.T) (*REST, *tools.FakeEtcdClient) {
 	etcdStorage, fakeClient := registrytest.NewEtcdStorage(t, "")
-	storage, _, _ := NewREST(etcdStorage)
-	return storage, fakeClient
+	namespaceStorage, _, _ := NewREST(etcdStorage, storage.NoDecoration)
+	return namespaceStorage, fakeClient
 }
 
 func validNewNamespace() *api.Namespace {

--- a/pkg/registry/persistentvolume/etcd/etcd.go
+++ b/pkg/registry/persistentvolume/etcd/etcd.go
@@ -32,11 +32,16 @@ type REST struct {
 }
 
 // NewREST returns a RESTStorage object that will work against persistent volumes.
-func NewREST(s storage.Interface) (*REST, *StatusREST) {
+func NewREST(s storage.Interface, storageFactory storage.StorageFactory) (*REST, *StatusREST) {
 	prefix := "/persistentvolumes"
+
+	newListFunc := func() runtime.Object { return &api.PersistentVolumeList{} }
+	storageInterface := storageFactory(
+		s, 100, nil, &api.PersistentVolume{}, prefix, true, newListFunc)
+
 	store := &etcdgeneric.Etcd{
 		NewFunc:     func() runtime.Object { return &api.PersistentVolume{} },
-		NewListFunc: func() runtime.Object { return &api.PersistentVolumeList{} },
+		NewListFunc: newListFunc,
 		KeyRootFunc: func(ctx api.Context) string {
 			return prefix
 		},
@@ -55,7 +60,7 @@ func NewREST(s storage.Interface) (*REST, *StatusREST) {
 		UpdateStrategy:      persistentvolume.Strategy,
 		ReturnDeletedObject: true,
 
-		Storage: s,
+		Storage: storageInterface,
 	}
 
 	statusStore := *store

--- a/pkg/registry/persistentvolume/etcd/etcd_test.go
+++ b/pkg/registry/persistentvolume/etcd/etcd_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 	"k8s.io/kubernetes/pkg/tools"
 	"k8s.io/kubernetes/pkg/tools/etcdtest"
 	"k8s.io/kubernetes/pkg/util"
@@ -33,8 +34,8 @@ import (
 
 func newStorage(t *testing.T) (*REST, *StatusREST, *tools.FakeEtcdClient) {
 	etcdStorage, fakeClient := registrytest.NewEtcdStorage(t, "")
-	storage, statusStorage := NewREST(etcdStorage)
-	return storage, statusStorage, fakeClient
+	persistentVolumeStorage, statusStorage := NewREST(etcdStorage, storage.NoDecoration)
+	return persistentVolumeStorage, statusStorage, fakeClient
 }
 
 func validNewPersistentVolume(name string) *api.PersistentVolume {

--- a/pkg/registry/persistentvolumeclaim/etcd/etcd.go
+++ b/pkg/registry/persistentvolumeclaim/etcd/etcd.go
@@ -32,11 +32,16 @@ type REST struct {
 }
 
 // NewREST returns a RESTStorage object that will work against persistent volume claims.
-func NewREST(s storage.Interface) (*REST, *StatusREST) {
+func NewREST(s storage.Interface, storageFactory storage.StorageFactory) (*REST, *StatusREST) {
 	prefix := "/persistentvolumeclaims"
+
+	newListFunc := func() runtime.Object { return &api.PersistentVolumeClaimList{} }
+	storageInterface := storageFactory(
+		s, 100, nil, &api.PersistentVolumeClaim{}, prefix, true, newListFunc)
+
 	store := &etcdgeneric.Etcd{
 		NewFunc:     func() runtime.Object { return &api.PersistentVolumeClaim{} },
-		NewListFunc: func() runtime.Object { return &api.PersistentVolumeClaimList{} },
+		NewListFunc: newListFunc,
 		KeyRootFunc: func(ctx api.Context) string {
 			return etcdgeneric.NamespaceKeyRootFunc(ctx, prefix)
 		},
@@ -55,7 +60,7 @@ func NewREST(s storage.Interface) (*REST, *StatusREST) {
 		UpdateStrategy:      persistentvolumeclaim.Strategy,
 		ReturnDeletedObject: true,
 
-		Storage: s,
+		Storage: storageInterface,
 	}
 
 	statusStore := *store

--- a/pkg/registry/persistentvolumeclaim/etcd/etcd_test.go
+++ b/pkg/registry/persistentvolumeclaim/etcd/etcd_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 	"k8s.io/kubernetes/pkg/tools"
 	"k8s.io/kubernetes/pkg/tools/etcdtest"
 	"k8s.io/kubernetes/pkg/util"
@@ -33,8 +34,8 @@ import (
 
 func newStorage(t *testing.T) (*REST, *StatusREST, *tools.FakeEtcdClient) {
 	etcdStorage, fakeClient := registrytest.NewEtcdStorage(t, "")
-	storage, statusStorage := NewREST(etcdStorage)
-	return storage, statusStorage, fakeClient
+	persistentVolumeClaimStorage, statusStorage := NewREST(etcdStorage, storage.NoDecoration)
+	return persistentVolumeClaimStorage, statusStorage, fakeClient
 }
 
 func validNewPersistentVolumeClaim(name, ns string) *api.PersistentVolumeClaim {

--- a/pkg/registry/podtemplate/etcd/etcd_test.go
+++ b/pkg/registry/podtemplate/etcd/etcd_test.go
@@ -24,12 +24,13 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 	"k8s.io/kubernetes/pkg/tools"
 )
 
 func newStorage(t *testing.T) (*REST, *tools.FakeEtcdClient) {
 	etcdStorage, fakeClient := registrytest.NewEtcdStorage(t, "")
-	return NewREST(etcdStorage), fakeClient
+	return NewREST(etcdStorage, storage.NoDecoration), fakeClient
 }
 
 func validNewPodTemplate(name string) *api.PodTemplate {

--- a/pkg/registry/resourcequota/etcd/etcd_test.go
+++ b/pkg/registry/resourcequota/etcd/etcd_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 	"k8s.io/kubernetes/pkg/tools"
 	"k8s.io/kubernetes/pkg/tools/etcdtest"
 	"k8s.io/kubernetes/pkg/util"
@@ -34,8 +35,8 @@ import (
 
 func newStorage(t *testing.T) (*REST, *StatusREST, *tools.FakeEtcdClient) {
 	etcdStorage, fakeClient := registrytest.NewEtcdStorage(t, "")
-	storage, statusStorage := NewREST(etcdStorage)
-	return storage, statusStorage, fakeClient
+	resourceQuotaStorage, statusStorage := NewREST(etcdStorage, storage.NoDecoration)
+	return resourceQuotaStorage, statusStorage, fakeClient
 }
 
 func validNewResourceQuota() *api.ResourceQuota {

--- a/pkg/registry/secret/etcd/etcd_test.go
+++ b/pkg/registry/secret/etcd/etcd_test.go
@@ -24,12 +24,13 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 	"k8s.io/kubernetes/pkg/tools"
 )
 
 func newStorage(t *testing.T) (*REST, *tools.FakeEtcdClient) {
 	etcdStorage, fakeClient := registrytest.NewEtcdStorage(t, "")
-	return NewREST(etcdStorage), fakeClient
+	return NewREST(etcdStorage, storage.NoDecoration), fakeClient
 }
 
 func validNewSecret(name string) *api.Secret {

--- a/pkg/registry/service/etcd/etcd_test.go
+++ b/pkg/registry/service/etcd/etcd_test.go
@@ -24,13 +24,14 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 	"k8s.io/kubernetes/pkg/tools"
 	"k8s.io/kubernetes/pkg/util"
 )
 
 func newStorage(t *testing.T) (*REST, *tools.FakeEtcdClient) {
 	etcdStorage, fakeClient := registrytest.NewEtcdStorage(t, "")
-	return NewREST(etcdStorage), fakeClient
+	return NewREST(etcdStorage, storage.NoDecoration), fakeClient
 }
 
 func validService() *api.Service {

--- a/pkg/registry/serviceaccount/etcd/etcd.go
+++ b/pkg/registry/serviceaccount/etcd/etcd.go
@@ -32,11 +32,16 @@ type REST struct {
 }
 
 // NewREST returns a RESTStorage object that will work against service accounts.
-func NewREST(s storage.Interface) *REST {
+func NewREST(s storage.Interface, storageFactory storage.StorageFactory) *REST {
 	prefix := "/serviceaccounts"
+
+	newListFunc := func() runtime.Object { return &api.ServiceAccountList{} }
+	storageInterface := storageFactory(
+		s, 100, nil, &api.ServiceAccount{}, prefix, true, newListFunc)
+
 	store := &etcdgeneric.Etcd{
 		NewFunc:     func() runtime.Object { return &api.ServiceAccount{} },
-		NewListFunc: func() runtime.Object { return &api.ServiceAccountList{} },
+		NewListFunc: newListFunc,
 		KeyRootFunc: func(ctx api.Context) string {
 			return etcdgeneric.NamespaceKeyRootFunc(ctx, prefix)
 		},
@@ -55,7 +60,7 @@ func NewREST(s storage.Interface) *REST {
 		UpdateStrategy:      serviceaccount.Strategy,
 		ReturnDeletedObject: true,
 
-		Storage: s,
+		Storage: storageInterface,
 	}
 	return &REST{store}
 }

--- a/pkg/registry/serviceaccount/etcd/etcd_test.go
+++ b/pkg/registry/serviceaccount/etcd/etcd_test.go
@@ -24,12 +24,13 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 	"k8s.io/kubernetes/pkg/tools"
 )
 
 func newStorage(t *testing.T) (*REST, *tools.FakeEtcdClient) {
 	etcdStorage, fakeClient := registrytest.NewEtcdStorage(t, "")
-	return NewREST(etcdStorage), fakeClient
+	return NewREST(etcdStorage, storage.NoDecoration), fakeClient
 }
 
 func validNewServiceAccount(name string) *api.ServiceAccount {

--- a/pkg/registry/thirdpartyresource/etcd/etcd.go
+++ b/pkg/registry/thirdpartyresource/etcd/etcd.go
@@ -34,8 +34,11 @@ type REST struct {
 }
 
 // NewREST returns a registry which will store ThirdPartyResource in the given helper
-func NewREST(s storage.Interface) *REST {
+func NewREST(s storage.Interface, storageFactory storage.StorageFactory) *REST {
 	prefix := "/thirdpartyresources"
+
+	// We explicitly do NOT do any decoration here yet.
+	storageInterface := s
 
 	store := &etcdgeneric.Etcd{
 		NewFunc:     func() runtime.Object { return &extensions.ThirdPartyResource{} },
@@ -56,7 +59,7 @@ func NewREST(s storage.Interface) *REST {
 		CreateStrategy: thirdpartyresource.Strategy,
 		UpdateStrategy: thirdpartyresource.Strategy,
 
-		Storage: s,
+		Storage: storageInterface,
 	}
 
 	return &REST{store}

--- a/pkg/registry/thirdpartyresource/etcd/etcd_test.go
+++ b/pkg/registry/thirdpartyresource/etcd/etcd_test.go
@@ -27,12 +27,13 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 	"k8s.io/kubernetes/pkg/tools"
 )
 
 func newStorage(t *testing.T) (*REST, *tools.FakeEtcdClient) {
 	etcdStorage, fakeClient := registrytest.NewEtcdStorage(t, "extensions")
-	return NewREST(etcdStorage), fakeClient
+	return NewREST(etcdStorage, storage.NoDecoration), fakeClient
 }
 
 func validNewThirdPartyResource(name string) *extensions.ThirdPartyResource {

--- a/pkg/registry/thirdpartyresourcedata/etcd/etcd.go
+++ b/pkg/registry/thirdpartyresourcedata/etcd/etcd.go
@@ -36,8 +36,11 @@ type REST struct {
 }
 
 // NewREST returns a registry which will store ThirdPartyResourceData in the given helper
-func NewREST(s storage.Interface, group, kind string) *REST {
+func NewREST(s storage.Interface, storageFactory storage.StorageFactory, group, kind string) *REST {
 	prefix := "/ThirdPartyResourceData/" + group + "/" + strings.ToLower(kind) + "s"
+
+	// We explicitly do NOT do any decoration here yet.
+	storageInterface := s
 
 	store := &etcdgeneric.Etcd{
 		NewFunc:     func() runtime.Object { return &extensions.ThirdPartyResourceData{} },
@@ -58,7 +61,7 @@ func NewREST(s storage.Interface, group, kind string) *REST {
 		CreateStrategy: thirdpartyresourcedata.Strategy,
 		UpdateStrategy: thirdpartyresourcedata.Strategy,
 
-		Storage: s,
+		Storage: storageInterface,
 	}
 
 	return &REST{store}

--- a/pkg/registry/thirdpartyresourcedata/etcd/etcd_test.go
+++ b/pkg/registry/thirdpartyresourcedata/etcd/etcd_test.go
@@ -27,12 +27,13 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/storage"
 	"k8s.io/kubernetes/pkg/tools"
 )
 
 func newStorage(t *testing.T) (*REST, *tools.FakeEtcdClient) {
 	etcdStorage, fakeClient := registrytest.NewEtcdStorage(t, "extensions")
-	return NewREST(etcdStorage, "foo", "bar"), fakeClient
+	return NewREST(etcdStorage, storage.NoDecoration, "foo", "bar"), fakeClient
 }
 
 func validNewThirdPartyResourceData(name string) *extensions.ThirdPartyResourceData {


### PR DESCRIPTION
Ref #10475

Motivated by looking into logs from our scalability tests, which look like this:

```
....
W1029 07:03:53.937978       5 reflector.go:281] pkg/admission/serviceaccount/admission.go:108: watch of *api.Secret ended with: 401: The event in requested index is outdated and cleared (the requested history has been cleared [115370/113036]) [116369]
W1029 07:04:35.935729       5 reflector.go:281] pkg/admission/limitranger/admission.go:109: watch of *api.LimitRange ended with: 401: The event in requested index is outdated and cleared (the requested history has been cleared [115781/113395]) [116780]
W1029 07:05:22.913064       5 reflector.go:281] pkg/admission/serviceaccount/admission.go:94: watch of *api.ServiceAccount ended with: 401: The event in requested index is outdated and cleared (the requested history has been cleared [116249/113235]) [117248]
W1029 07:08:27.935827       5 reflector.go:281] pkg/admission/resourcequota/admission.go:60: watch of *api.ResourceQuota ended with: 401: The event in requested index is outdated and cleared (the requested history has been cleared [118091/114813]) [119090]
W1029 07:09:42.939472       5 reflector.go:281] pkg/admission/limitranger/admission.go:109: watch of *api.LimitRange ended with: 401: The event in requested index is outdated and cleared (the requested history has been cleared [118849/116782]) [119848]
W1029 07:12:55.943636       5 reflector.go:281] pkg/admission/serviceaccount/admission.go:108: watch of *api.Secret ended with: 401: The event in requested index is outdated and cleared (the requested history has been cleared [120858/120848]) [121857]
W1029 07:13:32.939571       5 reflector.go:281] pkg/admission/resourcequota/admission.go:60: watch of *api.ResourceQuota ended with: 401: The event in requested index is outdated and cleared (the requested history has been cleared [121307/119100]) [122306]
....
```

@lavalamp 
