### PR TITLE
Add missing field label conversions for Namespace

### DIFF
--- a/pkg/api/testing/conversion.go
+++ b/pkg/api/testing/conversion.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+// TestSelectableFieldLabelConversions verifies that given resource have field
+// label conversion defined for each its selectable field.
+// fields contains selectable fields of the resource.
+// labelMap maps deprecated labels to their canonical names.
+func TestSelectableFieldLabelConversionsOfKind(t *testing.T, apiVersion string, kind string, fields labels.Set, labelMap map[string]string) {
+	badFieldLabels := []string{
+		"name",
+		".name",
+		"bad",
+		"metadata",
+		"foo.bar",
+	}
+
+	value := "value"
+
+	if len(fields) == 0 {
+		t.Logf("no selectable fields for kind %q, skipping", kind)
+	}
+	for label := range fields {
+		if label == "name" {
+			t.Logf("FIXME: \"name\" is deprecated by \"metadata.name\", it should be removed from selectable fields of kind=%s", kind)
+			continue
+		}
+		newLabel, newValue, err := api.Scheme.ConvertFieldLabel(apiVersion, kind, label, value)
+		if err != nil {
+			t.Errorf("kind=%s label=%s: got unexpected error: %v", kind, label, err)
+		} else {
+			expectedLabel := label
+			if l, exists := labelMap[label]; exists {
+				expectedLabel = l
+			}
+			if newLabel != expectedLabel {
+				t.Errorf("kind=%s label=%s: got unexpected label name (%q != %q)", kind, label, newLabel, expectedLabel)
+			}
+			if newValue != value {
+				t.Errorf("kind=%s label=%s: got unexpected new value (%q != %q)", kind, label, newValue, value)
+			}
+		}
+	}
+
+	for _, label := range badFieldLabels {
+		_, _, err := api.Scheme.ConvertFieldLabel(apiVersion, kind, label, "value")
+		if err == nil {
+			t.Errorf("kind=%s label=%s: got unexpected non-error", kind, label)
+		}
+	}
+}

--- a/pkg/api/v1/conversion.go
+++ b/pkg/api/v1/conversion.go
@@ -52,6 +52,30 @@ func addConversionFuncs(scheme *runtime.Scheme) {
 		panic(err)
 	}
 
