### PR TITLE
Spark: kubectl proxy, liveness

### DIFF
--- a/examples/spark/spark-driver-controller.yaml
+++ b/examples/spark/spark-driver-controller.yaml
@@ -2,8 +2,6 @@ kind: ReplicationController
 apiVersion: v1
 metadata:
   name: spark-driver-controller
-  labels:
-    component: spark-driver
 spec:
   replicas: 1
   selector:

--- a/examples/spark/spark-master-controller.yaml
+++ b/examples/spark/spark-master-controller.yaml
@@ -2,8 +2,6 @@ kind: ReplicationController
 apiVersion: v1
 metadata:
   name: spark-master-controller
-  labels:
-    component: spark-master
 spec:
   replicas: 1
   selector:
@@ -19,6 +17,15 @@ spec:
           ports:
             - containerPort: 7077
             - containerPort: 8080
+          livenessProbe:
+            exec:
+              command:
+              - /opt/spark/sbin/spark-daemon.sh
+              - status
+              - org.apache.spark.deploy.master.Master
+              - '1'
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
           resources:
             requests:
               cpu: 100m

--- a/examples/spark/spark-master-service.yaml
+++ b/examples/spark/spark-master-service.yaml
@@ -2,8 +2,6 @@ kind: Service
 apiVersion: v1
 metadata:
   name: spark-master
-  labels:
-    component: spark-master-service
 spec:
   ports:
     - port: 7077

--- a/examples/spark/spark-webui.yaml
+++ b/examples/spark/spark-webui.yaml
@@ -8,4 +8,3 @@ spec:
       targetPort: 8080
   selector:
     component: spark-master
-  type: LoadBalancer

--- a/examples/spark/spark-worker-controller.yaml
+++ b/examples/spark/spark-worker-controller.yaml
@@ -2,8 +2,6 @@ kind: ReplicationController
 apiVersion: v1
 metadata:
   name: spark-worker-controller
-  labels:
-    component: spark-worker
 spec:
   replicas: 3
   selector:
@@ -12,13 +10,21 @@ spec:
     metadata:
       labels:
         component: spark-worker
-        uses: spark-master
     spec:
       containers:
         - name: spark-worker
           image: gcr.io/google_containers/spark-worker:1.5.1_v1
           ports:
             - containerPort: 8888
+          livenessProbe:
+            exec:
+              command:
+              - /opt/spark/sbin/spark-daemon.sh
+              - status
+              - org.apache.spark.deploy.worker.Worker
+              - '1'
+            initialDelaySeconds: 30
+            timeoutSeconds: 1
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
- Update example to use kubectl proxy rather than load balancer
- Add liveness probes for master/worker (it turns out, the pods don't exit when the master or worker crash)
- Along the way: remove redundant metadata.
