### PR TITLE
Update fluentd-gcp to include all recent improvements that are in the

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
@@ -14,7 +14,7 @@
 
 .PHONY:	kbuild kpush
 
-TAG = 1.13
+TAG = 1.14
 
 # Rules for building the test image for deployment to Dockerhub with user kubernetes.
 

--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
   - name: fluentd-cloud-logging
-    image: gcr.io/google_containers/fluentd-gcp:1.13
+    image: gcr.io/google_containers/fluentd-gcp:1.14
     resources:
       limits:
         cpu: 100m

--- a/docs/getting-started-guides/logging.md
+++ b/docs/getting-started-guides/logging.md
@@ -169,7 +169,7 @@ metadata:
 spec:
   containers:
   - name: fluentd-cloud-logging
-    image: gcr.io/google_containers/fluentd-gcp:1.13
+    image: gcr.io/google_containers/fluentd-gcp:1.14
     resources:
       limits:
         cpu: 100m


### PR DESCRIPTION
new google-fluentd 1.5.4-1 build.

The changes are awkwardly picked up by this change because the default version of the google-fluentd package has changed since the last time the image was built.

@swalkowski