+	// Add field label conversions for kinds having selectable nothing but ObjectMeta fields.
+	for _, kind := range []string{
+		"Endpoints",
+		"ResourceQuota",
+		"PersistentVolumeClaim",
+		"Service",
+		"ServiceAccount",
+	} {
+		err = api.Scheme.AddFieldLabelConversionFunc("v1", kind,
+			func(label, value string) (string, string, error) {
+				switch label {
+				case "metadata.namespace",
+					"metadata.name":
+					return label, value, nil
+				default:
+					return "", "", fmt.Errorf("field label %q not supported for %q", label, kind)
+				}
+			})
+		if err != nil {
+			// If one of the conversion functions is malformed, detect it immediately.
+			panic(err)
+		}
+	}
+
 	// Add field conversion funcs.
 	err = api.Scheme.AddFieldLabelConversionFunc("v1", "Pod",
 		func(label, value string) (string, string, error) {
@@ -143,53 +167,24 @@ func addConversionFuncs(scheme *runtime.Scheme) {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)
 	}
+	err = api.Scheme.AddFieldLabelConversionFunc("v1", "PersistentVolume",
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "metadata.name":
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		})
+	if err != nil {
+		// If one of the conversion functions is malformed, detect it immediately.
+		panic(err)
+	}
 	err = api.Scheme.AddFieldLabelConversionFunc("v1", "Secret",
 		func(label, value string) (string, string, error) {
 			switch label {
 			case "type",
 				"metadata.namespace",
-				"metadata.name":
-				return label, value, nil
-			default:
-				return "", "", fmt.Errorf("field label not supported: %s", label)
-			}
-		})
-	if err != nil {
-		// If one of the conversion functions is malformed, detect it immediately.
-		panic(err)
-	}
-	err = api.Scheme.AddFieldLabelConversionFunc("v1", "ServiceAccount",
-		func(label, value string) (string, string, error) {
-			switch label {
-			case "metadata.name",
-				"metadata.namespace":
-				return label, value, nil
-			default:
-				return "", "", fmt.Errorf("field label not supported: %s", label)
-			}
-		})
-	if err != nil {
-		// If one of the conversion functions is malformed, detect it immediately.
-		panic(err)
-	}
-	err = api.Scheme.AddFieldLabelConversionFunc("v1", "Endpoints",
-		func(label, value string) (string, string, error) {
-			switch label {
-			case "metadata.namespace",
-				"metadata.name":
-				return label, value, nil
-			default:
-				return "", "", fmt.Errorf("field label not supported: %s", label)
-			}
-		})
-	if err != nil {
-		// If one of the conversion functions is malformed, detect it immediately.
-		panic(err)
-	}
-	err = api.Scheme.AddFieldLabelConversionFunc("v1", "Service",
-		func(label, value string) (string, string, error) {
-			switch label {
-			case "metadata.namespace",
 				"metadata.name":
 				return label, value, nil
 			default:

--- a/pkg/apis/extensions/v1beta1/conversion.go
+++ b/pkg/apis/extensions/v1beta1/conversion.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"fmt"
 	"reflect"
 
 	"k8s.io/kubernetes/pkg/api"
@@ -39,6 +40,37 @@ func addConversionFuncs(scheme *runtime.Scheme) {
 		Convert_extensions_RollingUpdateDeployment_To_v1beta1_RollingUpdateDeployment,
 		Convert_v1beta1_RollingUpdateDeployment_To_extensions_RollingUpdateDeployment,
 	)
+	if err != nil {
+		// If one of the conversion functions is malformed, detect it immediately.
+		panic(err)
+	}
+
+	// Add field label conversions for kinds having selectable nothing but ObjectMeta fields.
+	for _, kind := range []string{"ConfigMap", "DaemonSet", "Deployment", "Ingress"} {
+		err = api.Scheme.AddFieldLabelConversionFunc("extensions/v1beta1", kind,
+			func(label, value string) (string, string, error) {
+				switch label {
+				case "metadata.name", "metadata.namespace":
+					return label, value, nil
+				default:
+					return "", "", fmt.Errorf("field label %q not supported for %q", label, kind)
+				}
+			})
+		if err != nil {
+			// If one of the conversion functions is malformed, detect it immediately.
+			panic(err)
+		}
+	}
+
+	err = api.Scheme.AddFieldLabelConversionFunc("extensions/v1beta1", "Job",
+		func(label, value string) (string, string, error) {
+			switch label {
+			case "metadata.name", "metadata.namespace", "status.successful":
+				return label, value, nil
+			default:
+				return "", "", fmt.Errorf("field label not supported: %s", label)
+			}
+		})
 	if err != nil {
 		// If one of the conversion functions is malformed, detect it immediately.
 		panic(err)

--- a/pkg/registry/configmap/strategy_test.go
+++ b/pkg/registry/configmap/strategy_test.go
@@ -20,7 +20,10 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/labels"
 )
 
 func TestConfigMapStrategy(t *testing.T) {
@@ -66,4 +69,13 @@ func TestConfigMapStrategy(t *testing.T) {
 	if len(errs) == 0 {
 		t.Errorf("Expected a validation error")
 	}
+}
+
+func TestSelectableFieldLabelConversions(t *testing.T) {
+	apitesting.TestSelectableFieldLabelConversionsOfKind(t,
+		testapi.Extensions.GroupVersion().String(),
+		"ConfigMap",
+		labels.Set(ConfigMapToSelectableFields(&extensions.ConfigMap{})),
+		nil,
+	)
 }

--- a/pkg/registry/controller/strategy_test.go
+++ b/pkg/registry/controller/strategy_test.go
@@ -20,6 +20,9 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	"k8s.io/kubernetes/pkg/labels"
 )
 
 func TestControllerStrategy(t *testing.T) {
@@ -137,4 +140,13 @@ func TestControllerStatusStrategy(t *testing.T) {
 	if len(errs) != 0 {
 		t.Errorf("Unexpected error %v", errs)
 	}
+}
+
+func TestSelectableFieldLabelConversions(t *testing.T) {
+	apitesting.TestSelectableFieldLabelConversionsOfKind(t,
+		testapi.Default.GroupVersion().String(),
+		"ReplicationController",
+		labels.Set(ControllerToSelectableFields(&api.ReplicationController{})),
+		nil,
+	)
 }

--- a/pkg/registry/daemonset/strategy_test.go
+++ b/pkg/registry/daemonset/strategy_test.go
@@ -14,44 +14,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package node
+package daemonset
 
 import (
 	"testing"
 
-	"k8s.io/kubernetes/pkg/api"
+	_ "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
-	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/labels"
 )
 
-func TestMatchNode(t *testing.T) {
-	testFieldMap := map[bool][]fields.Set{
-		true: {
-			{"metadata.name": "foo"},
-		},
-		false: {
-			{"foo": "bar"},
-		},
-	}
-
-	for expectedResult, fieldSet := range testFieldMap {
-		for _, field := range fieldSet {
-			m := MatchNode(labels.Everything(), field.AsSelector())
-			_, matchesSingle := m.MatchesSingle()
-			if e, a := expectedResult, matchesSingle; e != a {
-				t.Errorf("%+v: expected %v, got %v", fieldSet, e, a)
-			}
-		}
-	}
-}
-
 func TestSelectableFieldLabelConversions(t *testing.T) {
 	apitesting.TestSelectableFieldLabelConversionsOfKind(t,
-		testapi.Default.GroupVersion().String(),
-		"Node",
-		labels.Set(NodeToSelectableFields(&api.Node{})),
+		testapi.Extensions.GroupVersion().String(),
+		"DaemonSet",
+		labels.Set(DaemonSetToSelectableFields(&extensions.DaemonSet{})),
 		nil,
 	)
 }

--- a/pkg/registry/deployment/strategy_test.go
+++ b/pkg/registry/deployment/strategy_test.go
@@ -14,44 +14,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package node
+package deployment
 
 import (
 	"testing"
 
-	"k8s.io/kubernetes/pkg/api"
+	_ "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
-	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/labels"
 )
 
-func TestMatchNode(t *testing.T) {
-	testFieldMap := map[bool][]fields.Set{
-		true: {
-			{"metadata.name": "foo"},
-		},
-		false: {
-			{"foo": "bar"},
-		},
-	}
-
-	for expectedResult, fieldSet := range testFieldMap {
-		for _, field := range fieldSet {
-			m := MatchNode(labels.Everything(), field.AsSelector())
-			_, matchesSingle := m.MatchesSingle()
-			if e, a := expectedResult, matchesSingle; e != a {
-				t.Errorf("%+v: expected %v, got %v", fieldSet, e, a)
-			}
-		}
-	}
-}
-
 func TestSelectableFieldLabelConversions(t *testing.T) {
 	apitesting.TestSelectableFieldLabelConversionsOfKind(t,
-		testapi.Default.GroupVersion().String(),
-		"Node",
-		labels.Set(NodeToSelectableFields(&api.Node{})),
+		testapi.Extensions.GroupVersion().String(),
+		"Deployment",
+		labels.Set(DeploymentToSelectableFields(&extensions.Deployment{})),
 		nil,
 	)
 }

--- a/pkg/registry/endpoint/strategy_test.go
+++ b/pkg/registry/endpoint/strategy_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 The Kubernetes Authors All rights reserved.
+Copyright 2014 The Kubernetes Authors All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package node
+package endpoint
 
 import (
 	"testing"
@@ -22,36 +22,18 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
-	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 )
 
-func TestMatchNode(t *testing.T) {
-	testFieldMap := map[bool][]fields.Set{
-		true: {
-			{"metadata.name": "foo"},
-		},
-		false: {
-			{"foo": "bar"},
-		},
-	}
-
-	for expectedResult, fieldSet := range testFieldMap {
-		for _, field := range fieldSet {
-			m := MatchNode(labels.Everything(), field.AsSelector())
-			_, matchesSingle := m.MatchesSingle()
-			if e, a := expectedResult, matchesSingle; e != a {
-				t.Errorf("%+v: expected %v, got %v", fieldSet, e, a)
-			}
-		}
-	}
-}
-
 func TestSelectableFieldLabelConversions(t *testing.T) {
+	_, fieldsSet, err := EndpointsAttributes(&api.Endpoints{})
+	if err != nil {
+		t.Fatal(err)
+	}
 	apitesting.TestSelectableFieldLabelConversionsOfKind(t,
 		testapi.Default.GroupVersion().String(),
-		"Node",
-		labels.Set(NodeToSelectableFields(&api.Node{})),
+		"Endpoints",
+		labels.Set(fieldsSet),
 		nil,
 	)
 }

--- a/pkg/registry/event/strategy_test.go
+++ b/pkg/registry/event/strategy_test.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/util"
@@ -83,4 +84,17 @@ func TestGetAttrs(t *testing.T) {
 	if e, a := expect, field; !reflect.DeepEqual(e, a) {
 		t.Errorf("diff: %s", util.ObjectDiff(e, a))
 	}
+}
+
+func TestSelectableFieldLabelConversions(t *testing.T) {
+	_, fset, err := getAttrs(&api.Event{})
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	apitesting.TestSelectableFieldLabelConversionsOfKind(t,
+		testapi.Default.GroupVersion().String(),
+		"Event",
+		labels.Set(fset),
+		nil,
+	)
 }

--- a/pkg/registry/horizontalpodautoscaler/strategy_test.go
+++ b/pkg/registry/horizontalpodautoscaler/strategy_test.go
@@ -14,44 +14,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package node
+package horizontalpodautoscaler
 
 import (
 	"testing"
 
-	"k8s.io/kubernetes/pkg/api"
+	_ "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
-	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/labels"
 )
 
-func TestMatchNode(t *testing.T) {
-	testFieldMap := map[bool][]fields.Set{
-		true: {
-			{"metadata.name": "foo"},
-		},
-		false: {
-			{"foo": "bar"},
-		},
-	}
-
-	for expectedResult, fieldSet := range testFieldMap {
-		for _, field := range fieldSet {
-			m := MatchNode(labels.Everything(), field.AsSelector())
-			_, matchesSingle := m.MatchesSingle()
-			if e, a := expectedResult, matchesSingle; e != a {
-				t.Errorf("%+v: expected %v, got %v", fieldSet, e, a)
-			}
-		}
-	}
-}
-
 func TestSelectableFieldLabelConversions(t *testing.T) {
 	apitesting.TestSelectableFieldLabelConversionsOfKind(t,
-		testapi.Default.GroupVersion().String(),
-		"Node",
-		labels.Set(NodeToSelectableFields(&api.Node{})),
+		testapi.Extensions.GroupVersion().String(),
+		"Autoscaler",
+		labels.Set(AutoscalerToSelectableFields(&extensions.HorizontalPodAutoscaler{})),
 		nil,
 	)
 }

--- a/pkg/registry/ingress/strategy_test.go
+++ b/pkg/registry/ingress/strategy_test.go
@@ -20,7 +20,10 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/util/intstr"
 )
 
@@ -127,4 +130,13 @@ func TestIngressStatusStrategy(t *testing.T) {
 	if len(errs) != 0 {
 		t.Errorf("Unexpected error %v", errs)
 	}
+}
+
+func TestSelectableFieldLabelConversions(t *testing.T) {
+	apitesting.TestSelectableFieldLabelConversionsOfKind(t,
+		testapi.Extensions.GroupVersion().String(),
+		"Ingress",
+		labels.Set(IngressToSelectableFields(&extensions.Ingress{})),
+		nil,
+	)
 }

--- a/pkg/registry/job/strategy_test.go
+++ b/pkg/registry/job/strategy_test.go
@@ -20,7 +20,10 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/labels"
 )
 
 func TestJobStrategy(t *testing.T) {
@@ -157,4 +160,13 @@ func TestJobStatusStrategy(t *testing.T) {
 	if newJob.ResourceVersion != "9" {
 		t.Errorf("Incoming resource version on update should not be mutated")
 	}
+}
+
+func TestSelectableFieldLabelConversions(t *testing.T) {
+	apitesting.TestSelectableFieldLabelConversionsOfKind(t,
+		testapi.Extensions.GroupVersion().String(),
+		"Job",
+		labels.Set(JobToSelectableFields(&extensions.Job{})),
+		nil,
+	)
 }

--- a/pkg/registry/limitrange/strategy_test.go
+++ b/pkg/registry/limitrange/strategy_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package node
+package limitrange
 
 import (
 	"testing"
@@ -22,36 +22,14 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
-	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 )
-
-func TestMatchNode(t *testing.T) {
-	testFieldMap := map[bool][]fields.Set{
-		true: {
-			{"metadata.name": "foo"},
-		},
-		false: {
-			{"foo": "bar"},
-		},
-	}
-
-	for expectedResult, fieldSet := range testFieldMap {
-		for _, field := range fieldSet {
-			m := MatchNode(labels.Everything(), field.AsSelector())
-			_, matchesSingle := m.MatchesSingle()
-			if e, a := expectedResult, matchesSingle; e != a {
-				t.Errorf("%+v: expected %v, got %v", fieldSet, e, a)
-			}
-		}
-	}
-}
 
 func TestSelectableFieldLabelConversions(t *testing.T) {
 	apitesting.TestSelectableFieldLabelConversionsOfKind(t,
 		testapi.Default.GroupVersion().String(),
-		"Node",
-		labels.Set(NodeToSelectableFields(&api.Node{})),
+		"LimitRange",
+		labels.Set(LimitRangeToSelectableFields(&api.LimitRange{})),
 		nil,
 	)
 }

--- a/pkg/registry/namespace/strategy_test.go
+++ b/pkg/registry/namespace/strategy_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 )
 
@@ -129,4 +131,13 @@ func TestNamespaceFinalizeStrategy(t *testing.T) {
 	if namespace.ResourceVersion != "9" {
 		t.Errorf("Incoming resource version on update should not be mutated")
 	}
+}
+
+func TestSelectableFieldLabelConversions(t *testing.T) {
+	apitesting.TestSelectableFieldLabelConversionsOfKind(t,
+		testapi.Default.GroupVersion().String(),
+		"Namespace",
+		NamespaceToSelectableFields(&api.Namespace{}),
+		map[string]string{"name": "metadata.name"},
+	)
 }

--- a/pkg/registry/persistentvolume/strategy_test.go
+++ b/pkg/registry/persistentvolume/strategy_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package node
+package persistentvolume
 
 import (
 	"testing"
@@ -22,36 +22,13 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
-	"k8s.io/kubernetes/pkg/fields"
-	"k8s.io/kubernetes/pkg/labels"
 )
-
-func TestMatchNode(t *testing.T) {
-	testFieldMap := map[bool][]fields.Set{
-		true: {
-			{"metadata.name": "foo"},
-		},
-		false: {
-			{"foo": "bar"},
-		},
-	}
-
-	for expectedResult, fieldSet := range testFieldMap {
-		for _, field := range fieldSet {
-			m := MatchNode(labels.Everything(), field.AsSelector())
-			_, matchesSingle := m.MatchesSingle()
-			if e, a := expectedResult, matchesSingle; e != a {
-				t.Errorf("%+v: expected %v, got %v", fieldSet, e, a)
-			}
-		}
-	}
-}
 
 func TestSelectableFieldLabelConversions(t *testing.T) {
 	apitesting.TestSelectableFieldLabelConversionsOfKind(t,
 		testapi.Default.GroupVersion().String(),
-		"Node",
-		labels.Set(NodeToSelectableFields(&api.Node{})),
-		nil,
+		"PersistentVolume",
+		PersistentVolumeToSelectableFields(&api.PersistentVolume{}),
+		map[string]string{"name": "metadata.name"},
 	)
 }

--- a/pkg/registry/persistentvolumeclaim/strategy_test.go
+++ b/pkg/registry/persistentvolumeclaim/strategy_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package node
+package persistentvolumeclaim
 
 import (
 	"testing"
@@ -22,36 +22,13 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
-	"k8s.io/kubernetes/pkg/fields"
-	"k8s.io/kubernetes/pkg/labels"
 )
-
-func TestMatchNode(t *testing.T) {
-	testFieldMap := map[bool][]fields.Set{
-		true: {
-			{"metadata.name": "foo"},
-		},
-		false: {
-			{"foo": "bar"},
-		},
-	}
-
-	for expectedResult, fieldSet := range testFieldMap {
-		for _, field := range fieldSet {
-			m := MatchNode(labels.Everything(), field.AsSelector())
-			_, matchesSingle := m.MatchesSingle()
-			if e, a := expectedResult, matchesSingle; e != a {
-				t.Errorf("%+v: expected %v, got %v", fieldSet, e, a)
-			}
-		}
-	}
-}
 
 func TestSelectableFieldLabelConversions(t *testing.T) {
 	apitesting.TestSelectableFieldLabelConversionsOfKind(t,
 		testapi.Default.GroupVersion().String(),
-		"Node",
-		labels.Set(NodeToSelectableFields(&api.Node{})),
-		nil,
+		"PersistentVolumeClaim",
+		PersistentVolumeClaimToSelectableFields(&api.PersistentVolumeClaim{}),
+		map[string]string{"name": "metadata.name"},
 	)
 }

--- a/pkg/registry/pod/strategy_test.go
+++ b/pkg/registry/pod/strategy_test.go
@@ -22,6 +22,9 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
@@ -166,4 +169,13 @@ func TestCheckLogLocation(t *testing.T) {
 			t.Errorf("expected %v, got %v", tc.expectedErr, err)
 		}
 	}
+}
+
+func TestSelectableFieldLabelConversions(t *testing.T) {
+	apitesting.TestSelectableFieldLabelConversionsOfKind(t,
+		testapi.Default.GroupVersion().String(),
+		"Pod",
+		labels.Set(PodToSelectableFields(&api.Pod{})),
+		nil,
+	)
 }

--- a/pkg/registry/podtemplate/strategy_test.go
+++ b/pkg/registry/podtemplate/strategy_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package node
+package podtemplate
 
 import (
 	"testing"
@@ -22,36 +22,14 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
-	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
 )
-
-func TestMatchNode(t *testing.T) {
-	testFieldMap := map[bool][]fields.Set{
-		true: {
-			{"metadata.name": "foo"},
-		},
-		false: {
-			{"foo": "bar"},
-		},
-	}
-
-	for expectedResult, fieldSet := range testFieldMap {
-		for _, field := range fieldSet {
-			m := MatchNode(labels.Everything(), field.AsSelector())
-			_, matchesSingle := m.MatchesSingle()
-			if e, a := expectedResult, matchesSingle; e != a {
-				t.Errorf("%+v: expected %v, got %v", fieldSet, e, a)
-			}
-		}
-	}
-}
 
 func TestSelectableFieldLabelConversions(t *testing.T) {
 	apitesting.TestSelectableFieldLabelConversionsOfKind(t,
 		testapi.Default.GroupVersion().String(),
-		"Node",
-		labels.Set(NodeToSelectableFields(&api.Node{})),
+		"PodTemplate",
+		labels.Set(PodTemplateToSelectableFields(&api.PodTemplate{})),
 		nil,
 	)
 }

--- a/pkg/registry/resourcequota/strategy_test.go
+++ b/pkg/registry/resourcequota/strategy_test.go
@@ -21,6 +21,8 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
 )
 
 func TestResourceQuotaStrategy(t *testing.T) {
@@ -55,4 +57,13 @@ func TestResourceQuotaStrategy(t *testing.T) {
 	if resourceQuota.Status.Used != nil {
 		t.Errorf("ResourceQuota does not allow setting status on create")
 	}
+}
+
+func TestSelectableFieldLabelConversions(t *testing.T) {
+	apitesting.TestSelectableFieldLabelConversionsOfKind(t,
+		testapi.Default.GroupVersion().String(),
+		"ResourceQuota",
+		ResourceQuotaToSelectableFields(&api.ResourceQuota{}),
+		nil,
+	)
 }

--- a/pkg/registry/secret/strategy.go
+++ b/pkg/registry/secret/strategy.go
@@ -107,7 +107,9 @@ func Matcher(label labels.Selector, field fields.Selector) generic.Matcher {
 
 // SelectableFields returns a label set that can be used for filter selection
 func SelectableFields(obj *api.Secret) labels.Set {
-	return labels.Set{
+	objectMetaFieldsSet := generic.ObjectMetaFieldsSet(obj.ObjectMeta, true)
+	secretSpecificFieldsSet := fields.Set{
 		"type": string(obj.Type),
 	}
+	return labels.Set(generic.MergeFieldsSets(objectMetaFieldsSet, secretSpecificFieldsSet))
 }

--- a/pkg/registry/secret/strategy_test.go
+++ b/pkg/registry/secret/strategy_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	"k8s.io/kubernetes/pkg/runtime"
 )
 
@@ -96,4 +98,13 @@ func TestExportSecret(t *testing.T) {
 			t.Errorf("expected:\n%v\nsaw:\n%v\n", test.objOut, test.objIn)
 		}
 	}
+}
+
+func TestSelectableFieldLabelConversions(t *testing.T) {
+	apitesting.TestSelectableFieldLabelConversionsOfKind(t,
+		testapi.Default.GroupVersion().String(),
+		"Secret",
+		SelectableFields(&api.Secret{}),
+		nil,
+	)
 }

--- a/pkg/registry/service/strategy_test.go
+++ b/pkg/registry/service/strategy_test.go
@@ -23,6 +23,9 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/rest"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/util/intstr"
 )
@@ -204,4 +207,13 @@ func TestBeforeUpdate(t *testing.T) {
 			t.Errorf("unexpected error for %q: %v", tc.name, err)
 		}
 	}
+}
+
+func TestSelectableFieldLabelConversions(t *testing.T) {
+	apitesting.TestSelectableFieldLabelConversionsOfKind(t,
+		testapi.Default.GroupVersion().String(),
+		"Service",
+		labels.Set(ServiceToSelectableFields(&api.Service{})),
+		nil,
+	)
 }

--- a/pkg/registry/serviceaccount/strategy_test.go
+++ b/pkg/registry/serviceaccount/strategy_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package node
+package serviceaccount
 
 import (
 	"testing"
@@ -22,36 +22,13 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
-	"k8s.io/kubernetes/pkg/fields"
-	"k8s.io/kubernetes/pkg/labels"
 )
-
-func TestMatchNode(t *testing.T) {
-	testFieldMap := map[bool][]fields.Set{
-		true: {
-			{"metadata.name": "foo"},
-		},
-		false: {
-			{"foo": "bar"},
-		},
-	}
-
-	for expectedResult, fieldSet := range testFieldMap {
-		for _, field := range fieldSet {
-			m := MatchNode(labels.Everything(), field.AsSelector())
-			_, matchesSingle := m.MatchesSingle()
-			if e, a := expectedResult, matchesSingle; e != a {
-				t.Errorf("%+v: expected %v, got %v", fieldSet, e, a)
-			}
-		}
-	}
-}
 
 func TestSelectableFieldLabelConversions(t *testing.T) {
 	apitesting.TestSelectableFieldLabelConversionsOfKind(t,
 		testapi.Default.GroupVersion().String(),
-		"Node",
-		labels.Set(NodeToSelectableFields(&api.Node{})),
+		"ServiceAccount",
+		SelectableFields(&api.ServiceAccount{}),
 		nil,
 	)
 }

--- a/pkg/registry/thirdpartyresource/strategy_test.go
+++ b/pkg/registry/thirdpartyresource/strategy_test.go
@@ -14,44 +14,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package node
+package thirdpartyresource
 
 import (
 	"testing"
 
-	"k8s.io/kubernetes/pkg/api"
+	_ "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
-	"k8s.io/kubernetes/pkg/fields"
-	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/apis/extensions"
 )
-
-func TestMatchNode(t *testing.T) {
-	testFieldMap := map[bool][]fields.Set{
-		true: {
-			{"metadata.name": "foo"},
-		},
-		false: {
-			{"foo": "bar"},
-		},
-	}
-
-	for expectedResult, fieldSet := range testFieldMap {
-		for _, field := range fieldSet {
-			m := MatchNode(labels.Everything(), field.AsSelector())
-			_, matchesSingle := m.MatchesSingle()
-			if e, a := expectedResult, matchesSingle; e != a {
-				t.Errorf("%+v: expected %v, got %v", fieldSet, e, a)
-			}
-		}
-	}
-}
 
 func TestSelectableFieldLabelConversions(t *testing.T) {
 	apitesting.TestSelectableFieldLabelConversionsOfKind(t,
-		testapi.Default.GroupVersion().String(),
-		"Node",
-		labels.Set(NodeToSelectableFields(&api.Node{})),
+		testapi.Extensions.GroupVersion().String(),
+		"ThirdPartyResource",
+		SelectableFields(&extensions.ThirdPartyResource{}),
 		nil,
 	)
 }

--- a/pkg/registry/thirdpartyresourcedata/strategy_test.go
+++ b/pkg/registry/thirdpartyresourcedata/strategy_test.go
@@ -14,44 +14,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package node
+package thirdpartyresourcedata
 
 import (
 	"testing"
 
-	"k8s.io/kubernetes/pkg/api"
+	_ "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	apitesting "k8s.io/kubernetes/pkg/api/testing"
-	"k8s.io/kubernetes/pkg/fields"
-	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/apis/extensions"
 )
-
-func TestMatchNode(t *testing.T) {
-	testFieldMap := map[bool][]fields.Set{
-		true: {
-			{"metadata.name": "foo"},
-		},
-		false: {
-			{"foo": "bar"},
-		},
-	}
-
-	for expectedResult, fieldSet := range testFieldMap {
-		for _, field := range fieldSet {
-			m := MatchNode(labels.Everything(), field.AsSelector())
-			_, matchesSingle := m.MatchesSingle()
-			if e, a := expectedResult, matchesSingle; e != a {
-				t.Errorf("%+v: expected %v, got %v", fieldSet, e, a)
-			}
-		}
-	}
-}
 
 func TestSelectableFieldLabelConversions(t *testing.T) {
 	apitesting.TestSelectableFieldLabelConversionsOfKind(t,
-		testapi.Default.GroupVersion().String(),
-		"Node",
-		labels.Set(NodeToSelectableFields(&api.Node{})),
+		testapi.Extensions.GroupVersion().String(),
+		"ThirdPartyResourceData",
+		SelectableFields(&extensions.ThirdPartyResourceData{}),
 		nil,
 	)
 }


### PR DESCRIPTION
Missing field labels in conversion functions:
- "name"
- "metadata.name"
- "metadata.namespace"

Resolves #16501
Follow-up to #15766
