### PR TITLE
rewrite links to v1.1.0 tag to release-1.1

### DIFF
--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -11080,15 +11080,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata"
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata"
      },
      "target": {
       "$ref": "v1.ObjectReference",
@@ -11102,15 +11102,15 @@
     "properties": {
      "name": {
       "type": "string",
-      "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#names"
+      "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#names"
      },
      "generateName": {
       "type": "string",
-      "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).\n\nApplied only if Name is not specified. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#idempotency"
+      "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).\n\nApplied only if Name is not specified. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#idempotency"
      },
      "namespace": {
       "type": "string",
-      "description": "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/namespaces.md"
+      "description": "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: http://releases.k8s.io/release-1.1/docs/user-guide/namespaces.md"
      },
      "selfLink": {
       "type": "string",
@@ -11118,11 +11118,11 @@
      },
      "uid": {
       "type": "string",
-      "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#uids"
+      "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#uids"
      },
      "resourceVersion": {
       "type": "string",
-      "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#concurrency-control-and-consistency"
+      "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#concurrency-control-and-consistency"
      },
      "generation": {
       "type": "integer",
@@ -11131,11 +11131,11 @@
      },
      "creationTimestamp": {
       "type": "string",
-      "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata"
+      "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata"
      },
      "deletionTimestamp": {
       "type": "string",
-      "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource will be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field. Once set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. Once the resource is deleted in the API, the Kubelet will send a hard termination signal to the container. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata"
+      "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource will be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field. Once set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. Once the resource is deleted in the API, the Kubelet will send a hard termination signal to the container. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata"
      },
      "deletionGracePeriodSeconds": {
       "type": "integer",
@@ -11144,11 +11144,11 @@
      },
      "labels": {
       "type": "any",
-      "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md"
+      "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://releases.k8s.io/release-1.1/docs/user-guide/labels.md"
      },
      "annotations": {
       "type": "any",
-      "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/annotations.md"
+      "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://releases.k8s.io/release-1.1/docs/user-guide/annotations.md"
      }
     }
    },
@@ -11158,19 +11158,19 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind of the referent. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind of the referent. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "namespace": {
       "type": "string",
-      "description": "Namespace of the referent. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/namespaces.md"
+      "description": "Namespace of the referent. More info: http://releases.k8s.io/release-1.1/docs/user-guide/namespaces.md"
      },
      "name": {
       "type": "string",
-      "description": "Name of the referent. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#names"
+      "description": "Name of the referent. More info: http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#names"
      },
      "uid": {
       "type": "string",
-      "description": "UID of the referent. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#uids"
+      "description": "UID of the referent. More info: http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#uids"
      },
      "apiVersion": {
       "type": "string",
@@ -11178,7 +11178,7 @@
      },
      "resourceVersion": {
       "type": "string",
-      "description": "Specific resourceVersion to which this reference is made, if any. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#concurrency-control-and-consistency"
+      "description": "Specific resourceVersion to which this reference is made, if any. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#concurrency-control-and-consistency"
      },
      "fieldPath": {
       "type": "string",
@@ -11195,15 +11195,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "unversioned.ListMeta",
-      "description": "Standard list metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Standard list metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "items": {
       "type": "array",
@@ -11224,7 +11224,7 @@
      },
      "resourceVersion": {
       "type": "string",
-      "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#concurrency-control-and-consistency"
+      "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#concurrency-control-and-consistency"
      }
     }
    },
@@ -11234,15 +11234,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata"
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata"
      },
      "conditions": {
       "type": "array",
@@ -11288,15 +11288,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "unversioned.ListMeta",
-      "description": "Standard list metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Standard list metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "items": {
       "type": "array",
@@ -11316,15 +11316,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata"
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata"
      },
      "subsets": {
       "type": "array",
@@ -11425,19 +11425,19 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "unversioned.ListMeta",
-      "description": "Standard list metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Standard list metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "status": {
       "type": "string",
-      "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status"
+      "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status"
      },
      "message": {
       "type": "string",
@@ -11468,7 +11468,7 @@
      },
      "kind": {
       "type": "string",
-      "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "causes": {
       "type": "array",
@@ -11511,11 +11511,11 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "gracePeriodSeconds": {
       "type": "integer",
@@ -11533,15 +11533,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "unversioned.ListMeta",
-      "description": "Standard list metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Standard list metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "items": {
       "type": "array",
@@ -11562,15 +11562,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata"
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata"
      },
      "involvedObject": {
       "$ref": "v1.ObjectReference",
@@ -11626,22 +11626,22 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "unversioned.ListMeta",
-      "description": "Standard list metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Standard list metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "items": {
       "type": "array",
       "items": {
        "$ref": "v1.LimitRange"
       },
-      "description": "Items is a list of LimitRange objects. More info: http://releases.k8s.io/v1.1.0/docs/design/admission_control_limit_range.md"
+      "description": "Items is a list of LimitRange objects. More info: http://releases.k8s.io/release-1.1/docs/design/admission_control_limit_range.md"
      }
     }
    },
@@ -11651,19 +11651,19 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata"
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1.LimitRangeSpec",
-      "description": "Spec defines the limits enforced. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status"
+      "description": "Spec defines the limits enforced. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -11722,22 +11722,22 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "unversioned.ListMeta",
-      "description": "Standard list metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Standard list metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "items": {
       "type": "array",
       "items": {
        "$ref": "v1.Namespace"
       },
-      "description": "Items is the list of Namespace objects in the list. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/namespaces.md"
+      "description": "Items is the list of Namespace objects in the list. More info: http://releases.k8s.io/release-1.1/docs/user-guide/namespaces.md"
      }
     }
    },
@@ -11747,23 +11747,23 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata"
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1.NamespaceSpec",
-      "description": "Spec defines the behavior of the Namespace. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status"
+      "description": "Spec defines the behavior of the Namespace. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1.NamespaceStatus",
-      "description": "Status describes the current status of a Namespace. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status"
+      "description": "Status describes the current status of a Namespace. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -11776,7 +11776,7 @@
       "items": {
        "$ref": "v1.FinalizerName"
       },
-      "description": "Finalizers is an opaque list of values that must be empty to permanently remove object from storage. More info: http://releases.k8s.io/v1.1.0/docs/design/namespaces.md#finalizers"
+      "description": "Finalizers is an opaque list of values that must be empty to permanently remove object from storage. More info: http://releases.k8s.io/release-1.1/docs/design/namespaces.md#finalizers"
      }
     }
    },
@@ -11790,7 +11790,7 @@
     "properties": {
      "phase": {
       "type": "string",
-      "description": "Phase is the current lifecycle phase of the namespace. More info: http://releases.k8s.io/v1.1.0/docs/design/namespaces.md#phases"
+      "description": "Phase is the current lifecycle phase of the namespace. More info: http://releases.k8s.io/release-1.1/docs/design/namespaces.md#phases"
      }
     }
    },
@@ -11803,15 +11803,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "unversioned.ListMeta",
-      "description": "Standard list metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Standard list metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "items": {
       "type": "array",
@@ -11828,23 +11828,23 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata"
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1.NodeSpec",
-      "description": "Spec defines the behavior of a node. http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status"
+      "description": "Spec defines the behavior of a node. http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1.NodeStatus",
-      "description": "Most recently observed status of the node. Populated by the system. Read-only. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status"
+      "description": "Most recently observed status of the node. Populated by the system. Read-only. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -11866,7 +11866,7 @@
      },
      "unschedulable": {
       "type": "boolean",
-      "description": "Unschedulable controls node schedulability of new pods. By default, node is schedulable. More info: http://releases.k8s.io/v1.1.0/docs/admin/node.md#manual-node-administration\"`"
+      "description": "Unschedulable controls node schedulability of new pods. By default, node is schedulable. More info: http://releases.k8s.io/release-1.1/docs/admin/node.md#manual-node-administration\"`"
      }
     }
    },
@@ -11876,25 +11876,25 @@
     "properties": {
      "capacity": {
       "type": "any",
-      "description": "Capacity represents the available resources of a node. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#capacity for more details."
+      "description": "Capacity represents the available resources of a node. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#capacity for more details."
      },
      "phase": {
       "type": "string",
-      "description": "NodePhase is the recently observed lifecycle phase of the node. More info: http://releases.k8s.io/v1.1.0/docs/admin/node.md#node-phase"
+      "description": "NodePhase is the recently observed lifecycle phase of the node. More info: http://releases.k8s.io/release-1.1/docs/admin/node.md#node-phase"
      },
      "conditions": {
       "type": "array",
       "items": {
        "$ref": "v1.NodeCondition"
       },
-      "description": "Conditions is an array of current observed node conditions. More info: http://releases.k8s.io/v1.1.0/docs/admin/node.md#node-condition"
+      "description": "Conditions is an array of current observed node conditions. More info: http://releases.k8s.io/release-1.1/docs/admin/node.md#node-condition"
      },
      "addresses": {
       "type": "array",
       "items": {
        "$ref": "v1.NodeAddress"
       },
-      "description": "List of addresses reachable to the node. Queried from cloud provider, if available. More info: http://releases.k8s.io/v1.1.0/docs/admin/node.md#node-addresses"
+      "description": "List of addresses reachable to the node. Queried from cloud provider, if available. More info: http://releases.k8s.io/release-1.1/docs/admin/node.md#node-addresses"
      },
      "daemonEndpoints": {
       "$ref": "v1.NodeDaemonEndpoints",
@@ -11902,7 +11902,7 @@
      },
      "nodeInfo": {
       "$ref": "v1.NodeSystemInfo",
-      "description": "Set of ids/uuids to uniquely identify the node. More info: http://releases.k8s.io/v1.1.0/docs/admin/node.md#node-info"
+      "description": "Set of ids/uuids to uniquely identify the node. More info: http://releases.k8s.io/release-1.1/docs/admin/node.md#node-info"
      }
     }
    },
@@ -12039,22 +12039,22 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "unversioned.ListMeta",
-      "description": "Standard list metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Standard list metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "items": {
       "type": "array",
       "items": {
        "$ref": "v1.PersistentVolumeClaim"
       },
-      "description": "A list of persistent volume claims. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"
+      "description": "A list of persistent volume claims. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"
      }
     }
    },
@@ -12064,23 +12064,23 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata"
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1.PersistentVolumeClaimSpec",
-      "description": "Spec defines the desired characteristics of a volume requested by a pod author. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"
+      "description": "Spec defines the desired characteristics of a volume requested by a pod author. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"
      },
      "status": {
       "$ref": "v1.PersistentVolumeClaimStatus",
-      "description": "Status represents the current information/status of a persistent volume claim. Read-only. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"
+      "description": "Status represents the current information/status of a persistent volume claim. Read-only. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"
      }
     }
    },
@@ -12093,11 +12093,11 @@
       "items": {
        "$ref": "v1.PersistentVolumeAccessMode"
       },
-      "description": "AccessModes contains the desired access modes the volume should have. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#access-modes-1"
+      "description": "AccessModes contains the desired access modes the volume should have. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#access-modes-1"
      },
      "resources": {
       "$ref": "v1.ResourceRequirements",
-      "description": "Resources represents the minimum resources the volume should have. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#resources"
+      "description": "Resources represents the minimum resources the volume should have. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#resources"
      },
      "volumeName": {
       "type": "string",
@@ -12115,11 +12115,11 @@
     "properties": {
      "limits": {
       "type": "any",
-      "description": "Limits describes the maximum amount of compute resources allowed. More info: http://releases.k8s.io/v1.1.0/docs/design/resources.md#resource-specifications"
+      "description": "Limits describes the maximum amount of compute resources allowed. More info: http://releases.k8s.io/release-1.1/docs/design/resources.md#resource-specifications"
      },
      "requests": {
       "type": "any",
-      "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: http://releases.k8s.io/v1.1.0/docs/design/resources.md#resource-specifications"
+      "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: http://releases.k8s.io/release-1.1/docs/design/resources.md#resource-specifications"
      }
     }
    },
@@ -12136,7 +12136,7 @@
       "items": {
        "$ref": "v1.PersistentVolumeAccessMode"
       },
-      "description": "AccessModes contains the actual access modes the volume backing the PVC has. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#access-modes-1"
+      "description": "AccessModes contains the actual access modes the volume backing the PVC has. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#access-modes-1"
      },
      "capacity": {
       "type": "any",
@@ -12153,48 +12153,48 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "unversioned.ListMeta",
-      "description": "Standard list metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Standard list metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "items": {
       "type": "array",
       "items": {
        "$ref": "v1.PersistentVolume"
       },
-      "description": "List of persistent volumes. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md"
+      "description": "List of persistent volumes. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md"
      }
     }
    },
    "v1.PersistentVolume": {
     "id": "v1.PersistentVolume",
-    "description": "PersistentVolume (PV) is a storage resource provisioned by an administrator. It is analogous to a node. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md",
+    "description": "PersistentVolume (PV) is a storage resource provisioned by an administrator. It is analogous to a node. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md",
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata"
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1.PersistentVolumeSpec",
-      "description": "Spec defines a specification of a persistent volume owned by the cluster. Provisioned by an administrator. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistent-volumes"
+      "description": "Spec defines a specification of a persistent volume owned by the cluster. Provisioned by an administrator. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistent-volumes"
      },
      "status": {
       "$ref": "v1.PersistentVolumeStatus",
-      "description": "Status represents the current information/status for the persistent volume. Populated by the system. Read-only. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistent-volumes"
+      "description": "Status represents the current information/status for the persistent volume. Populated by the system. Read-only. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistent-volumes"
      }
     }
    },
@@ -12204,31 +12204,31 @@
     "properties": {
      "capacity": {
       "type": "any",
-      "description": "A description of the persistent volume's resources and capacity. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#capacity"
+      "description": "A description of the persistent volume's resources and capacity. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#capacity"
      },
      "gcePersistentDisk": {
       "$ref": "v1.GCEPersistentDiskVolumeSource",
-      "description": "GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk"
+      "description": "GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk"
      },
      "awsElasticBlockStore": {
       "$ref": "v1.AWSElasticBlockStoreVolumeSource",
-      "description": "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore"
+      "description": "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore"
      },
      "hostPath": {
       "$ref": "v1.HostPathVolumeSource",
-      "description": "HostPath represents a directory on the host. Provisioned by a developer or tester. This is useful for single-node development and testing only! On-host storage is not supported in any way and WILL NOT WORK in a multi-node cluster. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#hostpath"
+      "description": "HostPath represents a directory on the host. Provisioned by a developer or tester. This is useful for single-node development and testing only! On-host storage is not supported in any way and WILL NOT WORK in a multi-node cluster. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#hostpath"
      },
      "glusterfs": {
       "$ref": "v1.GlusterfsVolumeSource",
-      "description": "Glusterfs represents a Glusterfs volume that is attached to a host and exposed to the pod. Provisioned by an admin. More info: http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md"
+      "description": "Glusterfs represents a Glusterfs volume that is attached to a host and exposed to the pod. Provisioned by an admin. More info: http://releases.k8s.io/release-1.1/examples/glusterfs/README.md"
      },
      "nfs": {
       "$ref": "v1.NFSVolumeSource",
-      "description": "NFS represents an NFS mount on the host. Provisioned by an admin. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs"
+      "description": "NFS represents an NFS mount on the host. Provisioned by an admin. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs"
      },
      "rbd": {
       "$ref": "v1.RBDVolumeSource",
-      "description": "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/v1.1.0/examples/rbd/README.md"
+      "description": "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/release-1.1/examples/rbd/README.md"
      },
      "iscsi": {
       "$ref": "v1.ISCSIVolumeSource",
@@ -12236,7 +12236,7 @@
      },
      "cinder": {
       "$ref": "v1.CinderVolumeSource",
-      "description": "Cinder represents a cinder volume attached and mounted on kubelets host machine More info: http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md"
+      "description": "Cinder represents a cinder volume attached and mounted on kubelets host machine More info: http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md"
      },
      "cephfs": {
       "$ref": "v1.CephFSVolumeSource",
@@ -12255,15 +12255,15 @@
       "items": {
        "$ref": "v1.PersistentVolumeAccessMode"
       },
-      "description": "AccessModes contains all ways the volume can be mounted. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#access-modes"
+      "description": "AccessModes contains all ways the volume can be mounted. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#access-modes"
      },
      "claimRef": {
       "$ref": "v1.ObjectReference",
-      "description": "ClaimRef is part of a bi-directional binding between PersistentVolume and PersistentVolumeClaim. Expected to be non-nil when bound. claim.VolumeName is the authoritative bind between PV and PVC. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#binding"
+      "description": "ClaimRef is part of a bi-directional binding between PersistentVolume and PersistentVolumeClaim. Expected to be non-nil when bound. claim.VolumeName is the authoritative bind between PV and PVC. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#binding"
      },
      "persistentVolumeReclaimPolicy": {
       "type": "string",
-      "description": "What happens to a persistent volume when released from its claim. Valid options are Retain (default) and Recycle. Recyling must be supported by the volume plugin underlying this persistent volume. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#recycling-policy"
+      "description": "What happens to a persistent volume when released from its claim. Valid options are Retain (default) and Recycle. Recyling must be supported by the volume plugin underlying this persistent volume. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#recycling-policy"
      }
     }
    },
@@ -12277,20 +12277,20 @@
     "properties": {
      "pdName": {
       "type": "string",
-      "description": "Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk"
+      "description": "Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk"
      },
      "fsType": {
       "type": "string",
-      "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk"
+      "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk"
      },
      "partition": {
       "type": "integer",
       "format": "int32",
-      "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk"
+      "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk"
      },
      "readOnly": {
       "type": "boolean",
-      "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk"
+      "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk"
      }
     }
    },
@@ -12304,11 +12304,11 @@
     "properties": {
      "volumeID": {
       "type": "string",
-      "description": "Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore"
+      "description": "Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore"
      },
      "fsType": {
       "type": "string",
-      "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore"
+      "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore"
      },
      "partition": {
       "type": "integer",
@@ -12317,7 +12317,7 @@
      },
      "readOnly": {
       "type": "boolean",
-      "description": "Specify \"true\" to force and set the ReadOnly property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore"
+      "description": "Specify \"true\" to force and set the ReadOnly property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore"
      }
     }
    },
@@ -12330,7 +12330,7 @@
     "properties": {
      "path": {
       "type": "string",
-      "description": "Path of the directory on the host. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#hostpath"
+      "description": "Path of the directory on the host. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#hostpath"
      }
     }
    },
@@ -12344,15 +12344,15 @@
     "properties": {
      "endpoints": {
       "type": "string",
-      "description": "EndpointsName is the endpoint name that details Glusterfs topology. More info: http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md#create-a-pod"
+      "description": "EndpointsName is the endpoint name that details Glusterfs topology. More info: http://releases.k8s.io/release-1.1/examples/glusterfs/README.md#create-a-pod"
      },
      "path": {
       "type": "string",
-      "description": "Path is the Glusterfs volume path. More info: http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md#create-a-pod"
+      "description": "Path is the Glusterfs volume path. More info: http://releases.k8s.io/release-1.1/examples/glusterfs/README.md#create-a-pod"
      },
      "readOnly": {
       "type": "boolean",
-      "description": "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md#create-a-pod"
+      "description": "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: http://releases.k8s.io/release-1.1/examples/glusterfs/README.md#create-a-pod"
      }
     }
    },
@@ -12366,15 +12366,15 @@
     "properties": {
      "server": {
       "type": "string",
-      "description": "Server is the hostname or IP address of the NFS server. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs"
+      "description": "Server is the hostname or IP address of the NFS server. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs"
      },
      "path": {
       "type": "string",
-      "description": "Path that is exported by the NFS server. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs"
+      "description": "Path that is exported by the NFS server. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs"
      },
      "readOnly": {
       "type": "boolean",
-      "description": "ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs"
+      "description": "ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs"
      }
     }
    },
@@ -12395,35 +12395,35 @@
       "items": {
        "type": "string"
       },
-      "description": "A collection of Ceph monitors. More info: http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it"
+      "description": "A collection of Ceph monitors. More info: http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it"
      },
      "image": {
       "type": "string",
-      "description": "The rados image name. More info: http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it"
+      "description": "The rados image name. More info: http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it"
      },
      "fsType": {
       "type": "string",
-      "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#rbd"
+      "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#rbd"
      },
      "pool": {
       "type": "string",
-      "description": "The rados pool name. Default is rbd. More info: http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it."
+      "description": "The rados pool name. Default is rbd. More info: http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it."
      },
      "user": {
       "type": "string",
-      "description": "The rados user name. Default is admin. More info: http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it"
+      "description": "The rados user name. Default is admin. More info: http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it"
      },
      "keyring": {
       "type": "string",
-      "description": "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it"
+      "description": "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it"
      },
      "secretRef": {
       "$ref": "v1.LocalObjectReference",
-      "description": "SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is empty. More info: http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it"
+      "description": "SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is empty. More info: http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it"
      },
      "readOnly": {
       "type": "boolean",
-      "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it"
+      "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it"
      }
     }
    },
@@ -12433,7 +12433,7 @@
     "properties": {
      "name": {
       "type": "string",
-      "description": "Name of the referent. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#names"
+      "description": "Name of the referent. More info: http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#names"
      }
     }
    },
@@ -12462,7 +12462,7 @@
      },
      "fsType": {
       "type": "string",
-      "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#iscsi"
+      "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#iscsi"
      },
      "readOnly": {
       "type": "boolean",
@@ -12479,15 +12479,15 @@
     "properties": {
      "volumeID": {
       "type": "string",
-      "description": "volume id used to identify the volume in cinder More info: http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md"
+      "description": "volume id used to identify the volume in cinder More info: http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md"
      },
      "fsType": {
       "type": "string",
-      "description": "Required: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Only ext3 and ext4 are allowed More info: http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md"
+      "description": "Required: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Only ext3 and ext4 are allowed More info: http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md"
      },
      "readOnly": {
       "type": "boolean",
-      "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md"
+      "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md"
      }
     }
    },
@@ -12503,23 +12503,23 @@
       "items": {
        "type": "string"
       },
-      "description": "Required: Monitors is a collection of Ceph monitors More info: http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it"
+      "description": "Required: Monitors is a collection of Ceph monitors More info: http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it"
      },
      "user": {
       "type": "string",
-      "description": "Optional: User is the rados user name, default is admin More info: http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it"
+      "description": "Optional: User is the rados user name, default is admin More info: http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it"
      },
      "secretFile": {
       "type": "string",
-      "description": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it"
+      "description": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it"
      },
      "secretRef": {
       "$ref": "v1.LocalObjectReference",
-      "description": "Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it"
+      "description": "Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it"
      },
      "readOnly": {
       "type": "boolean",
-      "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it"
+      "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it"
      }
     }
    },
@@ -12573,7 +12573,7 @@
     "properties": {
      "phase": {
       "type": "string",
-      "description": "Phase indicates if a volume is available, bound to a claim, or released by a claim. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#phase"
+      "description": "Phase indicates if a volume is available, bound to a claim, or released by a claim. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#phase"
      },
      "message": {
       "type": "string",
@@ -12594,22 +12594,22 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "unversioned.ListMeta",
-      "description": "Standard list metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Standard list metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "items": {
       "type": "array",
       "items": {
        "$ref": "v1.Pod"
       },
-      "description": "List of pods. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pods.md"
+      "description": "List of pods. More info: http://releases.k8s.io/release-1.1/docs/user-guide/pods.md"
      }
     }
    },
@@ -12619,23 +12619,23 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata"
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1.PodSpec",
-      "description": "Specification of the desired behavior of the pod. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status"
+      "description": "Specification of the desired behavior of the pod. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1.PodStatus",
-      "description": "Most recently observed status of the pod. This data may not be up to date. Populated by the system. Read-only. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status"
+      "description": "Most recently observed status of the pod. This data may not be up to date. Populated by the system. Read-only. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -12651,18 +12651,18 @@
       "items": {
        "$ref": "v1.Volume"
       },
-      "description": "List of volumes that can be mounted by containers belonging to the pod. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md"
+      "description": "List of volumes that can be mounted by containers belonging to the pod. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md"
      },
      "containers": {
       "type": "array",
       "items": {
        "$ref": "v1.Container"
       },
-      "description": "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/containers.md"
+      "description": "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. More info: http://releases.k8s.io/release-1.1/docs/user-guide/containers.md"
      },
      "restartPolicy": {
       "type": "string",
-      "description": "Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#restartpolicy"
+      "description": "Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#restartpolicy"
      },
      "terminationGracePeriodSeconds": {
       "type": "integer",
@@ -12680,11 +12680,11 @@
      },
      "nodeSelector": {
       "type": "any",
-      "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/node-selection/README.md"
+      "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: http://releases.k8s.io/release-1.1/docs/user-guide/node-selection/README.md"
      },
      "serviceAccountName": {
       "type": "string",
-      "description": "ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: http://releases.k8s.io/v1.1.0/docs/design/service_accounts.md"
+      "description": "ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: http://releases.k8s.io/release-1.1/docs/design/service_accounts.md"
      },
      "serviceAccount": {
       "type": "string",
@@ -12711,7 +12711,7 @@
       "items": {
        "$ref": "v1.LocalObjectReference"
       },
-      "description": "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/images.md#specifying-imagepullsecrets-on-a-pod"
+      "description": "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: http://releases.k8s.io/release-1.1/docs/user-guide/images.md#specifying-imagepullsecrets-on-a-pod"
      }
     }
    },
@@ -12724,23 +12724,23 @@
     "properties": {
      "name": {
       "type": "string",
-      "description": "Volume's name. Must be a DNS_LABEL and unique within the pod. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#names"
+      "description": "Volume's name. Must be a DNS_LABEL and unique within the pod. More info: http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#names"
      },
      "hostPath": {
       "$ref": "v1.HostPathVolumeSource",
-      "description": "HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#hostpath"
+      "description": "HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#hostpath"
      },
      "emptyDir": {
       "$ref": "v1.EmptyDirVolumeSource",
-      "description": "EmptyDir represents a temporary directory that shares a pod's lifetime. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#emptydir"
+      "description": "EmptyDir represents a temporary directory that shares a pod's lifetime. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#emptydir"
      },
      "gcePersistentDisk": {
       "$ref": "v1.GCEPersistentDiskVolumeSource",
-      "description": "GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk"
+      "description": "GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk"
      },
      "awsElasticBlockStore": {
       "$ref": "v1.AWSElasticBlockStoreVolumeSource",
-      "description": "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore"
+      "description": "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore"
      },
      "gitRepo": {
       "$ref": "v1.GitRepoVolumeSource",
@@ -12748,31 +12748,31 @@
      },
      "secret": {
       "$ref": "v1.SecretVolumeSource",
-      "description": "Secret represents a secret that should populate this volume. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#secrets"
+      "description": "Secret represents a secret that should populate this volume. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#secrets"
      },
      "nfs": {
       "$ref": "v1.NFSVolumeSource",
-      "description": "NFS represents an NFS mount on the host that shares a pod's lifetime More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs"
+      "description": "NFS represents an NFS mount on the host that shares a pod's lifetime More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs"
      },
      "iscsi": {
       "$ref": "v1.ISCSIVolumeSource",
-      "description": "ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/v1.1.0/examples/iscsi/README.md"
+      "description": "ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/release-1.1/examples/iscsi/README.md"
      },
      "glusterfs": {
       "$ref": "v1.GlusterfsVolumeSource",
-      "description": "Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md"
+      "description": "Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/release-1.1/examples/glusterfs/README.md"
      },
      "persistentVolumeClaim": {
       "$ref": "v1.PersistentVolumeClaimVolumeSource",
-      "description": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"
+      "description": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"
      },
      "rbd": {
       "$ref": "v1.RBDVolumeSource",
-      "description": "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/v1.1.0/examples/rbd/README.md"
+      "description": "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/release-1.1/examples/rbd/README.md"
      },
      "cinder": {
       "$ref": "v1.CinderVolumeSource",
-      "description": "Cinder represents a cinder volume attached and mounted on kubelets host machine More info: http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md"
+      "description": "Cinder represents a cinder volume attached and mounted on kubelets host machine More info: http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md"
      },
      "cephfs": {
       "$ref": "v1.CephFSVolumeSource",
@@ -12798,7 +12798,7 @@
     "properties": {
      "medium": {
       "type": "string",
-      "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#emptydir"
+      "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#emptydir"
      }
     }
    },
@@ -12822,14 +12822,14 @@
    },
    "v1.SecretVolumeSource": {
     "id": "v1.SecretVolumeSource",
-    "description": "SecretVolumeSource adapts a Secret into a VolumeSource. More info: http://releases.k8s.io/v1.1.0/docs/design/secrets.md",
+    "description": "SecretVolumeSource adapts a Secret into a VolumeSource. More info: http://releases.k8s.io/release-1.1/docs/design/secrets.md",
     "required": [
      "secretName"
     ],
     "properties": {
      "secretName": {
       "type": "string",
-      "description": "SecretName is the name of a secret in the pod's namespace. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#secrets"
+      "description": "SecretName is the name of a secret in the pod's namespace. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#secrets"
      }
     }
    },
@@ -12842,7 +12842,7 @@
     "properties": {
      "claimName": {
       "type": "string",
-      "description": "ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"
+      "description": "ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"
      },
      "readOnly": {
       "type": "boolean",
@@ -12911,21 +12911,21 @@
      },
      "image": {
       "type": "string",
-      "description": "Docker image name. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/images.md"
+      "description": "Docker image name. More info: http://releases.k8s.io/release-1.1/docs/user-guide/images.md"
      },
      "command": {
       "type": "array",
       "items": {
        "type": "string"
       },
-      "description": "Entrypoint array. Not executed within a shell. The docker image's entrypoint is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/containers.md#containers-and-commands"
+      "description": "Entrypoint array. Not executed within a shell. The docker image's entrypoint is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: http://releases.k8s.io/release-1.1/docs/user-guide/containers.md#containers-and-commands"
      },
      "args": {
       "type": "array",
       "items": {
        "type": "string"
       },
-      "description": "Arguments to the entrypoint. The docker image's cmd is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/containers.md#containers-and-commands"
+      "description": "Arguments to the entrypoint. The docker image's cmd is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: http://releases.k8s.io/release-1.1/docs/user-guide/containers.md#containers-and-commands"
      },
      "workingDir": {
       "type": "string",
@@ -12947,7 +12947,7 @@
      },
      "resources": {
       "$ref": "v1.ResourceRequirements",
-      "description": "Compute Resources required by this container. Cannot be updated. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#resources"
+      "description": "Compute Resources required by this container. Cannot be updated. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#resources"
      },
      "volumeMounts": {
       "type": "array",
@@ -12958,11 +12958,11 @@
      },
      "livenessProbe": {
       "$ref": "v1.Probe",
-      "description": "Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-probes"
+      "description": "Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-probes"
      },
      "readinessProbe": {
       "$ref": "v1.Probe",
-      "description": "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-probes"
+      "description": "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-probes"
      },
      "lifecycle": {
       "$ref": "v1.Lifecycle",
@@ -12974,11 +12974,11 @@
      },
      "imagePullPolicy": {
       "type": "string",
-      "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/images.md#updating-images"
+      "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: http://releases.k8s.io/release-1.1/docs/user-guide/images.md#updating-images"
      },
      "securityContext": {
       "$ref": "v1.SecurityContext",
-      "description": "Security options the pod should run with. More info: http://releases.k8s.io/v1.1.0/docs/design/security_context.md"
+      "description": "Security options the pod should run with. More info: http://releases.k8s.io/release-1.1/docs/design/security_context.md"
      },
      "stdin": {
       "type": "boolean",
@@ -13100,12 +13100,12 @@
      "initialDelaySeconds": {
       "type": "integer",
       "format": "int64",
-      "description": "Number of seconds after the container has started before liveness probes are initiated. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-probes"
+      "description": "Number of seconds after the container has started before liveness probes are initiated. More info: http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-probes"
      },
      "timeoutSeconds": {
       "type": "integer",
       "format": "int64",
-      "description": "Number of seconds after which liveness probes timeout. Defaults to 1 second. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-probes"
+      "description": "Number of seconds after which liveness probes timeout. Defaults to 1 second. More info: http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-probes"
      }
     }
    },
@@ -13166,11 +13166,11 @@
     "properties": {
      "postStart": {
       "$ref": "v1.Handler",
-      "description": "PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/container-environment.md#hook-details"
+      "description": "PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: http://releases.k8s.io/release-1.1/docs/user-guide/container-environment.md#hook-details"
      },
      "preStop": {
       "$ref": "v1.Handler",
-      "description": "PreStop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/container-environment.md#hook-details"
+      "description": "PreStop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: http://releases.k8s.io/release-1.1/docs/user-guide/container-environment.md#hook-details"
      }
     }
    },
@@ -13198,20 +13198,20 @@
     "properties": {
      "capabilities": {
       "$ref": "v1.Capabilities",
-      "description": "The linux kernel capabilites that should be added or removed. Default to Container.Capabilities if left unset. More info: http://releases.k8s.io/v1.1.0/docs/design/security_context.md#security-context"
+      "description": "The linux kernel capabilites that should be added or removed. Default to Container.Capabilities if left unset. More info: http://releases.k8s.io/release-1.1/docs/design/security_context.md#security-context"
      },
      "privileged": {
       "type": "boolean",
-      "description": "Run the container in privileged mode. Default to Container.Privileged if left unset. More info: http://releases.k8s.io/v1.1.0/docs/design/security_context.md#security-context"
+      "description": "Run the container in privileged mode. Default to Container.Privileged if left unset. More info: http://releases.k8s.io/release-1.1/docs/design/security_context.md#security-context"
      },
      "seLinuxOptions": {
       "$ref": "v1.SELinuxOptions",
-      "description": "SELinuxOptions are the labels to be applied to the container and volumes. Options that control the SELinux labels applied. More info: http://releases.k8s.io/v1.1.0/docs/design/security_context.md#security-context"
+      "description": "SELinuxOptions are the labels to be applied to the container and volumes. Options that control the SELinux labels applied. More info: http://releases.k8s.io/release-1.1/docs/design/security_context.md#security-context"
      },
      "runAsUser": {
       "type": "integer",
       "format": "int64",
-      "description": "RunAsUser is the UID to run the entrypoint of the container process. The user id that runs the first process in the container. More info: http://releases.k8s.io/v1.1.0/docs/design/security_context.md#security-context"
+      "description": "RunAsUser is the UID to run the entrypoint of the container process. The user id that runs the first process in the container. More info: http://releases.k8s.io/release-1.1/docs/design/security_context.md#security-context"
      },
      "runAsNonRoot": {
       "type": "boolean",
@@ -13249,19 +13249,19 @@
     "properties": {
      "user": {
       "type": "string",
-      "description": "User is a SELinux user label that applies to the container. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md"
+      "description": "User is a SELinux user label that applies to the container. More info: http://releases.k8s.io/release-1.1/docs/user-guide/labels.md"
      },
      "role": {
       "type": "string",
-      "description": "Role is a SELinux role label that applies to the container. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md"
+      "description": "Role is a SELinux role label that applies to the container. More info: http://releases.k8s.io/release-1.1/docs/user-guide/labels.md"
      },
      "type": {
       "type": "string",
-      "description": "Type is a SELinux type label that applies to the container. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md"
+      "description": "Type is a SELinux type label that applies to the container. More info: http://releases.k8s.io/release-1.1/docs/user-guide/labels.md"
      },
      "level": {
       "type": "string",
-      "description": "Level is SELinux level label that applies to the container. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md"
+      "description": "Level is SELinux level label that applies to the container. More info: http://releases.k8s.io/release-1.1/docs/user-guide/labels.md"
      }
     }
    },
@@ -13271,14 +13271,14 @@
     "properties": {
      "phase": {
       "type": "string",
-      "description": "Current condition of the pod. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#pod-phase"
+      "description": "Current condition of the pod. More info: http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#pod-phase"
      },
      "conditions": {
       "type": "array",
       "items": {
        "$ref": "v1.PodCondition"
       },
-      "description": "Current service state of pod. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#pod-conditions"
+      "description": "Current service state of pod. More info: http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#pod-conditions"
      },
      "message": {
       "type": "string",
@@ -13305,7 +13305,7 @@
       "items": {
        "$ref": "v1.ContainerStatus"
       },
-      "description": "The list has one entry per container in the manifest. Each entry is currently the output of `docker inspect`. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-statuses"
+      "description": "The list has one entry per container in the manifest. Each entry is currently the output of `docker inspect`. More info: http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-statuses"
      }
     }
    },
@@ -13319,11 +13319,11 @@
     "properties": {
      "type": {
       "type": "string",
-      "description": "Type is the type of the condition. Currently only Ready. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#pod-conditions"
+      "description": "Type is the type of the condition. Currently only Ready. More info: http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#pod-conditions"
      },
      "status": {
       "type": "string",
-      "description": "Status is the status of the condition. Can be True, False, Unknown. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#pod-conditions"
+      "description": "Status is the status of the condition. Can be True, False, Unknown. More info: http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#pod-conditions"
      },
      "lastProbeTime": {
       "type": "string",
@@ -13377,7 +13377,7 @@
      },
      "image": {
       "type": "string",
-      "description": "The image the container is running. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/images.md"
+      "description": "The image the container is running. More info: http://releases.k8s.io/release-1.1/docs/user-guide/images.md"
      },
      "imageID": {
       "type": "string",
@@ -13385,7 +13385,7 @@
      },
      "containerID": {
       "type": "string",
-      "description": "Container's ID in the format 'docker://\u003ccontainer_id\u003e'. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/container-environment.md#container-information"
+      "description": "Container's ID in the format 'docker://\u003ccontainer_id\u003e'. More info: http://releases.k8s.io/release-1.1/docs/user-guide/container-environment.md#container-information"
      }
     }
    },
@@ -13479,15 +13479,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "unversioned.ListMeta",
-      "description": "Standard list metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Standard list metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "items": {
       "type": "array",
@@ -13504,19 +13504,19 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata"
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata"
      },
      "template": {
       "$ref": "v1.PodTemplateSpec",
-      "description": "Template defines the pods that will be created from this pod template. http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status"
+      "description": "Template defines the pods that will be created from this pod template. http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -13526,11 +13526,11 @@
     "properties": {
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata"
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1.PodSpec",
-      "description": "Specification of the desired behavior of the pod. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status"
+      "description": "Specification of the desired behavior of the pod. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -13543,22 +13543,22 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "unversioned.ListMeta",
-      "description": "Standard list metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Standard list metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "items": {
       "type": "array",
       "items": {
        "$ref": "v1.ReplicationController"
       },
-      "description": "List of replication controllers. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/replication-controller.md"
+      "description": "List of replication controllers. More info: http://releases.k8s.io/release-1.1/docs/user-guide/replication-controller.md"
      }
     }
    },
@@ -13568,23 +13568,23 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "If the Labels of a ReplicationController are empty, they are defaulted to be the same as the Pod(s) that the replication controller manages. Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata"
+      "description": "If the Labels of a ReplicationController are empty, they are defaulted to be the same as the Pod(s) that the replication controller manages. Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1.ReplicationControllerSpec",
-      "description": "Spec defines the specification of the desired behavior of the replication controller. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status"
+      "description": "Spec defines the specification of the desired behavior of the replication controller. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1.ReplicationControllerStatus",
-      "description": "Status is the most recently observed status of the replication controller. This data may be out of date by some window of time. Populated by the system. Read-only. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status"
+      "description": "Status is the most recently observed status of the replication controller. This data may be out of date by some window of time. Populated by the system. Read-only. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -13595,15 +13595,15 @@
      "replicas": {
       "type": "integer",
       "format": "int32",
-      "description": "Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/replication-controller.md#what-is-a-replication-controller"
+      "description": "Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: http://releases.k8s.io/release-1.1/docs/user-guide/replication-controller.md#what-is-a-replication-controller"
      },
      "selector": {
       "type": "any",
-      "description": "Selector is a label query over pods that should match the Replicas count. If Selector is empty, it is defaulted to the labels present on the Pod template. Label keys and values that must match in order to be controlled by this replication controller, if empty defaulted to labels on Pod template. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md#label-selectors"
+      "description": "Selector is a label query over pods that should match the Replicas count. If Selector is empty, it is defaulted to the labels present on the Pod template. Label keys and values that must match in order to be controlled by this replication controller, if empty defaulted to labels on Pod template. More info: http://releases.k8s.io/release-1.1/docs/user-guide/labels.md#label-selectors"
      },
      "template": {
       "$ref": "v1.PodTemplateSpec",
-      "description": "Template is the object that describes the pod that will be created if insufficient replicas are detected. This takes precedence over a TemplateRef. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/replication-controller.md#pod-template"
+      "description": "Template is the object that describes the pod that will be created if insufficient replicas are detected. This takes precedence over a TemplateRef. More info: http://releases.k8s.io/release-1.1/docs/user-guide/replication-controller.md#pod-template"
      }
     }
    },
@@ -13617,7 +13617,7 @@
      "replicas": {
       "type": "integer",
       "format": "int32",
-      "description": "Replicas is the most recently oberved number of replicas. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/replication-controller.md#what-is-a-replication-controller"
+      "description": "Replicas is the most recently oberved number of replicas. More info: http://releases.k8s.io/release-1.1/docs/user-guide/replication-controller.md#what-is-a-replication-controller"
      },
      "observedGeneration": {
       "type": "integer",
@@ -13635,22 +13635,22 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "unversioned.ListMeta",
-      "description": "Standard list metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Standard list metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "items": {
       "type": "array",
       "items": {
        "$ref": "v1.ResourceQuota"
       },
-      "description": "Items is a list of ResourceQuota objects. More info: http://releases.k8s.io/v1.1.0/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota"
+      "description": "Items is a list of ResourceQuota objects. More info: http://releases.k8s.io/release-1.1/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota"
      }
     }
    },
@@ -13660,23 +13660,23 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata"
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1.ResourceQuotaSpec",
-      "description": "Spec defines the desired quota. http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status"
+      "description": "Spec defines the desired quota. http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1.ResourceQuotaStatus",
-      "description": "Status defines the actual enforced quota and its current usage. http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status"
+      "description": "Status defines the actual enforced quota and its current usage. http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -13686,7 +13686,7 @@
     "properties": {
      "hard": {
       "type": "any",
-      "description": "Hard is the set of desired hard limits for each named resource. More info: http://releases.k8s.io/v1.1.0/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota"
+      "description": "Hard is the set of desired hard limits for each named resource. More info: http://releases.k8s.io/release-1.1/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota"
      }
     }
    },
@@ -13696,7 +13696,7 @@
     "properties": {
      "hard": {
       "type": "any",
-      "description": "Hard is the set of enforced hard limits for each named resource. More info: http://releases.k8s.io/v1.1.0/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota"
+      "description": "Hard is the set of enforced hard limits for each named resource. More info: http://releases.k8s.io/release-1.1/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota"
      },
      "used": {
       "type": "any",
@@ -13713,22 +13713,22 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "unversioned.ListMeta",
-      "description": "Standard list metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Standard list metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "items": {
       "type": "array",
       "items": {
        "$ref": "v1.Secret"
       },
-      "description": "Items is a list of secret objects. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/secrets.md"
+      "description": "Items is a list of secret objects. More info: http://releases.k8s.io/release-1.1/docs/user-guide/secrets.md"
      }
     }
    },
@@ -13738,15 +13738,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata"
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata"
      },
      "data": {
       "type": "any",
@@ -13767,22 +13767,22 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "unversioned.ListMeta",
-      "description": "Standard list metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Standard list metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "items": {
       "type": "array",
       "items": {
        "$ref": "v1.ServiceAccount"
       },
-      "description": "List of ServiceAccounts. More info: http://releases.k8s.io/v1.1.0/docs/design/service_accounts.md#service-accounts"
+      "description": "List of ServiceAccounts. More info: http://releases.k8s.io/release-1.1/docs/design/service_accounts.md#service-accounts"
      }
     }
    },
@@ -13792,29 +13792,29 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata"
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata"
      },
      "secrets": {
       "type": "array",
       "items": {
        "$ref": "v1.ObjectReference"
       },
-      "description": "Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/secrets.md"
+      "description": "Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount. More info: http://releases.k8s.io/release-1.1/docs/user-guide/secrets.md"
      },
      "imagePullSecrets": {
       "type": "array",
       "items": {
        "$ref": "v1.LocalObjectReference"
       },
-      "description": "ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/secrets.md#manually-specifying-an-imagepullsecret"
+      "description": "ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: http://releases.k8s.io/release-1.1/docs/user-guide/secrets.md#manually-specifying-an-imagepullsecret"
      }
     }
    },
@@ -13827,15 +13827,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "unversioned.ListMeta",
-      "description": "Standard list metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Standard list metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "items": {
       "type": "array",
@@ -13852,23 +13852,23 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata"
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1.ServiceSpec",
-      "description": "Spec defines the behavior of a service. http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status"
+      "description": "Spec defines the behavior of a service. http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1.ServiceStatus",
-      "description": "Most recently observed status of the service. Populated by the system. Read-only. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status"
+      "description": "Most recently observed status of the service. Populated by the system. Read-only. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -13884,19 +13884,19 @@
       "items": {
        "$ref": "v1.ServicePort"
       },
-      "description": "The list of ports that are exposed by this service. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/services.md#virtual-ips-and-service-proxies"
+      "description": "The list of ports that are exposed by this service. More info: http://releases.k8s.io/release-1.1/docs/user-guide/services.md#virtual-ips-and-service-proxies"
      },
      "selector": {
       "type": "any",
-      "description": "This service will route traffic to pods having labels matching this selector. Label keys and values that must match in order to receive traffic for this service. If empty, all pods are selected, if not specified, endpoints must be manually specified. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/services.md#overview"
+      "description": "This service will route traffic to pods having labels matching this selector. Label keys and values that must match in order to receive traffic for this service. If empty, all pods are selected, if not specified, endpoints must be manually specified. More info: http://releases.k8s.io/release-1.1/docs/user-guide/services.md#overview"
      },
      "clusterIP": {
       "type": "string",
-      "description": "ClusterIP is usually assigned by the master and is the IP address of the service. If specified, it will be allocated to the service if it is unused or else creation of the service will fail. Valid values are None, empty string (\"\"), or a valid IP address. 'None' can be specified for a headless service when proxying is not required. Cannot be updated. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/services.md#virtual-ips-and-service-proxies"
+      "description": "ClusterIP is usually assigned by the master and is the IP address of the service. If specified, it will be allocated to the service if it is unused or else creation of the service will fail. Valid values are None, empty string (\"\"), or a valid IP address. 'None' can be specified for a headless service when proxying is not required. Cannot be updated. More info: http://releases.k8s.io/release-1.1/docs/user-guide/services.md#virtual-ips-and-service-proxies"
      },
      "type": {
       "type": "string",
-      "description": "Type of exposed service. Must be ClusterIP, NodePort, or LoadBalancer. Defaults to ClusterIP. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/services.md#external-services"
+      "description": "Type of exposed service. Must be ClusterIP, NodePort, or LoadBalancer. Defaults to ClusterIP. More info: http://releases.k8s.io/release-1.1/docs/user-guide/services.md#external-services"
      },
      "externalIPs": {
       "type": "array",
@@ -13914,7 +13914,7 @@
      },
      "sessionAffinity": {
       "type": "string",
-      "description": "Supports \"ClientIP\" and \"None\". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/services.md#virtual-ips-and-service-proxies"
+      "description": "Supports \"ClientIP\" and \"None\". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: http://releases.k8s.io/release-1.1/docs/user-guide/services.md#virtual-ips-and-service-proxies"
      },
      "loadBalancerIP": {
       "type": "string",
@@ -13944,12 +13944,12 @@
      },
      "targetPort": {
       "type": "string",
-      "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of Port is used (an identity map). Defaults to the service port. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/services.md#defining-a-service"
+      "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of Port is used (an identity map). Defaults to the service port. More info: http://releases.k8s.io/release-1.1/docs/user-guide/services.md#defining-a-service"
      },
      "nodePort": {
       "type": "integer",
       "format": "int32",
-      "description": "The port on each node on which this service is exposed when type=NodePort or LoadBalancer. Usually assigned by the system. If specified, it will be allocated to the service if unused or else creation of the service will fail. Default is to auto-allocate a port if the ServiceType of this Service requires one. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/services.md#type--nodeport"
+      "description": "The port on each node on which this service is exposed when type=NodePort or LoadBalancer. Usually assigned by the system. If specified, it will be allocated to the service if unused or else creation of the service will fail. Default is to auto-allocate a port if the ServiceType of this Service requires one. More info: http://releases.k8s.io/release-1.1/docs/user-guide/services.md#type--nodeport"
      }
     }
    },

--- a/api/swagger-spec/v1beta1.json
+++ b/api/swagger-spec/v1beta1.json
@@ -2242,11 +2242,11 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "unversioned.ListMeta",
@@ -2271,7 +2271,7 @@
      },
      "resourceVersion": {
       "type": "string",
-      "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#concurrency-control-and-consistency"
+      "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#concurrency-control-and-consistency"
      }
     }
    },
@@ -2281,19 +2281,19 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "Standard object metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata"
+      "description": "Standard object metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1beta1.HorizontalPodAutoscalerSpec",
-      "description": "behaviour of autoscaler. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status."
+      "description": "behaviour of autoscaler. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status."
      },
      "status": {
       "$ref": "v1beta1.HorizontalPodAutoscalerStatus",
@@ -2307,15 +2307,15 @@
     "properties": {
      "name": {
       "type": "string",
-      "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#names"
+      "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#names"
      },
      "generateName": {
       "type": "string",
-      "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).\n\nApplied only if Name is not specified. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#idempotency"
+      "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).\n\nApplied only if Name is not specified. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#idempotency"
      },
      "namespace": {
       "type": "string",
-      "description": "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/namespaces.md"
+      "description": "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: http://releases.k8s.io/release-1.1/docs/user-guide/namespaces.md"
      },
      "selfLink": {
       "type": "string",
@@ -2323,11 +2323,11 @@
      },
      "uid": {
       "type": "string",
-      "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#uids"
+      "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#uids"
      },
      "resourceVersion": {
       "type": "string",
-      "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#concurrency-control-and-consistency"
+      "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#concurrency-control-and-consistency"
      },
      "generation": {
       "type": "integer",
@@ -2336,11 +2336,11 @@
      },
      "creationTimestamp": {
       "type": "string",
-      "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata"
+      "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata"
      },
      "deletionTimestamp": {
       "type": "string",
-      "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource will be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field. Once set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. Once the resource is deleted in the API, the Kubelet will send a hard termination signal to the container. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata"
+      "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource will be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field. Once set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. Once the resource is deleted in the API, the Kubelet will send a hard termination signal to the container. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata"
      },
      "deletionGracePeriodSeconds": {
       "type": "integer",
@@ -2349,11 +2349,11 @@
      },
      "labels": {
       "type": "any",
-      "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md"
+      "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://releases.k8s.io/release-1.1/docs/user-guide/labels.md"
      },
      "annotations": {
       "type": "any",
-      "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/annotations.md"
+      "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://releases.k8s.io/release-1.1/docs/user-guide/annotations.md"
      }
     }
    },
@@ -2391,15 +2391,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind of the referent; More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds\""
+      "description": "Kind of the referent; More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds\""
      },
      "namespace": {
       "type": "string",
-      "description": "Namespace of the referent; More info: http://releases.k8s.io/v1.1.0/docs/user-guide/namespaces.md"
+      "description": "Namespace of the referent; More info: http://releases.k8s.io/release-1.1/docs/user-guide/namespaces.md"
      },
      "name": {
       "type": "string",
-      "description": "Name of the referent; More info: http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#names"
+      "description": "Name of the referent; More info: http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#names"
      },
      "apiVersion": {
       "type": "string",
@@ -2482,19 +2482,19 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "unversioned.ListMeta",
-      "description": "Standard list metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Standard list metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "status": {
       "type": "string",
-      "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status"
+      "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status"
      },
      "message": {
       "type": "string",
@@ -2525,7 +2525,7 @@
      },
      "kind": {
       "type": "string",
-      "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "causes": {
       "type": "array",
@@ -2568,11 +2568,11 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "gracePeriodSeconds": {
       "type": "integer",
@@ -2590,15 +2590,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "unversioned.ListMeta",
-      "description": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata"
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
@@ -2615,23 +2615,23 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata"
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1beta1.IngressSpec",
-      "description": "Spec is the desired state of the Ingress. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status"
+      "description": "Spec is the desired state of the Ingress. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1beta1.IngressStatus",
-      "description": "Status is the current state of the Ingress. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status"
+      "description": "Status is the current state of the Ingress. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -2769,15 +2769,15 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "unversioned.ListMeta",
-      "description": "Standard list metadata More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata"
+      "description": "Standard list metadata More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata"
      },
      "items": {
       "type": "array",
@@ -2794,23 +2794,23 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata"
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1beta1.JobSpec",
-      "description": "Spec is a structure defining the expected behavior of a job. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status"
+      "description": "Spec is a structure defining the expected behavior of a job. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1beta1.JobStatus",
-      "description": "Status is a structure describing current status of a job. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status"
+      "description": "Status is a structure describing current status of a job. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -2824,20 +2824,20 @@
      "parallelism": {
       "type": "integer",
       "format": "int32",
-      "description": "Parallelism specifies the maximum desired number of pods the job should run at any given time. The actual number of pods running in steady state will be less than this number when ((.spec.completions - .status.successful) \u003c .spec.parallelism), i.e. when the work left to do is less than max parallelism. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/jobs.md"
+      "description": "Parallelism specifies the maximum desired number of pods the job should run at any given time. The actual number of pods running in steady state will be less than this number when ((.spec.completions - .status.successful) \u003c .spec.parallelism), i.e. when the work left to do is less than max parallelism. More info: http://releases.k8s.io/release-1.1/docs/user-guide/jobs.md"
      },
      "completions": {
       "type": "integer",
       "format": "int32",
-      "description": "Completions specifies the desired number of successfully finished pods the job should be run with. Defaults to 1. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/jobs.md"
+      "description": "Completions specifies the desired number of successfully finished pods the job should be run with. Defaults to 1. More info: http://releases.k8s.io/release-1.1/docs/user-guide/jobs.md"
      },
      "selector": {
       "$ref": "v1beta1.PodSelector",
-      "description": "Selector is a label query over pods that should match the pod count. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md#label-selectors"
+      "description": "Selector is a label query over pods that should match the pod count. More info: http://releases.k8s.io/release-1.1/docs/user-guide/labels.md#label-selectors"
      },
      "template": {
       "$ref": "v1.PodTemplateSpec",
-      "description": "Template is the object that describes the pod that will be created when executing a job. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/jobs.md"
+      "description": "Template is the object that describes the pod that will be created when executing a job. More info: http://releases.k8s.io/release-1.1/docs/user-guide/jobs.md"
      }
     }
    },
@@ -2889,11 +2889,11 @@
     "properties": {
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata"
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata"
      },
      "spec": {
       "$ref": "v1.PodSpec",
-      "description": "Specification of the desired behavior of the pod. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status"
+      "description": "Specification of the desired behavior of the pod. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status"
      }
     }
    },
@@ -2909,18 +2909,18 @@
       "items": {
        "$ref": "v1.Volume"
       },
-      "description": "List of volumes that can be mounted by containers belonging to the pod. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md"
+      "description": "List of volumes that can be mounted by containers belonging to the pod. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md"
      },
      "containers": {
       "type": "array",
       "items": {
        "$ref": "v1.Container"
       },
-      "description": "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/containers.md"
+      "description": "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. More info: http://releases.k8s.io/release-1.1/docs/user-guide/containers.md"
      },
      "restartPolicy": {
       "type": "string",
-      "description": "Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#restartpolicy"
+      "description": "Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#restartpolicy"
      },
      "terminationGracePeriodSeconds": {
       "type": "integer",
@@ -2938,11 +2938,11 @@
      },
      "nodeSelector": {
       "type": "any",
-      "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/node-selection/README.md"
+      "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: http://releases.k8s.io/release-1.1/docs/user-guide/node-selection/README.md"
      },
      "serviceAccountName": {
       "type": "string",
-      "description": "ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: http://releases.k8s.io/v1.1.0/docs/design/service_accounts.md"
+      "description": "ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: http://releases.k8s.io/release-1.1/docs/design/service_accounts.md"
      },
      "serviceAccount": {
       "type": "string",
@@ -2969,7 +2969,7 @@
       "items": {
        "$ref": "v1.LocalObjectReference"
       },
-      "description": "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/images.md#specifying-imagepullsecrets-on-a-pod"
+      "description": "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: http://releases.k8s.io/release-1.1/docs/user-guide/images.md#specifying-imagepullsecrets-on-a-pod"
      }
     }
    },
@@ -2982,23 +2982,23 @@
     "properties": {
      "name": {
       "type": "string",
-      "description": "Volume's name. Must be a DNS_LABEL and unique within the pod. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#names"
+      "description": "Volume's name. Must be a DNS_LABEL and unique within the pod. More info: http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#names"
      },
      "hostPath": {
       "$ref": "v1.HostPathVolumeSource",
-      "description": "HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#hostpath"
+      "description": "HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#hostpath"
      },
      "emptyDir": {
       "$ref": "v1.EmptyDirVolumeSource",
-      "description": "EmptyDir represents a temporary directory that shares a pod's lifetime. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#emptydir"
+      "description": "EmptyDir represents a temporary directory that shares a pod's lifetime. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#emptydir"
      },
      "gcePersistentDisk": {
       "$ref": "v1.GCEPersistentDiskVolumeSource",
-      "description": "GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk"
+      "description": "GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk"
      },
      "awsElasticBlockStore": {
       "$ref": "v1.AWSElasticBlockStoreVolumeSource",
-      "description": "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore"
+      "description": "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore"
      },
      "gitRepo": {
       "$ref": "v1.GitRepoVolumeSource",
@@ -3006,31 +3006,31 @@
      },
      "secret": {
       "$ref": "v1.SecretVolumeSource",
-      "description": "Secret represents a secret that should populate this volume. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#secrets"
+      "description": "Secret represents a secret that should populate this volume. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#secrets"
      },
      "nfs": {
       "$ref": "v1.NFSVolumeSource",
-      "description": "NFS represents an NFS mount on the host that shares a pod's lifetime More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs"
+      "description": "NFS represents an NFS mount on the host that shares a pod's lifetime More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs"
      },
      "iscsi": {
       "$ref": "v1.ISCSIVolumeSource",
-      "description": "ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/v1.1.0/examples/iscsi/README.md"
+      "description": "ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/release-1.1/examples/iscsi/README.md"
      },
      "glusterfs": {
       "$ref": "v1.GlusterfsVolumeSource",
-      "description": "Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md"
+      "description": "Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/release-1.1/examples/glusterfs/README.md"
      },
      "persistentVolumeClaim": {
       "$ref": "v1.PersistentVolumeClaimVolumeSource",
-      "description": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"
+      "description": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"
      },
      "rbd": {
       "$ref": "v1.RBDVolumeSource",
-      "description": "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/v1.1.0/examples/rbd/README.md"
+      "description": "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/release-1.1/examples/rbd/README.md"
      },
      "cinder": {
       "$ref": "v1.CinderVolumeSource",
-      "description": "Cinder represents a cinder volume attached and mounted on kubelets host machine More info: http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md"
+      "description": "Cinder represents a cinder volume attached and mounted on kubelets host machine More info: http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md"
      },
      "cephfs": {
       "$ref": "v1.CephFSVolumeSource",
@@ -3059,7 +3059,7 @@
     "properties": {
      "path": {
       "type": "string",
-      "description": "Path of the directory on the host. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#hostpath"
+      "description": "Path of the directory on the host. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#hostpath"
      }
     }
    },
@@ -3069,7 +3069,7 @@
     "properties": {
      "medium": {
       "type": "string",
-      "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#emptydir"
+      "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#emptydir"
      }
     }
    },
@@ -3083,20 +3083,20 @@
     "properties": {
      "pdName": {
       "type": "string",
-      "description": "Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk"
+      "description": "Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk"
      },
      "fsType": {
       "type": "string",
-      "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk"
+      "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk"
      },
      "partition": {
       "type": "integer",
       "format": "int32",
-      "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk"
+      "description": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk"
      },
      "readOnly": {
       "type": "boolean",
-      "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk"
+      "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk"
      }
     }
    },
@@ -3110,11 +3110,11 @@
     "properties": {
      "volumeID": {
       "type": "string",
-      "description": "Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore"
+      "description": "Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore"
      },
      "fsType": {
       "type": "string",
-      "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore"
+      "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore"
      },
      "partition": {
       "type": "integer",
@@ -3123,7 +3123,7 @@
      },
      "readOnly": {
       "type": "boolean",
-      "description": "Specify \"true\" to force and set the ReadOnly property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore"
+      "description": "Specify \"true\" to force and set the ReadOnly property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore"
      }
     }
    },
@@ -3147,14 +3147,14 @@
    },
    "v1.SecretVolumeSource": {
     "id": "v1.SecretVolumeSource",
-    "description": "SecretVolumeSource adapts a Secret into a VolumeSource. More info: http://releases.k8s.io/v1.1.0/docs/design/secrets.md",
+    "description": "SecretVolumeSource adapts a Secret into a VolumeSource. More info: http://releases.k8s.io/release-1.1/docs/design/secrets.md",
     "required": [
      "secretName"
     ],
     "properties": {
      "secretName": {
       "type": "string",
-      "description": "SecretName is the name of a secret in the pod's namespace. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#secrets"
+      "description": "SecretName is the name of a secret in the pod's namespace. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#secrets"
      }
     }
    },
@@ -3168,15 +3168,15 @@
     "properties": {
      "server": {
       "type": "string",
-      "description": "Server is the hostname or IP address of the NFS server. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs"
+      "description": "Server is the hostname or IP address of the NFS server. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs"
      },
      "path": {
       "type": "string",
-      "description": "Path that is exported by the NFS server. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs"
+      "description": "Path that is exported by the NFS server. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs"
      },
      "readOnly": {
       "type": "boolean",
-      "description": "ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs"
+      "description": "ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs"
      }
     }
    },
@@ -3205,7 +3205,7 @@
      },
      "fsType": {
       "type": "string",
-      "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#iscsi"
+      "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#iscsi"
      },
      "readOnly": {
       "type": "boolean",
@@ -3223,15 +3223,15 @@
     "properties": {
      "endpoints": {
       "type": "string",
-      "description": "EndpointsName is the endpoint name that details Glusterfs topology. More info: http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md#create-a-pod"
+      "description": "EndpointsName is the endpoint name that details Glusterfs topology. More info: http://releases.k8s.io/release-1.1/examples/glusterfs/README.md#create-a-pod"
      },
      "path": {
       "type": "string",
-      "description": "Path is the Glusterfs volume path. More info: http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md#create-a-pod"
+      "description": "Path is the Glusterfs volume path. More info: http://releases.k8s.io/release-1.1/examples/glusterfs/README.md#create-a-pod"
      },
      "readOnly": {
       "type": "boolean",
-      "description": "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md#create-a-pod"
+      "description": "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: http://releases.k8s.io/release-1.1/examples/glusterfs/README.md#create-a-pod"
      }
     }
    },
@@ -3244,7 +3244,7 @@
     "properties": {
      "claimName": {
       "type": "string",
-      "description": "ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"
+      "description": "ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistentvolumeclaims"
      },
      "readOnly": {
       "type": "boolean",
@@ -3269,35 +3269,35 @@
       "items": {
        "type": "string"
       },
-      "description": "A collection of Ceph monitors. More info: http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it"
+      "description": "A collection of Ceph monitors. More info: http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it"
      },
      "image": {
       "type": "string",
-      "description": "The rados image name. More info: http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it"
+      "description": "The rados image name. More info: http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it"
      },
      "fsType": {
       "type": "string",
-      "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#rbd"
+      "description": "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#rbd"
      },
      "pool": {
       "type": "string",
-      "description": "The rados pool name. Default is rbd. More info: http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it."
+      "description": "The rados pool name. Default is rbd. More info: http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it."
      },
      "user": {
       "type": "string",
-      "description": "The rados user name. Default is admin. More info: http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it"
+      "description": "The rados user name. Default is admin. More info: http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it"
      },
      "keyring": {
       "type": "string",
-      "description": "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it"
+      "description": "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it"
      },
      "secretRef": {
       "$ref": "v1.LocalObjectReference",
-      "description": "SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is empty. More info: http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it"
+      "description": "SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is empty. More info: http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it"
      },
      "readOnly": {
       "type": "boolean",
-      "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it"
+      "description": "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it"
      }
     }
    },
@@ -3307,7 +3307,7 @@
     "properties": {
      "name": {
       "type": "string",
-      "description": "Name of the referent. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#names"
+      "description": "Name of the referent. More info: http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#names"
      }
     }
    },
@@ -3320,15 +3320,15 @@
     "properties": {
      "volumeID": {
       "type": "string",
-      "description": "volume id used to identify the volume in cinder More info: http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md"
+      "description": "volume id used to identify the volume in cinder More info: http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md"
      },
      "fsType": {
       "type": "string",
-      "description": "Required: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Only ext3 and ext4 are allowed More info: http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md"
+      "description": "Required: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Only ext3 and ext4 are allowed More info: http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md"
      },
      "readOnly": {
       "type": "boolean",
-      "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md"
+      "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md"
      }
     }
    },
@@ -3344,23 +3344,23 @@
       "items": {
        "type": "string"
       },
-      "description": "Required: Monitors is a collection of Ceph monitors More info: http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it"
+      "description": "Required: Monitors is a collection of Ceph monitors More info: http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it"
      },
      "user": {
       "type": "string",
-      "description": "Optional: User is the rados user name, default is admin More info: http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it"
+      "description": "Optional: User is the rados user name, default is admin More info: http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it"
      },
      "secretFile": {
       "type": "string",
-      "description": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it"
+      "description": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it"
      },
      "secretRef": {
       "$ref": "v1.LocalObjectReference",
-      "description": "Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it"
+      "description": "Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it"
      },
      "readOnly": {
       "type": "boolean",
-      "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it"
+      "description": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it"
      }
     }
    },
@@ -3469,21 +3469,21 @@
      },
      "image": {
       "type": "string",
-      "description": "Docker image name. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/images.md"
+      "description": "Docker image name. More info: http://releases.k8s.io/release-1.1/docs/user-guide/images.md"
      },
      "command": {
       "type": "array",
       "items": {
        "type": "string"
       },
-      "description": "Entrypoint array. Not executed within a shell. The docker image's entrypoint is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/containers.md#containers-and-commands"
+      "description": "Entrypoint array. Not executed within a shell. The docker image's entrypoint is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: http://releases.k8s.io/release-1.1/docs/user-guide/containers.md#containers-and-commands"
      },
      "args": {
       "type": "array",
       "items": {
        "type": "string"
       },
-      "description": "Arguments to the entrypoint. The docker image's cmd is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/containers.md#containers-and-commands"
+      "description": "Arguments to the entrypoint. The docker image's cmd is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: http://releases.k8s.io/release-1.1/docs/user-guide/containers.md#containers-and-commands"
      },
      "workingDir": {
       "type": "string",
@@ -3505,7 +3505,7 @@
      },
      "resources": {
       "$ref": "v1.ResourceRequirements",
-      "description": "Compute Resources required by this container. Cannot be updated. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#resources"
+      "description": "Compute Resources required by this container. Cannot be updated. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#resources"
      },
      "volumeMounts": {
       "type": "array",
@@ -3516,11 +3516,11 @@
      },
      "livenessProbe": {
       "$ref": "v1.Probe",
-      "description": "Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-probes"
+      "description": "Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-probes"
      },
      "readinessProbe": {
       "$ref": "v1.Probe",
-      "description": "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-probes"
+      "description": "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-probes"
      },
      "lifecycle": {
       "$ref": "v1.Lifecycle",
@@ -3532,11 +3532,11 @@
      },
      "imagePullPolicy": {
       "type": "string",
-      "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/images.md#updating-images"
+      "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: http://releases.k8s.io/release-1.1/docs/user-guide/images.md#updating-images"
      },
      "securityContext": {
       "$ref": "v1.SecurityContext",
-      "description": "Security options the pod should run with. More info: http://releases.k8s.io/v1.1.0/docs/design/security_context.md"
+      "description": "Security options the pod should run with. More info: http://releases.k8s.io/release-1.1/docs/design/security_context.md"
      },
      "stdin": {
       "type": "boolean",
@@ -3623,11 +3623,11 @@
     "properties": {
      "limits": {
       "type": "any",
-      "description": "Limits describes the maximum amount of compute resources allowed. More info: http://releases.k8s.io/v1.1.0/docs/design/resources.md#resource-specifications"
+      "description": "Limits describes the maximum amount of compute resources allowed. More info: http://releases.k8s.io/release-1.1/docs/design/resources.md#resource-specifications"
      },
      "requests": {
       "type": "any",
-      "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: http://releases.k8s.io/v1.1.0/docs/design/resources.md#resource-specifications"
+      "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: http://releases.k8s.io/release-1.1/docs/design/resources.md#resource-specifications"
      }
     }
    },
@@ -3672,12 +3672,12 @@
      "initialDelaySeconds": {
       "type": "integer",
       "format": "int64",
-      "description": "Number of seconds after the container has started before liveness probes are initiated. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-probes"
+      "description": "Number of seconds after the container has started before liveness probes are initiated. More info: http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-probes"
      },
      "timeoutSeconds": {
       "type": "integer",
       "format": "int64",
-      "description": "Number of seconds after which liveness probes timeout. Defaults to 1 second. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-probes"
+      "description": "Number of seconds after which liveness probes timeout. Defaults to 1 second. More info: http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-probes"
      }
     }
    },
@@ -3738,11 +3738,11 @@
     "properties": {
      "postStart": {
       "$ref": "v1.Handler",
-      "description": "PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/container-environment.md#hook-details"
+      "description": "PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: http://releases.k8s.io/release-1.1/docs/user-guide/container-environment.md#hook-details"
      },
      "preStop": {
       "$ref": "v1.Handler",
-      "description": "PreStop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/container-environment.md#hook-details"
+      "description": "PreStop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: http://releases.k8s.io/release-1.1/docs/user-guide/container-environment.md#hook-details"
      }
     }
    },
@@ -3770,20 +3770,20 @@
     "properties": {
      "capabilities": {
       "$ref": "v1.Capabilities",
-      "description": "The linux kernel capabilites that should be added or removed. Default to Container.Capabilities if left unset. More info: http://releases.k8s.io/v1.1.0/docs/design/security_context.md#security-context"
+      "description": "The linux kernel capabilites that should be added or removed. Default to Container.Capabilities if left unset. More info: http://releases.k8s.io/release-1.1/docs/design/security_context.md#security-context"
      },
      "privileged": {
       "type": "boolean",
-      "description": "Run the container in privileged mode. Default to Container.Privileged if left unset. More info: http://releases.k8s.io/v1.1.0/docs/design/security_context.md#security-context"
+      "description": "Run the container in privileged mode. Default to Container.Privileged if left unset. More info: http://releases.k8s.io/release-1.1/docs/design/security_context.md#security-context"
      },
      "seLinuxOptions": {
       "$ref": "v1.SELinuxOptions",
-      "description": "SELinuxOptions are the labels to be applied to the container and volumes. Options that control the SELinux labels applied. More info: http://releases.k8s.io/v1.1.0/docs/design/security_context.md#security-context"
+      "description": "SELinuxOptions are the labels to be applied to the container and volumes. Options that control the SELinux labels applied. More info: http://releases.k8s.io/release-1.1/docs/design/security_context.md#security-context"
      },
      "runAsUser": {
       "type": "integer",
       "format": "int64",
-      "description": "RunAsUser is the UID to run the entrypoint of the container process. The user id that runs the first process in the container. More info: http://releases.k8s.io/v1.1.0/docs/design/security_context.md#security-context"
+      "description": "RunAsUser is the UID to run the entrypoint of the container process. The user id that runs the first process in the container. More info: http://releases.k8s.io/release-1.1/docs/design/security_context.md#security-context"
      },
      "runAsNonRoot": {
       "type": "boolean",
@@ -3821,19 +3821,19 @@
     "properties": {
      "user": {
       "type": "string",
-      "description": "User is a SELinux user label that applies to the container. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md"
+      "description": "User is a SELinux user label that applies to the container. More info: http://releases.k8s.io/release-1.1/docs/user-guide/labels.md"
      },
      "role": {
       "type": "string",
-      "description": "Role is a SELinux role label that applies to the container. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md"
+      "description": "Role is a SELinux role label that applies to the container. More info: http://releases.k8s.io/release-1.1/docs/user-guide/labels.md"
      },
      "type": {
       "type": "string",
-      "description": "Type is a SELinux type label that applies to the container. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md"
+      "description": "Type is a SELinux type label that applies to the container. More info: http://releases.k8s.io/release-1.1/docs/user-guide/labels.md"
      },
      "level": {
       "type": "string",
-      "description": "Level is SELinux level label that applies to the container. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md"
+      "description": "Level is SELinux level label that applies to the container. More info: http://releases.k8s.io/release-1.1/docs/user-guide/labels.md"
      }
     }
    },
@@ -3846,7 +3846,7 @@
       "items": {
        "$ref": "v1beta1.JobCondition"
       },
-      "description": "Conditions represent the latest available observations of an object's current state. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/jobs.md"
+      "description": "Conditions represent the latest available observations of an object's current state. More info: http://releases.k8s.io/release-1.1/docs/user-guide/jobs.md"
      },
      "startTime": {
       "type": "string",
@@ -3913,23 +3913,23 @@
     "properties": {
      "kind": {
       "type": "string",
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
      },
      "apiVersion": {
       "type": "string",
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources"
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources"
      },
      "metadata": {
       "$ref": "v1.ObjectMeta",
-      "description": "Standard object metadata; More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata."
+      "description": "Standard object metadata; More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata."
      },
      "spec": {
       "$ref": "v1beta1.ScaleSpec",
-      "description": "defines the behavior of the scale. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status."
+      "description": "defines the behavior of the scale. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status."
      },
      "status": {
       "$ref": "v1beta1.ScaleStatus",
-      "description": "current status of the scale. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status. Read-only."
+      "description": "current status of the scale. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status. Read-only."
      }
     }
    },
@@ -3958,7 +3958,7 @@
      },
      "selector": {
       "type": "any",
-      "description": "label query over pods that should match the replicas count. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md#label-selectors"
+      "description": "label query over pods that should match the replicas count. More info: http://releases.k8s.io/release-1.1/docs/user-guide/labels.md#label-selectors"
      }
     }
    }

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 
 <!-- END MUNGE: UNVERSIONED_WARNING -->
 
-# Kubernetes Documentation: releases.k8s.io/v1.1.0
+# Kubernetes Documentation: releases.k8s.io/release-1.1
 
 * The [User's guide](user-guide/README.md) is for anyone who wants to run programs and
   services on an existing Kubernetes cluster.

--- a/docs/admin/authorization.md
+++ b/docs/admin/authorization.md
@@ -87,7 +87,7 @@ To permit an action Policy with an unset namespace applies regardless of namespa
  3. Kubelet can read and write events: `{"user":"kubelet", "resource": "events"}`
  4. Bob can just read pods in namespace "projectCaribou": `{"user":"bob", "resource": "pods", "readonly": true, "namespace": "projectCaribou"}`
 
-[Complete file example](http://releases.k8s.io/v1.1.0/pkg/auth/authorizer/abac/example_policy_file.jsonl)
+[Complete file example](http://releases.k8s.io/release-1.1/pkg/auth/authorizer/abac/example_policy_file.jsonl)
 
 ### A quick note on service accounts
 

--- a/docs/admin/cluster-components.md
+++ b/docs/admin/cluster-components.md
@@ -69,17 +69,17 @@ selects a node for them to run on.
 Addons are pods and services that implement cluster features. They don't run on
 the master VM, but currently the default setup scripts that make the API calls
 to create these pods and services does run on the master VM. See:
-[kube-master-addons](http://releases.k8s.io/v1.1.0/cluster/saltbase/salt/kube-master-addons/kube-master-addons.sh)
+[kube-master-addons](http://releases.k8s.io/release-1.1/cluster/saltbase/salt/kube-master-addons/kube-master-addons.sh)
 
 Addon objects are created in the "kube-system" namespace.
 
 Example addons are:
-* [DNS](http://releases.k8s.io/v1.1.0/cluster/addons/dns/) provides cluster local DNS.
-* [kube-ui](http://releases.k8s.io/v1.1.0/cluster/addons/kube-ui/) provides a graphical UI for the
+* [DNS](http://releases.k8s.io/release-1.1/cluster/addons/dns/) provides cluster local DNS.
+* [kube-ui](http://releases.k8s.io/release-1.1/cluster/addons/kube-ui/) provides a graphical UI for the
   cluster.
-* [fluentd-elasticsearch](http://releases.k8s.io/v1.1.0/cluster/addons/fluentd-elasticsearch/) provides
-  log storage. Also see the [gcp version](http://releases.k8s.io/v1.1.0/cluster/addons/fluentd-gcp/).
-* [cluster-monitoring](http://releases.k8s.io/v1.1.0/cluster/addons/cluster-monitoring/) provides
+* [fluentd-elasticsearch](http://releases.k8s.io/release-1.1/cluster/addons/fluentd-elasticsearch/) provides
+  log storage. Also see the [gcp version](http://releases.k8s.io/release-1.1/cluster/addons/fluentd-gcp/).
+* [cluster-monitoring](http://releases.k8s.io/release-1.1/cluster/addons/cluster-monitoring/) provides
   monitoring for the cluster.
 
 ## Node components

--- a/docs/admin/cluster-large.md
+++ b/docs/admin/cluster-large.md
@@ -13,7 +13,7 @@ At v1.0, Kubernetes supports clusters up to 100 nodes with 30 pods per node and 
 
 A cluster is a set of nodes (physical or virtual machines) running Kubernetes agents, managed by a "master" (the cluster-level control plane).
 
-Normally the number of nodes in a cluster is controlled by the the value `NUM_MINIONS` in the platform-specific `config-default.sh` file (for example, see [GCE's `config-default.sh`](http://releases.k8s.io/v1.1.0/cluster/gce/config-default.sh)).
+Normally the number of nodes in a cluster is controlled by the the value `NUM_MINIONS` in the platform-specific `config-default.sh` file (for example, see [GCE's `config-default.sh`](http://releases.k8s.io/release-1.1/cluster/gce/config-default.sh)).
 
 Simply changing that value to something very large, however, may cause the setup script to fail for many cloud providers. A GCE deployment, for example, will run in to quota issues and fail to bring the cluster up.
 
@@ -54,15 +54,15 @@ These limits, however, are based on data collected from addons running on 4-node
 
 To avoid running into cluster addon resource issues, when creating a cluster with many nodes, consider the following:
 * Scale memory and CPU limits for each of the following addons, if used, along with the size of cluster (there is one replica of each handling the entire cluster so memory and CPU usage tends to grow proportionally with size/load on cluster):
-  * Heapster ([GCM/GCL backed](http://releases.k8s.io/v1.1.0/cluster/addons/cluster-monitoring/google/heapster-controller.yaml), [InfluxDB backed](http://releases.k8s.io/v1.1.0/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml), [InfluxDB/GCL backed](http://releases.k8s.io/v1.1.0/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml), [standalone](http://releases.k8s.io/v1.1.0/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml))
-  * [InfluxDB and Grafana](http://releases.k8s.io/v1.1.0/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml)
-  * [skydns, kube2sky, and dns etcd](http://releases.k8s.io/v1.1.0/cluster/addons/dns/skydns-rc.yaml.in)
-  * [Kibana](http://releases.k8s.io/v1.1.0/cluster/addons/fluentd-elasticsearch/kibana-controller.yaml)
+  * Heapster ([GCM/GCL backed](http://releases.k8s.io/release-1.1/cluster/addons/cluster-monitoring/google/heapster-controller.yaml), [InfluxDB backed](http://releases.k8s.io/release-1.1/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml), [InfluxDB/GCL backed](http://releases.k8s.io/release-1.1/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml), [standalone](http://releases.k8s.io/release-1.1/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml))
+  * [InfluxDB and Grafana](http://releases.k8s.io/release-1.1/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml)
+  * [skydns, kube2sky, and dns etcd](http://releases.k8s.io/release-1.1/cluster/addons/dns/skydns-rc.yaml.in)
+  * [Kibana](http://releases.k8s.io/release-1.1/cluster/addons/fluentd-elasticsearch/kibana-controller.yaml)
 * Scale number of replicas for the following addons, if used, along with the size of cluster (there are multiple replicas of each so increasing replicas should help handle increased load, but, since load per replica also increases slightly, also consider increasing CPU/memory limits):
-  * [elasticsearch](http://releases.k8s.io/v1.1.0/cluster/addons/fluentd-elasticsearch/es-controller.yaml)
+  * [elasticsearch](http://releases.k8s.io/release-1.1/cluster/addons/fluentd-elasticsearch/es-controller.yaml)
 * Increase memory and CPU limits slightly for each of the following addons, if used, along with the size of cluster (there is one replica per node but CPU/memory usage increases slightly along with cluster load/size as well):
-  * [FluentD with ElasticSearch Plugin](http://releases.k8s.io/v1.1.0/cluster/saltbase/salt/fluentd-es/fluentd-es.yaml)
-  * [FluentD with GCP Plugin](http://releases.k8s.io/v1.1.0/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml)
+  * [FluentD with ElasticSearch Plugin](http://releases.k8s.io/release-1.1/cluster/saltbase/salt/fluentd-es/fluentd-es.yaml)
+  * [FluentD with GCP Plugin](http://releases.k8s.io/release-1.1/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml)
 
 For directions on how to detect if addon containers are hitting resource limits, see the [Troubleshooting section of Compute Resources](../user-guide/compute-resources.md#troubleshooting).
 

--- a/docs/admin/dns.md
+++ b/docs/admin/dns.md
@@ -5,7 +5,7 @@
 
 # DNS Integration with Kubernetes
 
-As of Kubernetes 0.8, DNS is offered as a [cluster add-on](http://releases.k8s.io/v1.1.0/cluster/addons/README.md).
+As of Kubernetes 0.8, DNS is offered as a [cluster add-on](http://releases.k8s.io/release-1.1/cluster/addons/README.md).
 If enabled, a DNS Pod and Service will be scheduled on the cluster, and the kubelets will be
 configured to tell individual containers to use the DNS Service's IP to resolve DNS names.
 
@@ -40,7 +40,7 @@ time.
 
 ## For more information
 
-See [the docs for the DNS cluster addon](http://releases.k8s.io/v1.1.0/cluster/addons/dns/README.md).
+See [the docs for the DNS cluster addon](http://releases.k8s.io/release-1.1/cluster/addons/dns/README.md).
 
 
 

--- a/docs/admin/etcd.md
+++ b/docs/admin/etcd.md
@@ -27,7 +27,7 @@ to reduce downtime in case of corruption.
 ## Default configuration
 
 The default setup scripts use kubelet's file-based static pods feature to run etcd in a
-[pod](http://releases.k8s.io/v1.1.0/cluster/saltbase/salt/etcd/etcd.manifest). This manifest should only
+[pod](http://releases.k8s.io/release-1.1/cluster/saltbase/salt/etcd/etcd.manifest). This manifest should only
 be run on master VMs. The default location that kubelet scans for manifests is
 `/etc/kubernetes/manifests/`.
 

--- a/docs/admin/high-availability.md
+++ b/docs/admin/high-availability.md
@@ -79,7 +79,7 @@ choices. For example, on systemd-based systems (e.g. RHEL, CentOS), you can run 
 If you are extending from a standard Kubernetes installation, the `kubelet` binary should already be present on your system.  You can run
 `which kubelet` to determine if the binary is in fact installed.  If it is not installed,
 you should install the [kubelet binary](https://storage.googleapis.com/kubernetes-release/release/v0.19.3/bin/linux/amd64/kubelet), the
-[kubelet init file](http://releases.k8s.io/v1.1.0/cluster/saltbase/salt/kubelet/initd) and [high-availability/default-kubelet](high-availability/default-kubelet)
+[kubelet init file](http://releases.k8s.io/release-1.1/cluster/saltbase/salt/kubelet/initd) and [high-availability/default-kubelet](high-availability/default-kubelet)
 scripts.
 
 If you are using monit, you should also install the monit daemon (`apt-get install monit`) and the [high-availability/monit-kubelet](high-availability/monit-kubelet) and

--- a/docs/admin/node.md
+++ b/docs/admin/node.md
@@ -229,7 +229,7 @@ on each kubelet where you want to reserve resources.
 
 Node is a top-level resource in the kubernetes REST API. More details about the
 API object can be found at: [Node API
-object](https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/blob/v1.1.0/docs/api-reference/v1/definitions.html#_v1_node).
+object](https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/release-1.1/docs/api-reference/v1/definitions.html#_v1_node).
 
 
 

--- a/docs/admin/salt.md
+++ b/docs/admin/salt.md
@@ -101,7 +101,7 @@ We should define a grains.conf key that captures more specifically what network 
 
 ## Further reading
 
-The [cluster/saltbase](http://releases.k8s.io/v1.1.0/cluster/saltbase/) tree has more details on the current SaltStack configuration.
+The [cluster/saltbase](http://releases.k8s.io/release-1.1/cluster/saltbase/) tree has more details on the current SaltStack configuration.
 
 
 

--- a/docs/api-reference/extensions/v1beta1/definitions.html
+++ b/docs/api-reference/extensions/v1beta1/definitions.html
@@ -470,35 +470,35 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">spec</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Spec is a structure defining the expected behavior of a job. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Spec is a structure defining the expected behavior of a job. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_jobspec">v1beta1.JobSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Status is a structure describing current status of a job. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Status is a structure describing current status of a job. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_jobstatus">v1beta1.JobStatus</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -532,28 +532,28 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">user</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">User is a SELinux user label that applies to the container. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md">http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">User is a SELinux user label that applies to the container. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/labels.md">http://releases.k8s.io/release-1.1/docs/user-guide/labels.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">role</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Role is a SELinux role label that applies to the container. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md">http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Role is a SELinux role label that applies to the container. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/labels.md">http://releases.k8s.io/release-1.1/docs/user-guide/labels.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">type</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Type is a SELinux type label that applies to the container. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md">http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Type is a SELinux type label that applies to the container. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/labels.md">http://releases.k8s.io/release-1.1/docs/user-guide/labels.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">level</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Level is SELinux level label that applies to the container. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md">http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Level is SELinux level label that applies to the container. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/labels.md">http://releases.k8s.io/release-1.1/docs/user-guide/labels.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -635,7 +635,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">selector</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">label query over pods that should match the replicas count. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md#label-selectors">http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md#label-selectors</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">label query over pods that should match the replicas count. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/labels.md#label-selectors">http://releases.k8s.io/release-1.1/docs/user-guide/labels.md#label-selectors</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_any">any</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -758,21 +758,21 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">server</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Server is the hostname or IP address of the NFS server. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Server is the hostname or IP address of the NFS server. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">path</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Path that is exported by the NFS server. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Path that is exported by the NFS server. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">readOnly</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">boolean</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
@@ -847,35 +847,35 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">monitors</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Required: Monitors is a collection of Ceph monitors More info: <a href="http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it">http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Required: Monitors is a collection of Ceph monitors More info: <a href="http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it">http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">user</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Optional: User is the rados user name, default is admin More info: <a href="http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it">http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Optional: User is the rados user name, default is admin More info: <a href="http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it">http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">secretFile</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: <a href="http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it">http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: <a href="http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it">http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">secretRef</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: <a href="http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it">http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: <a href="http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it">http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_localobjectreference">v1.LocalObjectReference</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">readOnly</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: <a href="http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it">http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: <a href="http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it">http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">boolean</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
@@ -1149,28 +1149,28 @@ Examples:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">pdName</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">fsType</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">partition</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">readOnly</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">boolean</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
@@ -1284,21 +1284,21 @@ Both these may change in the future. Incoming requests are matched against the H
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_unversioned_listmeta">unversioned.ListMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1380,7 +1380,7 @@ Both these may change in the future. Incoming requests are matched against the H
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1524,7 +1524,7 @@ Both these may change in the future. Incoming requests are matched against the H
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">conditions</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Conditions represent the latest available observations of an object&#8217;s current state. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/jobs.md">http://releases.k8s.io/v1.1.0/docs/user-guide/jobs.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Conditions represent the latest available observations of an object&#8217;s current state. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/jobs.md">http://releases.k8s.io/release-1.1/docs/user-guide/jobs.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_jobcondition">v1beta1.JobCondition</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1634,7 +1634,7 @@ Both these may change in the future. Incoming requests are matched against the H
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">name</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Name of the referent. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#names">http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#names</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Name of the referent. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#names">http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#names</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1740,21 +1740,21 @@ Both these may change in the future. Incoming requests are matched against the H
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">image</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Docker image name. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/images.md">http://releases.k8s.io/v1.1.0/docs/user-guide/images.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Docker image name. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/images.md">http://releases.k8s.io/release-1.1/docs/user-guide/images.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">command</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Entrypoint array. Not executed within a shell. The docker image&#8217;s entrypoint is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container&#8217;s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double , ie: (VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/containers.md#containers-and-commands">http://releases.k8s.io/v1.1.0/docs/user-guide/containers.md#containers-and-commands</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Entrypoint array. Not executed within a shell. The docker image&#8217;s entrypoint is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container&#8217;s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double , ie: (VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/containers.md#containers-and-commands">http://releases.k8s.io/release-1.1/docs/user-guide/containers.md#containers-and-commands</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">args</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Arguments to the entrypoint. The docker image&#8217;s cmd is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container&#8217;s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double , ie: (VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/containers.md#containers-and-commands">http://releases.k8s.io/v1.1.0/docs/user-guide/containers.md#containers-and-commands</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Arguments to the entrypoint. The docker image&#8217;s cmd is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container&#8217;s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double , ie: (VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/containers.md#containers-and-commands">http://releases.k8s.io/release-1.1/docs/user-guide/containers.md#containers-and-commands</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1782,7 +1782,7 @@ Both these may change in the future. Incoming requests are matched against the H
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">resources</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Compute Resources required by this container. Cannot be updated. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#resources">http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Compute Resources required by this container. Cannot be updated. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#resources">http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_resourcerequirements">v1.ResourceRequirements</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1796,14 +1796,14 @@ Both these may change in the future. Incoming requests are matched against the H
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">livenessProbe</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-probes">http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-probes</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-probes">http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-probes</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_probe">v1.Probe</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">readinessProbe</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-probes">http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-probes</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-probes">http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-probes</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_probe">v1.Probe</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1824,14 +1824,14 @@ Both these may change in the future. Incoming requests are matched against the H
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">imagePullPolicy</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/images.md#updating-images">http://releases.k8s.io/v1.1.0/docs/user-guide/images.md#updating-images</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/images.md#updating-images">http://releases.k8s.io/release-1.1/docs/user-guide/images.md#updating-images</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">securityContext</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Security options the pod should run with. More info: <a href="http://releases.k8s.io/v1.1.0/docs/design/security_context.md">http://releases.k8s.io/v1.1.0/docs/design/security_context.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Security options the pod should run with. More info: <a href="http://releases.k8s.io/release-1.1/docs/design/security_context.md">http://releases.k8s.io/release-1.1/docs/design/security_context.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_securitycontext">v1.SecurityContext</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1920,7 +1920,7 @@ Both these may change in the future. Incoming requests are matched against the H
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">name</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#names">http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#names</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#names">http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#names</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1931,7 +1931,7 @@ Both these may change in the future. Incoming requests are matched against the H
 <br>
 If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).<br>
 <br>
-Applied only if Name is not specified. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#idempotency">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#idempotency</a></p></td>
+Applied only if Name is not specified. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#idempotency">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#idempotency</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1940,7 +1940,7 @@ Applied only if Name is not specified. More info: <a href="http://releases.k8s.i
 <td class="tableblock halign-left valign-top"><p class="tableblock">namespace</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.<br>
 <br>
-Must be a DNS_LABEL. Cannot be updated. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/namespaces.md">http://releases.k8s.io/v1.1.0/docs/user-guide/namespaces.md</a></p></td>
+Must be a DNS_LABEL. Cannot be updated. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/namespaces.md">http://releases.k8s.io/release-1.1/docs/user-guide/namespaces.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1956,7 +1956,7 @@ Must be a DNS_LABEL. Cannot be updated. More info: <a href="http://releases.k8s.
 <td class="tableblock halign-left valign-top"><p class="tableblock">uid</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.<br>
 <br>
-Populated by the system. Read-only. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#uids">http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#uids</a></p></td>
+Populated by the system. Read-only. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#uids">http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#uids</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1965,7 +1965,7 @@ Populated by the system. Read-only. More info: <a href="http://releases.k8s.io/v
 <td class="tableblock halign-left valign-top"><p class="tableblock">resourceVersion</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.<br>
 <br>
-Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#concurrency-control-and-consistency">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#concurrency-control-and-consistency</a></p></td>
+Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#concurrency-control-and-consistency">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#concurrency-control-and-consistency</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1981,7 +1981,7 @@ Populated by the system. Read-only. Value must be treated as opaque by clients a
 <td class="tableblock halign-left valign-top"><p class="tableblock">creationTimestamp</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.<br>
 <br>
-Populated by the system. Read-only. Null for lists. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata</a></p></td>
+Populated by the system. Read-only. Null for lists. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1990,7 +1990,7 @@ Populated by the system. Read-only. Null for lists. More info: <a href="http://r
 <td class="tableblock halign-left valign-top"><p class="tableblock">deletionTimestamp</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource will be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field. Once set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. Once the resource is deleted in the API, the Kubelet will send a hard termination signal to the container. If not set, graceful deletion of the object has not been requested.<br>
 <br>
-Populated by the system when a graceful deletion is requested. Read-only. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata</a></p></td>
+Populated by the system when a graceful deletion is requested. Read-only. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2004,14 +2004,14 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">labels</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md">http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/labels.md">http://releases.k8s.io/release-1.1/docs/user-guide/labels.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_any">any</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">annotations</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/annotations.md">http://releases.k8s.io/v1.1.0/docs/user-guide/annotations.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/annotations.md">http://releases.k8s.io/release-1.1/docs/user-guide/annotations.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_any">any</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2045,7 +2045,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">path</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Path of the directory on the host. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#hostpath">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#hostpath</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Path of the directory on the host. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#hostpath">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#hostpath</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2100,7 +2100,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">fsType</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#iscsi">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#iscsi</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#iscsi">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#iscsi</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2179,21 +2179,21 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_unversioned_listmeta">unversioned.ListMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2234,7 +2234,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">medium</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">What type of storage medium should back this directory. The default is "" which means to use the node&#8217;s default medium. Must be an empty string (default) or Memory. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#emptydir">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#emptydir</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">What type of storage medium should back this directory. The default is "" which means to use the node&#8217;s default medium. Must be an empty string (default) or Memory. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#emptydir">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#emptydir</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2308,21 +2308,21 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">volumeID</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">volume id used to identify the volume in cinder More info: <a href="http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md">http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">volume id used to identify the volume in cinder More info: <a href="http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md">http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">fsType</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Required: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Only ext3 and ext4 are allowed More info: <a href="http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md">http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Required: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Only ext3 and ext4 are allowed More info: <a href="http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md">http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">readOnly</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: <a href="http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md">http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: <a href="http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md">http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">boolean</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
@@ -2356,28 +2356,28 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">capabilities</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The linux kernel capabilites that should be added or removed. Default to Container.Capabilities if left unset. More info: <a href="http://releases.k8s.io/v1.1.0/docs/design/security_context.md#security-context">http://releases.k8s.io/v1.1.0/docs/design/security_context.md#security-context</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The linux kernel capabilites that should be added or removed. Default to Container.Capabilities if left unset. More info: <a href="http://releases.k8s.io/release-1.1/docs/design/security_context.md#security-context">http://releases.k8s.io/release-1.1/docs/design/security_context.md#security-context</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_capabilities">v1.Capabilities</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">privileged</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Run the container in privileged mode. Default to Container.Privileged if left unset. More info: <a href="http://releases.k8s.io/v1.1.0/docs/design/security_context.md#security-context">http://releases.k8s.io/v1.1.0/docs/design/security_context.md#security-context</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Run the container in privileged mode. Default to Container.Privileged if left unset. More info: <a href="http://releases.k8s.io/release-1.1/docs/design/security_context.md#security-context">http://releases.k8s.io/release-1.1/docs/design/security_context.md#security-context</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">boolean</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">seLinuxOptions</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">SELinuxOptions are the labels to be applied to the container and volumes. Options that control the SELinux labels applied. More info: <a href="http://releases.k8s.io/v1.1.0/docs/design/security_context.md#security-context">http://releases.k8s.io/v1.1.0/docs/design/security_context.md#security-context</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SELinuxOptions are the labels to be applied to the container and volumes. Options that control the SELinux labels applied. More info: <a href="http://releases.k8s.io/release-1.1/docs/design/security_context.md#security-context">http://releases.k8s.io/release-1.1/docs/design/security_context.md#security-context</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_selinuxoptions">v1.SELinuxOptions</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">runAsUser</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">RunAsUser is the UID to run the entrypoint of the container process. The user id that runs the first process in the container. More info: <a href="http://releases.k8s.io/v1.1.0/docs/design/security_context.md#security-context">http://releases.k8s.io/v1.1.0/docs/design/security_context.md#security-context</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">RunAsUser is the UID to run the entrypoint of the container process. The user id that runs the first process in the container. More info: <a href="http://releases.k8s.io/release-1.1/docs/design/security_context.md#security-context">http://releases.k8s.io/release-1.1/docs/design/security_context.md#security-context</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int64)</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2421,14 +2421,14 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">volumeID</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">fsType</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2442,7 +2442,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">readOnly</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">boolean</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
@@ -2476,7 +2476,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">claimName</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistentvolumeclaims">http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistentvolumeclaims</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistentvolumeclaims">http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistentvolumeclaims</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2558,7 +2558,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">resourceVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">String that identifies the server&#8217;s internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#concurrency-control-and-consistency">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#concurrency-control-and-consistency</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String that identifies the server&#8217;s internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#concurrency-control-and-consistency">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#concurrency-control-and-consistency</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2647,28 +2647,28 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">spec</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">behaviour of autoscaler. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status</a>.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">behaviour of autoscaler. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status</a>.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_horizontalpodautoscalerspec">v1beta1.HorizontalPodAutoscalerSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2735,7 +2735,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <div class="sect2">
 <h3 id="_v1_secretvolumesource">v1.SecretVolumeSource</h3>
 <div class="paragraph">
-<p>SecretVolumeSource adapts a Secret into a VolumeSource. More info: <a href="http://releases.k8s.io/v1.1.0/docs/design/secrets.md">http://releases.k8s.io/v1.1.0/docs/design/secrets.md</a></p>
+<p>SecretVolumeSource adapts a Secret into a VolumeSource. More info: <a href="http://releases.k8s.io/release-1.1/docs/design/secrets.md">http://releases.k8s.io/release-1.1/docs/design/secrets.md</a></p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -2757,7 +2757,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">secretName</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">SecretName is the name of a secret in the pod&#8217;s namespace. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#secrets">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#secrets</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SecretName is the name of a secret in the pod&#8217;s namespace. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#secrets">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#secrets</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2791,14 +2791,14 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">limits</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Limits describes the maximum amount of compute resources allowed. More info: <a href="http://releases.k8s.io/v1.1.0/docs/design/resources.md#resource-specifications">http://releases.k8s.io/v1.1.0/docs/design/resources.md#resource-specifications</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Limits describes the maximum amount of compute resources allowed. More info: <a href="http://releases.k8s.io/release-1.1/docs/design/resources.md#resource-specifications">http://releases.k8s.io/release-1.1/docs/design/resources.md#resource-specifications</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_any">any</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">requests</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: <a href="http://releases.k8s.io/v1.1.0/docs/design/resources.md#resource-specifications">http://releases.k8s.io/v1.1.0/docs/design/resources.md#resource-specifications</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: <a href="http://releases.k8s.io/release-1.1/docs/design/resources.md#resource-specifications">http://releases.k8s.io/release-1.1/docs/design/resources.md#resource-specifications</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_any">any</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2976,14 +2976,14 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">spec</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Specification of the desired behavior of the pod. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Specification of the desired behavior of the pod. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_podspec">v1.PodSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3017,14 +3017,14 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3065,35 +3065,35 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">name</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Volume&#8217;s name. Must be a DNS_LABEL and unique within the pod. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#names">http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#names</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Volume&#8217;s name. Must be a DNS_LABEL and unique within the pod. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#names">http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#names</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">hostPath</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#hostpath">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#hostpath</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#hostpath">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#hostpath</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_hostpathvolumesource">v1.HostPathVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">emptyDir</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">EmptyDir represents a temporary directory that shares a pod&#8217;s lifetime. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#emptydir">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#emptydir</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">EmptyDir represents a temporary directory that shares a pod&#8217;s lifetime. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#emptydir">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#emptydir</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_emptydirvolumesource">v1.EmptyDirVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">gcePersistentDisk</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet&#8217;s host machine and then exposed to the pod. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet&#8217;s host machine and then exposed to the pod. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_gcepersistentdiskvolumesource">v1.GCEPersistentDiskVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">awsElasticBlockStore</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet&#8217;s host machine and then exposed to the pod. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet&#8217;s host machine and then exposed to the pod. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_awselasticblockstorevolumesource">v1.AWSElasticBlockStoreVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3107,49 +3107,49 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">secret</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Secret represents a secret that should populate this volume. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#secrets">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#secrets</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Secret represents a secret that should populate this volume. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#secrets">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#secrets</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_secretvolumesource">v1.SecretVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">nfs</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">NFS represents an NFS mount on the host that shares a pod&#8217;s lifetime More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">NFS represents an NFS mount on the host that shares a pod&#8217;s lifetime More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_nfsvolumesource">v1.NFSVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">iscsi</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">ISCSI represents an ISCSI Disk resource that is attached to a kubelet&#8217;s host machine and then exposed to the pod. More info: <a href="http://releases.k8s.io/v1.1.0/examples/iscsi/README.md">http://releases.k8s.io/v1.1.0/examples/iscsi/README.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">ISCSI represents an ISCSI Disk resource that is attached to a kubelet&#8217;s host machine and then exposed to the pod. More info: <a href="http://releases.k8s.io/release-1.1/examples/iscsi/README.md">http://releases.k8s.io/release-1.1/examples/iscsi/README.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_iscsivolumesource">v1.ISCSIVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">glusterfs</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Glusterfs represents a Glusterfs mount on the host that shares a pod&#8217;s lifetime. More info: <a href="http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md">http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Glusterfs represents a Glusterfs mount on the host that shares a pod&#8217;s lifetime. More info: <a href="http://releases.k8s.io/release-1.1/examples/glusterfs/README.md">http://releases.k8s.io/release-1.1/examples/glusterfs/README.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_glusterfsvolumesource">v1.GlusterfsVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">persistentVolumeClaim</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistentvolumeclaims">http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistentvolumeclaims</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistentvolumeclaims">http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistentvolumeclaims</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_persistentvolumeclaimvolumesource">v1.PersistentVolumeClaimVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">rbd</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">RBD represents a Rados Block Device mount on the host that shares a pod&#8217;s lifetime. More info: <a href="http://releases.k8s.io/v1.1.0/examples/rbd/README.md">http://releases.k8s.io/v1.1.0/examples/rbd/README.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">RBD represents a Rados Block Device mount on the host that shares a pod&#8217;s lifetime. More info: <a href="http://releases.k8s.io/release-1.1/examples/rbd/README.md">http://releases.k8s.io/release-1.1/examples/rbd/README.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_rbdvolumesource">v1.RBDVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">cinder</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Cinder represents a cinder volume attached and mounted on kubelets host machine More info: <a href="http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md">http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Cinder represents a cinder volume attached and mounted on kubelets host machine More info: <a href="http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md">http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_cindervolumesource">v1.CinderVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3232,14 +3232,14 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">initialDelaySeconds</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Number of seconds after the container has started before liveness probes are initiated. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-probes">http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-probes</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Number of seconds after the container has started before liveness probes are initiated. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-probes">http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-probes</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int64)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">timeoutSeconds</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Number of seconds after which liveness probes timeout. Defaults to 1 second. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-probes">http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-probes</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Number of seconds after which liveness probes timeout. Defaults to 1 second. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-probes">http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-probes</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int64)</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3273,28 +3273,28 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">parallelism</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Parallelism specifies the maximum desired number of pods the job should run at any given time. The actual number of pods running in steady state will be less than this number when ((.spec.completions - .status.successful) &lt; .spec.parallelism), i.e. when the work left to do is less than max parallelism. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/jobs.md">http://releases.k8s.io/v1.1.0/docs/user-guide/jobs.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Parallelism specifies the maximum desired number of pods the job should run at any given time. The actual number of pods running in steady state will be less than this number when ((.spec.completions - .status.successful) &lt; .spec.parallelism), i.e. when the work left to do is less than max parallelism. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/jobs.md">http://releases.k8s.io/release-1.1/docs/user-guide/jobs.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">completions</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Completions specifies the desired number of successfully finished pods the job should be run with. Defaults to 1. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/jobs.md">http://releases.k8s.io/v1.1.0/docs/user-guide/jobs.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Completions specifies the desired number of successfully finished pods the job should be run with. Defaults to 1. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/jobs.md">http://releases.k8s.io/release-1.1/docs/user-guide/jobs.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">selector</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Selector is a label query over pods that should match the pod count. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md#label-selectors">http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md#label-selectors</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Selector is a label query over pods that should match the pod count. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/labels.md#label-selectors">http://releases.k8s.io/release-1.1/docs/user-guide/labels.md#label-selectors</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_podselector">v1beta1.PodSelector</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">template</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Template is the object that describes the pod that will be created when executing a job. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/jobs.md">http://releases.k8s.io/v1.1.0/docs/user-guide/jobs.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Template is the object that describes the pod that will be created when executing a job. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/jobs.md">http://releases.k8s.io/release-1.1/docs/user-guide/jobs.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_podtemplatespec">v1.PodTemplateSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3373,28 +3373,28 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_unversioned_listmeta">unversioned.ListMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Status of the operation. One of: "Success" or "Failure". More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Status of the operation. One of: "Success" or "Failure". More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3559,21 +3559,21 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">volumes</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">List of volumes that can be mounted by containers belonging to the pod. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">List of volumes that can be mounted by containers belonging to the pod. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_volume">v1.Volume</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">containers</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/containers.md">http://releases.k8s.io/v1.1.0/docs/user-guide/containers.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/containers.md">http://releases.k8s.io/release-1.1/docs/user-guide/containers.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_container">v1.Container</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">restartPolicy</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#restartpolicy">http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#restartpolicy</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#restartpolicy">http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#restartpolicy</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3601,14 +3601,14 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">nodeSelector</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node&#8217;s labels for the pod to be scheduled on that node. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/node-selection/README.md">http://releases.k8s.io/v1.1.0/docs/user-guide/node-selection/README.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node&#8217;s labels for the pod to be scheduled on that node. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/node-selection/README.md">http://releases.k8s.io/release-1.1/docs/user-guide/node-selection/README.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_any">any</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">serviceAccountName</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: <a href="http://releases.k8s.io/v1.1.0/docs/design/service_accounts.md">http://releases.k8s.io/v1.1.0/docs/design/service_accounts.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: <a href="http://releases.k8s.io/release-1.1/docs/design/service_accounts.md">http://releases.k8s.io/release-1.1/docs/design/service_accounts.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3650,7 +3650,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">imagePullSecrets</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/images.md#specifying-imagepullsecrets-on-a-pod">http://releases.k8s.io/v1.1.0/docs/user-guide/images.md#specifying-imagepullsecrets-on-a-pod</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/images.md#specifying-imagepullsecrets-on-a-pod">http://releases.k8s.io/release-1.1/docs/user-guide/images.md#specifying-imagepullsecrets-on-a-pod</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_localobjectreference">v1.LocalObjectReference</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3684,14 +3684,14 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3739,14 +3739,14 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">postStart</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/container-environment.md#hook-details">http://releases.k8s.io/v1.1.0/docs/user-guide/container-environment.md#hook-details</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/container-environment.md#hook-details">http://releases.k8s.io/release-1.1/docs/user-guide/container-environment.md#hook-details</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_handler">v1.Handler</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">preStop</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">PreStop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/container-environment.md#hook-details">http://releases.k8s.io/v1.1.0/docs/user-guide/container-environment.md#hook-details</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">PreStop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/container-environment.md#hook-details">http://releases.k8s.io/release-1.1/docs/user-guide/container-environment.md#hook-details</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_handler">v1.Handler</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3828,21 +3828,21 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">endpoints</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">EndpointsName is the endpoint name that details Glusterfs topology. More info: <a href="http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md#create-a-pod">http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md#create-a-pod</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">EndpointsName is the endpoint name that details Glusterfs topology. More info: <a href="http://releases.k8s.io/release-1.1/examples/glusterfs/README.md#create-a-pod">http://releases.k8s.io/release-1.1/examples/glusterfs/README.md#create-a-pod</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">path</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Path is the Glusterfs volume path. More info: <a href="http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md#create-a-pod">http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md#create-a-pod</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Path is the Glusterfs volume path. More info: <a href="http://releases.k8s.io/release-1.1/examples/glusterfs/README.md#create-a-pod">http://releases.k8s.io/release-1.1/examples/glusterfs/README.md#create-a-pod</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">readOnly</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: <a href="http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md#create-a-pod">http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md#create-a-pod</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: <a href="http://releases.k8s.io/release-1.1/examples/glusterfs/README.md#create-a-pod">http://releases.k8s.io/release-1.1/examples/glusterfs/README.md#create-a-pod</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">boolean</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
@@ -3917,21 +3917,21 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind of the referent; More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind of the referent; More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">namespace</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Namespace of the referent; More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/namespaces.md">http://releases.k8s.io/v1.1.0/docs/user-guide/namespaces.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Namespace of the referent; More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/namespaces.md">http://releases.k8s.io/release-1.1/docs/user-guide/namespaces.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">name</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Name of the referent; More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#names">http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#names</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Name of the referent; More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#names">http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#names</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3979,35 +3979,35 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">spec</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Spec is the desired state of the Ingress. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Spec is the desired state of the Ingress. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_ingressspec">v1beta1.IngressSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Status is the current state of the Ingress. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Status is the current state of the Ingress. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_ingressstatus">v1beta1.IngressStatus</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4041,35 +4041,35 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object metadata; More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata</a>.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object metadata; More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata</a>.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">spec</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">defines the behavior of the scale. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status</a>.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">defines the behavior of the scale. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status</a>.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_scalespec">v1beta1.ScaleSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">current status of the scale. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status</a>. Read-only.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">current status of the scale. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status</a>. Read-only.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_scalestatus">v1beta1.ScaleStatus</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4103,56 +4103,56 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">monitors</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">A collection of Ceph monitors. More info: <a href="http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">A collection of Ceph monitors. More info: <a href="http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">image</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The rados image name. More info: <a href="http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The rados image name. More info: <a href="http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">fsType</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#rbd">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#rbd</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#rbd">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#rbd</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">pool</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The rados pool name. Default is rbd. More info: <a href="http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it</a>.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The rados pool name. Default is rbd. More info: <a href="http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it</a>.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">user</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The rados user name. Default is admin. More info: <a href="http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The rados user name. Default is admin. More info: <a href="http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">keyring</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: <a href="http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: <a href="http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">secretRef</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is empty. More info: <a href="http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is empty. More info: <a href="http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_localobjectreference">v1.LocalObjectReference</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">readOnly</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: <a href="http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: <a href="http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">boolean</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>

--- a/docs/api-reference/v1/definitions.html
+++ b/docs/api-reference/v1/definitions.html
@@ -497,35 +497,35 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">spec</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Spec defines the behavior of a node. <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Spec defines the behavior of a node. <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_nodespec">v1.NodeSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Most recently observed status of the node. Populated by the system. Read-only. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Most recently observed status of the node. Populated by the system. Read-only. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_nodestatus">v1.NodeStatus</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -559,28 +559,28 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_unversioned_listmeta">unversioned.ListMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">items</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">A list of persistent volume claims. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistentvolumeclaims">http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistentvolumeclaims</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">A list of persistent volume claims. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistentvolumeclaims">http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistentvolumeclaims</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_persistentvolumeclaim">v1.PersistentVolumeClaim</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -655,28 +655,28 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">user</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">User is a SELinux user label that applies to the container. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md">http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">User is a SELinux user label that applies to the container. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/labels.md">http://releases.k8s.io/release-1.1/docs/user-guide/labels.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">role</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Role is a SELinux role label that applies to the container. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md">http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Role is a SELinux role label that applies to the container. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/labels.md">http://releases.k8s.io/release-1.1/docs/user-guide/labels.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">type</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Type is a SELinux type label that applies to the container. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md">http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Type is a SELinux type label that applies to the container. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/labels.md">http://releases.k8s.io/release-1.1/docs/user-guide/labels.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">level</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Level is SELinux level label that applies to the container. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md">http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Level is SELinux level label that applies to the container. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/labels.md">http://releases.k8s.io/release-1.1/docs/user-guide/labels.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -792,14 +792,14 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">accessModes</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">AccessModes contains the desired access modes the volume should have. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#access-modes-1">http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#access-modes-1</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AccessModes contains the desired access modes the volume should have. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#access-modes-1">http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#access-modes-1</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_persistentvolumeaccessmode">v1.PersistentVolumeAccessMode</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">resources</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Resources represents the minimum resources the volume should have. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#resources">http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Resources represents the minimum resources the volume should have. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#resources">http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_resourcerequirements">v1.ResourceRequirements</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -840,35 +840,35 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">monitors</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Required: Monitors is a collection of Ceph monitors More info: <a href="http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it">http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Required: Monitors is a collection of Ceph monitors More info: <a href="http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it">http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">user</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Optional: User is the rados user name, default is admin More info: <a href="http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it">http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Optional: User is the rados user name, default is admin More info: <a href="http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it">http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">secretFile</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: <a href="http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it">http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: <a href="http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it">http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">secretRef</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: <a href="http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it">http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: <a href="http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it">http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_localobjectreference">v1.LocalObjectReference</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">readOnly</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: <a href="http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it">http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: <a href="http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it">http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">boolean</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
@@ -991,28 +991,28 @@ Examples:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">pdName</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">fsType</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">partition</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">readOnly</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">boolean</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
@@ -1046,7 +1046,7 @@ Examples:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">hard</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Hard is the set of desired hard limits for each named resource. More info: <a href="http://releases.k8s.io/v1.1.0/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota">http://releases.k8s.io/v1.1.0/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Hard is the set of desired hard limits for each named resource. More info: <a href="http://releases.k8s.io/release-1.1/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota">http://releases.k8s.io/release-1.1/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_any">any</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1080,7 +1080,7 @@ Examples:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">phase</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Phase is the current lifecycle phase of the namespace. More info: <a href="http://releases.k8s.io/v1.1.0/docs/design/namespaces.md#phases">http://releases.k8s.io/v1.1.0/docs/design/namespaces.md#phases</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Phase is the current lifecycle phase of the namespace. More info: <a href="http://releases.k8s.io/release-1.1/docs/design/namespaces.md#phases">http://releases.k8s.io/release-1.1/docs/design/namespaces.md#phases</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1114,7 +1114,7 @@ Examples:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">finalizers</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Finalizers is an opaque list of values that must be empty to permanently remove object from storage. More info: <a href="http://releases.k8s.io/v1.1.0/docs/design/namespaces.md#finalizers">http://releases.k8s.io/v1.1.0/docs/design/namespaces.md#finalizers</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Finalizers is an opaque list of values that must be empty to permanently remove object from storage. More info: <a href="http://releases.k8s.io/release-1.1/docs/design/namespaces.md#finalizers">http://releases.k8s.io/release-1.1/docs/design/namespaces.md#finalizers</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_finalizername">v1.FinalizerName</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1126,7 +1126,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1_persistentvolume">v1.PersistentVolume</h3>
 <div class="paragraph">
-<p>PersistentVolume (PV) is a storage resource provisioned by an administrator. It is analogous to a node. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md">http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md</a></p>
+<p>PersistentVolume (PV) is a storage resource provisioned by an administrator. It is analogous to a node. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md">http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md</a></p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -1148,35 +1148,35 @@ Examples:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">spec</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Spec defines a specification of a persistent volume owned by the cluster. Provisioned by an administrator. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistent-volumes">http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistent-volumes</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Spec defines a specification of a persistent volume owned by the cluster. Provisioned by an administrator. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistent-volumes">http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistent-volumes</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_persistentvolumespec">v1.PersistentVolumeSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Status represents the current information/status for the persistent volume. Populated by the system. Read-only. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistent-volumes">http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistent-volumes</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Status represents the current information/status for the persistent volume. Populated by the system. Read-only. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistent-volumes">http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistent-volumes</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_persistentvolumestatus">v1.PersistentVolumeStatus</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1210,7 +1210,7 @@ Examples:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">phase</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Phase indicates if a volume is available, bound to a claim, or released by a claim. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#phase">http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#phase</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Phase indicates if a volume is available, bound to a claim, or released by a claim. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#phase">http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#phase</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1258,21 +1258,21 @@ Examples:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_unversioned_listmeta">unversioned.ListMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1464,21 +1464,21 @@ Examples:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_unversioned_listmeta">unversioned.ListMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1519,7 +1519,7 @@ Examples:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">name</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Name of the referent. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#names">http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#names</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Name of the referent. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#names">http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#names</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1553,7 +1553,7 @@ Examples:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">hard</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Hard is the set of enforced hard limits for each named resource. More info: <a href="http://releases.k8s.io/v1.1.0/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota">http://releases.k8s.io/v1.1.0/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Hard is the set of enforced hard limits for each named resource. More info: <a href="http://releases.k8s.io/release-1.1/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota">http://releases.k8s.io/release-1.1/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_any">any</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1628,7 +1628,7 @@ Examples:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">name</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#names">http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#names</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#names">http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#names</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1639,7 +1639,7 @@ Examples:<br>
 <br>
 If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).<br>
 <br>
-Applied only if Name is not specified. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#idempotency">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#idempotency</a></p></td>
+Applied only if Name is not specified. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#idempotency">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#idempotency</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1648,7 +1648,7 @@ Applied only if Name is not specified. More info: <a href="http://releases.k8s.i
 <td class="tableblock halign-left valign-top"><p class="tableblock">namespace</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.<br>
 <br>
-Must be a DNS_LABEL. Cannot be updated. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/namespaces.md">http://releases.k8s.io/v1.1.0/docs/user-guide/namespaces.md</a></p></td>
+Must be a DNS_LABEL. Cannot be updated. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/namespaces.md">http://releases.k8s.io/release-1.1/docs/user-guide/namespaces.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1664,7 +1664,7 @@ Must be a DNS_LABEL. Cannot be updated. More info: <a href="http://releases.k8s.
 <td class="tableblock halign-left valign-top"><p class="tableblock">uid</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.<br>
 <br>
-Populated by the system. Read-only. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#uids">http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#uids</a></p></td>
+Populated by the system. Read-only. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#uids">http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#uids</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1673,7 +1673,7 @@ Populated by the system. Read-only. More info: <a href="http://releases.k8s.io/v
 <td class="tableblock halign-left valign-top"><p class="tableblock">resourceVersion</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.<br>
 <br>
-Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#concurrency-control-and-consistency">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#concurrency-control-and-consistency</a></p></td>
+Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#concurrency-control-and-consistency">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#concurrency-control-and-consistency</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1689,7 +1689,7 @@ Populated by the system. Read-only. Value must be treated as opaque by clients a
 <td class="tableblock halign-left valign-top"><p class="tableblock">creationTimestamp</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.<br>
 <br>
-Populated by the system. Read-only. Null for lists. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata</a></p></td>
+Populated by the system. Read-only. Null for lists. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1698,7 +1698,7 @@ Populated by the system. Read-only. Null for lists. More info: <a href="http://r
 <td class="tableblock halign-left valign-top"><p class="tableblock">deletionTimestamp</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource will be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field. Once set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. Once the resource is deleted in the API, the Kubelet will send a hard termination signal to the container. If not set, graceful deletion of the object has not been requested.<br>
 <br>
-Populated by the system when a graceful deletion is requested. Read-only. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata</a></p></td>
+Populated by the system when a graceful deletion is requested. Read-only. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1712,14 +1712,14 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">labels</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md">http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/labels.md">http://releases.k8s.io/release-1.1/docs/user-guide/labels.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_any">any</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">annotations</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/annotations.md">http://releases.k8s.io/v1.1.0/docs/user-guide/annotations.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/annotations.md">http://releases.k8s.io/release-1.1/docs/user-guide/annotations.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_any">any</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1808,7 +1808,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">fsType</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#iscsi">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#iscsi</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#iscsi">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#iscsi</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1849,7 +1849,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">medium</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">What type of storage medium should back this directory. The default is "" which means to use the node&#8217;s default medium. Must be an empty string (default) or Memory. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#emptydir">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#emptydir</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">What type of storage medium should back this directory. The default is "" which means to use the node&#8217;s default medium. Must be an empty string (default) or Memory. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#emptydir">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#emptydir</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1883,21 +1883,21 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_unversioned_listmeta">unversioned.ListMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1944,35 +1944,35 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">spec</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Spec defines the desired characteristics of a volume requested by a pod author. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistentvolumeclaims">http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistentvolumeclaims</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Spec defines the desired characteristics of a volume requested by a pod author. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistentvolumeclaims">http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistentvolumeclaims</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_persistentvolumeclaimspec">v1.PersistentVolumeClaimSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Status represents the current information/status of a persistent volume claim. Read-only. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistentvolumeclaims">http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistentvolumeclaims</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Status represents the current information/status of a persistent volume claim. Read-only. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistentvolumeclaims">http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistentvolumeclaims</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_persistentvolumeclaimstatus">v1.PersistentVolumeClaimStatus</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2006,28 +2006,28 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_unversioned_listmeta">unversioned.ListMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">items</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Items is the list of Namespace objects in the list. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/namespaces.md">http://releases.k8s.io/v1.1.0/docs/user-guide/namespaces.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Items is the list of Namespace objects in the list. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/namespaces.md">http://releases.k8s.io/release-1.1/docs/user-guide/namespaces.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_namespace">v1.Namespace</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2061,35 +2061,35 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">secrets</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/secrets.md">http://releases.k8s.io/v1.1.0/docs/user-guide/secrets.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/secrets.md">http://releases.k8s.io/release-1.1/docs/user-guide/secrets.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectreference">v1.ObjectReference</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">imagePullSecrets</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/secrets.md#manually-specifying-an-imagepullsecret">http://releases.k8s.io/v1.1.0/docs/user-guide/secrets.md#manually-specifying-an-imagepullsecret</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/secrets.md#manually-specifying-an-imagepullsecret">http://releases.k8s.io/release-1.1/docs/user-guide/secrets.md#manually-specifying-an-imagepullsecret</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_localobjectreference">v1.LocalObjectReference</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2164,35 +2164,35 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">spec</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Spec defines the behavior of the Namespace. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Spec defines the behavior of the Namespace. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_namespacespec">v1.NamespaceSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Status describes the current status of a Namespace. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Status describes the current status of a Namespace. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_namespacestatus">v1.NamespaceStatus</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2260,7 +2260,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">claimName</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistentvolumeclaims">http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistentvolumeclaims</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistentvolumeclaims">http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistentvolumeclaims</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2308,7 +2308,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">resourceVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">String that identifies the server&#8217;s internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#concurrency-control-and-consistency">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#concurrency-control-and-consistency</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String that identifies the server&#8217;s internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#concurrency-control-and-consistency">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#concurrency-control-and-consistency</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2342,28 +2342,28 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_unversioned_listmeta">unversioned.ListMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">items</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Items is a list of ResourceQuota objects. More info: <a href="http://releases.k8s.io/v1.1.0/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota">http://releases.k8s.io/v1.1.0/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Items is a list of ResourceQuota objects. More info: <a href="http://releases.k8s.io/release-1.1/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota">http://releases.k8s.io/release-1.1/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_resourcequota">v1.ResourceQuota</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2404,7 +2404,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">accessModes</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">AccessModes contains the actual access modes the volume backing the PVC has. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#access-modes-1">http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#access-modes-1</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AccessModes contains the actual access modes the volume backing the PVC has. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#access-modes-1">http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#access-modes-1</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_persistentvolumeaccessmode">v1.PersistentVolumeAccessMode</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2478,7 +2478,7 @@ The resulting set of endpoints can be viewed as:<br>
 <div class="sect2">
 <h3 id="_v1_secretvolumesource">v1.SecretVolumeSource</h3>
 <div class="paragraph">
-<p>SecretVolumeSource adapts a Secret into a VolumeSource. More info: <a href="http://releases.k8s.io/v1.1.0/docs/design/secrets.md">http://releases.k8s.io/v1.1.0/docs/design/secrets.md</a></p>
+<p>SecretVolumeSource adapts a Secret into a VolumeSource. More info: <a href="http://releases.k8s.io/release-1.1/docs/design/secrets.md">http://releases.k8s.io/release-1.1/docs/design/secrets.md</a></p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -2500,7 +2500,7 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">secretName</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">SecretName is the name of a secret in the pod&#8217;s namespace. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#secrets">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#secrets</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SecretName is the name of a secret in the pod&#8217;s namespace. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#secrets">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#secrets</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2609,35 +2609,35 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">spec</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Spec defines the behavior of a service. <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Spec defines the behavior of a service. <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_servicespec">v1.ServiceSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Most recently observed status of the service. Populated by the system. Read-only. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Most recently observed status of the service. Populated by the system. Read-only. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_servicestatus">v1.ServiceStatus</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2671,28 +2671,28 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_unversioned_listmeta">unversioned.ListMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">items</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">List of ServiceAccounts. More info: <a href="http://releases.k8s.io/v1.1.0/docs/design/service_accounts.md#service-accounts">http://releases.k8s.io/v1.1.0/docs/design/service_accounts.md#service-accounts</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">List of ServiceAccounts. More info: <a href="http://releases.k8s.io/release-1.1/docs/design/service_accounts.md#service-accounts">http://releases.k8s.io/release-1.1/docs/design/service_accounts.md#service-accounts</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_serviceaccount">v1.ServiceAccount</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2726,28 +2726,28 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_unversioned_listmeta">unversioned.ListMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">items</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Items is a list of LimitRange objects. More info: <a href="http://releases.k8s.io/v1.1.0/docs/design/admission_control_limit_range.md">http://releases.k8s.io/v1.1.0/docs/design/admission_control_limit_range.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Items is a list of LimitRange objects. More info: <a href="http://releases.k8s.io/release-1.1/docs/design/admission_control_limit_range.md">http://releases.k8s.io/release-1.1/docs/design/admission_control_limit_range.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_limitrange">v1.LimitRange</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2792,21 +2792,21 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2847,14 +2847,14 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2895,35 +2895,35 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">name</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Volume&#8217;s name. Must be a DNS_LABEL and unique within the pod. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#names">http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#names</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Volume&#8217;s name. Must be a DNS_LABEL and unique within the pod. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#names">http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#names</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">hostPath</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#hostpath">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#hostpath</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#hostpath">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#hostpath</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_hostpathvolumesource">v1.HostPathVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">emptyDir</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">EmptyDir represents a temporary directory that shares a pod&#8217;s lifetime. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#emptydir">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#emptydir</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">EmptyDir represents a temporary directory that shares a pod&#8217;s lifetime. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#emptydir">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#emptydir</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_emptydirvolumesource">v1.EmptyDirVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">gcePersistentDisk</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet&#8217;s host machine and then exposed to the pod. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet&#8217;s host machine and then exposed to the pod. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_gcepersistentdiskvolumesource">v1.GCEPersistentDiskVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">awsElasticBlockStore</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet&#8217;s host machine and then exposed to the pod. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet&#8217;s host machine and then exposed to the pod. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_awselasticblockstorevolumesource">v1.AWSElasticBlockStoreVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2937,49 +2937,49 @@ The resulting set of endpoints can be viewed as:<br>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">secret</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Secret represents a secret that should populate this volume. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#secrets">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#secrets</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Secret represents a secret that should populate this volume. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#secrets">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#secrets</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_secretvolumesource">v1.SecretVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">nfs</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">NFS represents an NFS mount on the host that shares a pod&#8217;s lifetime More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">NFS represents an NFS mount on the host that shares a pod&#8217;s lifetime More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_nfsvolumesource">v1.NFSVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">iscsi</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">ISCSI represents an ISCSI Disk resource that is attached to a kubelet&#8217;s host machine and then exposed to the pod. More info: <a href="http://releases.k8s.io/v1.1.0/examples/iscsi/README.md">http://releases.k8s.io/v1.1.0/examples/iscsi/README.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">ISCSI represents an ISCSI Disk resource that is attached to a kubelet&#8217;s host machine and then exposed to the pod. More info: <a href="http://releases.k8s.io/release-1.1/examples/iscsi/README.md">http://releases.k8s.io/release-1.1/examples/iscsi/README.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_iscsivolumesource">v1.ISCSIVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">glusterfs</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Glusterfs represents a Glusterfs mount on the host that shares a pod&#8217;s lifetime. More info: <a href="http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md">http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Glusterfs represents a Glusterfs mount on the host that shares a pod&#8217;s lifetime. More info: <a href="http://releases.k8s.io/release-1.1/examples/glusterfs/README.md">http://releases.k8s.io/release-1.1/examples/glusterfs/README.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_glusterfsvolumesource">v1.GlusterfsVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">persistentVolumeClaim</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistentvolumeclaims">http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistentvolumeclaims</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistentvolumeclaims">http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistentvolumeclaims</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_persistentvolumeclaimvolumesource">v1.PersistentVolumeClaimVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">rbd</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">RBD represents a Rados Block Device mount on the host that shares a pod&#8217;s lifetime. More info: <a href="http://releases.k8s.io/v1.1.0/examples/rbd/README.md">http://releases.k8s.io/v1.1.0/examples/rbd/README.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">RBD represents a Rados Block Device mount on the host that shares a pod&#8217;s lifetime. More info: <a href="http://releases.k8s.io/release-1.1/examples/rbd/README.md">http://releases.k8s.io/release-1.1/examples/rbd/README.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_rbdvolumesource">v1.RBDVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">cinder</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Cinder represents a cinder volume attached and mounted on kubelets host machine More info: <a href="http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md">http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Cinder represents a cinder volume attached and mounted on kubelets host machine More info: <a href="http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md">http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_cindervolumesource">v1.CinderVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3062,14 +3062,14 @@ The resulting set of endpoints can be viewed as:<br>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">initialDelaySeconds</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Number of seconds after the container has started before liveness probes are initiated. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-probes">http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-probes</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Number of seconds after the container has started before liveness probes are initiated. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-probes">http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-probes</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int64)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">timeoutSeconds</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Number of seconds after which liveness probes timeout. Defaults to 1 second. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-probes">http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-probes</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Number of seconds after which liveness probes timeout. Defaults to 1 second. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-probes">http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-probes</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int64)</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3103,35 +3103,35 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">If the Labels of a ReplicationController are empty, they are defaulted to be the same as the Pod(s) that the replication controller manages. Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">If the Labels of a ReplicationController are empty, they are defaulted to be the same as the Pod(s) that the replication controller manages. Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">spec</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Spec defines the specification of the desired behavior of the replication controller. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Spec defines the specification of the desired behavior of the replication controller. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_replicationcontrollerspec">v1.ReplicationControllerSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Status is the most recently observed status of the replication controller. This data may be out of date by some window of time. Populated by the system. Read-only. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Status is the most recently observed status of the replication controller. This data may be out of date by some window of time. Populated by the system. Read-only. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_replicationcontrollerstatus">v1.ReplicationControllerStatus</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3169,28 +3169,28 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">spec</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Spec defines the limits enforced. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Spec defines the limits enforced. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_limitrangespec">v1.LimitRangeSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3265,14 +3265,14 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">phase</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Current condition of the pod. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#pod-phase">http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#pod-phase</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Current condition of the pod. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#pod-phase">http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#pod-phase</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">conditions</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Current service state of pod. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#pod-conditions">http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#pod-conditions</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Current service state of pod. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#pod-conditions">http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#pod-conditions</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_podcondition">v1.PodCondition</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3314,7 +3314,7 @@ The resulting set of endpoints can be viewed as:<br>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">containerStatuses</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The list has one entry per container in the manifest. Each entry is currently the output of <code>docker inspect</code>. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-statuses">http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-statuses</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The list has one entry per container in the manifest. Each entry is currently the output of <code>docker inspect</code>. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-statuses">http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-statuses</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_containerstatus">v1.ContainerStatus</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3348,21 +3348,21 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">volumes</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">List of volumes that can be mounted by containers belonging to the pod. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">List of volumes that can be mounted by containers belonging to the pod. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_volume">v1.Volume</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">containers</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/containers.md">http://releases.k8s.io/v1.1.0/docs/user-guide/containers.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/containers.md">http://releases.k8s.io/release-1.1/docs/user-guide/containers.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_container">v1.Container</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">restartPolicy</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#restartpolicy">http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#restartpolicy</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#restartpolicy">http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#restartpolicy</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3390,14 +3390,14 @@ The resulting set of endpoints can be viewed as:<br>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">nodeSelector</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node&#8217;s labels for the pod to be scheduled on that node. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/node-selection/README.md">http://releases.k8s.io/v1.1.0/docs/user-guide/node-selection/README.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node&#8217;s labels for the pod to be scheduled on that node. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/node-selection/README.md">http://releases.k8s.io/release-1.1/docs/user-guide/node-selection/README.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_any">any</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">serviceAccountName</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: <a href="http://releases.k8s.io/v1.1.0/docs/design/service_accounts.md">http://releases.k8s.io/v1.1.0/docs/design/service_accounts.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: <a href="http://releases.k8s.io/release-1.1/docs/design/service_accounts.md">http://releases.k8s.io/release-1.1/docs/design/service_accounts.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3439,7 +3439,7 @@ The resulting set of endpoints can be viewed as:<br>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">imagePullSecrets</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/images.md#specifying-imagepullsecrets-on-a-pod">http://releases.k8s.io/v1.1.0/docs/user-guide/images.md#specifying-imagepullsecrets-on-a-pod</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/images.md#specifying-imagepullsecrets-on-a-pod">http://releases.k8s.io/release-1.1/docs/user-guide/images.md#specifying-imagepullsecrets-on-a-pod</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_localobjectreference">v1.LocalObjectReference</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3535,35 +3535,35 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">spec</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Spec defines the desired quota. <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Spec defines the desired quota. <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_resourcequotaspec">v1.ResourceQuotaSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Status defines the actual enforced quota and its current usage. <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Status defines the actual enforced quota and its current usage. <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_resourcequotastatus">v1.ResourceQuotaStatus</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3597,21 +3597,21 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_unversioned_listmeta">unversioned.ListMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3652,14 +3652,14 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">postStart</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/container-environment.md#hook-details">http://releases.k8s.io/v1.1.0/docs/user-guide/container-environment.md#hook-details</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/container-environment.md#hook-details">http://releases.k8s.io/release-1.1/docs/user-guide/container-environment.md#hook-details</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_handler">v1.Handler</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">preStop</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">PreStop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/container-environment.md#hook-details">http://releases.k8s.io/v1.1.0/docs/user-guide/container-environment.md#hook-details</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">PreStop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/container-environment.md#hook-details">http://releases.k8s.io/release-1.1/docs/user-guide/container-environment.md#hook-details</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_handler">v1.Handler</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3693,21 +3693,21 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">replicas</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/replication-controller.md#what-is-a-replication-controller">http://releases.k8s.io/v1.1.0/docs/user-guide/replication-controller.md#what-is-a-replication-controller</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/replication-controller.md#what-is-a-replication-controller">http://releases.k8s.io/release-1.1/docs/user-guide/replication-controller.md#what-is-a-replication-controller</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">selector</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Selector is a label query over pods that should match the Replicas count. If Selector is empty, it is defaulted to the labels present on the Pod template. Label keys and values that must match in order to be controlled by this replication controller, if empty defaulted to labels on Pod template. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md#label-selectors">http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md#label-selectors</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Selector is a label query over pods that should match the Replicas count. If Selector is empty, it is defaulted to the labels present on the Pod template. Label keys and values that must match in order to be controlled by this replication controller, if empty defaulted to labels on Pod template. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/labels.md#label-selectors">http://releases.k8s.io/release-1.1/docs/user-guide/labels.md#label-selectors</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_any">any</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">template</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Template is the object that describes the pod that will be created if insufficient replicas are detected. This takes precedence over a TemplateRef. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/replication-controller.md#pod-template">http://releases.k8s.io/v1.1.0/docs/user-guide/replication-controller.md#pod-template</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Template is the object that describes the pod that will be created if insufficient replicas are detected. This takes precedence over a TemplateRef. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/replication-controller.md#pod-template">http://releases.k8s.io/release-1.1/docs/user-guide/replication-controller.md#pod-template</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_podtemplatespec">v1.PodTemplateSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3741,28 +3741,28 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">capacity</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Capacity represents the available resources of a node. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#capacity">http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#capacity</a> for more details.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capacity represents the available resources of a node. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#capacity">http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#capacity</a> for more details.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_any">any</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">phase</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">NodePhase is the recently observed lifecycle phase of the node. More info: <a href="http://releases.k8s.io/v1.1.0/docs/admin/node.md#node-phase">http://releases.k8s.io/v1.1.0/docs/admin/node.md#node-phase</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">NodePhase is the recently observed lifecycle phase of the node. More info: <a href="http://releases.k8s.io/release-1.1/docs/admin/node.md#node-phase">http://releases.k8s.io/release-1.1/docs/admin/node.md#node-phase</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">conditions</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Conditions is an array of current observed node conditions. More info: <a href="http://releases.k8s.io/v1.1.0/docs/admin/node.md#node-condition">http://releases.k8s.io/v1.1.0/docs/admin/node.md#node-condition</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Conditions is an array of current observed node conditions. More info: <a href="http://releases.k8s.io/release-1.1/docs/admin/node.md#node-condition">http://releases.k8s.io/release-1.1/docs/admin/node.md#node-condition</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_nodecondition">v1.NodeCondition</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">addresses</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">List of addresses reachable to the node. Queried from cloud provider, if available. More info: <a href="http://releases.k8s.io/v1.1.0/docs/admin/node.md#node-addresses">http://releases.k8s.io/v1.1.0/docs/admin/node.md#node-addresses</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">List of addresses reachable to the node. Queried from cloud provider, if available. More info: <a href="http://releases.k8s.io/release-1.1/docs/admin/node.md#node-addresses">http://releases.k8s.io/release-1.1/docs/admin/node.md#node-addresses</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_nodeaddress">v1.NodeAddress</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3776,7 +3776,7 @@ The resulting set of endpoints can be viewed as:<br>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">nodeInfo</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Set of ids/uuids to uniquely identify the node. More info: <a href="http://releases.k8s.io/v1.1.0/docs/admin/node.md#node-info">http://releases.k8s.io/v1.1.0/docs/admin/node.md#node-info</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Set of ids/uuids to uniquely identify the node. More info: <a href="http://releases.k8s.io/release-1.1/docs/admin/node.md#node-info">http://releases.k8s.io/release-1.1/docs/admin/node.md#node-info</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_nodesysteminfo">v1.NodeSystemInfo</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3810,21 +3810,21 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">endpoints</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">EndpointsName is the endpoint name that details Glusterfs topology. More info: <a href="http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md#create-a-pod">http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md#create-a-pod</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">EndpointsName is the endpoint name that details Glusterfs topology. More info: <a href="http://releases.k8s.io/release-1.1/examples/glusterfs/README.md#create-a-pod">http://releases.k8s.io/release-1.1/examples/glusterfs/README.md#create-a-pod</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">path</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Path is the Glusterfs volume path. More info: <a href="http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md#create-a-pod">http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md#create-a-pod</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Path is the Glusterfs volume path. More info: <a href="http://releases.k8s.io/release-1.1/examples/glusterfs/README.md#create-a-pod">http://releases.k8s.io/release-1.1/examples/glusterfs/README.md#create-a-pod</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">readOnly</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: <a href="http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md#create-a-pod">http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md#create-a-pod</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: <a href="http://releases.k8s.io/release-1.1/examples/glusterfs/README.md#create-a-pod">http://releases.k8s.io/release-1.1/examples/glusterfs/README.md#create-a-pod</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">boolean</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
@@ -3947,14 +3947,14 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">type</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Type is the type of the condition. Currently only Ready. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#pod-conditions">http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#pod-conditions</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Type is the type of the condition. Currently only Ready. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#pod-conditions">http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#pod-conditions</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Status is the status of the condition. Can be True, False, Unknown. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#pod-conditions">http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#pod-conditions</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Status is the status of the condition. Can be True, False, Unknown. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#pod-conditions">http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#pod-conditions</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4016,56 +4016,56 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">monitors</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">A collection of Ceph monitors. More info: <a href="http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">A collection of Ceph monitors. More info: <a href="http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">image</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The rados image name. More info: <a href="http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The rados image name. More info: <a href="http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">fsType</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#rbd">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#rbd</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#rbd">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#rbd</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">pool</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The rados pool name. Default is rbd. More info: <a href="http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it</a>.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The rados pool name. Default is rbd. More info: <a href="http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it</a>.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">user</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The rados user name. Default is admin. More info: <a href="http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The rados user name. Default is admin. More info: <a href="http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">keyring</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: <a href="http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: <a href="http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">secretRef</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is empty. More info: <a href="http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is empty. More info: <a href="http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_localobjectreference">v1.LocalObjectReference</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">readOnly</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: <a href="http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: <a href="http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it">http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">boolean</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
@@ -4099,28 +4099,28 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">template</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Template defines the pods that will be created from this pod template. <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Template defines the pods that will be created from this pod template. <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_podtemplatespec">v1.PodTemplateSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4188,21 +4188,21 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">server</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Server is the hostname or IP address of the NFS server. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Server is the hostname or IP address of the NFS server. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">path</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Path that is exported by the NFS server. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Path that is exported by the NFS server. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">readOnly</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">boolean</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
@@ -4380,7 +4380,7 @@ The resulting set of endpoints can be viewed as:<br>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4517,28 +4517,28 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_unversioned_listmeta">unversioned.ListMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">items</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Items is a list of secret objects. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/secrets.md">http://releases.k8s.io/v1.1.0/docs/user-guide/secrets.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Items is a list of secret objects. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/secrets.md">http://releases.k8s.io/release-1.1/docs/user-guide/secrets.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_secret">v1.Secret</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4579,21 +4579,21 @@ The resulting set of endpoints can be viewed as:<br>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">image</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Docker image name. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/images.md">http://releases.k8s.io/v1.1.0/docs/user-guide/images.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Docker image name. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/images.md">http://releases.k8s.io/release-1.1/docs/user-guide/images.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">command</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Entrypoint array. Not executed within a shell. The docker image&#8217;s entrypoint is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container&#8217;s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double , ie: (VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/containers.md#containers-and-commands">http://releases.k8s.io/v1.1.0/docs/user-guide/containers.md#containers-and-commands</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Entrypoint array. Not executed within a shell. The docker image&#8217;s entrypoint is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container&#8217;s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double , ie: (VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/containers.md#containers-and-commands">http://releases.k8s.io/release-1.1/docs/user-guide/containers.md#containers-and-commands</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">args</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Arguments to the entrypoint. The docker image&#8217;s cmd is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container&#8217;s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double , ie: (VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/containers.md#containers-and-commands">http://releases.k8s.io/v1.1.0/docs/user-guide/containers.md#containers-and-commands</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Arguments to the entrypoint. The docker image&#8217;s cmd is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container&#8217;s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double , ie: (VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/containers.md#containers-and-commands">http://releases.k8s.io/release-1.1/docs/user-guide/containers.md#containers-and-commands</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4621,7 +4621,7 @@ The resulting set of endpoints can be viewed as:<br>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">resources</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Compute Resources required by this container. Cannot be updated. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#resources">http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Compute Resources required by this container. Cannot be updated. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#resources">http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_resourcerequirements">v1.ResourceRequirements</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4635,14 +4635,14 @@ The resulting set of endpoints can be viewed as:<br>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">livenessProbe</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-probes">http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-probes</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-probes">http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-probes</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_probe">v1.Probe</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">readinessProbe</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-probes">http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-probes</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-probes">http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-probes</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_probe">v1.Probe</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4663,14 +4663,14 @@ The resulting set of endpoints can be viewed as:<br>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">imagePullPolicy</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/images.md#updating-images">http://releases.k8s.io/v1.1.0/docs/user-guide/images.md#updating-images</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/images.md#updating-images">http://releases.k8s.io/release-1.1/docs/user-guide/images.md#updating-images</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">securityContext</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Security options the pod should run with. More info: <a href="http://releases.k8s.io/v1.1.0/docs/design/security_context.md">http://releases.k8s.io/v1.1.0/docs/design/security_context.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Security options the pod should run with. More info: <a href="http://releases.k8s.io/release-1.1/docs/design/security_context.md">http://releases.k8s.io/release-1.1/docs/design/security_context.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_securitycontext">v1.SecurityContext</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4725,49 +4725,49 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">capacity</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">A description of the persistent volume&#8217;s resources and capacity. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#capacity">http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#capacity</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">A description of the persistent volume&#8217;s resources and capacity. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#capacity">http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#capacity</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_any">any</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">gcePersistentDisk</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet&#8217;s host machine and then exposed to the pod. Provisioned by an admin. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet&#8217;s host machine and then exposed to the pod. Provisioned by an admin. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_gcepersistentdiskvolumesource">v1.GCEPersistentDiskVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">awsElasticBlockStore</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet&#8217;s host machine and then exposed to the pod. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet&#8217;s host machine and then exposed to the pod. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_awselasticblockstorevolumesource">v1.AWSElasticBlockStoreVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">hostPath</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">HostPath represents a directory on the host. Provisioned by a developer or tester. This is useful for single-node development and testing only! On-host storage is not supported in any way and WILL NOT WORK in a multi-node cluster. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#hostpath">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#hostpath</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">HostPath represents a directory on the host. Provisioned by a developer or tester. This is useful for single-node development and testing only! On-host storage is not supported in any way and WILL NOT WORK in a multi-node cluster. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#hostpath">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#hostpath</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_hostpathvolumesource">v1.HostPathVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">glusterfs</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Glusterfs represents a Glusterfs volume that is attached to a host and exposed to the pod. Provisioned by an admin. More info: <a href="http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md">http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Glusterfs represents a Glusterfs volume that is attached to a host and exposed to the pod. Provisioned by an admin. More info: <a href="http://releases.k8s.io/release-1.1/examples/glusterfs/README.md">http://releases.k8s.io/release-1.1/examples/glusterfs/README.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_glusterfsvolumesource">v1.GlusterfsVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">nfs</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">NFS represents an NFS mount on the host. Provisioned by an admin. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">NFS represents an NFS mount on the host. Provisioned by an admin. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_nfsvolumesource">v1.NFSVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">rbd</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">RBD represents a Rados Block Device mount on the host that shares a pod&#8217;s lifetime. More info: <a href="http://releases.k8s.io/v1.1.0/examples/rbd/README.md">http://releases.k8s.io/v1.1.0/examples/rbd/README.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">RBD represents a Rados Block Device mount on the host that shares a pod&#8217;s lifetime. More info: <a href="http://releases.k8s.io/release-1.1/examples/rbd/README.md">http://releases.k8s.io/release-1.1/examples/rbd/README.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_rbdvolumesource">v1.RBDVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4781,7 +4781,7 @@ The resulting set of endpoints can be viewed as:<br>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">cinder</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Cinder represents a cinder volume attached and mounted on kubelets host machine More info: <a href="http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md">http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Cinder represents a cinder volume attached and mounted on kubelets host machine More info: <a href="http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md">http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_cindervolumesource">v1.CinderVolumeSource</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4809,21 +4809,21 @@ The resulting set of endpoints can be viewed as:<br>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">accessModes</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">AccessModes contains all ways the volume can be mounted. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#access-modes">http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#access-modes</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AccessModes contains all ways the volume can be mounted. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#access-modes">http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#access-modes</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_persistentvolumeaccessmode">v1.PersistentVolumeAccessMode</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">claimRef</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">ClaimRef is part of a bi-directional binding between PersistentVolume and PersistentVolumeClaim. Expected to be non-nil when bound. claim.VolumeName is the authoritative bind between PV and PVC. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#binding">http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#binding</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">ClaimRef is part of a bi-directional binding between PersistentVolume and PersistentVolumeClaim. Expected to be non-nil when bound. claim.VolumeName is the authoritative bind between PV and PVC. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#binding">http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#binding</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectreference">v1.ObjectReference</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">persistentVolumeReclaimPolicy</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">What happens to a persistent volume when released from its claim. Valid options are Retain (default) and Recycle. Recyling must be supported by the volume plugin underlying this persistent volume. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#recycling-policy">http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#recycling-policy</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">What happens to a persistent volume when released from its claim. Valid options are Retain (default) and Recycle. Recyling must be supported by the volume plugin underlying this persistent volume. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#recycling-policy">http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#recycling-policy</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4857,7 +4857,7 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">replicas</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Replicas is the most recently oberved number of replicas. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/replication-controller.md#what-is-a-replication-controller">http://releases.k8s.io/v1.1.0/docs/user-guide/replication-controller.md#what-is-a-replication-controller</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Replicas is the most recently oberved number of replicas. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/replication-controller.md#what-is-a-replication-controller">http://releases.k8s.io/release-1.1/docs/user-guide/replication-controller.md#what-is-a-replication-controller</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4923,14 +4923,14 @@ The resulting set of endpoints can be viewed as:<br>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">targetPort</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod&#8217;s container ports. If this is not specified, the value of Port is used (an identity map). Defaults to the service port. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/services.md#defining-a-service">http://releases.k8s.io/v1.1.0/docs/user-guide/services.md#defining-a-service</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod&#8217;s container ports. If this is not specified, the value of Port is used (an identity map). Defaults to the service port. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/services.md#defining-a-service">http://releases.k8s.io/release-1.1/docs/user-guide/services.md#defining-a-service</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">nodePort</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The port on each node on which this service is exposed when type=NodePort or LoadBalancer. Usually assigned by the system. If specified, it will be allocated to the service if unused or else creation of the service will fail. Default is to auto-allocate a port if the ServiceType of this Service requires one. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/services.md#type&#8212;nodeport">http://releases.k8s.io/v1.1.0/docs/user-guide/services.md#type&#8212;nodeport</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The port on each node on which this service is exposed when type=NodePort or LoadBalancer. Usually assigned by the system. If specified, it will be allocated to the service if unused or else creation of the service will fail. Default is to auto-allocate a port if the ServiceType of this Service requires one. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/services.md#type&#8212;nodeport">http://releases.k8s.io/release-1.1/docs/user-guide/services.md#type&#8212;nodeport</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5019,21 +5019,21 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_unversioned_listmeta">unversioned.ListMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5074,7 +5074,7 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">path</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Path of the directory on the host. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#hostpath">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#hostpath</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Path of the directory on the host. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#hostpath">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#hostpath</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5146,21 +5146,21 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5277,21 +5277,21 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">volumeID</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">volume id used to identify the volume in cinder More info: <a href="http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md">http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">volume id used to identify the volume in cinder More info: <a href="http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md">http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">fsType</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Required: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Only ext3 and ext4 are allowed More info: <a href="http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md">http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Required: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Only ext3 and ext4 are allowed More info: <a href="http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md">http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">readOnly</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: <a href="http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md">http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: <a href="http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md">http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">boolean</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
@@ -5325,28 +5325,28 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">capabilities</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The linux kernel capabilites that should be added or removed. Default to Container.Capabilities if left unset. More info: <a href="http://releases.k8s.io/v1.1.0/docs/design/security_context.md#security-context">http://releases.k8s.io/v1.1.0/docs/design/security_context.md#security-context</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The linux kernel capabilites that should be added or removed. Default to Container.Capabilities if left unset. More info: <a href="http://releases.k8s.io/release-1.1/docs/design/security_context.md#security-context">http://releases.k8s.io/release-1.1/docs/design/security_context.md#security-context</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_capabilities">v1.Capabilities</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">privileged</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Run the container in privileged mode. Default to Container.Privileged if left unset. More info: <a href="http://releases.k8s.io/v1.1.0/docs/design/security_context.md#security-context">http://releases.k8s.io/v1.1.0/docs/design/security_context.md#security-context</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Run the container in privileged mode. Default to Container.Privileged if left unset. More info: <a href="http://releases.k8s.io/release-1.1/docs/design/security_context.md#security-context">http://releases.k8s.io/release-1.1/docs/design/security_context.md#security-context</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">boolean</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">seLinuxOptions</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">SELinuxOptions are the labels to be applied to the container and volumes. Options that control the SELinux labels applied. More info: <a href="http://releases.k8s.io/v1.1.0/docs/design/security_context.md#security-context">http://releases.k8s.io/v1.1.0/docs/design/security_context.md#security-context</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SELinuxOptions are the labels to be applied to the container and volumes. Options that control the SELinux labels applied. More info: <a href="http://releases.k8s.io/release-1.1/docs/design/security_context.md#security-context">http://releases.k8s.io/release-1.1/docs/design/security_context.md#security-context</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_selinuxoptions">v1.SELinuxOptions</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">runAsUser</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">RunAsUser is the UID to run the entrypoint of the container process. The user id that runs the first process in the container. More info: <a href="http://releases.k8s.io/v1.1.0/docs/design/security_context.md#security-context">http://releases.k8s.io/v1.1.0/docs/design/security_context.md#security-context</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">RunAsUser is the UID to run the entrypoint of the container process. The user id that runs the first process in the container. More info: <a href="http://releases.k8s.io/release-1.1/docs/design/security_context.md#security-context">http://releases.k8s.io/release-1.1/docs/design/security_context.md#security-context</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int64)</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5438,14 +5438,14 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">volumeID</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">fsType</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5459,7 +5459,7 @@ The resulting set of endpoints can be viewed as:<br>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">readOnly</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore">http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore">http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">boolean</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
@@ -5528,7 +5528,7 @@ The resulting set of endpoints can be viewed as:<br>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">image</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The image the container is running. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/images.md">http://releases.k8s.io/v1.1.0/docs/user-guide/images.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The image the container is running. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/images.md">http://releases.k8s.io/release-1.1/docs/user-guide/images.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5542,7 +5542,7 @@ The resulting set of endpoints can be viewed as:<br>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">containerID</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Container&#8217;s ID in the format <em>docker://&lt;container_id&gt;</em>. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/container-environment.md#container-information">http://releases.k8s.io/v1.1.0/docs/user-guide/container-environment.md#container-information</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Container&#8217;s ID in the format <em>docker://&lt;container_id&gt;</em>. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/container-environment.md#container-information">http://releases.k8s.io/release-1.1/docs/user-guide/container-environment.md#container-information</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5576,28 +5576,28 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_unversioned_listmeta">unversioned.ListMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">items</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">List of replication controllers. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/replication-controller.md">http://releases.k8s.io/v1.1.0/docs/user-guide/replication-controller.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">List of replication controllers. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/replication-controller.md">http://releases.k8s.io/release-1.1/docs/user-guide/replication-controller.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_replicationcontroller">v1.ReplicationController</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5665,21 +5665,21 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5727,21 +5727,21 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5872,14 +5872,14 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">limits</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Limits describes the maximum amount of compute resources allowed. More info: <a href="http://releases.k8s.io/v1.1.0/docs/design/resources.md#resource-specifications">http://releases.k8s.io/v1.1.0/docs/design/resources.md#resource-specifications</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Limits describes the maximum amount of compute resources allowed. More info: <a href="http://releases.k8s.io/release-1.1/docs/design/resources.md#resource-specifications">http://releases.k8s.io/release-1.1/docs/design/resources.md#resource-specifications</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_any">any</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">requests</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: <a href="http://releases.k8s.io/v1.1.0/docs/design/resources.md#resource-specifications">http://releases.k8s.io/v1.1.0/docs/design/resources.md#resource-specifications</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: <a href="http://releases.k8s.io/release-1.1/docs/design/resources.md#resource-specifications">http://releases.k8s.io/release-1.1/docs/design/resources.md#resource-specifications</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_any">any</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5917,21 +5917,21 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -6041,14 +6041,14 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">spec</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Specification of the desired behavior of the pod. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Specification of the desired behavior of the pod. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_podspec">v1.PodSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -6082,28 +6082,28 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_unversioned_listmeta">unversioned.ListMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">items</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">List of pods. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/pods.md">http://releases.k8s.io/v1.1.0/docs/user-guide/pods.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">List of pods. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/pods.md">http://releases.k8s.io/release-1.1/docs/user-guide/pods.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_pod">v1.Pod</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -6137,21 +6137,21 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_unversioned_listmeta">unversioned.ListMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -6192,28 +6192,28 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_unversioned_listmeta">unversioned.ListMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">items</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">List of persistent volumes. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md">http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">List of persistent volumes. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md">http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_persistentvolume">v1.PersistentVolume</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -6247,28 +6247,28 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind of the referent. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind of the referent. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">namespace</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Namespace of the referent. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/namespaces.md">http://releases.k8s.io/v1.1.0/docs/user-guide/namespaces.md</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Namespace of the referent. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/namespaces.md">http://releases.k8s.io/release-1.1/docs/user-guide/namespaces.md</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">name</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Name of the referent. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#names">http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#names</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Name of the referent. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#names">http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#names</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">uid</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">UID of the referent. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#uids">http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#uids</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">UID of the referent. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#uids">http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#uids</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -6282,7 +6282,7 @@ The resulting set of endpoints can be viewed as:<br>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">resourceVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Specific resourceVersion to which this reference is made, if any. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#concurrency-control-and-consistency">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#concurrency-control-and-consistency</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Specific resourceVersion to which this reference is made, if any. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#concurrency-control-and-consistency">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#concurrency-control-and-consistency</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -6323,28 +6323,28 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard list metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_unversioned_listmeta">unversioned.ListMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Status of the operation. One of: "Success" or "Failure". More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Status of the operation. One of: "Success" or "Failure". More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -6530,28 +6530,28 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">ports</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The list of ports that are exposed by this service. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/services.md#virtual-ips-and-service-proxies">http://releases.k8s.io/v1.1.0/docs/user-guide/services.md#virtual-ips-and-service-proxies</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The list of ports that are exposed by this service. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/services.md#virtual-ips-and-service-proxies">http://releases.k8s.io/release-1.1/docs/user-guide/services.md#virtual-ips-and-service-proxies</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_serviceport">v1.ServicePort</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">selector</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">This service will route traffic to pods having labels matching this selector. Label keys and values that must match in order to receive traffic for this service. If empty, all pods are selected, if not specified, endpoints must be manually specified. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/services.md#overview">http://releases.k8s.io/v1.1.0/docs/user-guide/services.md#overview</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">This service will route traffic to pods having labels matching this selector. Label keys and values that must match in order to receive traffic for this service. If empty, all pods are selected, if not specified, endpoints must be manually specified. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/services.md#overview">http://releases.k8s.io/release-1.1/docs/user-guide/services.md#overview</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_any">any</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">clusterIP</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">ClusterIP is usually assigned by the master and is the IP address of the service. If specified, it will be allocated to the service if it is unused or else creation of the service will fail. Valid values are None, empty string (""), or a valid IP address. <em>None</em> can be specified for a headless service when proxying is not required. Cannot be updated. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/services.md#virtual-ips-and-service-proxies">http://releases.k8s.io/v1.1.0/docs/user-guide/services.md#virtual-ips-and-service-proxies</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">ClusterIP is usually assigned by the master and is the IP address of the service. If specified, it will be allocated to the service if it is unused or else creation of the service will fail. Valid values are None, empty string (""), or a valid IP address. <em>None</em> can be specified for a headless service when proxying is not required. Cannot be updated. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/services.md#virtual-ips-and-service-proxies">http://releases.k8s.io/release-1.1/docs/user-guide/services.md#virtual-ips-and-service-proxies</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">type</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Type of exposed service. Must be ClusterIP, NodePort, or LoadBalancer. Defaults to ClusterIP. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/services.md#external-services">http://releases.k8s.io/v1.1.0/docs/user-guide/services.md#external-services</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Type of exposed service. Must be ClusterIP, NodePort, or LoadBalancer. Defaults to ClusterIP. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/services.md#external-services">http://releases.k8s.io/release-1.1/docs/user-guide/services.md#external-services</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -6572,7 +6572,7 @@ The resulting set of endpoints can be viewed as:<br>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">sessionAffinity</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: <a href="http://releases.k8s.io/v1.1.0/docs/user-guide/services.md#virtual-ips-and-service-proxies">http://releases.k8s.io/v1.1.0/docs/user-guide/services.md#virtual-ips-and-service-proxies</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: <a href="http://releases.k8s.io/release-1.1/docs/user-guide/services.md#virtual-ips-and-service-proxies">http://releases.k8s.io/release-1.1/docs/user-guide/services.md#virtual-ips-and-service-proxies</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -6613,35 +6613,35 @@ The resulting set of endpoints can be viewed as:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">kind</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">apiVersion</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">metadata</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Standard object&#8217;s metadata. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectmeta">v1.ObjectMeta</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">spec</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Specification of the desired behavior of the pod. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Specification of the desired behavior of the pod. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_podspec">v1.PodSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Most recently observed status of the pod. This data may not be up to date. Populated by the system. Read-only. More info: <a href="http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Most recently observed status of the pod. This data may not be up to date. Populated by the system. Read-only. More info: <a href="http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status">http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_podstatus">v1.PodStatus</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -6696,7 +6696,7 @@ The resulting set of endpoints can be viewed as:<br>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">unschedulable</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Unschedulable controls node schedulability of new pods. By default, node is schedulable. More info: <a href="http://releases.k8s.io/v1.1.0/docs/admin/node.md#manual-node-administration"`">http://releases.k8s.io/v1.1.0/docs/admin/node.md#manual-node-administration"`</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Unschedulable controls node schedulability of new pods. By default, node is schedulable. More info: <a href="http://releases.k8s.io/release-1.1/docs/admin/node.md#manual-node-administration"`">http://releases.k8s.io/release-1.1/docs/admin/node.md#manual-node-administration"`</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">boolean</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>

--- a/docs/design/admission_control_limit_range.md
+++ b/docs/design/admission_control_limit_range.md
@@ -61,11 +61,11 @@ type LimitRangeSpec struct {
 type LimitRange struct {
   TypeMeta `json:",inline"`
   // Standard object's metadata.
-  // More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+  // More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
   ObjectMeta `json:"metadata,omitempty"`
 
   // Spec defines the limits enforced.
-  // More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status
+  // More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status
   Spec LimitRangeSpec `json:"spec,omitempty"`
 }
 
@@ -73,11 +73,11 @@ type LimitRange struct {
 type LimitRangeList struct {
   TypeMeta `json:",inline"`
   // Standard list metadata.
-  // More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds
+  // More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds
   ListMeta `json:"metadata,omitempty"`
 
   // Items is a list of LimitRange objects.
-  // More info: http://releases.k8s.io/v1.1.0/docs/design/admission_control_limit_range.md
+  // More info: http://releases.k8s.io/release-1.1/docs/design/admission_control_limit_range.md
   Items []LimitRange `json:"items"`
 }
 ```

--- a/docs/design/admission_control_resource_quota.md
+++ b/docs/design/admission_control_resource_quota.md
@@ -39,13 +39,13 @@ const (
 // ResourceQuotaSpec defines the desired hard limits to enforce for Quota
 type ResourceQuotaSpec struct {
   // Hard is the set of desired hard limits for each named resource
-  Hard ResourceList `json:"hard,omitempty" description:"hard is the set of desired hard limits for each named resource; see http://releases.k8s.io/v1.1.0/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota"`
+  Hard ResourceList `json:"hard,omitempty" description:"hard is the set of desired hard limits for each named resource; see http://releases.k8s.io/release-1.1/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota"`
 }
 
 // ResourceQuotaStatus defines the enforced hard limits and observed use
 type ResourceQuotaStatus struct {
   // Hard is the set of enforced hard limits for each named resource
-  Hard ResourceList `json:"hard,omitempty" description:"hard is the set of enforced hard limits for each named resource; see http://releases.k8s.io/v1.1.0/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota"`
+  Hard ResourceList `json:"hard,omitempty" description:"hard is the set of enforced hard limits for each named resource; see http://releases.k8s.io/release-1.1/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota"`
   // Used is the current observed total usage of the resource in the namespace
   Used ResourceList `json:"used,omitempty" description:"used is the current observed total usage of the resource in the namespace"`
 }
@@ -53,22 +53,22 @@ type ResourceQuotaStatus struct {
 // ResourceQuota sets aggregate quota restrictions enforced per namespace
 type ResourceQuota struct {
   TypeMeta   `json:",inline"`
-  ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata"`
+  ObjectMeta `json:"metadata,omitempty" description:"standard object metadata; see http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata"`
 
   // Spec defines the desired quota
-  Spec ResourceQuotaSpec `json:"spec,omitempty" description:"spec defines the desired quota; http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status"`
+  Spec ResourceQuotaSpec `json:"spec,omitempty" description:"spec defines the desired quota; http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status"`
 
   // Status defines the actual enforced quota and its current usage
-  Status ResourceQuotaStatus `json:"status,omitempty" description:"status defines the actual enforced quota and current usage; http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status"`
+  Status ResourceQuotaStatus `json:"status,omitempty" description:"status defines the actual enforced quota and current usage; http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status"`
 }
 
 // ResourceQuotaList is a list of ResourceQuota items
 type ResourceQuotaList struct {
   TypeMeta `json:",inline"`
-  ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata"`
+  ListMeta `json:"metadata,omitempty" description:"standard list metadata; see http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata"`
 
   // Items is a list of ResourceQuota objects
-  Items []ResourceQuota `json:"items" description:"items is a list of ResourceQuota objects; see http://releases.k8s.io/v1.1.0/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota"`
+  Items []ResourceQuota `json:"items" description:"items is a list of ResourceQuota objects; see http://releases.k8s.io/release-1.1/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota"`
 }
 ```
 

--- a/docs/design/event_compression.md
+++ b/docs/design/event_compression.md
@@ -20,7 +20,7 @@ Event compression should be best effort (not guaranteed). Meaning, in the worst 
 
 ## Design
 
-Instead of a single Timestamp, each event object [contains](http://releases.k8s.io/v1.1.0/pkg/api/types.go#L1111) the following fields:
+Instead of a single Timestamp, each event object [contains](http://releases.k8s.io/release-1.1/pkg/api/types.go#L1111) the following fields:
  * `FirstTimestamp unversioned.Time`
    * The date/time of the first occurrence of the event.
  * `LastTimestamp unversioned.Time`
@@ -44,7 +44,7 @@ Each binary that generates events:
      * `event.Reason`
      * `event.Message`
    * The LRU cache is capped at 4096 events. That means if a component (e.g. kubelet) runs for a long period of time and generates tons of unique events, the previously generated events cache will not grow unchecked in memory. Instead, after 4096 unique events are generated, the oldest events are evicted from the cache.
- * When an event is generated, the previously generated events cache is checked (see [`pkg/client/unversioned/record/event.go`](http://releases.k8s.io/v1.1.0/pkg/client/unversioned/record/event.go)).
+ * When an event is generated, the previously generated events cache is checked (see [`pkg/client/unversioned/record/event.go`](http://releases.k8s.io/release-1.1/pkg/client/unversioned/record/event.go)).
    * If the key for the new event matches the key for a previously generated event (meaning all of the above fields match between the new event and some previously generated event), then the event is considered to be a duplicate and the existing event entry is updated in etcd:
      * The new PUT (update) event API is called to update the existing event entry in etcd with the new last seen timestamp and count.
      * The event is also updated in the previously generated events cache with an incremented count, updated last seen timestamp, name, and new resource version (all required to issue a future event update).

--- a/docs/design/horizontal-pod-autoscaler.md
+++ b/docs/design/horizontal-pod-autoscaler.md
@@ -12,7 +12,7 @@ The autoscaler (implemented as a Kubernetes API resource and controller) is resp
 the number of replicas of some collection (e.g. the pods of a ReplicationController) to meet some objective(s),
 for example a target per-pod CPU utilization.
 
-This design supersedes [autoscaling.md](http://releases.k8s.io/v1.1.0/docs/proposals/autoscaling.md).
+This design supersedes [autoscaling.md](http://releases.k8s.io/release-1.1/docs/proposals/autoscaling.md).
 
 ## Overview
 

--- a/docs/devel/cherry-picks.md
+++ b/docs/devel/cherry-picks.md
@@ -26,7 +26,7 @@ particular, they may be self-merged by the release branch owner without fanfare,
 in the case the release branch owner knows the cherry pick was already
 requested - this should not be the norm, but it may happen.
 
-[Contributor License Agreements](http://releases.k8s.io/v1.1.0/CONTRIBUTING.md) is considered implicit
+[Contributor License Agreements](http://releases.k8s.io/release-1.1/CONTRIBUTING.md) is considered implicit
 for all code within cherry-pick pull requests, ***unless there is a large
 conflict***.
 

--- a/docs/devel/client-libraries.md
+++ b/docs/devel/client-libraries.md
@@ -7,7 +7,7 @@
 
 ### Supported
 
-   * [Go](http://releases.k8s.io/v1.1.0/pkg/client/)
+   * [Go](http://releases.k8s.io/release-1.1/pkg/client/)
 
 ### User Contributed
 

--- a/docs/devel/development.md
+++ b/docs/devel/development.md
@@ -7,7 +7,7 @@
 
 # Releases and Official Builds
 
-Official releases are built in Docker containers.  Details are [here](http://releases.k8s.io/v1.1.0/build/README.md).  You can do simple builds and development with just a local Docker installation.  If want to build go locally outside of docker, please continue below.
+Official releases are built in Docker containers.  Details are [here](http://releases.k8s.io/release-1.1/build/README.md).  You can do simple builds and development with just a local Docker installation.  If want to build go locally outside of docker, please continue below.
 
 ## Go development environment
 
@@ -319,7 +319,7 @@ The conformance test runs a subset of the e2e-tests against a manually-created c
 require support for up/push/down and other operations.  To run a conformance test, you need to know the
 IP of the master for your cluster and the authorization arguments to use.  The conformance test is
 intended to run against a cluster at a specific binary release of Kubernetes.
-See [conformance-test.sh](http://releases.k8s.io/v1.1.0/hack/conformance-test.sh).
+See [conformance-test.sh](http://releases.k8s.io/release-1.1/hack/conformance-test.sh).
 
 ## Testing out flaky tests
 

--- a/docs/devel/getting-builds.md
+++ b/docs/devel/getting-builds.md
@@ -5,7 +5,7 @@
 
 # Getting Kubernetes Builds
 
-You can use [hack/get-build.sh](http://releases.k8s.io/v1.1.0/hack/get-build.sh) to or use as a reference on how to get the most recent builds with curl. With `get-build.sh` you can grab the most recent stable build, the most recent release candidate, or the most recent build to pass our ci and gce e2e tests (essentially a nightly build).
+You can use [hack/get-build.sh](http://releases.k8s.io/release-1.1/hack/get-build.sh) to or use as a reference on how to get the most recent builds with curl. With `get-build.sh` you can grab the most recent stable build, the most recent release candidate, or the most recent build to pass our ci and gce e2e tests (essentially a nightly build).
 
 ```console
 usage:

--- a/docs/devel/scheduler.md
+++ b/docs/devel/scheduler.md
@@ -25,30 +25,30 @@ divided by the node's capacity).
 Finally, the node with the highest priority is chosen
 (or, if there are multiple such nodes, then one of them is chosen at random). The code
 for this main scheduling loop is in the function `Schedule()` in
-[plugin/pkg/scheduler/generic_scheduler.go](http://releases.k8s.io/v1.1.0/plugin/pkg/scheduler/generic_scheduler.go)
+[plugin/pkg/scheduler/generic_scheduler.go](http://releases.k8s.io/release-1.1/plugin/pkg/scheduler/generic_scheduler.go)
 
 ## Scheduler extensibility
 
 The scheduler is extensible: the cluster administrator can choose which of the pre-defined
 scheduling policies to apply, and can add new ones. The built-in predicates and priorities are
-defined in [plugin/pkg/scheduler/algorithm/predicates/predicates.go](http://releases.k8s.io/v1.1.0/plugin/pkg/scheduler/algorithm/predicates/predicates.go) and
-[plugin/pkg/scheduler/algorithm/priorities/priorities.go](http://releases.k8s.io/v1.1.0/plugin/pkg/scheduler/algorithm/priorities/priorities.go), respectively.
+defined in [plugin/pkg/scheduler/algorithm/predicates/predicates.go](http://releases.k8s.io/release-1.1/plugin/pkg/scheduler/algorithm/predicates/predicates.go) and
+[plugin/pkg/scheduler/algorithm/priorities/priorities.go](http://releases.k8s.io/release-1.1/plugin/pkg/scheduler/algorithm/priorities/priorities.go), respectively.
 The policies that are applied when scheduling can be chosen in one of two ways. Normally,
 the policies used are selected by the functions `defaultPredicates()` and `defaultPriorities()` in
-[plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go](http://releases.k8s.io/v1.1.0/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go).
+[plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go](http://releases.k8s.io/release-1.1/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go).
 However, the choice of policies
 can be overridden by passing the command-line flag `--policy-config-file` to the scheduler, pointing to a JSON
 file specifying which scheduling policies to use. See
 [examples/scheduler-policy-config.json](../../examples/scheduler-policy-config.json) for an example
 config file. (Note that the config file format is versioned; the API is defined in
-[plugin/pkg/scheduler/api](http://releases.k8s.io/v1.1.0/plugin/pkg/scheduler/api/)).
+[plugin/pkg/scheduler/api](http://releases.k8s.io/release-1.1/plugin/pkg/scheduler/api/)).
 Thus to add a new scheduling policy, you should modify predicates.go or priorities.go,
 and either register the policy in `defaultPredicates()` or `defaultPriorities()`, or use a policy config file.
 
 ## Exploring the code
 
 If you want to get a global picture of how the scheduler works, you can start in
-[plugin/cmd/kube-scheduler/app/server.go](http://releases.k8s.io/v1.1.0/plugin/cmd/kube-scheduler/app/server.go)
+[plugin/cmd/kube-scheduler/app/server.go](http://releases.k8s.io/release-1.1/plugin/cmd/kube-scheduler/app/server.go)
 
 
 

--- a/docs/devel/scheduler_algorithm.md
+++ b/docs/devel/scheduler_algorithm.md
@@ -18,7 +18,7 @@ The purpose of filtering the nodes is to filter out the nodes that do not meet c
 - `PodSelectorMatches`: Check if the labels of the node match the labels specified in the Pod's `nodeSelector` field ([Here](../user-guide/node-selection/) is an example of how to use `nodeSelector` field).
 - `CheckNodeLabelPresence`: Check if all the specified labels exist on a node or not, regardless of the value.
 
-The details of the above predicates can be found in [plugin/pkg/scheduler/algorithm/predicates/predicates.go](http://releases.k8s.io/v1.1.0/plugin/pkg/scheduler/algorithm/predicates/predicates.go). All predicates mentioned above can be used in combination to perform a sophisticated filtering policy. Kubernetes uses some, but not all, of these predicates by default. You can see which ones are used by default in [plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go](http://releases.k8s.io/v1.1.0/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go).
+The details of the above predicates can be found in [plugin/pkg/scheduler/algorithm/predicates/predicates.go](http://releases.k8s.io/release-1.1/plugin/pkg/scheduler/algorithm/predicates/predicates.go). All predicates mentioned above can be used in combination to perform a sophisticated filtering policy. Kubernetes uses some, but not all, of these predicates by default. You can see which ones are used by default in [plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go](http://releases.k8s.io/release-1.1/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go).
 
 ## Ranking the nodes
 
@@ -36,7 +36,7 @@ Currently, Kubernetes scheduler provides some practical priority functions, incl
 - `CalculateSpreadPriority`: Spread Pods by minimizing the number of Pods belonging to the same service on the same node.
 - `CalculateAntiAffinityPriority`: Spread Pods by minimizing the number of Pods belonging to the same service on nodes with the same value for a particular label.
 
-The details of the above priority functions can be found in [plugin/pkg/scheduler/algorithm/priorities](http://releases.k8s.io/v1.1.0/plugin/pkg/scheduler/algorithm/priorities/). Kubernetes uses some, but not all, of these priority functions by default. You can see which ones are used by default in [plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go](http://releases.k8s.io/v1.1.0/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go). Similar as predicates, you can combine the above priority functions and assign weight factors (positive number) to them as you want (check [scheduler.md](scheduler.md) for how to customize).
+The details of the above priority functions can be found in [plugin/pkg/scheduler/algorithm/priorities](http://releases.k8s.io/release-1.1/plugin/pkg/scheduler/algorithm/priorities/). Kubernetes uses some, but not all, of these priority functions by default. You can see which ones are used by default in [plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go](http://releases.k8s.io/release-1.1/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go). Similar as predicates, you can combine the above priority functions and assign weight factors (positive number) to them as you want (check [scheduler.md](scheduler.md) for how to customize).
 
 
 

--- a/docs/getting-started-guides/aws.md
+++ b/docs/getting-started-guides/aws.md
@@ -42,16 +42,16 @@ export KUBERNETES_PROVIDER=aws; wget -q -O - https://get.k8s.io | bash
 export KUBERNETES_PROVIDER=aws; curl -sS https://get.k8s.io | bash
 ```
 
-NOTE: This script calls [cluster/kube-up.sh](http://releases.k8s.io/v1.1.0/cluster/kube-up.sh)
-which in turn calls [cluster/aws/util.sh](http://releases.k8s.io/v1.1.0/cluster/aws/util.sh)
-using [cluster/aws/config-default.sh](http://releases.k8s.io/v1.1.0/cluster/aws/config-default.sh).
+NOTE: This script calls [cluster/kube-up.sh](http://releases.k8s.io/release-1.1/cluster/kube-up.sh)
+which in turn calls [cluster/aws/util.sh](http://releases.k8s.io/release-1.1/cluster/aws/util.sh)
+using [cluster/aws/config-default.sh](http://releases.k8s.io/release-1.1/cluster/aws/config-default.sh).
 
 This process takes about 5 to 10 minutes. Once the cluster is up, the IP addresses of your master and node(s) will be printed,
 as well as information about the default services running in the cluster (monitoring, logging, dns). User credentials and security
 tokens are written in `~/.kube/config`, they will be necessary to use the CLI or the HTTP Basic Auth.
 
 By default, the script will provision a new VPC and a 4 node k8s cluster in us-west-2a (Oregon) with `t2.micro` instances running on Ubuntu.
-You can override the variables defined in [config-default.sh](http://releases.k8s.io/v1.1.0/cluster/aws/config-default.sh) to change this behavior as follows:
+You can override the variables defined in [config-default.sh](http://releases.k8s.io/release-1.1/cluster/aws/config-default.sh) to change this behavior as follows:
 
 ```bash
 export KUBE_AWS_ZONE=eu-west-1c

--- a/docs/getting-started-guides/binary_release.md
+++ b/docs/getting-started-guides/binary_release.md
@@ -25,7 +25,7 @@ cd kubernetes
 make release
 ```
 
-For more details on the release process see the [`build/` directory](http://releases.k8s.io/v1.1.0/build/)
+For more details on the release process see the [`build/` directory](http://releases.k8s.io/release-1.1/build/)
 
 
 

--- a/docs/getting-started-guides/gce.md
+++ b/docs/getting-started-guides/gce.md
@@ -58,7 +58,7 @@ wget -q -O - https://get.k8s.io | bash
 
 Once this command completes, you will have a master VM and four worker VMs, running as a Kubernetes cluster.
 
-By default, some containers will already be running on your cluster. Containers like `kibana` and `elasticsearch` provide [logging](logging.md), while `heapster` provides [monitoring](http://releases.k8s.io/v1.1.0/cluster/addons/cluster-monitoring/README.md) services.
+By default, some containers will already be running on your cluster. Containers like `kibana` and `elasticsearch` provide [logging](logging.md), while `heapster` provides [monitoring](http://releases.k8s.io/release-1.1/cluster/addons/cluster-monitoring/README.md) services.
 
 The script run by the commands above creates a cluster with the name/prefix "kubernetes". It defines one specific cluster config, so you can't run it more than once.
 

--- a/docs/getting-started-guides/juju.md
+++ b/docs/getting-started-guides/juju.md
@@ -213,7 +213,7 @@ or destroy your current Juju environment (using the `juju env` command):
 The Kubernetes charms and bundles can be found in the `kubernetes` project on
 github.com:
 
- - [Bundle Repository](http://releases.k8s.io/v1.1.0/cluster/juju/bundles)
+ - [Bundle Repository](http://releases.k8s.io/release-1.1/cluster/juju/bundles)
    * [Kubernetes master charm](../../cluster/juju/charms/trusty/kubernetes-master/)
    * [Kubernetes node charm](../../cluster/juju/charms/trusty/kubernetes/)
  - [More about Juju](https://jujucharms.com)

--- a/docs/getting-started-guides/logging.md
+++ b/docs/getting-started-guides/logging.md
@@ -217,7 +217,7 @@ $ cat 21\:00\:00_21\:59\:59_S0.json | jq '.structPayload.log'
 ...
 ```
 
-This page has touched briefly on the underlying mechanisms that support gathering cluster level logs on a Kubernetes deployment. The approach here only works for gathering the standard output and standard error output of the processes running in the pod’s containers. To gather other logs that are stored in files one can use a sidecar container to gather the required files as described at the page [Collecting log files within containers with Fluentd](http://releases.k8s.io/v1.1.0/contrib/logging/fluentd-sidecar-gcp/README.md) and sending them to the Google Cloud Logging service.
+This page has touched briefly on the underlying mechanisms that support gathering cluster level logs on a Kubernetes deployment. The approach here only works for gathering the standard output and standard error output of the processes running in the pod’s containers. To gather other logs that are stored in files one can use a sidecar container to gather the required files as described at the page [Collecting log files within containers with Fluentd](http://releases.k8s.io/release-1.1/contrib/logging/fluentd-sidecar-gcp/README.md) and sending them to the Google Cloud Logging service.
 
 Some of the material in this section also appears in the blog article [Cluster Level Logging with Kubernetes](http://blog.kubernetes.io/2015/06/cluster-level-logging-with-kubernetes.html).
 

--- a/docs/getting-started-guides/scratch.md
+++ b/docs/getting-started-guides/scratch.md
@@ -837,7 +837,7 @@ At this point you should be able to run through one of the basic examples, such 
 
 ### Running the Conformance Test
 
-You may want to try to run the [Conformance test](http://releases.k8s.io/v1.1.0/hack/conformance-test.sh).  Any failures may give a hint as to areas that need more attention.
+You may want to try to run the [Conformance test](http://releases.k8s.io/release-1.1/hack/conformance-test.sh).  Any failures may give a hint as to areas that need more attention.
 
 ### Networking
 

--- a/docs/man/man1/kubectl-autoscale.1
+++ b/docs/man/man1/kubectl-autoscale.1
@@ -57,7 +57,7 @@ An autoscaler can automatically increase or decrease number of pods deployed wit
 \fB\-o\fP, \fB\-\-output\fP=""
     Output format. One of: json|yaml|wide|name|go\-template=...|go\-template\-file=...|jsonpath=...|jsonpath\-file=... See golang template [
 \[la]http://golang.org/pkg/text/template/#pkg-overview\[ra]] and jsonpath template [
-\[la]http://releases.k8s.io/v1.1.0/docs/user-guide/jsonpath.md\[ra]].
+\[la]http://releases.k8s.io/release-1.1/docs/user-guide/jsonpath.md\[ra]].
 
 .PP
 \fB\-\-output\-version\fP=""

--- a/docs/man/man1/kubectl-config-view.1
+++ b/docs/man/man1/kubectl-config-view.1
@@ -40,7 +40,7 @@ You can use \-\-output=template \-\-template=TEMPLATE to extract specific values
 \fB\-o\fP, \fB\-\-output\fP=""
     Output format. One of: json|yaml|wide|name|go\-template=...|go\-template\-file=...|jsonpath=...|jsonpath\-file=... See golang template [
 \[la]http://golang.org/pkg/text/template/#pkg-overview\[ra]] and jsonpath template [
-\[la]http://releases.k8s.io/v1.1.0/docs/user-guide/jsonpath.md\[ra]].
+\[la]http://releases.k8s.io/release-1.1/docs/user-guide/jsonpath.md\[ra]].
 
 .PP
 \fB\-\-output\-version\fP=""

--- a/docs/man/man1/kubectl-expose.1
+++ b/docs/man/man1/kubectl-expose.1
@@ -66,7 +66,7 @@ re\-use the labels from the resource it exposes.
 \fB\-o\fP, \fB\-\-output\fP=""
     Output format. One of: json|yaml|wide|name|go\-template=...|go\-template\-file=...|jsonpath=...|jsonpath\-file=... See golang template [
 \[la]http://golang.org/pkg/text/template/#pkg-overview\[ra]] and jsonpath template [
-\[la]http://releases.k8s.io/v1.1.0/docs/user-guide/jsonpath.md\[ra]].
+\[la]http://releases.k8s.io/release-1.1/docs/user-guide/jsonpath.md\[ra]].
 
 .PP
 \fB\-\-output\-version\fP=""

--- a/docs/man/man1/kubectl-get.1
+++ b/docs/man/man1/kubectl-get.1
@@ -47,7 +47,7 @@ of the \-\-template flag, you can filter the attributes of the fetched resource(
 \fB\-o\fP, \fB\-\-output\fP=""
     Output format. One of: json|yaml|wide|name|go\-template=...|go\-template\-file=...|jsonpath=...|jsonpath\-file=... See golang template [
 \[la]http://golang.org/pkg/text/template/#pkg-overview\[ra]] and jsonpath template [
-\[la]http://releases.k8s.io/v1.1.0/docs/user-guide/jsonpath.md\[ra]].
+\[la]http://releases.k8s.io/release-1.1/docs/user-guide/jsonpath.md\[ra]].
 
 .PP
 \fB\-\-output\-version\fP=""

--- a/docs/man/man1/kubectl-label.1
+++ b/docs/man/man1/kubectl-label.1
@@ -42,7 +42,7 @@ If \-\-resource\-version is specified, then updates will use this resource versi
 \fB\-o\fP, \fB\-\-output\fP=""
     Output format. One of: json|yaml|wide|name|go\-template=...|go\-template\-file=...|jsonpath=...|jsonpath\-file=... See golang template [
 \[la]http://golang.org/pkg/text/template/#pkg-overview\[ra]] and jsonpath template [
-\[la]http://releases.k8s.io/v1.1.0/docs/user-guide/jsonpath.md\[ra]].
+\[la]http://releases.k8s.io/release-1.1/docs/user-guide/jsonpath.md\[ra]].
 
 .PP
 \fB\-\-output\-version\fP=""

--- a/docs/man/man1/kubectl-patch.1
+++ b/docs/man/man1/kubectl-patch.1
@@ -20,7 +20,7 @@ JSON and YAML formats are accepted.
 
 .PP
 Please refer to the models in 
-\[la]https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/blob/v1.1.0/docs/api-reference/v1/definitions.html\[ra] to find if a field is mutable.
+\[la]https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/release-1.1/docs/api-reference/v1/definitions.html\[ra] to find if a field is mutable.
 
 
 .SH OPTIONS

--- a/docs/man/man1/kubectl-replace.1
+++ b/docs/man/man1/kubectl-replace.1
@@ -22,7 +22,7 @@ $ kubectl get TYPE NAME \-o yaml
 
 .PP
 Please refer to the models in 
-\[la]https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/blob/v1.1.0/docs/api-reference/v1/definitions.html\[ra] to find if a field is mutable.
+\[la]https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/release-1.1/docs/api-reference/v1/definitions.html\[ra] to find if a field is mutable.
 
 
 .SH OPTIONS

--- a/docs/man/man1/kubectl-rolling-update.1
+++ b/docs/man/man1/kubectl-rolling-update.1
@@ -46,7 +46,7 @@ existing replication controller and overwrite at least one (common) label in its
 \fB\-o\fP, \fB\-\-output\fP=""
     Output format. One of: json|yaml|wide|name|go\-template=...|go\-template\-file=...|jsonpath=...|jsonpath\-file=... See golang template [
 \[la]http://golang.org/pkg/text/template/#pkg-overview\[ra]] and jsonpath template [
-\[la]http://releases.k8s.io/v1.1.0/docs/user-guide/jsonpath.md\[ra]].
+\[la]http://releases.k8s.io/release-1.1/docs/user-guide/jsonpath.md\[ra]].
 
 .PP
 \fB\-\-output\-version\fP=""

--- a/docs/man/man1/kubectl-run.1
+++ b/docs/man/man1/kubectl-run.1
@@ -66,7 +66,7 @@ Creates a replication controller to manage the created container(s).
 \fB\-o\fP, \fB\-\-output\fP=""
     Output format. One of: json|yaml|wide|name|go\-template=...|go\-template\-file=...|jsonpath=...|jsonpath\-file=... See golang template [
 \[la]http://golang.org/pkg/text/template/#pkg-overview\[ra]] and jsonpath template [
-\[la]http://releases.k8s.io/v1.1.0/docs/user-guide/jsonpath.md\[ra]].
+\[la]http://releases.k8s.io/release-1.1/docs/user-guide/jsonpath.md\[ra]].
 
 .PP
 \fB\-\-output\-version\fP=""

--- a/docs/user-guide/accessing-the-cluster.md
+++ b/docs/user-guide/accessing-the-cluster.md
@@ -120,7 +120,7 @@ with future high-availability support.
 
 There are [client libraries](../devel/client-libraries.md) for accessing the API
 from several languages.  The Kubernetes project-supported
-[Go](http://releases.k8s.io/v1.1.0/pkg/client/)
+[Go](http://releases.k8s.io/release-1.1/pkg/client/)
 client library can use the same [kubeconfig file](kubeconfig-file.md)
 as the kubectl CLI does to locate and authenticate to the apiserver.
 

--- a/docs/user-guide/compute-resources.md
+++ b/docs/user-guide/compute-resources.md
@@ -126,7 +126,7 @@ To determine if a container cannot be scheduled or is being killed due to resour
 
 The resource usage of a pod is reported as part of the Pod status.
 
-If [optional monitoring](http://releases.k8s.io/v1.1.0/cluster/addons/cluster-monitoring/README.md) is configured for your cluster,
+If [optional monitoring](http://releases.k8s.io/release-1.1/cluster/addons/cluster-monitoring/README.md) is configured for your cluster,
 then pod resource usage can be retrieved from the monitoring system.
 
 ## Troubleshooting

--- a/docs/user-guide/configuring-containers.md
+++ b/docs/user-guide/configuring-containers.md
@@ -81,7 +81,7 @@ pods/hello-world
 
 `kubectl create --validate` currently warns about problems it detects, but creates the resource anyway, unless a required field is absent or a field value is invalid. Unknown API fields are ignored, so be careful. This pod was created, but with no `command`, which is an optional field, since the image may specify an `Entrypoint`.
 View the [Pod API
-object](https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/blob/v1.1.0/docs/api-reference/v1/definitions.html#_v1_pod)
+object](https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/release-1.1/docs/api-reference/v1/definitions.html#_v1_pod)
 to see the list of valid fields.
 
 ## Environment variables and variable expansion

--- a/docs/user-guide/connecting-applications.md
+++ b/docs/user-guide/connecting-applications.md
@@ -100,7 +100,7 @@ spec:
     app: nginx
 ```
 
-This specification will create a Service which targets TCP port 80 on any Pod with the `app=nginx` label, and expose it on an abstracted Service port (`targetPort`: is the port the container accepts traffic on, `port`: is the abstracted Service port, which can be any port other pods use to access the Service). View [service API object](https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/blob/v1.1.0/docs/api-reference/v1/definitions.html#_v1_service) to see the list of supported fields in service definition.
+This specification will create a Service which targets TCP port 80 on any Pod with the `app=nginx` label, and expose it on an abstracted Service port (`targetPort`: is the port the container accepts traffic on, `port`: is the abstracted Service port, which can be any port other pods use to access the Service). View [service API object](https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/release-1.1/docs/api-reference/v1/definitions.html#_v1_service) to see the list of supported fields in service definition.
 Check your Service:
 
 ```console
@@ -134,7 +134,7 @@ You should now be able to curl the nginx Service on `10.0.116.146:80` from any n
 
 ## Accessing the Service
 
-Kubernetes supports 2 primary modes of finding a Service - environment variables and DNS. The former works out of the box while the latter requires the [kube-dns cluster addon](http://releases.k8s.io/v1.1.0/cluster/addons/dns/README.md).
+Kubernetes supports 2 primary modes of finding a Service - environment variables and DNS. The former works out of the box while the latter requires the [kube-dns cluster addon](http://releases.k8s.io/release-1.1/cluster/addons/dns/README.md).
 
 ### Environment Variables
 
@@ -172,7 +172,7 @@ NAME       CLUSTER_IP      EXTERNAL_IP   PORT(S)         SELECTOR           AGE
 kube-dns   10.179.240.10   <none>        53/UDP,53/TCP   k8s-app=kube-dns   8d
 ```
 
-If it isn’t running, you can [enable it](http://releases.k8s.io/v1.1.0/cluster/addons/dns/README.md#how-do-i-configure-it). The rest of this section will assume you have a Service with a long lived IP (nginxsvc), and a dns server that has assigned a name to that IP (the kube-dns cluster addon), so you can talk to the Service from any pod in your cluster using standard methods (e.g. gethostbyname). Let’s create another pod to test this:
+If it isn’t running, you can [enable it](http://releases.k8s.io/release-1.1/cluster/addons/dns/README.md#how-do-i-configure-it). The rest of this section will assume you have a Service with a long lived IP (nginxsvc), and a dns server that has assigned a name to that IP (the kube-dns cluster addon), so you can talk to the Service from any pod in your cluster using standard methods (e.g. gethostbyname). Let’s create another pod to test this:
 
 ```yaml
 $ cat curlpod.yaml

--- a/docs/user-guide/container-environment.md
+++ b/docs/user-guide/container-environment.md
@@ -57,7 +57,7 @@ FOO_SERVICE_HOST=<the host the service is running on>
 FOO_SERVICE_PORT=<the port the service is running on>
 ```
 
-Services have dedicated IP address, and are also surfaced to the container via DNS (If [DNS addon](http://releases.k8s.io/v1.1.0/cluster/addons/dns/) is enabled).  Of course DNS is still not an enumerable protocol, so we will continue to provide environment variables so that containers can do discovery.
+Services have dedicated IP address, and are also surfaced to the container via DNS (If [DNS addon](http://releases.k8s.io/release-1.1/cluster/addons/dns/) is enabled).  Of course DNS is still not an enumerable protocol, so we will continue to provide environment variables so that containers can do discovery.
 
 ## Container Hooks
 

--- a/docs/user-guide/deploying-applications.md
+++ b/docs/user-guide/deploying-applications.md
@@ -48,7 +48,7 @@ spec:
 
 Some differences compared to specifying just a pod are that the `kind` is `ReplicationController`, the number of `replicas` desired is specified, and the pod specification is under the `template` field. The names of the pods don’t need to be specified explicitly because they are generated from the name of the replication controller.
 View the [replication controller API
-object](https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/blob/v1.1.0/docs/api-reference/v1/definitions.html#_v1_replicationcontroller)
+object](https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/release-1.1/docs/api-reference/v1/definitions.html#_v1_replicationcontroller)
 to view the list of supported fields.
 
 This replication controller can be created using `create`, just as with pods:

--- a/docs/user-guide/kubectl/kubectl_autoscale.md
+++ b/docs/user-guide/kubectl/kubectl_autoscale.md
@@ -40,7 +40,7 @@ $ kubectl autoscale rc foo --max=5 --cpu-percent=80
       --min=-1: The lower limit for the number of pods that can be set by the autoscaler. If it's not specified or negative, the server will apply a default value.
       --name="": The name for the newly created object. If not specified, the name of the input resource will be used.
       --no-headers[=false]: When using the default output, don't print headers.
-  -o, --output="": Output format. One of: json|yaml|wide|name|go-template=...|go-template-file=...|jsonpath=...|jsonpath-file=... See golang template [http://golang.org/pkg/text/template/#pkg-overview] and jsonpath template [http://releases.k8s.io/v1.1.0/docs/user-guide/jsonpath.md].
+  -o, --output="": Output format. One of: json|yaml|wide|name|go-template=...|go-template-file=...|jsonpath=...|jsonpath-file=... See golang template [http://golang.org/pkg/text/template/#pkg-overview] and jsonpath template [http://releases.k8s.io/release-1.1/docs/user-guide/jsonpath.md].
       --output-version="": Output the formatted object with the given version (default api-version).
   -a, --show-all[=false]: When printing, show all resources (default hide terminated pods.)
       --sort-by="": If non-empty, sort list types using this field specification.  The field specification is expressed as a JSONPath expression (e.g. 'ObjectMeta.Name'). The field in the API resource specified by this JSONPath expression must be an integer or a string.

--- a/docs/user-guide/kubectl/kubectl_config_view.md
+++ b/docs/user-guide/kubectl/kubectl_config_view.md
@@ -35,7 +35,7 @@ $ kubectl config view -o template --template='{{range .users}}{{ if eq .name "e2
       --merge=true: merge together the full hierarchy of kubeconfig files
       --minify[=false]: remove all information not used by current-context from the output
       --no-headers[=false]: When using the default output, don't print headers.
-  -o, --output="": Output format. One of: json|yaml|wide|name|go-template=...|go-template-file=...|jsonpath=...|jsonpath-file=... See golang template [http://golang.org/pkg/text/template/#pkg-overview] and jsonpath template [http://releases.k8s.io/v1.1.0/docs/user-guide/jsonpath.md].
+  -o, --output="": Output format. One of: json|yaml|wide|name|go-template=...|go-template-file=...|jsonpath=...|jsonpath-file=... See golang template [http://golang.org/pkg/text/template/#pkg-overview] and jsonpath template [http://releases.k8s.io/release-1.1/docs/user-guide/jsonpath.md].
       --output-version="": Output the formatted object with the given version (default api-version).
       --raw[=false]: display raw byte data
   -a, --show-all[=false]: When printing, show all resources (default hide terminated pods.)

--- a/docs/user-guide/kubectl/kubectl_expose.md
+++ b/docs/user-guide/kubectl/kubectl_expose.md
@@ -51,7 +51,7 @@ $ kubectl expose rc streamer --port=4100 --protocol=udp --name=video-stream
       --load-balancer-ip="": IP to assign to to the Load Balancer. If empty, an ephemeral IP will be created and used(cloud-provider specific).
       --name="": The name for the newly created object.
       --no-headers[=false]: When using the default output, don't print headers.
-  -o, --output="": Output format. One of: json|yaml|wide|name|go-template=...|go-template-file=...|jsonpath=...|jsonpath-file=... See golang template [http://golang.org/pkg/text/template/#pkg-overview] and jsonpath template [http://releases.k8s.io/v1.1.0/docs/user-guide/jsonpath.md].
+  -o, --output="": Output format. One of: json|yaml|wide|name|go-template=...|go-template-file=...|jsonpath=...|jsonpath-file=... See golang template [http://golang.org/pkg/text/template/#pkg-overview] and jsonpath template [http://releases.k8s.io/release-1.1/docs/user-guide/jsonpath.md].
       --output-version="": Output the formatted object with the given version (default api-version).
       --overrides="": An inline JSON override for the generated object. If this is non-empty, it is used to override the generated object. Requires that the object supply a valid apiVersion field.
       --port=-1: The port that the service should serve on. Copied from the resource being exposed, if unspecified

--- a/docs/user-guide/kubectl/kubectl_get.md
+++ b/docs/user-guide/kubectl/kubectl_get.md
@@ -62,7 +62,7 @@ $ kubectl get rc/web service/frontend pods/web-pod-13je7
   -f, --filename=[]: Filename, directory, or URL to a file identifying the resource to get from a server.
   -L, --label-columns=[]: Accepts a comma separated list of labels that are going to be presented as columns. Names are case-sensitive. You can also use multiple flag statements like -L label1 -L label2...
       --no-headers[=false]: When using the default output, don't print headers.
-  -o, --output="": Output format. One of: json|yaml|wide|name|go-template=...|go-template-file=...|jsonpath=...|jsonpath-file=... See golang template [http://golang.org/pkg/text/template/#pkg-overview] and jsonpath template [http://releases.k8s.io/v1.1.0/docs/user-guide/jsonpath.md].
+  -o, --output="": Output format. One of: json|yaml|wide|name|go-template=...|go-template-file=...|jsonpath=...|jsonpath-file=... See golang template [http://golang.org/pkg/text/template/#pkg-overview] and jsonpath template [http://releases.k8s.io/release-1.1/docs/user-guide/jsonpath.md].
       --output-version="": Output the formatted object with the given version (default api-version).
   -l, --selector="": Selector (label query) to filter on
   -a, --show-all[=false]: When printing, show all resources (default hide terminated pods.)

--- a/docs/user-guide/kubectl/kubectl_label.md
+++ b/docs/user-guide/kubectl/kubectl_label.md
@@ -50,7 +50,7 @@ $ kubectl label pods foo bar-
       --dry-run[=false]: If true, only print the object that would be sent, without sending it.
   -f, --filename=[]: Filename, directory, or URL to a file identifying the resource to update the labels
       --no-headers[=false]: When using the default output, don't print headers.
-  -o, --output="": Output format. One of: json|yaml|wide|name|go-template=...|go-template-file=...|jsonpath=...|jsonpath-file=... See golang template [http://golang.org/pkg/text/template/#pkg-overview] and jsonpath template [http://releases.k8s.io/v1.1.0/docs/user-guide/jsonpath.md].
+  -o, --output="": Output format. One of: json|yaml|wide|name|go-template=...|go-template-file=...|jsonpath=...|jsonpath-file=... See golang template [http://golang.org/pkg/text/template/#pkg-overview] and jsonpath template [http://releases.k8s.io/release-1.1/docs/user-guide/jsonpath.md].
       --output-version="": Output the formatted object with the given version (default api-version).
       --overwrite[=false]: If true, allow labels to be overwritten, otherwise reject label updates that overwrite existing labels.
       --resource-version="": If non-empty, the labels update will only succeed if this is the current resource-version for the object. Only valid when specifying a single resource.

--- a/docs/user-guide/kubectl/kubectl_patch.md
+++ b/docs/user-guide/kubectl/kubectl_patch.md
@@ -14,7 +14,7 @@ Update field(s) of a resource using strategic merge patch
 
 JSON and YAML formats are accepted.
 
-Please refer to the models in https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/blob/v1.1.0/docs/api-reference/v1/definitions.html to find if a field is mutable.
+Please refer to the models in https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/release-1.1/docs/api-reference/v1/definitions.html to find if a field is mutable.
 
 ```
 kubectl patch (-f FILENAME | TYPE NAME) -p PATCH

--- a/docs/user-guide/kubectl/kubectl_replace.md
+++ b/docs/user-guide/kubectl/kubectl_replace.md
@@ -16,7 +16,7 @@ JSON and YAML formats are accepted. If replacing an existing resource, the
 complete resource spec must be provided. This can be obtained by
 $ kubectl get TYPE NAME -o yaml
 
-Please refer to the models in https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/blob/v1.1.0/docs/api-reference/v1/definitions.html to find if a field is mutable.
+Please refer to the models in https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/release-1.1/docs/api-reference/v1/definitions.html to find if a field is mutable.
 
 ```
 kubectl replace -f FILENAME

--- a/docs/user-guide/kubectl/kubectl_rolling-update.md
+++ b/docs/user-guide/kubectl/kubectl_rolling-update.md
@@ -46,7 +46,7 @@ $ kubectl rolling-update frontend --image=image:v2
   -f, --filename=[]: Filename or URL to file to use to create the new replication controller.
       --image="": Image to use for upgrading the replication controller.  Can not be used with --filename/-f
       --no-headers[=false]: When using the default output, don't print headers.
-  -o, --output="": Output format. One of: json|yaml|wide|name|go-template=...|go-template-file=...|jsonpath=...|jsonpath-file=... See golang template [http://golang.org/pkg/text/template/#pkg-overview] and jsonpath template [http://releases.k8s.io/v1.1.0/docs/user-guide/jsonpath.md].
+  -o, --output="": Output format. One of: json|yaml|wide|name|go-template=...|go-template-file=...|jsonpath=...|jsonpath-file=... See golang template [http://golang.org/pkg/text/template/#pkg-overview] and jsonpath template [http://releases.k8s.io/release-1.1/docs/user-guide/jsonpath.md].
       --output-version="": Output the formatted object with the given version (default api-version).
       --poll-interval=3s: Time delay between polling for replication controller status after the update. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
       --rollback[=false]: If true, this is a request to abort an existing rollout that is partially rolled out. It effectively reverses current and next and runs a rollout

--- a/docs/user-guide/kubectl/kubectl_run.md
+++ b/docs/user-guide/kubectl/kubectl_run.md
@@ -62,7 +62,7 @@ $ kubectl run nginx --image=nginx --command -- <cmd> <arg1> ... <argN>
       --leave-stdin-open[=false]: If the pod is started in interactive mode or with stdin, leave stdin open after the first attach completes. By default, stdin will be closed after the first attach completes.
       --limits="": The resource requirement limits for this container.  For example, 'cpu=200m,memory=512Mi'
       --no-headers[=false]: When using the default output, don't print headers.
-  -o, --output="": Output format. One of: json|yaml|wide|name|go-template=...|go-template-file=...|jsonpath=...|jsonpath-file=... See golang template [http://golang.org/pkg/text/template/#pkg-overview] and jsonpath template [http://releases.k8s.io/v1.1.0/docs/user-guide/jsonpath.md].
+  -o, --output="": Output format. One of: json|yaml|wide|name|go-template=...|go-template-file=...|jsonpath=...|jsonpath-file=... See golang template [http://golang.org/pkg/text/template/#pkg-overview] and jsonpath template [http://releases.k8s.io/release-1.1/docs/user-guide/jsonpath.md].
       --output-version="": Output the formatted object with the given version (default api-version).
       --overrides="": An inline JSON override for the generated object. If this is non-empty, it is used to override the generated object. Requires that the object supply a valid apiVersion field.
       --port=-1: The port that this container exposes.

--- a/docs/user-guide/logging.md
+++ b/docs/user-guide/logging.md
@@ -88,7 +88,7 @@ describes how to ingest cluster level logs into Elasticsearch and view them usin
 ## Ingesting Application Log Files
 
 Cluster level logging only collects the standard output and standard error output of the applications
-running in containers. The guide [Collecting log files within containers with Fluentd](http://releases.k8s.io/v1.1.0/contrib/logging/fluentd-sidecar-gcp/README.md) explains how the log files of applications can also be ingested into Google Cloud logging.
+running in containers. The guide [Collecting log files within containers with Fluentd](http://releases.k8s.io/release-1.1/contrib/logging/fluentd-sidecar-gcp/README.md) explains how the log files of applications can also be ingested into Google Cloud logging.
 
 ## Known issues
 

--- a/docs/user-guide/pods.md
+++ b/docs/user-guide/pods.md
@@ -136,7 +136,7 @@ spec.containers[0].securityContext.privileged: forbidden '<*>(0xc20b222db0)true'
 
 Pod is a top-level resource in the kubernetes REST API. More details about the
 API object can be found at: [Pod API
-object](https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/blob/v1.1.0/docs/api-reference/v1/definitions.html#_v1_pod).
+object](https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/release-1.1/docs/api-reference/v1/definitions.html#_v1_pod).
 
 
 

--- a/docs/user-guide/production-pods.md
+++ b/docs/user-guide/production-pods.md
@@ -178,7 +178,7 @@ spec:
 
 [Pods](pods.md) support running multiple containers co-located together. They can be used to host vertically integrated application stacks, but their primary motivation is to support auxiliary helper programs that assist the primary application. Typical examples are data pullers, data pushers, and proxies.
 
-Such containers typically need to communicate with one another, often through the file system. This can be achieved by mounting the same volume into both containers. An example of this pattern would be a web server with a [program that polls a git repository](http://releases.k8s.io/v1.1.0/contrib/git-sync/) for new updates:
+Such containers typically need to communicate with one another, often through the file system. This can be achieved by mounting the same volume into both containers. An example of this pattern would be a web server with a [program that polls a git repository](http://releases.k8s.io/release-1.1/contrib/git-sync/) for new updates:
 
 ```yaml
 apiVersion: v1

--- a/docs/user-guide/replication-controller.md
+++ b/docs/user-guide/replication-controller.md
@@ -94,7 +94,7 @@ For instance, a service might target all pods with `tier in (frontend), environm
 
 Replication controller is a top-level resource in the kubernetes REST API. More details about the
 API object can be found at: [ReplicationController API
-object](https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/blob/v1.1.0/docs/api-reference/v1/definitions.html#_v1_replicationcontroller).
+object](https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/release-1.1/docs/api-reference/v1/definitions.html#_v1_replicationcontroller).
 
 
 

--- a/docs/user-guide/services.md
+++ b/docs/user-guide/services.md
@@ -271,7 +271,7 @@ variables and DNS.
 When a `Pod` is run on a `Node`, the kubelet adds a set of environment variables
 for each active `Service`.  It supports both [Docker links
 compatible](https://docs.docker.com/userguide/dockerlinks/) variables (see
-[makeLinkVariables](http://releases.k8s.io/v1.1.0/pkg/kubelet/envvars/envvars.go#L49))
+[makeLinkVariables](http://releases.k8s.io/release-1.1/pkg/kubelet/envvars/envvars.go#L49))
 and simpler `{SVCNAME}_SERVICE_HOST` and `{SVCNAME}_SERVICE_PORT` variables,
 where the Service name is upper-cased and dashes are converted to underscores.
 
@@ -296,7 +296,7 @@ variables will not be populated.  DNS does not have this restriction.
 ### DNS
 
 An optional (though strongly recommended) [cluster
-add-on](http://releases.k8s.io/v1.1.0/cluster/addons/README.md) is a DNS server.  The
+add-on](http://releases.k8s.io/release-1.1/cluster/addons/README.md) is a DNS server.  The
 DNS server watches the Kubernetes API for new `Services` and creates a set of
 DNS records for each.  If DNS has been enabled throughout the cluster then all
 `Pods` should be able to do name resolution of `Services` automatically.
@@ -559,7 +559,7 @@ of which `Pods` they are actually accessing.
 
 Service is a top-level resource in the kubernetes REST API. More details about the
 API object can be found at: [Service API
-object](https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/blob/v1.1.0/docs/api-reference/v1/definitions.html#_v1_service).
+object](https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/release-1.1/docs/api-reference/v1/definitions.html#_v1_service).
 
 
 

--- a/docs/user-guide/ui.md
+++ b/docs/user-guide/ui.md
@@ -18,7 +18,7 @@ kubectl create -f cluster/addons/kube-ui/kube-ui-rc.yaml --namespace=kube-system
 kubectl create -f cluster/addons/kube-ui/kube-ui-svc.yaml --namespace=kube-system
 ```
 
-Normally, this should be taken care of automatically by the [`kube-addons.sh`](http://releases.k8s.io/v1.1.0/cluster/saltbase/salt/kube-addons/kube-addons.sh) script that runs on the master.
+Normally, this should be taken care of automatically by the [`kube-addons.sh`](http://releases.k8s.io/release-1.1/cluster/saltbase/salt/kube-addons/kube-addons.sh) script that runs on the master.
 
 ## Using the UI
 
@@ -51,7 +51,7 @@ Other views (Pods, Nodes, Replication Controllers, Services, and Events) simply 
 
 ## More Information
 
-For more information, see the [Kubernetes UI development document](http://releases.k8s.io/v1.1.0/www/README.md) in the www directory.
+For more information, see the [Kubernetes UI development document](http://releases.k8s.io/release-1.1/www/README.md) in the www directory.
 
 
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,7 +3,7 @@
 
 <!-- END MUNGE: UNVERSIONED_WARNING -->
 
-# Kubernetes Examples: releases.k8s.io/v1.1.0
+# Kubernetes Examples: releases.k8s.io/release-1.1
 
 This directory contains a number of different examples of how to run
 applications with Kubernetes.

--- a/pkg/api/unversioned/types.go
+++ b/pkg/api/unversioned/types.go
@@ -27,13 +27,13 @@ type TypeMeta struct {
 	// Servers may infer this from the endpoint the client submits requests to.
 	// Cannot be updated.
 	// In CamelCase.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds
 	Kind string `json:"kind,omitempty"`
 
 	// APIVersion defines the versioned schema of this representation of an object.
 	// Servers should convert recognized schemas to the latest internal value, and
 	// may reject unrecognized values.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources
 	APIVersion string `json:"apiVersion,omitempty"`
 }
 
@@ -50,7 +50,7 @@ type ListMeta struct {
 	// Value must be treated as opaque by clients and passed unmodified back to the server.
 	// Populated by the system.
 	// Read-only.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#concurrency-control-and-consistency
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#concurrency-control-and-consistency
 	ResourceVersion string `json:"resourceVersion,omitempty"`
 }
 
@@ -58,12 +58,12 @@ type ListMeta struct {
 type Status struct {
 	TypeMeta `json:",inline"`
 	// Standard list metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds
 	ListMeta `json:"metadata,omitempty"`
 
 	// Status of the operation.
 	// One of: "Success" or "Failure".
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status
 	Status string `json:"status,omitempty"`
 	// A human-readable description of the status of this operation.
 	Message string `json:"message,omitempty"`
@@ -93,7 +93,7 @@ type StatusDetails struct {
 	Name string `json:"name,omitempty"`
 	// The kind attribute of the resource associated with the status StatusReason.
 	// On some operations may differ from the requested resource Kind.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds
 	Kind string `json:"kind,omitempty"`
 	// The Causes array includes more details associated with the StatusReason
 	// failure. Not all StatusReasons may provide detailed causes.

--- a/pkg/api/unversioned/types_swagger_doc_generated.go
+++ b/pkg/api/unversioned/types_swagger_doc_generated.go
@@ -89,7 +89,7 @@ func (GroupVersion) SwaggerDoc() map[string]string {
 var map_ListMeta = map[string]string{
 	"":                "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
 	"selfLink":        "SelfLink is a URL representing this object. Populated by the system. Read-only.",
-	"resourceVersion": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#concurrency-control-and-consistency",
+	"resourceVersion": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#concurrency-control-and-consistency",
 }
 
 func (ListMeta) SwaggerDoc() map[string]string {
@@ -115,8 +115,8 @@ func (RootPaths) SwaggerDoc() map[string]string {
 
 var map_Status = map[string]string{
 	"":         "Status is a return value for calls that don't return other objects.",
-	"metadata": "Standard list metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds",
-	"status":   "Status of the operation. One of: \"Success\" or \"Failure\". More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status",
+	"metadata": "Standard list metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds",
+	"status":   "Status of the operation. One of: \"Success\" or \"Failure\". More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status",
 	"message":  "A human-readable description of the status of this operation.",
 	"reason":   "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.",
 	"details":  "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.",
@@ -141,7 +141,7 @@ func (StatusCause) SwaggerDoc() map[string]string {
 var map_StatusDetails = map[string]string{
 	"":                  "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
 	"name":              "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described).",
-	"kind":              "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds",
+	"kind":              "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds",
 	"causes":            "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes.",
 	"retryAfterSeconds": "If specified, the time in seconds before the operation should be retried.",
 }
@@ -152,8 +152,8 @@ func (StatusDetails) SwaggerDoc() map[string]string {
 
 var map_TypeMeta = map[string]string{
 	"":           "TypeMeta describes an individual object in an API response or request with strings representing the type of the object and its API schema version. Structures that are versioned or persisted should inline TypeMeta.",
-	"kind":       "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds",
-	"apiVersion": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#resources",
+	"kind":       "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds",
+	"apiVersion": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#resources",
 }
 
 func (TypeMeta) SwaggerDoc() map[string]string {

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -71,7 +71,7 @@ type ObjectMeta struct {
 	// automatically. Name is primarily intended for creation idempotence and configuration
 	// definition.
 	// Cannot be updated.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#names
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#names
 	Name string `json:"name,omitempty"`
 
 	// GenerateName is an optional prefix, used by the server, to generate a unique
@@ -88,7 +88,7 @@ type ObjectMeta struct {
 	// should retry (optionally after the time indicated in the Retry-After header).
 	//
 	// Applied only if Name is not specified.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#idempotency
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#idempotency
 	GenerateName string `json:"generateName,omitempty"`
 
 	// Namespace defines the space within each name must be unique. An empty namespace is
@@ -98,7 +98,7 @@ type ObjectMeta struct {
 	//
 	// Must be a DNS_LABEL.
 	// Cannot be updated.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/namespaces.md
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/namespaces.md
 	Namespace string `json:"namespace,omitempty"`
 
 	// SelfLink is a URL representing this object.
@@ -112,7 +112,7 @@ type ObjectMeta struct {
 	//
 	// Populated by the system.
 	// Read-only.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#uids
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#uids
 	UID types.UID `json:"uid,omitempty"`
 
 	// An opaque value that represents the internal version of this object that can
@@ -124,7 +124,7 @@ type ObjectMeta struct {
 	// Populated by the system.
 	// Read-only.
 	// Value must be treated as opaque by clients and .
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#concurrency-control-and-consistency
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#concurrency-control-and-consistency
 	ResourceVersion string `json:"resourceVersion,omitempty"`
 
 	// A sequence number representing a specific generation of the desired state.
@@ -140,7 +140,7 @@ type ObjectMeta struct {
 	// Populated by the system.
 	// Read-only.
 	// Null for lists.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	CreationTimestamp unversioned.Time `json:"creationTimestamp,omitempty"`
 
 	// DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This
@@ -156,7 +156,7 @@ type ObjectMeta struct {
 	//
 	// Populated by the system when a graceful deletion is requested.
 	// Read-only.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	DeletionTimestamp *unversioned.Time `json:"deletionTimestamp,omitempty"`
 
 	// Number of seconds allowed for this object to gracefully terminate before
@@ -168,14 +168,14 @@ type ObjectMeta struct {
 	// Map of string keys and values that can be used to organize and categorize
 	// (scope and select) objects. May match selectors of replication controllers
 	// and services.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/labels.md
 	// TODO: replace map[string]string with labels.LabelSet type
 	Labels map[string]string `json:"labels,omitempty"`
 
 	// Annotations is an unstructured key value map stored with a resource that may be
 	// set by external tools to store and retrieve arbitrary metadata. They are not
 	// queryable and should be preserved when modifying objects.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/annotations.md
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/annotations.md
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
@@ -190,7 +190,7 @@ const (
 type Volume struct {
 	// Volume's name.
 	// Must be a DNS_LABEL and unique within the pod.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#names
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#names
 	Name string `json:"name"`
 	// VolumeSource represents the location and type of the mounted volume.
 	// If not specified, the Volume is implied to be an EmptyDir.
@@ -205,46 +205,46 @@ type VolumeSource struct {
 	// machine that is directly exposed to the container. This is generally
 	// used for system agents or other privileged things that are allowed
 	// to see the host machine. Most containers will NOT need this.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#hostpath
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#hostpath
 	// ---
 	// TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
 	// mount host directories as read/write.
 	HostPath *HostPathVolumeSource `json:"hostPath,omitempty"`
 	// EmptyDir represents a temporary directory that shares a pod's lifetime.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#emptydir
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#emptydir
 	EmptyDir *EmptyDirVolumeSource `json:"emptyDir,omitempty"`
 	// GCEPersistentDisk represents a GCE Disk resource that is attached to a
 	// kubelet's host machine and then exposed to the pod.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk
 	GCEPersistentDisk *GCEPersistentDiskVolumeSource `json:"gcePersistentDisk,omitempty"`
 	// AWSElasticBlockStore represents an AWS Disk resource that is attached to a
 	// kubelet's host machine and then exposed to the pod.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore
 	AWSElasticBlockStore *AWSElasticBlockStoreVolumeSource `json:"awsElasticBlockStore,omitempty"`
 	// GitRepo represents a git repository at a particular revision.
 	GitRepo *GitRepoVolumeSource `json:"gitRepo,omitempty"`
 	// Secret represents a secret that should populate this volume.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#secrets
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#secrets
 	Secret *SecretVolumeSource `json:"secret,omitempty"`
 	// NFS represents an NFS mount on the host that shares a pod's lifetime
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs
 	NFS *NFSVolumeSource `json:"nfs,omitempty"`
 	// ISCSI represents an ISCSI Disk resource that is attached to a
 	// kubelet's host machine and then exposed to the pod.
-	// More info: http://releases.k8s.io/v1.1.0/examples/iscsi/README.md
+	// More info: http://releases.k8s.io/release-1.1/examples/iscsi/README.md
 	ISCSI *ISCSIVolumeSource `json:"iscsi,omitempty"`
 	// Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
-	// More info: http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md
+	// More info: http://releases.k8s.io/release-1.1/examples/glusterfs/README.md
 	Glusterfs *GlusterfsVolumeSource `json:"glusterfs,omitempty"`
 	// PersistentVolumeClaimVolumeSource represents a reference to a
 	// PersistentVolumeClaim in the same namespace.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistentvolumeclaims
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistentvolumeclaims
 	PersistentVolumeClaim *PersistentVolumeClaimVolumeSource `json:"persistentVolumeClaim,omitempty"`
 	// RBD represents a Rados Block Device mount on the host that shares a pod's lifetime.
-	// More info: http://releases.k8s.io/v1.1.0/examples/rbd/README.md
+	// More info: http://releases.k8s.io/release-1.1/examples/rbd/README.md
 	RBD *RBDVolumeSource `json:"rbd,omitempty"`
 	// Cinder represents a cinder volume attached and mounted on kubelets host machine
-	// More info: http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md
+	// More info: http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md
 	Cinder *CinderVolumeSource `json:"cinder,omitempty"`
 
 	// CephFS represents a Ceph FS mount on the host that shares a pod's lifetime
@@ -265,7 +265,7 @@ type VolumeSource struct {
 // type of volume that is owned by someone else (the system).
 type PersistentVolumeClaimVolumeSource struct {
 	// ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistentvolumeclaims
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistentvolumeclaims
 	ClaimName string `json:"claimName"`
 	// Will force the ReadOnly setting in VolumeMounts.
 	// Default false.
@@ -277,33 +277,33 @@ type PersistentVolumeClaimVolumeSource struct {
 type PersistentVolumeSource struct {
 	// GCEPersistentDisk represents a GCE Disk resource that is attached to a
 	// kubelet's host machine and then exposed to the pod. Provisioned by an admin.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk
 	GCEPersistentDisk *GCEPersistentDiskVolumeSource `json:"gcePersistentDisk,omitempty"`
 	// AWSElasticBlockStore represents an AWS Disk resource that is attached to a
 	// kubelet's host machine and then exposed to the pod.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore
 	AWSElasticBlockStore *AWSElasticBlockStoreVolumeSource `json:"awsElasticBlockStore,omitempty"`
 	// HostPath represents a directory on the host.
 	// Provisioned by a developer or tester.
 	// This is useful for single-node development and testing only!
 	// On-host storage is not supported in any way and WILL NOT WORK in a multi-node cluster.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#hostpath
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#hostpath
 	HostPath *HostPathVolumeSource `json:"hostPath,omitempty"`
 	// Glusterfs represents a Glusterfs volume that is attached to a host and
 	// exposed to the pod. Provisioned by an admin.
-	// More info: http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md
+	// More info: http://releases.k8s.io/release-1.1/examples/glusterfs/README.md
 	Glusterfs *GlusterfsVolumeSource `json:"glusterfs,omitempty"`
 	// NFS represents an NFS mount on the host. Provisioned by an admin.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs
 	NFS *NFSVolumeSource `json:"nfs,omitempty"`
 	// RBD represents a Rados Block Device mount on the host that shares a pod's lifetime.
-	// More info: http://releases.k8s.io/v1.1.0/examples/rbd/README.md
+	// More info: http://releases.k8s.io/release-1.1/examples/rbd/README.md
 	RBD *RBDVolumeSource `json:"rbd,omitempty"`
 	// ISCSI represents an ISCSI Disk resource that is attached to a
 	// kubelet's host machine and then exposed to the pod. Provisioned by an admin.
 	ISCSI *ISCSIVolumeSource `json:"iscsi,omitempty"`
 	// Cinder represents a cinder volume attached and mounted on kubelets host machine
-	// More info: http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md
+	// More info: http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md
 	Cinder *CinderVolumeSource `json:"cinder,omitempty"`
 	// CephFS represents a Ceph FS mount on the host that shares a pod's lifetime
 	CephFS *CephFSVolumeSource `json:"cephfs,omitempty"`
@@ -315,44 +315,44 @@ type PersistentVolumeSource struct {
 
 // PersistentVolume (PV) is a storage resource provisioned by an administrator.
 // It is analogous to a node.
-// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md
+// More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md
 type PersistentVolume struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	ObjectMeta `json:"metadata,omitempty"`
 
 	// Spec defines a specification of a persistent volume owned by the cluster.
 	// Provisioned by an administrator.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistent-volumes
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistent-volumes
 	Spec PersistentVolumeSpec `json:"spec,omitempty"`
 
 	// Status represents the current information/status for the persistent volume.
 	// Populated by the system.
 	// Read-only.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistent-volumes
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistent-volumes
 	Status PersistentVolumeStatus `json:"status,omitempty"`
 }
 
 // PersistentVolumeSpec is the specification of a persistent volume.
 type PersistentVolumeSpec struct {
 	// A description of the persistent volume's resources and capacity.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#capacity
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#capacity
 	Capacity ResourceList `json:"capacity,omitempty"`
 	// The actual volume backing the persistent volume.
 	PersistentVolumeSource `json:",inline"`
 	// AccessModes contains all ways the volume can be mounted.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#access-modes
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#access-modes
 	AccessModes []PersistentVolumeAccessMode `json:"accessModes,omitempty"`
 	// ClaimRef is part of a bi-directional binding between PersistentVolume and PersistentVolumeClaim.
 	// Expected to be non-nil when bound.
 	// claim.VolumeName is the authoritative bind between PV and PVC.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#binding
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#binding
 	ClaimRef *ObjectReference `json:"claimRef,omitempty"`
 	// What happens to a persistent volume when released from its claim.
 	// Valid options are Retain (default) and Recycle.
 	// Recyling must be supported by the volume plugin underlying this persistent volume.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#recycling-policy
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#recycling-policy
 	PersistentVolumeReclaimPolicy PersistentVolumeReclaimPolicy `json:"persistentVolumeReclaimPolicy,omitempty"`
 }
 
@@ -374,7 +374,7 @@ const (
 // PersistentVolumeStatus is the current status of a persistent volume.
 type PersistentVolumeStatus struct {
 	// Phase indicates if a volume is available, bound to a claim, or released by a claim.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#phase
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#phase
 	Phase PersistentVolumePhase `json:"phase,omitempty"`
 	// A human-readable message indicating details about why the volume is in this state.
 	Message string `json:"message,omitempty"`
@@ -387,10 +387,10 @@ type PersistentVolumeStatus struct {
 type PersistentVolumeList struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard list metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds
 	unversioned.ListMeta `json:"metadata,omitempty"`
 	// List of persistent volumes.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md
 	Items []PersistentVolume `json:"items"`
 }
 
@@ -398,16 +398,16 @@ type PersistentVolumeList struct {
 type PersistentVolumeClaim struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	ObjectMeta `json:"metadata,omitempty"`
 
 	// Spec defines the desired characteristics of a volume requested by a pod author.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistentvolumeclaims
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistentvolumeclaims
 	Spec PersistentVolumeClaimSpec `json:"spec,omitempty"`
 
 	// Status represents the current information/status of a persistent volume claim.
 	// Read-only.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistentvolumeclaims
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistentvolumeclaims
 	Status PersistentVolumeClaimStatus `json:"status,omitempty"`
 }
 
@@ -415,10 +415,10 @@ type PersistentVolumeClaim struct {
 type PersistentVolumeClaimList struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard list metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds
 	unversioned.ListMeta `json:"metadata,omitempty"`
 	// A list of persistent volume claims.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistentvolumeclaims
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistentvolumeclaims
 	Items []PersistentVolumeClaim `json:"items"`
 }
 
@@ -426,10 +426,10 @@ type PersistentVolumeClaimList struct {
 // and allows a Source for provider-specific attributes
 type PersistentVolumeClaimSpec struct {
 	// AccessModes contains the desired access modes the volume should have.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#access-modes-1
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#access-modes-1
 	AccessModes []PersistentVolumeAccessMode `json:"accessModes,omitempty"`
 	// Resources represents the minimum resources the volume should have.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#resources
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#resources
 	Resources ResourceRequirements `json:"resources,omitempty"`
 	// VolumeName is the binding reference to the PersistentVolume backing this claim.
 	VolumeName string `json:"volumeName,omitempty"`
@@ -440,7 +440,7 @@ type PersistentVolumeClaimStatus struct {
 	// Phase represents the current phase of PersistentVolumeClaim.
 	Phase PersistentVolumeClaimPhase `json:"phase,omitempty"`
 	// AccessModes contains the actual access modes the volume backing the PVC has.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#access-modes-1
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#access-modes-1
 	AccessModes []PersistentVolumeAccessMode `json:"accessModes,omitempty"`
 	// Represents the actual resources of the underlying volume.
 	Capacity ResourceList `json:"capacity,omitempty"`
@@ -487,7 +487,7 @@ const (
 // HostPathVolumeSource represents bare host directory volume.
 type HostPathVolumeSource struct {
 	// Path of the directory on the host.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#hostpath
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#hostpath
 	Path string `json:"path"`
 }
 
@@ -496,23 +496,23 @@ type EmptyDirVolumeSource struct {
 	// What type of storage medium should back this directory.
 	// The default is "" which means to use the node's default medium.
 	// Must be an empty string (default) or Memory.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#emptydir
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#emptydir
 	Medium StorageMedium `json:"medium,omitempty"`
 }
 
 // GlusterfsVolumeSource represents a Glusterfs Mount that lasts the lifetime of a pod.
 type GlusterfsVolumeSource struct {
 	// EndpointsName is the endpoint name that details Glusterfs topology.
-	// More info: http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md#create-a-pod
+	// More info: http://releases.k8s.io/release-1.1/examples/glusterfs/README.md#create-a-pod
 	EndpointsName string `json:"endpoints"`
 
 	// Path is the Glusterfs volume path.
-	// More info: http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md#create-a-pod
+	// More info: http://releases.k8s.io/release-1.1/examples/glusterfs/README.md#create-a-pod
 	Path string `json:"path"`
 
 	// ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions.
 	// Defaults to false.
-	// More info: http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md#create-a-pod
+	// More info: http://releases.k8s.io/release-1.1/examples/glusterfs/README.md#create-a-pod
 	ReadOnly bool `json:"readOnly,omitempty"`
 }
 
@@ -522,37 +522,37 @@ type StorageMedium string
 // RBDVolumeSource represents a Rados Block Device Mount that lasts the lifetime of a pod
 type RBDVolumeSource struct {
 	// A collection of Ceph monitors.
-	// More info: http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it
+	// More info: http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it
 	CephMonitors []string `json:"monitors"`
 	// The rados image name.
-	// More info: http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it
+	// More info: http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it
 	RBDImage string `json:"image"`
 	// Filesystem type of the volume that you want to mount.
 	// Tip: Ensure that the filesystem type is supported by the host operating system.
 	// Examples: "ext4", "xfs", "ntfs".
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#rbd
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#rbd
 	// TODO: how do we prevent errors in the filesystem from compromising the machine
 	FSType string `json:"fsType,omitempty"`
 	// The rados pool name.
 	// Default is rbd.
-	// More info: http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it.
+	// More info: http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it.
 	RBDPool string `json:"pool"`
 	// The rados user name.
 	// Default is admin.
-	// More info: http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it
+	// More info: http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it
 	RadosUser string `json:"user"`
 	// Keyring is the path to key ring for RBDUser.
 	// Default is /etc/ceph/keyring.
-	// More info: http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it
+	// More info: http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it
 	Keyring string `json:"keyring"`
 	// SecretRef is name of the authentication secret for RBDUser. If provided
 	// overrides keyring.
 	// Default is empty.
-	// More info: http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it
+	// More info: http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it
 	SecretRef *LocalObjectReference `json:"secretRef"`
 	// ReadOnly here will force the ReadOnly setting in VolumeMounts.
 	// Defaults to false.
-	// More info: http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it
+	// More info: http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it
 	ReadOnly bool `json:"readOnly,omitempty"`
 }
 
@@ -561,36 +561,36 @@ type RBDVolumeSource struct {
 // The volume must also be in the same region as the kubelet.
 type CinderVolumeSource struct {
 	// volume id used to identify the volume in cinder
-	// More info: http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md
+	// More info: http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md
 	VolumeID string `json:"volumeID"`
 	// Required: Filesystem type to mount.
 	// Must be a filesystem type supported by the host operating system.
 	// Only ext3 and ext4 are allowed
-	// More info: http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md
+	// More info: http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md
 	FSType string `json:"fsType,omitempty"`
 	// Optional: Defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
-	// More info: http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md
+	// More info: http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md
 	ReadOnly bool `json:"readOnly,omitempty"`
 }
 
 // CephFSVolumeSource represents a Ceph Filesystem Mount that lasts the lifetime of a pod
 type CephFSVolumeSource struct {
 	// Required: Monitors is a collection of Ceph monitors
-	// More info: http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it
+	// More info: http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it
 	Monitors []string `json:"monitors"`
 	// Optional: User is the rados user name, default is admin
-	// More info: http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it
+	// More info: http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it
 	User string `json:"user,omitempty"`
 	// Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
-	// More info: http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it
+	// More info: http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it
 	SecretFile string `json:"secretFile,omitempty"`
 	// Optional: SecretRef is reference to the authentication secret for User, default is empty.
-	// More info: http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it
+	// More info: http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it
 	SecretRef *LocalObjectReference `json:"secretRef,omitempty"`
 	// Optional: Defaults to false (read/write). ReadOnly here will force
 	// the ReadOnly setting in VolumeMounts.
-	// More info: http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it
+	// More info: http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it
 	ReadOnly bool `json:"readOnly,omitempty"`
 }
 
@@ -622,23 +622,23 @@ const (
 // A GCE PD can only be mounted as read/write once.
 type GCEPersistentDiskVolumeSource struct {
 	// Unique name of the PD resource in GCE. Used to identify the disk in GCE.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk
 	PDName string `json:"pdName"`
 	// Filesystem type of the volume that you want to mount.
 	// Tip: Ensure that the filesystem type is supported by the host operating system.
 	// Examples: "ext4", "xfs", "ntfs".
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk
 	// TODO: how do we prevent errors in the filesystem from compromising the machine
 	FSType string `json:"fsType"`
 	// The partition in the volume that you want to mount.
 	// If omitted, the default is to mount by volume name.
 	// Examples: For volume /dev/sda1, you specify the partition as "1".
 	// Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk
 	Partition int `json:"partition,omitempty"`
 	// ReadOnly here will force the ReadOnly setting in VolumeMounts.
 	// Defaults to false.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk
 	ReadOnly bool `json:"readOnly,omitempty"`
 }
 
@@ -649,12 +649,12 @@ type GCEPersistentDiskVolumeSource struct {
 // Note: Amazon EBS volumes can be mounted to only one instance at a time.
 type AWSElasticBlockStoreVolumeSource struct {
 	// Unique ID of the persistent disk resource in AWS (Amazon EBS volume).
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore
 	VolumeID string `json:"volumeID"`
 	// Filesystem type of the volume that you want to mount.
 	// Tip: Ensure that the filesystem type is supported by the host operating system.
 	// Examples: "ext4", "xfs", "ntfs".
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore
 	// TODO: how do we prevent errors in the filesystem from compromising the machine
 	FSType string `json:"fsType"`
 	// The partition in the volume that you want to mount.
@@ -664,7 +664,7 @@ type AWSElasticBlockStoreVolumeSource struct {
 	Partition int `json:"partition,omitempty"`
 	// Specify "true" to force and set the ReadOnly property in VolumeMounts to "true".
 	// If omitted, the default is "false".
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore
 	ReadOnly bool `json:"readOnly,omitempty"`
 }
 
@@ -677,27 +677,27 @@ type GitRepoVolumeSource struct {
 }
 
 // SecretVolumeSource adapts a Secret into a VolumeSource.
-// More info: http://releases.k8s.io/v1.1.0/docs/design/secrets.md
+// More info: http://releases.k8s.io/release-1.1/docs/design/secrets.md
 type SecretVolumeSource struct {
 	// SecretName is the name of a secret in the pod's namespace.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#secrets
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#secrets
 	SecretName string `json:"secretName"`
 }
 
 // NFSVolumeSource represents an NFS mount that lasts the lifetime of a pod
 type NFSVolumeSource struct {
 	// Server is the hostname or IP address of the NFS server.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs
 	Server string `json:"server"`
 
 	// Path that is exported by the NFS server.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs
 	Path string `json:"path"`
 
 	// ReadOnly here will force
 	// the NFS export to be mounted with read-only permissions.
 	// Defaults to false.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs
 	ReadOnly bool `json:"readOnly,omitempty"`
 }
 
@@ -713,7 +713,7 @@ type ISCSIVolumeSource struct {
 	// Filesystem type of the volume that you want to mount.
 	// Tip: Ensure that the filesystem type is supported by the host operating system.
 	// Examples: "ext4", "xfs", "ntfs".
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#iscsi
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#iscsi
 	// TODO: how do we prevent errors in the filesystem from compromising the machine
 	FSType string `json:"fsType"`
 	// ReadOnly here will force the ReadOnly setting in VolumeMounts.
@@ -851,11 +851,11 @@ type Probe struct {
 	// The action taken to determine the health of a container
 	Handler `json:",inline"`
 	// Number of seconds after the container has started before liveness probes are initiated.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-probes
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-probes
 	InitialDelaySeconds int64 `json:"initialDelaySeconds,omitempty"`
 	// Number of seconds after which liveness probes timeout.
 	// Defaults to 1 second.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-probes
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-probes
 	TimeoutSeconds int64 `json:"timeoutSeconds,omitempty"`
 }
 
@@ -885,12 +885,12 @@ type Capabilities struct {
 // ResourceRequirements describes the compute resource requirements.
 type ResourceRequirements struct {
 	// Limits describes the maximum amount of compute resources allowed.
-	// More info: http://releases.k8s.io/v1.1.0/docs/design/resources.md#resource-specifications
+	// More info: http://releases.k8s.io/release-1.1/docs/design/resources.md#resource-specifications
 	Limits ResourceList `json:"limits,omitempty"`
 	// Requests describes the minimum amount of compute resources required.
 	// If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
 	// otherwise to an implementation-defined value.
-	// More info: http://releases.k8s.io/v1.1.0/docs/design/resources.md#resource-specifications
+	// More info: http://releases.k8s.io/release-1.1/docs/design/resources.md#resource-specifications
 	Requests ResourceList `json:"requests,omitempty"`
 }
 
@@ -906,7 +906,7 @@ type Container struct {
 	// Cannot be updated.
 	Name string `json:"name"`
 	// Docker image name.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/images.md
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/images.md
 	Image string `json:"image,omitempty"`
 	// Entrypoint array. Not executed within a shell.
 	// The docker image's entrypoint is used if this is not provided.
@@ -915,7 +915,7 @@ type Container struct {
 	// can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
 	// regardless of whether the variable exists or not.
 	// Cannot be updated.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/containers.md#containers-and-commands
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/containers.md#containers-and-commands
 	Command []string `json:"command,omitempty"`
 	// Arguments to the entrypoint.
 	// The docker image's cmd is used if this is not provided.
@@ -924,7 +924,7 @@ type Container struct {
 	// can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
 	// regardless of whether the variable exists or not.
 	// Cannot be updated.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/containers.md#containers-and-commands
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/containers.md#containers-and-commands
 	Args []string `json:"args,omitempty"`
 	// Container's working directory.
 	// Defaults to Docker's default. D
@@ -939,7 +939,7 @@ type Container struct {
 	Env []EnvVar `json:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 	// Compute Resources required by this container.
 	// Cannot be updated.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#resources
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#resources
 	Resources ResourceRequirements `json:"resources,omitempty"`
 	// Pod volumes to mount into the container's filesyste.
 	// Cannot be updated.
@@ -947,12 +947,12 @@ type Container struct {
 	// Periodic probe of container liveness.
 	// Container will be restarted if the probe fails.
 	// Cannot be updated.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-probes
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-probes
 	LivenessProbe *Probe `json:"livenessProbe,omitempty"`
 	// Periodic probe of container service readiness.
 	// Container will be removed from service endpoints if the probe fails.
 	// Cannot be updated.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-probes
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-probes
 	ReadinessProbe *Probe `json:"readinessProbe,omitempty"`
 	// Actions that the management system should take in response to container lifecycle events.
 	// Cannot be updated.
@@ -967,10 +967,10 @@ type Container struct {
 	// One of Always, Never, IfNotPresent.
 	// Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
 	// Cannot be updated.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/images.md#updating-images
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/images.md#updating-images
 	ImagePullPolicy PullPolicy `json:"imagePullPolicy,omitempty"`
 	// Security options the pod should run with.
-	// More info: http://releases.k8s.io/v1.1.0/docs/design/security_context.md
+	// More info: http://releases.k8s.io/release-1.1/docs/design/security_context.md
 	SecurityContext *SecurityContext `json:"securityContext,omitempty"`
 
 	// Variables for interactive containers, these have very specialized use-cases (e.g. debugging)
@@ -1014,14 +1014,14 @@ type Lifecycle struct {
 	// PostStart is called immediately after a container is created. If the handler fails,
 	// the container is terminated and restarted according to its restart policy.
 	// Other management of the container blocks until the hook completes.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/container-environment.md#hook-details
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/container-environment.md#hook-details
 	PostStart *Handler `json:"postStart,omitempty"`
 	// PreStop is called immediately before a container is terminated.
 	// The container is terminated after the handler completes.
 	// The reason for termination is passed to the handler.
 	// Regardless of the outcome of the handler, the container is eventually terminated.
 	// Other management of the container blocks until the hook completes.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/container-environment.md#hook-details
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/container-environment.md#hook-details
 	PreStop *Handler `json:"preStop,omitempty"`
 }
 
@@ -1098,13 +1098,13 @@ type ContainerStatus struct {
 	// garbage collection. This value will get capped at 5 by GC.
 	RestartCount int `json:"restartCount"`
 	// The image the container is running.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/images.md
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/images.md
 	// TODO(dchen1107): Which image the container is running with?
 	Image string `json:"image"`
 	// ImageID of the container's image.
 	ImageID string `json:"imageID"`
 	// Container's ID in the format 'docker://<container_id>'.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/container-environment.md#container-information
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/container-environment.md#container-information
 	ContainerID string `json:"containerID,omitempty"`
 }
 
@@ -1145,11 +1145,11 @@ const (
 type PodCondition struct {
 	// Type is the type of the condition.
 	// Currently only Ready.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#pod-conditions
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#pod-conditions
 	Type PodConditionType `json:"type"`
 	// Status is the status of the condition.
 	// Can be True, False, Unknown.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#pod-conditions
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#pod-conditions
 	Status ConditionStatus `json:"status"`
 	// Last time we probed the condition.
 	LastProbeTime unversioned.Time `json:"lastProbeTime,omitempty"`
@@ -1192,18 +1192,18 @@ const (
 // PodSpec is a description of a pod.
 type PodSpec struct {
 	// List of volumes that can be mounted by containers belonging to the pod.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md
 	Volumes []Volume `json:"volumes,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 	// List of containers belonging to the pod.
 	// Containers cannot currently be added or removed.
 	// There must be at least one container in a Pod.
 	// Cannot be updated.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/containers.md
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/containers.md
 	Containers []Container `json:"containers" patchStrategy:"merge" patchMergeKey:"name"`
 	// Restart policy for all containers within the pod.
 	// One of Always, OnFailure, Never.
 	// Default to Always.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#restartpolicy
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#restartpolicy
 	RestartPolicy RestartPolicy `json:"restartPolicy,omitempty"`
 	// Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request.
 	// Value must be non-negative integer. The value zero indicates delete immediately.
@@ -1223,11 +1223,11 @@ type PodSpec struct {
 	DNSPolicy DNSPolicy `json:"dnsPolicy,omitempty"`
 	// NodeSelector is a selector which must be true for the pod to fit on a node.
 	// Selector which must match a node's labels for the pod to be scheduled on that node.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/node-selection/README.md
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/node-selection/README.md
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
 	// ServiceAccountName is the name of the ServiceAccount to use to run this pod.
-	// More info: http://releases.k8s.io/v1.1.0/docs/design/service_accounts.md
+	// More info: http://releases.k8s.io/release-1.1/docs/design/service_accounts.md
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 	// DeprecatedServiceAccount is a depreciated alias for ServiceAccountName.
 	// Deprecated: Use serviceAccountName instead.
@@ -1250,7 +1250,7 @@ type PodSpec struct {
 	// ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
 	// If specified, these secrets will be passed to individual puller implementations for them to use. For example,
 	// in the case of docker, only DockerConfig type secrets are honored.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/images.md#specifying-imagepullsecrets-on-a-pod
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/images.md#specifying-imagepullsecrets-on-a-pod
 	ImagePullSecrets []LocalObjectReference `json:"imagePullSecrets,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
@@ -1258,10 +1258,10 @@ type PodSpec struct {
 // state of a system.
 type PodStatus struct {
 	// Current condition of the pod.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#pod-phase
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#pod-phase
 	Phase PodPhase `json:"phase,omitempty"`
 	// Current service state of pod.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#pod-conditions
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#pod-conditions
 	Conditions []PodCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 	// A human readable message indicating details about why the pod is in this condition.
 	Message string `json:"message,omitempty"`
@@ -1281,7 +1281,7 @@ type PodStatus struct {
 
 	// The list has one entry per container in the manifest. Each entry is currently the output
 	// of `docker inspect`.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-statuses
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-statuses
 	ContainerStatuses []ContainerStatus `json:"containerStatuses,omitempty"`
 }
 
@@ -1289,13 +1289,13 @@ type PodStatus struct {
 type PodStatusResult struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	ObjectMeta `json:"metadata,omitempty"`
 	// Most recently observed status of the pod.
 	// This data may not be up to date.
 	// Populated by the system.
 	// Read-only.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status
 	Status PodStatus `json:"status,omitempty"`
 }
 
@@ -1304,18 +1304,18 @@ type PodStatusResult struct {
 type Pod struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	ObjectMeta `json:"metadata,omitempty"`
 
 	// Specification of the desired behavior of the pod.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status
 	Spec PodSpec `json:"spec,omitempty"`
 
 	// Most recently observed status of the pod.
 	// This data may not be up to date.
 	// Populated by the system.
 	// Read-only.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status
 	Status PodStatus `json:"status,omitempty"`
 }
 
@@ -1323,22 +1323,22 @@ type Pod struct {
 type PodList struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard list metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds
 	unversioned.ListMeta `json:"metadata,omitempty"`
 
 	// List of pods.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pods.md
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/pods.md
 	Items []Pod `json:"items"`
 }
 
 // PodTemplateSpec describes the data a pod should have when created from a template
 type PodTemplateSpec struct {
 	// Standard object's metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	ObjectMeta `json:"metadata,omitempty"`
 
 	// Specification of the desired behavior of the pod.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status
 	Spec PodSpec `json:"spec,omitempty"`
 }
 
@@ -1346,11 +1346,11 @@ type PodTemplateSpec struct {
 type PodTemplate struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	ObjectMeta `json:"metadata,omitempty"`
 
 	// Template defines the pods that will be created from this pod template.
-	// http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status
+	// http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status
 	Template PodTemplateSpec `json:"template,omitempty"`
 }
 
@@ -1358,7 +1358,7 @@ type PodTemplate struct {
 type PodTemplateList struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard list metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds
 	unversioned.ListMeta `json:"metadata,omitempty"`
 
 	// List of pod templates
@@ -1370,14 +1370,14 @@ type ReplicationControllerSpec struct {
 	// Replicas is the number of desired replicas.
 	// This is a pointer to distinguish between explicit zero and unspecified.
 	// Defaults to 1.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/replication-controller.md#what-is-a-replication-controller
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/replication-controller.md#what-is-a-replication-controller
 	Replicas *int `json:"replicas,omitempty"`
 
 	// Selector is a label query over pods that should match the Replicas count.
 	// If Selector is empty, it is defaulted to the labels present on the Pod template.
 	// Label keys and values that must match in order to be controlled by this replication
 	// controller, if empty defaulted to labels on Pod template.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md#label-selectors
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/labels.md#label-selectors
 	Selector map[string]string `json:"selector,omitempty"`
 
 	// TemplateRef is a reference to an object that describes the pod that will be created if
@@ -1387,7 +1387,7 @@ type ReplicationControllerSpec struct {
 
 	// Template is the object that describes the pod that will be created if
 	// insufficient replicas are detected. This takes precedence over a TemplateRef.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/replication-controller.md#pod-template
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/replication-controller.md#pod-template
 	Template *PodTemplateSpec `json:"template,omitempty"`
 }
 
@@ -1395,7 +1395,7 @@ type ReplicationControllerSpec struct {
 // controller.
 type ReplicationControllerStatus struct {
 	// Replicas is the most recently oberved number of replicas.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/replication-controller.md#what-is-a-replication-controller
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/replication-controller.md#what-is-a-replication-controller
 	Replicas int `json:"replicas"`
 
 	// ObservedGeneration reflects the generation of the most recently observed replication controller.
@@ -1408,18 +1408,18 @@ type ReplicationController struct {
 
 	// If the Labels of a ReplicationController are empty, they are defaulted to
 	// be the same as the Pod(s) that the replication controller manages.
-	// Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	ObjectMeta `json:"metadata,omitempty"`
 
 	// Spec defines the specification of the desired behavior of the replication controller.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status
 	Spec ReplicationControllerSpec `json:"spec,omitempty"`
 
 	// Status is the most recently observed status of the replication controller.
 	// This data may be out of date by some window of time.
 	// Populated by the system.
 	// Read-only.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status
 	Status ReplicationControllerStatus `json:"status,omitempty"`
 }
 
@@ -1427,11 +1427,11 @@ type ReplicationController struct {
 type ReplicationControllerList struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard list metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds
 	unversioned.ListMeta `json:"metadata,omitempty"`
 
 	// List of replication controllers.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/replication-controller.md
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/replication-controller.md
 	Items []ReplicationController `json:"items"`
 }
 
@@ -1493,13 +1493,13 @@ type LoadBalancerIngress struct {
 // ServiceSpec describes the attributes that a user creates on a service.
 type ServiceSpec struct {
 	// The list of ports that are exposed by this service.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/services.md#virtual-ips-and-service-proxies
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/services.md#virtual-ips-and-service-proxies
 	Ports []ServicePort `json:"ports"`
 
 	// This service will route traffic to pods having labels matching this selector.
 	// Label keys and values that must match in order to receive traffic for this service.
 	// If empty, all pods are selected, if not specified, endpoints must be manually specified.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/services.md#overview
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/services.md#overview
 	Selector map[string]string `json:"selector,omitempty"`
 
 	// ClusterIP is usually assigned by the master and is the IP address of the service.
@@ -1508,12 +1508,12 @@ type ServiceSpec struct {
 	// Valid values are None, empty string (""), or a valid IP address.
 	// 'None' can be specified for a headless service when proxying is not required.
 	// Cannot be updated.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/services.md#virtual-ips-and-service-proxies
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/services.md#virtual-ips-and-service-proxies
 	ClusterIP string `json:"clusterIP,omitempty"`
 
 	// Type of exposed service. Must be ClusterIP, NodePort, or LoadBalancer.
 	// Defaults to ClusterIP.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/services.md#external-services
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/services.md#external-services
 	Type ServiceType `json:"type,omitempty"`
 
 	// externalIPs is a list of IP addresses for which nodes in the cluster
@@ -1536,7 +1536,7 @@ type ServiceSpec struct {
 	// Enable client IP based session affinity.
 	// Must be ClientIP or None.
 	// Defaults to None.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/services.md#virtual-ips-and-service-proxies
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/services.md#virtual-ips-and-service-proxies
 	SessionAffinity ServiceAffinity `json:"sessionAffinity,omitempty"`
 
 	// Only applies to Service Type: LoadBalancer
@@ -1568,14 +1568,14 @@ type ServicePort struct {
 	// target Pod's container ports. If this is not specified, the value
 	// of Port is used (an identity map).
 	// Defaults to the service port.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/services.md#defining-a-service
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/services.md#defining-a-service
 	TargetPort util.IntOrString `json:"targetPort,omitempty"`
 
 	// The port on each node on which this service is exposed when type=NodePort or LoadBalancer.
 	// Usually assigned by the system. If specified, it will be allocated to the service
 	// if unused or else creation of the service will fail.
 	// Default is to auto-allocate a port if the ServiceType of this Service requires one.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/services.md#type--nodeport
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/services.md#type--nodeport
 	NodePort int `json:"nodePort,omitempty"`
 }
 
@@ -1585,17 +1585,17 @@ type ServicePort struct {
 type Service struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	ObjectMeta `json:"metadata,omitempty"`
 
 	// Spec defines the behavior of a service.
-	// http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status
+	// http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status
 	Spec ServiceSpec `json:"spec,omitempty"`
 
 	// Most recently observed status of the service.
 	// Populated by the system.
 	// Read-only.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status
 	Status ServiceStatus `json:"status,omitempty"`
 }
 
@@ -1609,7 +1609,7 @@ const (
 type ServiceList struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard list metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds
 	unversioned.ListMeta `json:"metadata,omitempty"`
 
 	// List of services
@@ -1623,17 +1623,17 @@ type ServiceList struct {
 type ServiceAccount struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	ObjectMeta `json:"metadata,omitempty"`
 
 	// Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/secrets.md
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/secrets.md
 	Secrets []ObjectReference `json:"secrets,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images
 	// in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets
 	// can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/secrets.md#manually-specifying-an-imagepullsecret
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/secrets.md#manually-specifying-an-imagepullsecret
 	ImagePullSecrets []LocalObjectReference `json:"imagePullSecrets,omitempty"`
 }
 
@@ -1641,11 +1641,11 @@ type ServiceAccount struct {
 type ServiceAccountList struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard list metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds
 	unversioned.ListMeta `json:"metadata,omitempty"`
 
 	// List of ServiceAccounts.
-	// More info: http://releases.k8s.io/v1.1.0/docs/design/service_accounts.md#service-accounts
+	// More info: http://releases.k8s.io/release-1.1/docs/design/service_accounts.md#service-accounts
 	Items []ServiceAccount `json:"items"`
 }
 
@@ -1664,7 +1664,7 @@ type ServiceAccountList struct {
 type Endpoints struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	ObjectMeta `json:"metadata,omitempty"`
 
 	// The set of all endpoints is the union of all subsets. Addresses are placed into
@@ -1731,7 +1731,7 @@ type EndpointPort struct {
 type EndpointsList struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard list metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds
 	unversioned.ListMeta `json:"metadata,omitempty"`
 
 	// List of endpoints.
@@ -1748,7 +1748,7 @@ type NodeSpec struct {
 	// ID of the node assigned by the cloud provider in the format: <ProviderName>://<ProviderSpecificNodeID>
 	ProviderID string `json:"providerID,omitempty"`
 	// Unschedulable controls node schedulability of new pods. By default, node is schedulable.
-	// More info: http://releases.k8s.io/v1.1.0/docs/admin/node.md#manual-node-administration"`
+	// More info: http://releases.k8s.io/release-1.1/docs/admin/node.md#manual-node-administration"`
 	Unschedulable bool `json:"unschedulable,omitempty"`
 }
 
@@ -1787,22 +1787,22 @@ type NodeSystemInfo struct {
 // NodeStatus is information about the current status of a node.
 type NodeStatus struct {
 	// Capacity represents the available resources of a node.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#capacity for more details.
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#capacity for more details.
 	Capacity ResourceList `json:"capacity,omitempty"`
 	// NodePhase is the recently observed lifecycle phase of the node.
-	// More info: http://releases.k8s.io/v1.1.0/docs/admin/node.md#node-phase
+	// More info: http://releases.k8s.io/release-1.1/docs/admin/node.md#node-phase
 	Phase NodePhase `json:"phase,omitempty"`
 	// Conditions is an array of current observed node conditions.
-	// More info: http://releases.k8s.io/v1.1.0/docs/admin/node.md#node-condition
+	// More info: http://releases.k8s.io/release-1.1/docs/admin/node.md#node-condition
 	Conditions []NodeCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 	// List of addresses reachable to the node.
 	// Queried from cloud provider, if available.
-	// More info: http://releases.k8s.io/v1.1.0/docs/admin/node.md#node-addresses
+	// More info: http://releases.k8s.io/release-1.1/docs/admin/node.md#node-addresses
 	Addresses []NodeAddress `json:"addresses,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 	// Endpoints of daemons running on the Node.
 	DaemonEndpoints NodeDaemonEndpoints `json:"daemonEndpoints,omitempty"`
 	// Set of ids/uuids to uniquely identify the node.
-	// More info: http://releases.k8s.io/v1.1.0/docs/admin/node.md#node-info
+	// More info: http://releases.k8s.io/release-1.1/docs/admin/node.md#node-info
 	NodeInfo NodeSystemInfo `json:"nodeInfo,omitempty"`
 }
 
@@ -1884,17 +1884,17 @@ type ResourceList map[ResourceName]resource.Quantity
 type Node struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	ObjectMeta `json:"metadata,omitempty"`
 
 	// Spec defines the behavior of a node.
-	// http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status
+	// http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status
 	Spec NodeSpec `json:"spec,omitempty"`
 
 	// Most recently observed status of the node.
 	// Populated by the system.
 	// Read-only.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status
 	Status NodeStatus `json:"status,omitempty"`
 }
 
@@ -1902,7 +1902,7 @@ type Node struct {
 type NodeList struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard list metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds
 	unversioned.ListMeta `json:"metadata,omitempty"`
 
 	// List of nodes
@@ -1919,14 +1919,14 @@ const (
 // NamespaceSpec describes the attributes on a Namespace.
 type NamespaceSpec struct {
 	// Finalizers is an opaque list of values that must be empty to permanently remove object from storage.
-	// More info: http://releases.k8s.io/v1.1.0/docs/design/namespaces.md#finalizers
+	// More info: http://releases.k8s.io/release-1.1/docs/design/namespaces.md#finalizers
 	Finalizers []FinalizerName `json:"finalizers,omitempty"`
 }
 
 // NamespaceStatus is information about the current status of a Namespace.
 type NamespaceStatus struct {
 	// Phase is the current lifecycle phase of the namespace.
-	// More info: http://releases.k8s.io/v1.1.0/docs/design/namespaces.md#phases
+	// More info: http://releases.k8s.io/release-1.1/docs/design/namespaces.md#phases
 	Phase NamespacePhase `json:"phase,omitempty"`
 }
 
@@ -1945,15 +1945,15 @@ const (
 type Namespace struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	ObjectMeta `json:"metadata,omitempty"`
 
 	// Spec defines the behavior of the Namespace.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status
 	Spec NamespaceSpec `json:"spec,omitempty"`
 
 	// Status describes the current status of a Namespace.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status
 	Status NamespaceStatus `json:"status,omitempty"`
 }
 
@@ -1961,11 +1961,11 @@ type Namespace struct {
 type NamespaceList struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard list metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds
 	unversioned.ListMeta `json:"metadata,omitempty"`
 
 	// Items is the list of Namespace objects in the list.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/namespaces.md
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/namespaces.md
 	Items []Namespace `json:"items"`
 }
 
@@ -1974,7 +1974,7 @@ type NamespaceList struct {
 type Binding struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	ObjectMeta `json:"metadata,omitempty"`
 
 	// The target object that you want to bind to the standard object.
@@ -2114,21 +2114,21 @@ type PodProxyOptions struct {
 // ObjectReference contains enough information to let you inspect or modify the referred object.
 type ObjectReference struct {
 	// Kind of the referent.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds
 	Kind string `json:"kind,omitempty"`
 	// Namespace of the referent.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/namespaces.md
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/namespaces.md
 	Namespace string `json:"namespace,omitempty"`
 	// Name of the referent.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#names
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#names
 	Name string `json:"name,omitempty"`
 	// UID of the referent.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#uids
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#uids
 	UID types.UID `json:"uid,omitempty"`
 	// API version of the referent.
 	APIVersion string `json:"apiVersion,omitempty"`
 	// Specific resourceVersion to which this reference is made, if any.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#concurrency-control-and-consistency
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#concurrency-control-and-consistency
 	ResourceVersion string `json:"resourceVersion,omitempty"`
 
 	// If referring to a piece of an object instead of an entire object, this string
@@ -2146,7 +2146,7 @@ type ObjectReference struct {
 // referenced object inside the same namespace.
 type LocalObjectReference struct {
 	// Name of the referent.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#names
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#names
 	// TODO: Add other useful fields. apiVersion, kind, uid?
 	Name string `json:"name,omitempty"`
 }
@@ -2171,7 +2171,7 @@ type EventSource struct {
 type Event struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	ObjectMeta `json:"metadata"`
 
 	// The object that this event is about.
@@ -2203,7 +2203,7 @@ type Event struct {
 type EventList struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard list metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds
 	unversioned.ListMeta `json:"metadata,omitempty"`
 
 	// List of events
@@ -2214,7 +2214,7 @@ type EventList struct {
 type List struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard list metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds
 	unversioned.ListMeta `json:"metadata,omitempty"`
 
 	// List of objects
@@ -2257,11 +2257,11 @@ type LimitRangeSpec struct {
 type LimitRange struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	ObjectMeta `json:"metadata,omitempty"`
 
 	// Spec defines the limits enforced.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status
 	Spec LimitRangeSpec `json:"spec,omitempty"`
 }
 
@@ -2269,11 +2269,11 @@ type LimitRange struct {
 type LimitRangeList struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard list metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds
 	unversioned.ListMeta `json:"metadata,omitempty"`
 
 	// Items is a list of LimitRange objects.
-	// More info: http://releases.k8s.io/v1.1.0/docs/design/admission_control_limit_range.md
+	// More info: http://releases.k8s.io/release-1.1/docs/design/admission_control_limit_range.md
 	Items []LimitRange `json:"items"`
 }
 
@@ -2296,14 +2296,14 @@ const (
 // ResourceQuotaSpec defines the desired hard limits to enforce for Quota.
 type ResourceQuotaSpec struct {
 	// Hard is the set of desired hard limits for each named resource.
-	// More info: http://releases.k8s.io/v1.1.0/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota
+	// More info: http://releases.k8s.io/release-1.1/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota
 	Hard ResourceList `json:"hard,omitempty"`
 }
 
 // ResourceQuotaStatus defines the enforced hard limits and observed use.
 type ResourceQuotaStatus struct {
 	// Hard is the set of enforced hard limits for each named resource.
-	// More info: http://releases.k8s.io/v1.1.0/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota
+	// More info: http://releases.k8s.io/release-1.1/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota
 	Hard ResourceList `json:"hard,omitempty"`
 	// Used is the current observed total usage of the resource in the namespace.
 	Used ResourceList `json:"used,omitempty"`
@@ -2313,15 +2313,15 @@ type ResourceQuotaStatus struct {
 type ResourceQuota struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	ObjectMeta `json:"metadata,omitempty"`
 
 	// Spec defines the desired quota.
-	// http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status
+	// http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status
 	Spec ResourceQuotaSpec `json:"spec,omitempty"`
 
 	// Status defines the actual enforced quota and its current usage.
-	// http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status
+	// http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status
 	Status ResourceQuotaStatus `json:"status,omitempty"`
 }
 
@@ -2329,11 +2329,11 @@ type ResourceQuota struct {
 type ResourceQuotaList struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard list metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds
 	unversioned.ListMeta `json:"metadata,omitempty"`
 
 	// Items is a list of ResourceQuota objects.
-	// More info: http://releases.k8s.io/v1.1.0/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota
+	// More info: http://releases.k8s.io/release-1.1/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota
 	Items []ResourceQuota `json:"items"`
 }
 
@@ -2342,7 +2342,7 @@ type ResourceQuotaList struct {
 type Secret struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	ObjectMeta `json:"metadata,omitempty"`
 
 	// Data contains the secret data. Each key must be a valid DNS_SUBDOMAIN
@@ -2397,11 +2397,11 @@ const (
 type SecretList struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard list metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds
 	unversioned.ListMeta `json:"metadata,omitempty"`
 
 	// Items is a list of secret objects.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/secrets.md
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/secrets.md
 	Items []Secret `json:"items"`
 }
 
@@ -2433,7 +2433,7 @@ type ComponentCondition struct {
 type ComponentStatus struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	ObjectMeta `json:"metadata,omitempty"`
 
 	// List of component conditions observed
@@ -2444,7 +2444,7 @@ type ComponentStatus struct {
 type ComponentStatusList struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard list metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds
 	unversioned.ListMeta `json:"metadata,omitempty"`
 
 	// List of ComponentStatus objects.
@@ -2469,23 +2469,23 @@ type DownwardAPIVolumeFile struct {
 type SecurityContext struct {
 	// The linux kernel capabilites that should be added or removed.
 	// Default to Container.Capabilities if left unset.
-	// More info: http://releases.k8s.io/v1.1.0/docs/design/security_context.md#security-context
+	// More info: http://releases.k8s.io/release-1.1/docs/design/security_context.md#security-context
 	Capabilities *Capabilities `json:"capabilities,omitempty"`
 
 	// Run the container in privileged mode.
 	// Default to Container.Privileged if left unset.
-	// More info: http://releases.k8s.io/v1.1.0/docs/design/security_context.md#security-context
+	// More info: http://releases.k8s.io/release-1.1/docs/design/security_context.md#security-context
 	Privileged *bool `json:"privileged,omitempty"`
 
 	// SELinuxOptions are the labels to be applied to the container
 	// and volumes.
 	// Options that control the SELinux labels applied.
-	// More info: http://releases.k8s.io/v1.1.0/docs/design/security_context.md#security-context
+	// More info: http://releases.k8s.io/release-1.1/docs/design/security_context.md#security-context
 	SELinuxOptions *SELinuxOptions `json:"seLinuxOptions,omitempty"`
 
 	// RunAsUser is the UID to run the entrypoint of the container process.
 	// The user id that runs the first process in the container.
-	// More info: http://releases.k8s.io/v1.1.0/docs/design/security_context.md#security-context
+	// More info: http://releases.k8s.io/release-1.1/docs/design/security_context.md#security-context
 	RunAsUser *int64 `json:"runAsUser,omitempty"`
 
 	// RunAsNonRoot indicates that the container should be run as a non-root user. If the RunAsUser
@@ -2497,19 +2497,19 @@ type SecurityContext struct {
 // SELinuxOptions are the labels to be applied to the container
 type SELinuxOptions struct {
 	// User is a SELinux user label that applies to the container.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/labels.md
 	User string `json:"user,omitempty"`
 
 	// Role is a SELinux role label that applies to the container.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/labels.md
 	Role string `json:"role,omitempty"`
 
 	// Type is a SELinux type label that applies to the container.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/labels.md
 	Type string `json:"type,omitempty"`
 
 	// Level is SELinux level label that applies to the container.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/labels.md
 	Level string `json:"level,omitempty"`
 }
 
@@ -2517,7 +2517,7 @@ type SELinuxOptions struct {
 type RangeAllocation struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	ObjectMeta `json:"metadata,omitempty"`
 
 	// Range is string that identifies the range represented by 'data'.

--- a/pkg/api/v1/types_swagger_doc_generated.go
+++ b/pkg/api/v1/types_swagger_doc_generated.go
@@ -29,10 +29,10 @@ package v1
 // AUTO-GENERATED FUNCTIONS START HERE
 var map_AWSElasticBlockStoreVolumeSource = map[string]string{
 	"":          "Represents a persistent disk resource in AWS.\n\nAn Amazon Elastic Block Store (EBS) must already be created, formatted, and reside in the same AWS zone as the kubelet before it can be mounted. Note: Amazon EBS volumes can be mounted to only one instance at a time.",
-	"volumeID":  "Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore",
-	"fsType":    "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore",
+	"volumeID":  "Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore",
+	"fsType":    "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore",
 	"partition": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
-	"readOnly":  "Specify \"true\" to force and set the ReadOnly property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore",
+	"readOnly":  "Specify \"true\" to force and set the ReadOnly property in VolumeMounts to \"true\". If omitted, the default is \"false\". More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore",
 }
 
 func (AWSElasticBlockStoreVolumeSource) SwaggerDoc() map[string]string {
@@ -41,7 +41,7 @@ func (AWSElasticBlockStoreVolumeSource) SwaggerDoc() map[string]string {
 
 var map_Binding = map[string]string{
 	"":         "Binding ties one object to another. For example, a pod is bound to a node by a scheduler.",
-	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata",
+	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata",
 	"target":   "The target object that you want to bind to the standard object.",
 }
 
@@ -61,11 +61,11 @@ func (Capabilities) SwaggerDoc() map[string]string {
 
 var map_CephFSVolumeSource = map[string]string{
 	"":           "CephFSVolumeSource represents a Ceph Filesystem Mount that lasts the lifetime of a pod",
-	"monitors":   "Required: Monitors is a collection of Ceph monitors More info: http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it",
-	"user":       "Optional: User is the rados user name, default is admin More info: http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it",
-	"secretFile": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it",
-	"secretRef":  "Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it",
-	"readOnly":   "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: http://releases.k8s.io/v1.1.0/examples/cephfs/README.md#how-to-use-it",
+	"monitors":   "Required: Monitors is a collection of Ceph monitors More info: http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it",
+	"user":       "Optional: User is the rados user name, default is admin More info: http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it",
+	"secretFile": "Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it",
+	"secretRef":  "Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it",
+	"readOnly":   "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: http://releases.k8s.io/release-1.1/examples/cephfs/README.md#how-to-use-it",
 }
 
 func (CephFSVolumeSource) SwaggerDoc() map[string]string {
@@ -74,9 +74,9 @@ func (CephFSVolumeSource) SwaggerDoc() map[string]string {
 
 var map_CinderVolumeSource = map[string]string{
 	"":         "CinderVolumeSource represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet.",
-	"volumeID": "volume id used to identify the volume in cinder More info: http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md",
-	"fsType":   "Required: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Only ext3 and ext4 are allowed More info: http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md",
-	"readOnly": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md",
+	"volumeID": "volume id used to identify the volume in cinder More info: http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md",
+	"fsType":   "Required: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Only ext3 and ext4 are allowed More info: http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md",
+	"readOnly": "Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md",
 }
 
 func (CinderVolumeSource) SwaggerDoc() map[string]string {
@@ -97,7 +97,7 @@ func (ComponentCondition) SwaggerDoc() map[string]string {
 
 var map_ComponentStatus = map[string]string{
 	"":           "ComponentStatus (and ComponentStatusList) holds the cluster validation info.",
-	"metadata":   "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata",
+	"metadata":   "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata",
 	"conditions": "List of component conditions observed",
 }
 
@@ -107,7 +107,7 @@ func (ComponentStatus) SwaggerDoc() map[string]string {
 
 var map_ComponentStatusList = map[string]string{
 	"":         "Status of all the conditions for the component as a list of ComponentStatus objects.",
-	"metadata": "Standard list metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds",
+	"metadata": "Standard list metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds",
 	"items":    "List of ComponentStatus objects.",
 }
 
@@ -118,20 +118,20 @@ func (ComponentStatusList) SwaggerDoc() map[string]string {
 var map_Container = map[string]string{
 	"":                       "A single application container that you want to run within a pod.",
 	"name":                   "Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.",
-	"image":                  "Docker image name. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/images.md",
-	"command":                "Entrypoint array. Not executed within a shell. The docker image's entrypoint is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/containers.md#containers-and-commands",
-	"args":                   "Arguments to the entrypoint. The docker image's cmd is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/containers.md#containers-and-commands",
+	"image":                  "Docker image name. More info: http://releases.k8s.io/release-1.1/docs/user-guide/images.md",
+	"command":                "Entrypoint array. Not executed within a shell. The docker image's entrypoint is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: http://releases.k8s.io/release-1.1/docs/user-guide/containers.md#containers-and-commands",
+	"args":                   "Arguments to the entrypoint. The docker image's cmd is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: http://releases.k8s.io/release-1.1/docs/user-guide/containers.md#containers-and-commands",
 	"workingDir":             "Container's working directory. Defaults to Docker's default. D efaults to image's default. Cannot be updated.",
 	"ports":                  "List of ports to expose from the container. Cannot be updated.",
 	"env":                    "List of environment variables to set in the container. Cannot be updated.",
-	"resources":              "Compute Resources required by this container. Cannot be updated. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#resources",
+	"resources":              "Compute Resources required by this container. Cannot be updated. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#resources",
 	"volumeMounts":           "Pod volumes to mount into the container's filesyste. Cannot be updated.",
-	"livenessProbe":          "Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-probes",
-	"readinessProbe":         "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-probes",
+	"livenessProbe":          "Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-probes",
+	"readinessProbe":         "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-probes",
 	"lifecycle":              "Actions that the management system should take in response to container lifecycle events. Cannot be updated.",
 	"terminationMessagePath": "Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Defaults to /dev/termination-log. Cannot be updated.",
-	"imagePullPolicy":        "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/images.md#updating-images",
-	"securityContext":        "Security options the pod should run with. More info: http://releases.k8s.io/v1.1.0/docs/design/security_context.md",
+	"imagePullPolicy":        "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: http://releases.k8s.io/release-1.1/docs/user-guide/images.md#updating-images",
+	"securityContext":        "Security options the pod should run with. More info: http://releases.k8s.io/release-1.1/docs/design/security_context.md",
 	"stdin":                  "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
 	"stdinOnce":              "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false",
 	"tty":                    "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.",
@@ -206,9 +206,9 @@ var map_ContainerStatus = map[string]string{
 	"lastState":    "Details about the container's last termination condition.",
 	"ready":        "Specifies whether the container has passed its readiness probe.",
 	"restartCount": "The number of times the container has been restarted, currently based on the number of dead containers that have not yet been removed. Note that this is calculated from dead containers. But those containers are subject to garbage collection. This value will get capped at 5 by GC.",
-	"image":        "The image the container is running. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/images.md",
+	"image":        "The image the container is running. More info: http://releases.k8s.io/release-1.1/docs/user-guide/images.md",
 	"imageID":      "ImageID of the container's image.",
-	"containerID":  "Container's ID in the format 'docker://<container_id>'. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/container-environment.md#container-information",
+	"containerID":  "Container's ID in the format 'docker://<container_id>'. More info: http://releases.k8s.io/release-1.1/docs/user-guide/container-environment.md#container-information",
 }
 
 func (ContainerStatus) SwaggerDoc() map[string]string {
@@ -254,7 +254,7 @@ func (DownwardAPIVolumeSource) SwaggerDoc() map[string]string {
 
 var map_EmptyDirVolumeSource = map[string]string{
 	"":       "EmptyDirVolumeSource is temporary directory that shares a pod's lifetime.",
-	"medium": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#emptydir",
+	"medium": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#emptydir",
 }
 
 func (EmptyDirVolumeSource) SwaggerDoc() map[string]string {
@@ -295,7 +295,7 @@ func (EndpointSubset) SwaggerDoc() map[string]string {
 
 var map_Endpoints = map[string]string{
 	"":         "Endpoints is a collection of endpoints that implement the actual service. Example:\n  Name: \"mysvc\",\n  Subsets: [\n    {\n      Addresses: [{\"ip\": \"10.10.1.1\"}, {\"ip\": \"10.10.2.2\"}],\n      Ports: [{\"name\": \"a\", \"port\": 8675}, {\"name\": \"b\", \"port\": 309}]\n    },\n    {\n      Addresses: [{\"ip\": \"10.10.3.3\"}],\n      Ports: [{\"name\": \"a\", \"port\": 93}, {\"name\": \"b\", \"port\": 76}]\n    },\n ]",
-	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata",
+	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata",
 	"subsets":  "The set of all endpoints is the union of all subsets. Addresses are placed into subsets according to the IPs they share. A single address with multiple ports, some of which are ready and some of which are not (because they come from different containers) will result in the address being displayed in different subsets for the different ports. No address will appear in both Addresses and NotReadyAddresses in the same subset. Sets of addresses and ports that comprise a service.",
 }
 
@@ -305,7 +305,7 @@ func (Endpoints) SwaggerDoc() map[string]string {
 
 var map_EndpointsList = map[string]string{
 	"":         "EndpointsList is a list of endpoints.",
-	"metadata": "Standard list metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds",
+	"metadata": "Standard list metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds",
 	"items":    "List of endpoints.",
 }
 
@@ -335,7 +335,7 @@ func (EnvVarSource) SwaggerDoc() map[string]string {
 
 var map_Event = map[string]string{
 	"":               "Event is a report of an event somewhere in the cluster.",
-	"metadata":       "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata",
+	"metadata":       "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata",
 	"involvedObject": "The object that this event is about.",
 	"reason":         "This should be a short, machine understandable string that gives the reason for the transition into the object's current status.",
 	"message":        "A human-readable description of the status of this operation.",
@@ -351,7 +351,7 @@ func (Event) SwaggerDoc() map[string]string {
 
 var map_EventList = map[string]string{
 	"":         "EventList is a list of events.",
-	"metadata": "Standard list metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds",
+	"metadata": "Standard list metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds",
 	"items":    "List of events",
 }
 
@@ -401,10 +401,10 @@ func (FlockerVolumeSource) SwaggerDoc() map[string]string {
 
 var map_GCEPersistentDiskVolumeSource = map[string]string{
 	"":          "GCEPersistentDiskVolumeSource represents a Persistent Disk resource in Google Compute Engine.\n\nA GCE PD must exist and be formatted before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once.",
-	"pdName":    "Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk",
-	"fsType":    "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk",
-	"partition": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk",
-	"readOnly":  "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk",
+	"pdName":    "Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk",
+	"fsType":    "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk",
+	"partition": "The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk",
+	"readOnly":  "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk",
 }
 
 func (GCEPersistentDiskVolumeSource) SwaggerDoc() map[string]string {
@@ -423,9 +423,9 @@ func (GitRepoVolumeSource) SwaggerDoc() map[string]string {
 
 var map_GlusterfsVolumeSource = map[string]string{
 	"":          "GlusterfsVolumeSource represents a Glusterfs Mount that lasts the lifetime of a pod.",
-	"endpoints": "EndpointsName is the endpoint name that details Glusterfs topology. More info: http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md#create-a-pod",
-	"path":      "Path is the Glusterfs volume path. More info: http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md#create-a-pod",
-	"readOnly":  "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md#create-a-pod",
+	"endpoints": "EndpointsName is the endpoint name that details Glusterfs topology. More info: http://releases.k8s.io/release-1.1/examples/glusterfs/README.md#create-a-pod",
+	"path":      "Path is the Glusterfs volume path. More info: http://releases.k8s.io/release-1.1/examples/glusterfs/README.md#create-a-pod",
+	"readOnly":  "ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: http://releases.k8s.io/release-1.1/examples/glusterfs/README.md#create-a-pod",
 }
 
 func (GlusterfsVolumeSource) SwaggerDoc() map[string]string {
@@ -457,7 +457,7 @@ func (Handler) SwaggerDoc() map[string]string {
 
 var map_HostPathVolumeSource = map[string]string{
 	"":     "HostPathVolumeSource represents bare host directory volume.",
-	"path": "Path of the directory on the host. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#hostpath",
+	"path": "Path of the directory on the host. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#hostpath",
 }
 
 func (HostPathVolumeSource) SwaggerDoc() map[string]string {
@@ -469,7 +469,7 @@ var map_ISCSIVolumeSource = map[string]string{
 	"targetPortal": "iSCSI target portal. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
 	"iqn":          "Target iSCSI Qualified Name.",
 	"lun":          "iSCSI target lun number.",
-	"fsType":       "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#iscsi",
+	"fsType":       "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#iscsi",
 	"readOnly":     "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
 }
 
@@ -479,8 +479,8 @@ func (ISCSIVolumeSource) SwaggerDoc() map[string]string {
 
 var map_Lifecycle = map[string]string{
 	"":          "Lifecycle describes actions that the management system should take in response to container lifecycle events. For the PostStart and PreStop lifecycle handlers, management of the container blocks until the action is complete, unless the container process fails, in which case the handler is aborted.",
-	"postStart": "PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/container-environment.md#hook-details",
-	"preStop":   "PreStop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/container-environment.md#hook-details",
+	"postStart": "PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: http://releases.k8s.io/release-1.1/docs/user-guide/container-environment.md#hook-details",
+	"preStop":   "PreStop is called immediately before a container is terminated. The container is terminated after the handler completes. The reason for termination is passed to the handler. Regardless of the outcome of the handler, the container is eventually terminated. Other management of the container blocks until the hook completes. More info: http://releases.k8s.io/release-1.1/docs/user-guide/container-environment.md#hook-details",
 }
 
 func (Lifecycle) SwaggerDoc() map[string]string {
@@ -489,8 +489,8 @@ func (Lifecycle) SwaggerDoc() map[string]string {
 
 var map_LimitRange = map[string]string{
 	"":         "LimitRange sets resource usage limits for each kind of resource in a Namespace.",
-	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata",
-	"spec":     "Spec defines the limits enforced. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status",
+	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata",
+	"spec":     "Spec defines the limits enforced. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status",
 }
 
 func (LimitRange) SwaggerDoc() map[string]string {
@@ -513,8 +513,8 @@ func (LimitRangeItem) SwaggerDoc() map[string]string {
 
 var map_LimitRangeList = map[string]string{
 	"":         "LimitRangeList is a list of LimitRange items.",
-	"metadata": "Standard list metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds",
-	"items":    "Items is a list of LimitRange objects. More info: http://releases.k8s.io/v1.1.0/docs/design/admission_control_limit_range.md",
+	"metadata": "Standard list metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds",
+	"items":    "Items is a list of LimitRange objects. More info: http://releases.k8s.io/release-1.1/docs/design/admission_control_limit_range.md",
 }
 
 func (LimitRangeList) SwaggerDoc() map[string]string {
@@ -532,7 +532,7 @@ func (LimitRangeSpec) SwaggerDoc() map[string]string {
 
 var map_List = map[string]string{
 	"":         "List holds a list of objects, which may not be known by the server.",
-	"metadata": "Standard list metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds",
+	"metadata": "Standard list metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds",
 	"items":    "List of objects",
 }
 
@@ -573,7 +573,7 @@ func (LoadBalancerStatus) SwaggerDoc() map[string]string {
 
 var map_LocalObjectReference = map[string]string{
 	"":     "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
-	"name": "Name of the referent. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#names",
+	"name": "Name of the referent. More info: http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#names",
 }
 
 func (LocalObjectReference) SwaggerDoc() map[string]string {
@@ -582,9 +582,9 @@ func (LocalObjectReference) SwaggerDoc() map[string]string {
 
 var map_NFSVolumeSource = map[string]string{
 	"":         "NFSVolumeSource represents an NFS mount that lasts the lifetime of a pod",
-	"server":   "Server is the hostname or IP address of the NFS server. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs",
-	"path":     "Path that is exported by the NFS server. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs",
-	"readOnly": "ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs",
+	"server":   "Server is the hostname or IP address of the NFS server. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs",
+	"path":     "Path that is exported by the NFS server. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs",
+	"readOnly": "ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs",
 }
 
 func (NFSVolumeSource) SwaggerDoc() map[string]string {
@@ -593,9 +593,9 @@ func (NFSVolumeSource) SwaggerDoc() map[string]string {
 
 var map_Namespace = map[string]string{
 	"":         "Namespace provides a scope for Names. Use of multiple namespaces is optional.",
-	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata",
-	"spec":     "Spec defines the behavior of the Namespace. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status",
-	"status":   "Status describes the current status of a Namespace. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status",
+	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata",
+	"spec":     "Spec defines the behavior of the Namespace. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status",
+	"status":   "Status describes the current status of a Namespace. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status",
 }
 
 func (Namespace) SwaggerDoc() map[string]string {
@@ -604,8 +604,8 @@ func (Namespace) SwaggerDoc() map[string]string {
 
 var map_NamespaceList = map[string]string{
 	"":         "NamespaceList is a list of Namespaces.",
-	"metadata": "Standard list metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds",
-	"items":    "Items is the list of Namespace objects in the list. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/namespaces.md",
+	"metadata": "Standard list metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds",
+	"items":    "Items is the list of Namespace objects in the list. More info: http://releases.k8s.io/release-1.1/docs/user-guide/namespaces.md",
 }
 
 func (NamespaceList) SwaggerDoc() map[string]string {
@@ -614,7 +614,7 @@ func (NamespaceList) SwaggerDoc() map[string]string {
 
 var map_NamespaceSpec = map[string]string{
 	"":           "NamespaceSpec describes the attributes on a Namespace.",
-	"finalizers": "Finalizers is an opaque list of values that must be empty to permanently remove object from storage. More info: http://releases.k8s.io/v1.1.0/docs/design/namespaces.md#finalizers",
+	"finalizers": "Finalizers is an opaque list of values that must be empty to permanently remove object from storage. More info: http://releases.k8s.io/release-1.1/docs/design/namespaces.md#finalizers",
 }
 
 func (NamespaceSpec) SwaggerDoc() map[string]string {
@@ -623,7 +623,7 @@ func (NamespaceSpec) SwaggerDoc() map[string]string {
 
 var map_NamespaceStatus = map[string]string{
 	"":      "NamespaceStatus is information about the current status of a Namespace.",
-	"phase": "Phase is the current lifecycle phase of the namespace. More info: http://releases.k8s.io/v1.1.0/docs/design/namespaces.md#phases",
+	"phase": "Phase is the current lifecycle phase of the namespace. More info: http://releases.k8s.io/release-1.1/docs/design/namespaces.md#phases",
 }
 
 func (NamespaceStatus) SwaggerDoc() map[string]string {
@@ -632,9 +632,9 @@ func (NamespaceStatus) SwaggerDoc() map[string]string {
 
 var map_Node = map[string]string{
 	"":         "Node is a worker node in Kubernetes, formerly known as minion. Each node will have a unique identifier in the cache (i.e. in etcd).",
-	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata",
-	"spec":     "Spec defines the behavior of a node. http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status",
-	"status":   "Most recently observed status of the node. Populated by the system. Read-only. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status",
+	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata",
+	"spec":     "Spec defines the behavior of a node. http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status",
+	"status":   "Most recently observed status of the node. Populated by the system. Read-only. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status",
 }
 
 func (Node) SwaggerDoc() map[string]string {
@@ -676,7 +676,7 @@ func (NodeDaemonEndpoints) SwaggerDoc() map[string]string {
 
 var map_NodeList = map[string]string{
 	"":         "NodeList is the whole list of all Nodes which have been registered with master.",
-	"metadata": "Standard list metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds",
+	"metadata": "Standard list metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds",
 	"items":    "List of nodes",
 }
 
@@ -689,7 +689,7 @@ var map_NodeSpec = map[string]string{
 	"podCIDR":       "PodCIDR represents the pod IP range assigned to the node.",
 	"externalID":    "External ID of the node assigned by some machine database (e.g. a cloud provider). Deprecated.",
 	"providerID":    "ID of the node assigned by the cloud provider in the format: <ProviderName>://<ProviderSpecificNodeID>",
-	"unschedulable": "Unschedulable controls node schedulability of new pods. By default, node is schedulable. More info: http://releases.k8s.io/v1.1.0/docs/admin/node.md#manual-node-administration\"`",
+	"unschedulable": "Unschedulable controls node schedulability of new pods. By default, node is schedulable. More info: http://releases.k8s.io/release-1.1/docs/admin/node.md#manual-node-administration\"`",
 }
 
 func (NodeSpec) SwaggerDoc() map[string]string {
@@ -698,12 +698,12 @@ func (NodeSpec) SwaggerDoc() map[string]string {
 
 var map_NodeStatus = map[string]string{
 	"":                "NodeStatus is information about the current status of a node.",
-	"capacity":        "Capacity represents the available resources of a node. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#capacity for more details.",
-	"phase":           "NodePhase is the recently observed lifecycle phase of the node. More info: http://releases.k8s.io/v1.1.0/docs/admin/node.md#node-phase",
-	"conditions":      "Conditions is an array of current observed node conditions. More info: http://releases.k8s.io/v1.1.0/docs/admin/node.md#node-condition",
-	"addresses":       "List of addresses reachable to the node. Queried from cloud provider, if available. More info: http://releases.k8s.io/v1.1.0/docs/admin/node.md#node-addresses",
+	"capacity":        "Capacity represents the available resources of a node. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#capacity for more details.",
+	"phase":           "NodePhase is the recently observed lifecycle phase of the node. More info: http://releases.k8s.io/release-1.1/docs/admin/node.md#node-phase",
+	"conditions":      "Conditions is an array of current observed node conditions. More info: http://releases.k8s.io/release-1.1/docs/admin/node.md#node-condition",
+	"addresses":       "List of addresses reachable to the node. Queried from cloud provider, if available. More info: http://releases.k8s.io/release-1.1/docs/admin/node.md#node-addresses",
 	"daemonEndpoints": "Endpoints of daemons running on the Node.",
-	"nodeInfo":        "Set of ids/uuids to uniquely identify the node. More info: http://releases.k8s.io/v1.1.0/docs/admin/node.md#node-info",
+	"nodeInfo":        "Set of ids/uuids to uniquely identify the node. More info: http://releases.k8s.io/release-1.1/docs/admin/node.md#node-info",
 }
 
 func (NodeStatus) SwaggerDoc() map[string]string {
@@ -738,18 +738,18 @@ func (ObjectFieldSelector) SwaggerDoc() map[string]string {
 
 var map_ObjectMeta = map[string]string{
 	"":                           "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
-	"name":                       "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#names",
-	"generateName":               "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).\n\nApplied only if Name is not specified. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#idempotency",
-	"namespace":                  "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/namespaces.md",
+	"name":                       "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#names",
+	"generateName":               "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).\n\nApplied only if Name is not specified. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#idempotency",
+	"namespace":                  "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: http://releases.k8s.io/release-1.1/docs/user-guide/namespaces.md",
 	"selfLink":                   "SelfLink is a URL representing this object. Populated by the system. Read-only.",
-	"uid":                        "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#uids",
-	"resourceVersion":            "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#concurrency-control-and-consistency",
+	"uid":                        "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#uids",
+	"resourceVersion":            "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#concurrency-control-and-consistency",
 	"generation":                 "A sequence number representing a specific generation of the desired state. Currently only implemented by replication controllers. Populated by the system. Read-only.",
-	"creationTimestamp":          "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata",
-	"deletionTimestamp":          "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource will be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field. Once set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. Once the resource is deleted in the API, the Kubelet will send a hard termination signal to the container. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata",
+	"creationTimestamp":          "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata",
+	"deletionTimestamp":          "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource will be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field. Once set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. Once the resource is deleted in the API, the Kubelet will send a hard termination signal to the container. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata",
 	"deletionGracePeriodSeconds": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
-	"labels":                     "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md",
-	"annotations":                "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/annotations.md",
+	"labels":                     "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://releases.k8s.io/release-1.1/docs/user-guide/labels.md",
+	"annotations":                "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://releases.k8s.io/release-1.1/docs/user-guide/annotations.md",
 }
 
 func (ObjectMeta) SwaggerDoc() map[string]string {
@@ -758,12 +758,12 @@ func (ObjectMeta) SwaggerDoc() map[string]string {
 
 var map_ObjectReference = map[string]string{
 	"":                "ObjectReference contains enough information to let you inspect or modify the referred object.",
-	"kind":            "Kind of the referent. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds",
-	"namespace":       "Namespace of the referent. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/namespaces.md",
-	"name":            "Name of the referent. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#names",
-	"uid":             "UID of the referent. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#uids",
+	"kind":            "Kind of the referent. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds",
+	"namespace":       "Namespace of the referent. More info: http://releases.k8s.io/release-1.1/docs/user-guide/namespaces.md",
+	"name":            "Name of the referent. More info: http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#names",
+	"uid":             "UID of the referent. More info: http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#uids",
 	"apiVersion":      "API version of the referent.",
-	"resourceVersion": "Specific resourceVersion to which this reference is made, if any. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#concurrency-control-and-consistency",
+	"resourceVersion": "Specific resourceVersion to which this reference is made, if any. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#concurrency-control-and-consistency",
 	"fieldPath":       "If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: \"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered the event) or if no container name is specified \"spec.containers[2]\" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object.",
 }
 
@@ -772,10 +772,10 @@ func (ObjectReference) SwaggerDoc() map[string]string {
 }
 
 var map_PersistentVolume = map[string]string{
-	"":         "PersistentVolume (PV) is a storage resource provisioned by an administrator. It is analogous to a node. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md",
-	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata",
-	"spec":     "Spec defines a specification of a persistent volume owned by the cluster. Provisioned by an administrator. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistent-volumes",
-	"status":   "Status represents the current information/status for the persistent volume. Populated by the system. Read-only. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistent-volumes",
+	"":         "PersistentVolume (PV) is a storage resource provisioned by an administrator. It is analogous to a node. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md",
+	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata",
+	"spec":     "Spec defines a specification of a persistent volume owned by the cluster. Provisioned by an administrator. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistent-volumes",
+	"status":   "Status represents the current information/status for the persistent volume. Populated by the system. Read-only. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistent-volumes",
 }
 
 func (PersistentVolume) SwaggerDoc() map[string]string {
@@ -784,9 +784,9 @@ func (PersistentVolume) SwaggerDoc() map[string]string {
 
 var map_PersistentVolumeClaim = map[string]string{
 	"":         "PersistentVolumeClaim is a user's request for and claim to a persistent volume",
-	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata",
-	"spec":     "Spec defines the desired characteristics of a volume requested by a pod author. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistentvolumeclaims",
-	"status":   "Status represents the current information/status of a persistent volume claim. Read-only. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistentvolumeclaims",
+	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata",
+	"spec":     "Spec defines the desired characteristics of a volume requested by a pod author. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistentvolumeclaims",
+	"status":   "Status represents the current information/status of a persistent volume claim. Read-only. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistentvolumeclaims",
 }
 
 func (PersistentVolumeClaim) SwaggerDoc() map[string]string {
@@ -795,8 +795,8 @@ func (PersistentVolumeClaim) SwaggerDoc() map[string]string {
 
 var map_PersistentVolumeClaimList = map[string]string{
 	"":         "PersistentVolumeClaimList is a list of PersistentVolumeClaim items.",
-	"metadata": "Standard list metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds",
-	"items":    "A list of persistent volume claims. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistentvolumeclaims",
+	"metadata": "Standard list metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds",
+	"items":    "A list of persistent volume claims. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistentvolumeclaims",
 }
 
 func (PersistentVolumeClaimList) SwaggerDoc() map[string]string {
@@ -805,8 +805,8 @@ func (PersistentVolumeClaimList) SwaggerDoc() map[string]string {
 
 var map_PersistentVolumeClaimSpec = map[string]string{
 	"":            "PersistentVolumeClaimSpec describes the common attributes of storage devices and allows a Source for provider-specific attributes",
-	"accessModes": "AccessModes contains the desired access modes the volume should have. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#access-modes-1",
-	"resources":   "Resources represents the minimum resources the volume should have. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#resources",
+	"accessModes": "AccessModes contains the desired access modes the volume should have. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#access-modes-1",
+	"resources":   "Resources represents the minimum resources the volume should have. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#resources",
 	"volumeName":  "VolumeName is the binding reference to the PersistentVolume backing this claim.",
 }
 
@@ -817,7 +817,7 @@ func (PersistentVolumeClaimSpec) SwaggerDoc() map[string]string {
 var map_PersistentVolumeClaimStatus = map[string]string{
 	"":            "PersistentVolumeClaimStatus is the current status of a persistent volume claim.",
 	"phase":       "Phase represents the current phase of PersistentVolumeClaim.",
-	"accessModes": "AccessModes contains the actual access modes the volume backing the PVC has. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#access-modes-1",
+	"accessModes": "AccessModes contains the actual access modes the volume backing the PVC has. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#access-modes-1",
 	"capacity":    "Represents the actual resources of the underlying volume.",
 }
 
@@ -827,7 +827,7 @@ func (PersistentVolumeClaimStatus) SwaggerDoc() map[string]string {
 
 var map_PersistentVolumeClaimVolumeSource = map[string]string{
 	"":          "PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a wrapper around another type of volume that is owned by someone else (the system).",
-	"claimName": "ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistentvolumeclaims",
+	"claimName": "ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistentvolumeclaims",
 	"readOnly":  "Will force the ReadOnly setting in VolumeMounts. Default false.",
 }
 
@@ -837,8 +837,8 @@ func (PersistentVolumeClaimVolumeSource) SwaggerDoc() map[string]string {
 
 var map_PersistentVolumeList = map[string]string{
 	"":         "PersistentVolumeList is a list of PersistentVolume items.",
-	"metadata": "Standard list metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds",
-	"items":    "List of persistent volumes. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md",
+	"metadata": "Standard list metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds",
+	"items":    "List of persistent volumes. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md",
 }
 
 func (PersistentVolumeList) SwaggerDoc() map[string]string {
@@ -847,14 +847,14 @@ func (PersistentVolumeList) SwaggerDoc() map[string]string {
 
 var map_PersistentVolumeSource = map[string]string{
 	"":                     "PersistentVolumeSource is similar to VolumeSource but meant for the administrator who creates PVs. Exactly one of its members must be set.",
-	"gcePersistentDisk":    "GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk",
-	"awsElasticBlockStore": "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore",
-	"hostPath":             "HostPath represents a directory on the host. Provisioned by a developer or tester. This is useful for single-node development and testing only! On-host storage is not supported in any way and WILL NOT WORK in a multi-node cluster. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#hostpath",
-	"glusterfs":            "Glusterfs represents a Glusterfs volume that is attached to a host and exposed to the pod. Provisioned by an admin. More info: http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md",
-	"nfs":                  "NFS represents an NFS mount on the host. Provisioned by an admin. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs",
-	"rbd":                  "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/v1.1.0/examples/rbd/README.md",
+	"gcePersistentDisk":    "GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk",
+	"awsElasticBlockStore": "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore",
+	"hostPath":             "HostPath represents a directory on the host. Provisioned by a developer or tester. This is useful for single-node development and testing only! On-host storage is not supported in any way and WILL NOT WORK in a multi-node cluster. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#hostpath",
+	"glusterfs":            "Glusterfs represents a Glusterfs volume that is attached to a host and exposed to the pod. Provisioned by an admin. More info: http://releases.k8s.io/release-1.1/examples/glusterfs/README.md",
+	"nfs":                  "NFS represents an NFS mount on the host. Provisioned by an admin. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs",
+	"rbd":                  "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/release-1.1/examples/rbd/README.md",
 	"iscsi":                "ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. Provisioned by an admin.",
-	"cinder":               "Cinder represents a cinder volume attached and mounted on kubelets host machine More info: http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md",
+	"cinder":               "Cinder represents a cinder volume attached and mounted on kubelets host machine More info: http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md",
 	"cephfs":               "CephFS represents a Ceph FS mount on the host that shares a pod's lifetime",
 	"fc":                   "FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
 	"flocker":              "Flocker represents a Flocker volume attached to a kubelet's host machine and exposed to the pod for its usage. This depends on the Flocker control service being running",
@@ -866,10 +866,10 @@ func (PersistentVolumeSource) SwaggerDoc() map[string]string {
 
 var map_PersistentVolumeSpec = map[string]string{
 	"":                              "PersistentVolumeSpec is the specification of a persistent volume.",
-	"capacity":                      "A description of the persistent volume's resources and capacity. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#capacity",
-	"accessModes":                   "AccessModes contains all ways the volume can be mounted. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#access-modes",
-	"claimRef":                      "ClaimRef is part of a bi-directional binding between PersistentVolume and PersistentVolumeClaim. Expected to be non-nil when bound. claim.VolumeName is the authoritative bind between PV and PVC. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#binding",
-	"persistentVolumeReclaimPolicy": "What happens to a persistent volume when released from its claim. Valid options are Retain (default) and Recycle. Recyling must be supported by the volume plugin underlying this persistent volume. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#recycling-policy",
+	"capacity":                      "A description of the persistent volume's resources and capacity. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#capacity",
+	"accessModes":                   "AccessModes contains all ways the volume can be mounted. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#access-modes",
+	"claimRef":                      "ClaimRef is part of a bi-directional binding between PersistentVolume and PersistentVolumeClaim. Expected to be non-nil when bound. claim.VolumeName is the authoritative bind between PV and PVC. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#binding",
+	"persistentVolumeReclaimPolicy": "What happens to a persistent volume when released from its claim. Valid options are Retain (default) and Recycle. Recyling must be supported by the volume plugin underlying this persistent volume. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#recycling-policy",
 }
 
 func (PersistentVolumeSpec) SwaggerDoc() map[string]string {
@@ -878,7 +878,7 @@ func (PersistentVolumeSpec) SwaggerDoc() map[string]string {
 
 var map_PersistentVolumeStatus = map[string]string{
 	"":        "PersistentVolumeStatus is the current status of a persistent volume.",
-	"phase":   "Phase indicates if a volume is available, bound to a claim, or released by a claim. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#phase",
+	"phase":   "Phase indicates if a volume is available, bound to a claim, or released by a claim. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#phase",
 	"message": "A human-readable message indicating details about why the volume is in this state.",
 	"reason":  "Reason is a brief CamelCase string that describes any failure and is meant for machine parsing and tidy display in the CLI.",
 }
@@ -889,9 +889,9 @@ func (PersistentVolumeStatus) SwaggerDoc() map[string]string {
 
 var map_Pod = map[string]string{
 	"":         "Pod is a collection of containers that can run on a host. This resource is created by clients and scheduled onto hosts.",
-	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata",
-	"spec":     "Specification of the desired behavior of the pod. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status",
-	"status":   "Most recently observed status of the pod. This data may not be up to date. Populated by the system. Read-only. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status",
+	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata",
+	"spec":     "Specification of the desired behavior of the pod. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status",
+	"status":   "Most recently observed status of the pod. This data may not be up to date. Populated by the system. Read-only. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status",
 }
 
 func (Pod) SwaggerDoc() map[string]string {
@@ -913,8 +913,8 @@ func (PodAttachOptions) SwaggerDoc() map[string]string {
 
 var map_PodCondition = map[string]string{
 	"":                   "PodCondition contains details for the current condition of this pod.",
-	"type":               "Type is the type of the condition. Currently only Ready. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#pod-conditions",
-	"status":             "Status is the status of the condition. Can be True, False, Unknown. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#pod-conditions",
+	"type":               "Type is the type of the condition. Currently only Ready. More info: http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#pod-conditions",
+	"status":             "Status is the status of the condition. Can be True, False, Unknown. More info: http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#pod-conditions",
 	"lastProbeTime":      "Last time we probed the condition.",
 	"lastTransitionTime": "Last time the condition transitioned from one status to another.",
 	"reason":             "Unique, one-word, CamelCase reason for the condition's last transition.",
@@ -941,8 +941,8 @@ func (PodExecOptions) SwaggerDoc() map[string]string {
 
 var map_PodList = map[string]string{
 	"":         "PodList is a list of Pods.",
-	"metadata": "Standard list metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds",
-	"items":    "List of pods. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pods.md",
+	"metadata": "Standard list metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds",
+	"items":    "List of pods. More info: http://releases.k8s.io/release-1.1/docs/user-guide/pods.md",
 }
 
 func (PodList) SwaggerDoc() map[string]string {
@@ -976,20 +976,20 @@ func (PodProxyOptions) SwaggerDoc() map[string]string {
 
 var map_PodSpec = map[string]string{
 	"":                              "PodSpec is a description of a pod.",
-	"volumes":                       "List of volumes that can be mounted by containers belonging to the pod. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md",
-	"containers":                    "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/containers.md",
-	"restartPolicy":                 "Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#restartpolicy",
+	"volumes":                       "List of volumes that can be mounted by containers belonging to the pod. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md",
+	"containers":                    "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. More info: http://releases.k8s.io/release-1.1/docs/user-guide/containers.md",
+	"restartPolicy":                 "Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#restartpolicy",
 	"terminationGracePeriodSeconds": "Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds.",
 	"activeDeadlineSeconds":         "Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.",
 	"dnsPolicy":                     "Set DNS policy for containers within the pod. One of 'ClusterFirst' or 'Default'. Defaults to \"ClusterFirst\".",
-	"nodeSelector":                  "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/node-selection/README.md",
-	"serviceAccountName":            "ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: http://releases.k8s.io/v1.1.0/docs/design/service_accounts.md",
+	"nodeSelector":                  "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: http://releases.k8s.io/release-1.1/docs/user-guide/node-selection/README.md",
+	"serviceAccountName":            "ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: http://releases.k8s.io/release-1.1/docs/design/service_accounts.md",
 	"serviceAccount":                "DeprecatedServiceAccount is a depreciated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead.",
 	"nodeName":                      "NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.",
 	"hostNetwork":                   "Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.",
 	"hostPID":                       "Use the host's pid namespace. Optional: Default to false.",
 	"hostIPC":                       "Use the host's ipc namespace. Optional: Default to false.",
-	"imagePullSecrets":              "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/images.md#specifying-imagepullsecrets-on-a-pod",
+	"imagePullSecrets":              "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: http://releases.k8s.io/release-1.1/docs/user-guide/images.md#specifying-imagepullsecrets-on-a-pod",
 }
 
 func (PodSpec) SwaggerDoc() map[string]string {
@@ -998,14 +998,14 @@ func (PodSpec) SwaggerDoc() map[string]string {
 
 var map_PodStatus = map[string]string{
 	"":                  "PodStatus represents information about the status of a pod. Status may trail the actual state of a system.",
-	"phase":             "Current condition of the pod. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#pod-phase",
-	"conditions":        "Current service state of pod. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#pod-conditions",
+	"phase":             "Current condition of the pod. More info: http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#pod-phase",
+	"conditions":        "Current service state of pod. More info: http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#pod-conditions",
 	"message":           "A human readable message indicating details about why the pod is in this condition.",
 	"reason":            "A brief CamelCase message indicating details about why the pod is in this state. e.g. 'OutOfDisk'",
 	"hostIP":            "IP address of the host to which the pod is assigned. Empty if not yet scheduled.",
 	"podIP":             "IP address allocated to the pod. Routable at least within the cluster. Empty if not yet allocated.",
 	"startTime":         "RFC 3339 date and time at which the object was acknowledged by the Kubelet. This is before the Kubelet pulled the container image(s) for the pod.",
-	"containerStatuses": "The list has one entry per container in the manifest. Each entry is currently the output of `docker inspect`. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-statuses",
+	"containerStatuses": "The list has one entry per container in the manifest. Each entry is currently the output of `docker inspect`. More info: http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-statuses",
 }
 
 func (PodStatus) SwaggerDoc() map[string]string {
@@ -1014,8 +1014,8 @@ func (PodStatus) SwaggerDoc() map[string]string {
 
 var map_PodStatusResult = map[string]string{
 	"":         "PodStatusResult is a wrapper for PodStatus returned by kubelet that can be encode/decoded",
-	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata",
-	"status":   "Most recently observed status of the pod. This data may not be up to date. Populated by the system. Read-only. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status",
+	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata",
+	"status":   "Most recently observed status of the pod. This data may not be up to date. Populated by the system. Read-only. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status",
 }
 
 func (PodStatusResult) SwaggerDoc() map[string]string {
@@ -1024,8 +1024,8 @@ func (PodStatusResult) SwaggerDoc() map[string]string {
 
 var map_PodTemplate = map[string]string{
 	"":         "PodTemplate describes a template for creating copies of a predefined pod.",
-	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata",
-	"template": "Template defines the pods that will be created from this pod template. http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status",
+	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata",
+	"template": "Template defines the pods that will be created from this pod template. http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status",
 }
 
 func (PodTemplate) SwaggerDoc() map[string]string {
@@ -1034,7 +1034,7 @@ func (PodTemplate) SwaggerDoc() map[string]string {
 
 var map_PodTemplateList = map[string]string{
 	"":         "PodTemplateList is a list of PodTemplates.",
-	"metadata": "Standard list metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds",
+	"metadata": "Standard list metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds",
 	"items":    "List of pod templates",
 }
 
@@ -1044,8 +1044,8 @@ func (PodTemplateList) SwaggerDoc() map[string]string {
 
 var map_PodTemplateSpec = map[string]string{
 	"":         "PodTemplateSpec describes the data a pod should have when created from a template",
-	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata",
-	"spec":     "Specification of the desired behavior of the pod. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status",
+	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata",
+	"spec":     "Specification of the desired behavior of the pod. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status",
 }
 
 func (PodTemplateSpec) SwaggerDoc() map[string]string {
@@ -1054,8 +1054,8 @@ func (PodTemplateSpec) SwaggerDoc() map[string]string {
 
 var map_Probe = map[string]string{
 	"": "Probe describes a liveness probe to be examined to the container.",
-	"initialDelaySeconds": "Number of seconds after the container has started before liveness probes are initiated. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-probes",
-	"timeoutSeconds":      "Number of seconds after which liveness probes timeout. Defaults to 1 second. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/pod-states.md#container-probes",
+	"initialDelaySeconds": "Number of seconds after the container has started before liveness probes are initiated. More info: http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-probes",
+	"timeoutSeconds":      "Number of seconds after which liveness probes timeout. Defaults to 1 second. More info: http://releases.k8s.io/release-1.1/docs/user-guide/pod-states.md#container-probes",
 }
 
 func (Probe) SwaggerDoc() map[string]string {
@@ -1064,14 +1064,14 @@ func (Probe) SwaggerDoc() map[string]string {
 
 var map_RBDVolumeSource = map[string]string{
 	"":          "RBDVolumeSource represents a Rados Block Device Mount that lasts the lifetime of a pod",
-	"monitors":  "A collection of Ceph monitors. More info: http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it",
-	"image":     "The rados image name. More info: http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it",
-	"fsType":    "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#rbd",
-	"pool":      "The rados pool name. Default is rbd. More info: http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it.",
-	"user":      "The rados user name. Default is admin. More info: http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it",
-	"keyring":   "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it",
-	"secretRef": "SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is empty. More info: http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it",
-	"readOnly":  "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: http://releases.k8s.io/v1.1.0/examples/rbd/README.md#how-to-use-it",
+	"monitors":  "A collection of Ceph monitors. More info: http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it",
+	"image":     "The rados image name. More info: http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it",
+	"fsType":    "Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#rbd",
+	"pool":      "The rados pool name. Default is rbd. More info: http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it.",
+	"user":      "The rados user name. Default is admin. More info: http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it",
+	"keyring":   "Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it",
+	"secretRef": "SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is empty. More info: http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it",
+	"readOnly":  "ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: http://releases.k8s.io/release-1.1/examples/rbd/README.md#how-to-use-it",
 }
 
 func (RBDVolumeSource) SwaggerDoc() map[string]string {
@@ -1080,7 +1080,7 @@ func (RBDVolumeSource) SwaggerDoc() map[string]string {
 
 var map_RangeAllocation = map[string]string{
 	"":         "RangeAllocation is not a public type.",
-	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata",
+	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata",
 	"range":    "Range is string that identifies the range represented by 'data'.",
 	"data":     "Data is a bit array containing all allocated addresses in the previous segment.",
 }
@@ -1091,9 +1091,9 @@ func (RangeAllocation) SwaggerDoc() map[string]string {
 
 var map_ReplicationController = map[string]string{
 	"":         "ReplicationController represents the configuration of a replication controller.",
-	"metadata": "If the Labels of a ReplicationController are empty, they are defaulted to be the same as the Pod(s) that the replication controller manages. Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata",
-	"spec":     "Spec defines the specification of the desired behavior of the replication controller. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status",
-	"status":   "Status is the most recently observed status of the replication controller. This data may be out of date by some window of time. Populated by the system. Read-only. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status",
+	"metadata": "If the Labels of a ReplicationController are empty, they are defaulted to be the same as the Pod(s) that the replication controller manages. Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata",
+	"spec":     "Spec defines the specification of the desired behavior of the replication controller. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status",
+	"status":   "Status is the most recently observed status of the replication controller. This data may be out of date by some window of time. Populated by the system. Read-only. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status",
 }
 
 func (ReplicationController) SwaggerDoc() map[string]string {
@@ -1102,8 +1102,8 @@ func (ReplicationController) SwaggerDoc() map[string]string {
 
 var map_ReplicationControllerList = map[string]string{
 	"":         "ReplicationControllerList is a collection of replication controllers.",
-	"metadata": "Standard list metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds",
-	"items":    "List of replication controllers. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/replication-controller.md",
+	"metadata": "Standard list metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds",
+	"items":    "List of replication controllers. More info: http://releases.k8s.io/release-1.1/docs/user-guide/replication-controller.md",
 }
 
 func (ReplicationControllerList) SwaggerDoc() map[string]string {
@@ -1112,9 +1112,9 @@ func (ReplicationControllerList) SwaggerDoc() map[string]string {
 
 var map_ReplicationControllerSpec = map[string]string{
 	"":         "ReplicationControllerSpec is the specification of a replication controller.",
-	"replicas": "Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/replication-controller.md#what-is-a-replication-controller",
-	"selector": "Selector is a label query over pods that should match the Replicas count. If Selector is empty, it is defaulted to the labels present on the Pod template. Label keys and values that must match in order to be controlled by this replication controller, if empty defaulted to labels on Pod template. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md#label-selectors",
-	"template": "Template is the object that describes the pod that will be created if insufficient replicas are detected. This takes precedence over a TemplateRef. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/replication-controller.md#pod-template",
+	"replicas": "Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: http://releases.k8s.io/release-1.1/docs/user-guide/replication-controller.md#what-is-a-replication-controller",
+	"selector": "Selector is a label query over pods that should match the Replicas count. If Selector is empty, it is defaulted to the labels present on the Pod template. Label keys and values that must match in order to be controlled by this replication controller, if empty defaulted to labels on Pod template. More info: http://releases.k8s.io/release-1.1/docs/user-guide/labels.md#label-selectors",
+	"template": "Template is the object that describes the pod that will be created if insufficient replicas are detected. This takes precedence over a TemplateRef. More info: http://releases.k8s.io/release-1.1/docs/user-guide/replication-controller.md#pod-template",
 }
 
 func (ReplicationControllerSpec) SwaggerDoc() map[string]string {
@@ -1123,7 +1123,7 @@ func (ReplicationControllerSpec) SwaggerDoc() map[string]string {
 
 var map_ReplicationControllerStatus = map[string]string{
 	"":                   "ReplicationControllerStatus represents the current status of a replication controller.",
-	"replicas":           "Replicas is the most recently oberved number of replicas. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/replication-controller.md#what-is-a-replication-controller",
+	"replicas":           "Replicas is the most recently oberved number of replicas. More info: http://releases.k8s.io/release-1.1/docs/user-guide/replication-controller.md#what-is-a-replication-controller",
 	"observedGeneration": "ObservedGeneration reflects the generation of the most recently observed replication controller.",
 }
 
@@ -1133,9 +1133,9 @@ func (ReplicationControllerStatus) SwaggerDoc() map[string]string {
 
 var map_ResourceQuota = map[string]string{
 	"":         "ResourceQuota sets aggregate quota restrictions enforced per namespace",
-	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata",
-	"spec":     "Spec defines the desired quota. http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status",
-	"status":   "Status defines the actual enforced quota and its current usage. http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status",
+	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata",
+	"spec":     "Spec defines the desired quota. http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status",
+	"status":   "Status defines the actual enforced quota and its current usage. http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status",
 }
 
 func (ResourceQuota) SwaggerDoc() map[string]string {
@@ -1144,8 +1144,8 @@ func (ResourceQuota) SwaggerDoc() map[string]string {
 
 var map_ResourceQuotaList = map[string]string{
 	"":         "ResourceQuotaList is a list of ResourceQuota items.",
-	"metadata": "Standard list metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds",
-	"items":    "Items is a list of ResourceQuota objects. More info: http://releases.k8s.io/v1.1.0/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota",
+	"metadata": "Standard list metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds",
+	"items":    "Items is a list of ResourceQuota objects. More info: http://releases.k8s.io/release-1.1/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota",
 }
 
 func (ResourceQuotaList) SwaggerDoc() map[string]string {
@@ -1154,7 +1154,7 @@ func (ResourceQuotaList) SwaggerDoc() map[string]string {
 
 var map_ResourceQuotaSpec = map[string]string{
 	"":     "ResourceQuotaSpec defines the desired hard limits to enforce for Quota.",
-	"hard": "Hard is the set of desired hard limits for each named resource. More info: http://releases.k8s.io/v1.1.0/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota",
+	"hard": "Hard is the set of desired hard limits for each named resource. More info: http://releases.k8s.io/release-1.1/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota",
 }
 
 func (ResourceQuotaSpec) SwaggerDoc() map[string]string {
@@ -1163,7 +1163,7 @@ func (ResourceQuotaSpec) SwaggerDoc() map[string]string {
 
 var map_ResourceQuotaStatus = map[string]string{
 	"":     "ResourceQuotaStatus defines the enforced hard limits and observed use.",
-	"hard": "Hard is the set of enforced hard limits for each named resource. More info: http://releases.k8s.io/v1.1.0/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota",
+	"hard": "Hard is the set of enforced hard limits for each named resource. More info: http://releases.k8s.io/release-1.1/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota",
 	"used": "Used is the current observed total usage of the resource in the namespace.",
 }
 
@@ -1173,8 +1173,8 @@ func (ResourceQuotaStatus) SwaggerDoc() map[string]string {
 
 var map_ResourceRequirements = map[string]string{
 	"":         "ResourceRequirements describes the compute resource requirements.",
-	"limits":   "Limits describes the maximum amount of compute resources allowed. More info: http://releases.k8s.io/v1.1.0/docs/design/resources.md#resource-specifications",
-	"requests": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: http://releases.k8s.io/v1.1.0/docs/design/resources.md#resource-specifications",
+	"limits":   "Limits describes the maximum amount of compute resources allowed. More info: http://releases.k8s.io/release-1.1/docs/design/resources.md#resource-specifications",
+	"requests": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: http://releases.k8s.io/release-1.1/docs/design/resources.md#resource-specifications",
 }
 
 func (ResourceRequirements) SwaggerDoc() map[string]string {
@@ -1183,10 +1183,10 @@ func (ResourceRequirements) SwaggerDoc() map[string]string {
 
 var map_SELinuxOptions = map[string]string{
 	"":      "SELinuxOptions are the labels to be applied to the container",
-	"user":  "User is a SELinux user label that applies to the container. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md",
-	"role":  "Role is a SELinux role label that applies to the container. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md",
-	"type":  "Type is a SELinux type label that applies to the container. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md",
-	"level": "Level is SELinux level label that applies to the container. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md",
+	"user":  "User is a SELinux user label that applies to the container. More info: http://releases.k8s.io/release-1.1/docs/user-guide/labels.md",
+	"role":  "Role is a SELinux role label that applies to the container. More info: http://releases.k8s.io/release-1.1/docs/user-guide/labels.md",
+	"type":  "Type is a SELinux type label that applies to the container. More info: http://releases.k8s.io/release-1.1/docs/user-guide/labels.md",
+	"level": "Level is SELinux level label that applies to the container. More info: http://releases.k8s.io/release-1.1/docs/user-guide/labels.md",
 }
 
 func (SELinuxOptions) SwaggerDoc() map[string]string {
@@ -1195,7 +1195,7 @@ func (SELinuxOptions) SwaggerDoc() map[string]string {
 
 var map_Secret = map[string]string{
 	"":         "Secret holds secret data of a certain type. The total bytes of the values in the Data field must be less than MaxSecretSize bytes.",
-	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata",
+	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata",
 	"data":     "Data contains the secret data. Each key must be a valid DNS_SUBDOMAIN or leading dot followed by valid DNS_SUBDOMAIN. The serialized form of the secret data is a base64 encoded string, representing the arbitrary (possibly non-string) data value here. Described in https://tools.ietf.org/html/rfc4648#section-4",
 	"type":     "Used to facilitate programmatic handling of secret data.",
 }
@@ -1206,8 +1206,8 @@ func (Secret) SwaggerDoc() map[string]string {
 
 var map_SecretList = map[string]string{
 	"":         "SecretList is a list of Secret.",
-	"metadata": "Standard list metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds",
-	"items":    "Items is a list of secret objects. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/secrets.md",
+	"metadata": "Standard list metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds",
+	"items":    "Items is a list of secret objects. More info: http://releases.k8s.io/release-1.1/docs/user-guide/secrets.md",
 }
 
 func (SecretList) SwaggerDoc() map[string]string {
@@ -1215,8 +1215,8 @@ func (SecretList) SwaggerDoc() map[string]string {
 }
 
 var map_SecretVolumeSource = map[string]string{
-	"":           "SecretVolumeSource adapts a Secret into a VolumeSource. More info: http://releases.k8s.io/v1.1.0/docs/design/secrets.md",
-	"secretName": "SecretName is the name of a secret in the pod's namespace. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#secrets",
+	"":           "SecretVolumeSource adapts a Secret into a VolumeSource. More info: http://releases.k8s.io/release-1.1/docs/design/secrets.md",
+	"secretName": "SecretName is the name of a secret in the pod's namespace. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#secrets",
 }
 
 func (SecretVolumeSource) SwaggerDoc() map[string]string {
@@ -1225,10 +1225,10 @@ func (SecretVolumeSource) SwaggerDoc() map[string]string {
 
 var map_SecurityContext = map[string]string{
 	"":               "SecurityContext holds security configuration that will be applied to a container.",
-	"capabilities":   "The linux kernel capabilites that should be added or removed. Default to Container.Capabilities if left unset. More info: http://releases.k8s.io/v1.1.0/docs/design/security_context.md#security-context",
-	"privileged":     "Run the container in privileged mode. Default to Container.Privileged if left unset. More info: http://releases.k8s.io/v1.1.0/docs/design/security_context.md#security-context",
-	"seLinuxOptions": "SELinuxOptions are the labels to be applied to the container and volumes. Options that control the SELinux labels applied. More info: http://releases.k8s.io/v1.1.0/docs/design/security_context.md#security-context",
-	"runAsUser":      "RunAsUser is the UID to run the entrypoint of the container process. The user id that runs the first process in the container. More info: http://releases.k8s.io/v1.1.0/docs/design/security_context.md#security-context",
+	"capabilities":   "The linux kernel capabilites that should be added or removed. Default to Container.Capabilities if left unset. More info: http://releases.k8s.io/release-1.1/docs/design/security_context.md#security-context",
+	"privileged":     "Run the container in privileged mode. Default to Container.Privileged if left unset. More info: http://releases.k8s.io/release-1.1/docs/design/security_context.md#security-context",
+	"seLinuxOptions": "SELinuxOptions are the labels to be applied to the container and volumes. Options that control the SELinux labels applied. More info: http://releases.k8s.io/release-1.1/docs/design/security_context.md#security-context",
+	"runAsUser":      "RunAsUser is the UID to run the entrypoint of the container process. The user id that runs the first process in the container. More info: http://releases.k8s.io/release-1.1/docs/design/security_context.md#security-context",
 	"runAsNonRoot":   "RunAsNonRoot indicates that the container should be run as a non-root user. If the RunAsUser field is not explicitly set then the kubelet may check the image for a specified user or perform defaulting to specify a user.",
 }
 
@@ -1247,9 +1247,9 @@ func (SerializedReference) SwaggerDoc() map[string]string {
 
 var map_Service = map[string]string{
 	"":         "Service is a named abstraction of software service (for example, mysql) consisting of local port (for example 3306) that the proxy listens on, and the selector that determines which pods will answer requests sent through the proxy.",
-	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata",
-	"spec":     "Spec defines the behavior of a service. http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status",
-	"status":   "Most recently observed status of the service. Populated by the system. Read-only. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status",
+	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata",
+	"spec":     "Spec defines the behavior of a service. http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status",
+	"status":   "Most recently observed status of the service. Populated by the system. Read-only. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status",
 }
 
 func (Service) SwaggerDoc() map[string]string {
@@ -1258,9 +1258,9 @@ func (Service) SwaggerDoc() map[string]string {
 
 var map_ServiceAccount = map[string]string{
 	"":                 "ServiceAccount binds together: * a name, understood by users, and perhaps by peripheral systems, for an identity * a principal that can be authenticated and authorized * a set of secrets",
-	"metadata":         "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata",
-	"secrets":          "Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/secrets.md",
-	"imagePullSecrets": "ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/secrets.md#manually-specifying-an-imagepullsecret",
+	"metadata":         "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata",
+	"secrets":          "Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount. More info: http://releases.k8s.io/release-1.1/docs/user-guide/secrets.md",
+	"imagePullSecrets": "ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: http://releases.k8s.io/release-1.1/docs/user-guide/secrets.md#manually-specifying-an-imagepullsecret",
 }
 
 func (ServiceAccount) SwaggerDoc() map[string]string {
@@ -1269,8 +1269,8 @@ func (ServiceAccount) SwaggerDoc() map[string]string {
 
 var map_ServiceAccountList = map[string]string{
 	"":         "ServiceAccountList is a list of ServiceAccount objects",
-	"metadata": "Standard list metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds",
-	"items":    "List of ServiceAccounts. More info: http://releases.k8s.io/v1.1.0/docs/design/service_accounts.md#service-accounts",
+	"metadata": "Standard list metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds",
+	"items":    "List of ServiceAccounts. More info: http://releases.k8s.io/release-1.1/docs/design/service_accounts.md#service-accounts",
 }
 
 func (ServiceAccountList) SwaggerDoc() map[string]string {
@@ -1279,7 +1279,7 @@ func (ServiceAccountList) SwaggerDoc() map[string]string {
 
 var map_ServiceList = map[string]string{
 	"":         "ServiceList holds a list of services.",
-	"metadata": "Standard list metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds",
+	"metadata": "Standard list metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds",
 	"items":    "List of services",
 }
 
@@ -1292,8 +1292,8 @@ var map_ServicePort = map[string]string{
 	"name":       "The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. This maps to the 'Name' field in EndpointPort objects. Optional if only one ServicePort is defined on this service.",
 	"protocol":   "The IP protocol for this port. Supports \"TCP\" and \"UDP\". Default is TCP.",
 	"port":       "The port that will be exposed by this service.",
-	"targetPort": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of Port is used (an identity map). Defaults to the service port. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/services.md#defining-a-service",
-	"nodePort":   "The port on each node on which this service is exposed when type=NodePort or LoadBalancer. Usually assigned by the system. If specified, it will be allocated to the service if unused or else creation of the service will fail. Default is to auto-allocate a port if the ServiceType of this Service requires one. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/services.md#type--nodeport",
+	"targetPort": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of Port is used (an identity map). Defaults to the service port. More info: http://releases.k8s.io/release-1.1/docs/user-guide/services.md#defining-a-service",
+	"nodePort":   "The port on each node on which this service is exposed when type=NodePort or LoadBalancer. Usually assigned by the system. If specified, it will be allocated to the service if unused or else creation of the service will fail. Default is to auto-allocate a port if the ServiceType of this Service requires one. More info: http://releases.k8s.io/release-1.1/docs/user-guide/services.md#type--nodeport",
 }
 
 func (ServicePort) SwaggerDoc() map[string]string {
@@ -1302,13 +1302,13 @@ func (ServicePort) SwaggerDoc() map[string]string {
 
 var map_ServiceSpec = map[string]string{
 	"":                    "ServiceSpec describes the attributes that a user creates on a service.",
-	"ports":               "The list of ports that are exposed by this service. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/services.md#virtual-ips-and-service-proxies",
-	"selector":            "This service will route traffic to pods having labels matching this selector. Label keys and values that must match in order to receive traffic for this service. If empty, all pods are selected, if not specified, endpoints must be manually specified. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/services.md#overview",
-	"clusterIP":           "ClusterIP is usually assigned by the master and is the IP address of the service. If specified, it will be allocated to the service if it is unused or else creation of the service will fail. Valid values are None, empty string (\"\"), or a valid IP address. 'None' can be specified for a headless service when proxying is not required. Cannot be updated. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/services.md#virtual-ips-and-service-proxies",
-	"type":                "Type of exposed service. Must be ClusterIP, NodePort, or LoadBalancer. Defaults to ClusterIP. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/services.md#external-services",
+	"ports":               "The list of ports that are exposed by this service. More info: http://releases.k8s.io/release-1.1/docs/user-guide/services.md#virtual-ips-and-service-proxies",
+	"selector":            "This service will route traffic to pods having labels matching this selector. Label keys and values that must match in order to receive traffic for this service. If empty, all pods are selected, if not specified, endpoints must be manually specified. More info: http://releases.k8s.io/release-1.1/docs/user-guide/services.md#overview",
+	"clusterIP":           "ClusterIP is usually assigned by the master and is the IP address of the service. If specified, it will be allocated to the service if it is unused or else creation of the service will fail. Valid values are None, empty string (\"\"), or a valid IP address. 'None' can be specified for a headless service when proxying is not required. Cannot be updated. More info: http://releases.k8s.io/release-1.1/docs/user-guide/services.md#virtual-ips-and-service-proxies",
+	"type":                "Type of exposed service. Must be ClusterIP, NodePort, or LoadBalancer. Defaults to ClusterIP. More info: http://releases.k8s.io/release-1.1/docs/user-guide/services.md#external-services",
 	"externalIPs":         "externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.  A previous form of this functionality exists as the deprecatedPublicIPs field.  When using this field, callers should also clear the deprecatedPublicIPs field.",
 	"deprecatedPublicIPs": "deprecatedPublicIPs is deprecated and replaced by the externalIPs field with almost the exact same semantics.  This field is retained in the v1 API for compatibility until at least 8/20/2016.  It will be removed from any new API revisions.  If both deprecatedPublicIPs *and* externalIPs are set, deprecatedPublicIPs is used.",
-	"sessionAffinity":     "Supports \"ClientIP\" and \"None\". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/services.md#virtual-ips-and-service-proxies",
+	"sessionAffinity":     "Supports \"ClientIP\" and \"None\". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: http://releases.k8s.io/release-1.1/docs/user-guide/services.md#virtual-ips-and-service-proxies",
 	"loadBalancerIP":      "Only applies to Service Type: LoadBalancer LoadBalancer will get created with the IP specified in this field. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.",
 }
 
@@ -1336,7 +1336,7 @@ func (TCPSocketAction) SwaggerDoc() map[string]string {
 
 var map_Volume = map[string]string{
 	"":     "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
-	"name": "Volume's name. Must be a DNS_LABEL and unique within the pod. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#names",
+	"name": "Volume's name. Must be a DNS_LABEL and unique within the pod. More info: http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#names",
 }
 
 func (Volume) SwaggerDoc() map[string]string {
@@ -1356,18 +1356,18 @@ func (VolumeMount) SwaggerDoc() map[string]string {
 
 var map_VolumeSource = map[string]string{
 	"":                      "VolumeSource represents the source location of a volume to mount. Only one of its members may be specified.",
-	"hostPath":              "HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#hostpath",
-	"emptyDir":              "EmptyDir represents a temporary directory that shares a pod's lifetime. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#emptydir",
-	"gcePersistentDisk":     "GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#gcepersistentdisk",
-	"awsElasticBlockStore":  "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#awselasticblockstore",
+	"hostPath":              "HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#hostpath",
+	"emptyDir":              "EmptyDir represents a temporary directory that shares a pod's lifetime. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#emptydir",
+	"gcePersistentDisk":     "GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#gcepersistentdisk",
+	"awsElasticBlockStore":  "AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#awselasticblockstore",
 	"gitRepo":               "GitRepo represents a git repository at a particular revision.",
-	"secret":                "Secret represents a secret that should populate this volume. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#secrets",
-	"nfs":                   "NFS represents an NFS mount on the host that shares a pod's lifetime More info: http://releases.k8s.io/v1.1.0/docs/user-guide/volumes.md#nfs",
-	"iscsi":                 "ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/v1.1.0/examples/iscsi/README.md",
-	"glusterfs":             "Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/v1.1.0/examples/glusterfs/README.md",
-	"persistentVolumeClaim": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/persistent-volumes.md#persistentvolumeclaims",
-	"rbd":         "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/v1.1.0/examples/rbd/README.md",
-	"cinder":      "Cinder represents a cinder volume attached and mounted on kubelets host machine More info: http://releases.k8s.io/v1.1.0/examples/mysql-cinder-pd/README.md",
+	"secret":                "Secret represents a secret that should populate this volume. More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#secrets",
+	"nfs":                   "NFS represents an NFS mount on the host that shares a pod's lifetime More info: http://releases.k8s.io/release-1.1/docs/user-guide/volumes.md#nfs",
+	"iscsi":                 "ISCSI represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: http://releases.k8s.io/release-1.1/examples/iscsi/README.md",
+	"glusterfs":             "Glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/release-1.1/examples/glusterfs/README.md",
+	"persistentVolumeClaim": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: http://releases.k8s.io/release-1.1/docs/user-guide/persistent-volumes.md#persistentvolumeclaims",
+	"rbd":         "RBD represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: http://releases.k8s.io/release-1.1/examples/rbd/README.md",
+	"cinder":      "Cinder represents a cinder volume attached and mounted on kubelets host machine More info: http://releases.k8s.io/release-1.1/examples/mysql-cinder-pd/README.md",
 	"cephfs":      "CephFS represents a Ceph FS mount on the host that shares a pod's lifetime",
 	"flocker":     "Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running",
 	"downwardAPI": "DownwardAPI represents downward API about the pod that should populate this volume",

--- a/pkg/apis/extensions/types.go
+++ b/pkg/apis/extensions/types.go
@@ -45,20 +45,20 @@ type ScaleStatus struct {
 	// actual number of observed instances of the scaled object.
 	Replicas int `json:"replicas"`
 
-	// label query over pods that should match the replicas count. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md#label-selectors
+	// label query over pods that should match the replicas count. More info: http://releases.k8s.io/release-1.1/docs/user-guide/labels.md#label-selectors
 	Selector map[string]string `json:"selector,omitempty"`
 }
 
 // represents a scaling request for a resource.
 type Scale struct {
 	unversioned.TypeMeta `json:",inline"`
-	// Standard object metadata; More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata.
+	// Standard object metadata; More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata.
 	api.ObjectMeta `json:"metadata,omitempty"`
 
-	// defines the behavior of the scale. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status.
+	// defines the behavior of the scale. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status.
 	Spec ScaleSpec `json:"spec,omitempty"`
 
-	// current status of the scale. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status. Read-only.
+	// current status of the scale. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status. Read-only.
 	Status ScaleStatus `json:"status,omitempty"`
 }
 
@@ -69,11 +69,11 @@ type ReplicationControllerDummy struct {
 
 // SubresourceReference contains enough information to let you inspect or modify the referred subresource.
 type SubresourceReference struct {
-	// Kind of the referent; More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+	// Kind of the referent; More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
 	Kind string `json:"kind,omitempty"`
-	// Namespace of the referent; More info: http://releases.k8s.io/v1.1.0/docs/user-guide/namespaces.md
+	// Namespace of the referent; More info: http://releases.k8s.io/release-1.1/docs/user-guide/namespaces.md
 	Namespace string `json:"namespace,omitempty"`
-	// Name of the referent; More info: http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#names
+	// Name of the referent; More info: http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#names
 	Name string `json:"name,omitempty"`
 	// API version of the referent
 	APIVersion string `json:"apiVersion,omitempty"`
@@ -126,7 +126,7 @@ type HorizontalPodAutoscaler struct {
 	unversioned.TypeMeta `json:",inline"`
 	api.ObjectMeta       `json:"metadata,omitempty"`
 
-	// behaviour of autoscaler. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status.
+	// behaviour of autoscaler. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status.
 	Spec HorizontalPodAutoscalerSpec `json:"spec,omitempty"`
 
 	// current information about the autoscaler.
@@ -299,14 +299,14 @@ type DaemonSetSpec struct {
 	// Selector is a label query over pods that are managed by the daemon set.
 	// Must match in order to be controlled.
 	// If empty, defaulted to labels on Pod template.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md#label-selectors
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/labels.md#label-selectors
 	Selector map[string]string `json:"selector,omitempty"`
 
 	// Template is the object that describes the pod that will be created.
 	// The DaemonSet will create exactly one copy of this pod on every node
 	// that matches the template's node selector (or on every node if no node
 	// selector is specified).
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/replication-controller.md#pod-template
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/replication-controller.md#pod-template
 	Template *api.PodTemplateSpec `json:"template,omitempty"`
 }
 
@@ -329,18 +329,18 @@ type DaemonSetStatus struct {
 type DaemonSet struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	api.ObjectMeta `json:"metadata,omitempty"`
 
 	// Spec defines the desired behavior of this daemon set.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status
 	Spec DaemonSetSpec `json:"spec,omitempty"`
 
 	// Status is the current status of this daemon set. This data may be
 	// out of date by some window of time.
 	// Populated by the system.
 	// Read-only.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status
 	Status DaemonSetStatus `json:"status,omitempty"`
 }
 
@@ -348,7 +348,7 @@ type DaemonSet struct {
 type DaemonSetList struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard list metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	unversioned.ListMeta `json:"metadata,omitempty"`
 
 	// Items is a list of daemon sets.
@@ -358,7 +358,7 @@ type DaemonSetList struct {
 type ThirdPartyResourceDataList struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard list metadata
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	unversioned.ListMeta `json:"metadata,omitempty"`
 	// Items is a list of third party objects
 	Items []ThirdPartyResourceData `json:"items"`
@@ -368,15 +368,15 @@ type ThirdPartyResourceDataList struct {
 type Job struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	api.ObjectMeta `json:"metadata,omitempty"`
 
 	// Spec is a structure defining the expected behavior of a job.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status
 	Spec JobSpec `json:"spec,omitempty"`
 
 	// Status is a structure describing current status of a job.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status
 	Status JobStatus `json:"status,omitempty"`
 }
 
@@ -384,7 +384,7 @@ type Job struct {
 type JobList struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard list metadata
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	unversioned.ListMeta `json:"metadata,omitempty"`
 
 	// Items is the list of Job.
@@ -469,15 +469,15 @@ type JobCondition struct {
 type Ingress struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	api.ObjectMeta `json:"metadata,omitempty"`
 
 	// Spec is the desired state of the Ingress.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status
 	Spec IngressSpec `json:"spec,omitempty"`
 
 	// Status is the current state of the Ingress.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status
 	Status IngressStatus `json:"status,omitempty"`
 }
 
@@ -485,7 +485,7 @@ type Ingress struct {
 type IngressList struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	unversioned.ListMeta `json:"metadata,omitempty"`
 
 	// Items is the list of Ingress.

--- a/pkg/apis/extensions/v1beta1/types.go
+++ b/pkg/apis/extensions/v1beta1/types.go
@@ -33,20 +33,20 @@ type ScaleStatus struct {
 	// actual number of observed instances of the scaled object.
 	Replicas int `json:"replicas"`
 
-	// label query over pods that should match the replicas count. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md#label-selectors
+	// label query over pods that should match the replicas count. More info: http://releases.k8s.io/release-1.1/docs/user-guide/labels.md#label-selectors
 	Selector map[string]string `json:"selector,omitempty"`
 }
 
 // represents a scaling request for a resource.
 type Scale struct {
 	unversioned.TypeMeta `json:",inline"`
-	// Standard object metadata; More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata.
+	// Standard object metadata; More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata.
 	v1.ObjectMeta `json:"metadata,omitempty"`
 
-	// defines the behavior of the scale. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status.
+	// defines the behavior of the scale. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status.
 	Spec ScaleSpec `json:"spec,omitempty"`
 
-	// current status of the scale. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status. Read-only.
+	// current status of the scale. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status. Read-only.
 	Status ScaleStatus `json:"status,omitempty"`
 }
 
@@ -57,11 +57,11 @@ type ReplicationControllerDummy struct {
 
 // SubresourceReference contains enough information to let you inspect or modify the referred subresource.
 type SubresourceReference struct {
-	// Kind of the referent; More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds"
+	// Kind of the referent; More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds"
 	Kind string `json:"kind,omitempty"`
-	// Namespace of the referent; More info: http://releases.k8s.io/v1.1.0/docs/user-guide/namespaces.md
+	// Namespace of the referent; More info: http://releases.k8s.io/release-1.1/docs/user-guide/namespaces.md
 	Namespace string `json:"namespace,omitempty"`
-	// Name of the referent; More info: http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#names
+	// Name of the referent; More info: http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#names
 	Name string `json:"name,omitempty"`
 	// API version of the referent
 	APIVersion string `json:"apiVersion,omitempty"`
@@ -112,10 +112,10 @@ type HorizontalPodAutoscalerStatus struct {
 // configuration of a horizontal pod autoscaler.
 type HorizontalPodAutoscaler struct {
 	unversioned.TypeMeta `json:",inline"`
-	// Standard object metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// Standard object metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	v1.ObjectMeta `json:"metadata,omitempty"`
 
-	// behaviour of autoscaler. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status.
+	// behaviour of autoscaler. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status.
 	Spec HorizontalPodAutoscalerSpec `json:"spec,omitempty"`
 
 	// current information about the autoscaler.
@@ -297,14 +297,14 @@ type DaemonSetSpec struct {
 	// Selector is a label query over pods that are managed by the daemon set.
 	// Must match in order to be controlled.
 	// If empty, defaulted to labels on Pod template.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md#label-selectors
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/labels.md#label-selectors
 	Selector map[string]string `json:"selector,omitempty"`
 
 	// Template is the object that describes the pod that will be created.
 	// The DaemonSet will create exactly one copy of this pod on every node
 	// that matches the template's node selector (or on every node if no node
 	// selector is specified).
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/replication-controller.md#pod-template
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/replication-controller.md#pod-template
 	Template *v1.PodTemplateSpec `json:"template,omitempty"`
 }
 
@@ -312,17 +312,17 @@ type DaemonSetSpec struct {
 type DaemonSetStatus struct {
 	// CurrentNumberScheduled is the number of nodes that are running at least 1
 	// daemon pod and are supposed to run the daemon pod.
-	// More info: http://releases.k8s.io/v1.1.0/docs/admin/daemon.md
+	// More info: http://releases.k8s.io/release-1.1/docs/admin/daemon.md
 	CurrentNumberScheduled int `json:"currentNumberScheduled"`
 
 	// NumberMisscheduled is the number of nodes that are running the daemon pod, but are
 	// not supposed to run the daemon pod.
-	// More info: http://releases.k8s.io/v1.1.0/docs/admin/daemon.md
+	// More info: http://releases.k8s.io/release-1.1/docs/admin/daemon.md
 	NumberMisscheduled int `json:"numberMisscheduled"`
 
 	// DesiredNumberScheduled is the total number of nodes that should be running the daemon
 	// pod (including nodes correctly running the daemon pod).
-	// More info: http://releases.k8s.io/v1.1.0/docs/admin/daemon.md
+	// More info: http://releases.k8s.io/release-1.1/docs/admin/daemon.md
 	DesiredNumberScheduled int `json:"desiredNumberScheduled"`
 }
 
@@ -330,18 +330,18 @@ type DaemonSetStatus struct {
 type DaemonSet struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	v1.ObjectMeta `json:"metadata,omitempty"`
 
 	// Spec defines the desired behavior of this daemon set.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status
 	Spec DaemonSetSpec `json:"spec,omitempty"`
 
 	// Status is the current status of this daemon set. This data may be
 	// out of date by some window of time.
 	// Populated by the system.
 	// Read-only.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status
 	Status DaemonSetStatus `json:"status,omitempty"`
 }
 
@@ -349,7 +349,7 @@ type DaemonSet struct {
 type DaemonSetList struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard list metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	unversioned.ListMeta `json:"metadata,omitempty"`
 
 	// Items is a list of daemon sets.
@@ -360,7 +360,7 @@ type DaemonSetList struct {
 type ThirdPartyResourceDataList struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard list metadata
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	unversioned.ListMeta `json:"metadata,omitempty"`
 
 	// Items is the list of ThirdpartyResourceData.
@@ -371,15 +371,15 @@ type ThirdPartyResourceDataList struct {
 type Job struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	v1.ObjectMeta `json:"metadata,omitempty"`
 
 	// Spec is a structure defining the expected behavior of a job.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status
 	Spec JobSpec `json:"spec,omitempty"`
 
 	// Status is a structure describing current status of a job.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status
 	Status JobStatus `json:"status,omitempty"`
 }
 
@@ -387,7 +387,7 @@ type Job struct {
 type JobList struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard list metadata
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	unversioned.ListMeta `json:"metadata,omitempty"`
 
 	// Items is the list of Job.
@@ -401,21 +401,21 @@ type JobSpec struct {
 	// run at any given time. The actual number of pods running in steady state will
 	// be less than this number when ((.spec.completions - .status.successful) < .spec.parallelism),
 	// i.e. when the work left to do is less than max parallelism.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/jobs.md
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/jobs.md
 	Parallelism *int `json:"parallelism,omitempty"`
 
 	// Completions specifies the desired number of successfully finished pods the
 	// job should be run with. Defaults to 1.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/jobs.md
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/jobs.md
 	Completions *int `json:"completions,omitempty"`
 
 	// Selector is a label query over pods that should match the pod count.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md#label-selectors
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/labels.md#label-selectors
 	Selector *PodSelector `json:"selector,omitempty"`
 
 	// Template is the object that describes the pod that will be created when
 	// executing a job.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/jobs.md
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/jobs.md
 	Template v1.PodTemplateSpec `json:"template"`
 }
 
@@ -423,7 +423,7 @@ type JobSpec struct {
 type JobStatus struct {
 
 	// Conditions represent the latest available observations of an object's current state.
-	// More info: http://releases.k8s.io/v1.1.0/docs/user-guide/jobs.md
+	// More info: http://releases.k8s.io/release-1.1/docs/user-guide/jobs.md
 	Conditions []JobCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 
 	// StartTime represents time when the job was acknowledged by the Job Manager.
@@ -477,15 +477,15 @@ type JobCondition struct {
 type Ingress struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	v1.ObjectMeta `json:"metadata,omitempty"`
 
 	// Spec is the desired state of the Ingress.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status
 	Spec IngressSpec `json:"spec,omitempty"`
 
 	// Status is the current state of the Ingress.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status
 	Status IngressStatus `json:"status,omitempty"`
 }
 
@@ -493,7 +493,7 @@ type Ingress struct {
 type IngressList struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard object's metadata.
-	// More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata
+	// More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata
 	unversioned.ListMeta `json:"metadata,omitempty"`
 
 	// Items is the list of Ingress.

--- a/pkg/apis/extensions/v1beta1/types_swagger_doc_generated.go
+++ b/pkg/apis/extensions/v1beta1/types_swagger_doc_generated.go
@@ -47,9 +47,9 @@ func (CPUTargetUtilization) SwaggerDoc() map[string]string {
 
 var map_DaemonSet = map[string]string{
 	"":         "DaemonSet represents the configuration of a daemon set.",
-	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata",
-	"spec":     "Spec defines the desired behavior of this daemon set. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status",
-	"status":   "Status is the current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status",
+	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata",
+	"spec":     "Spec defines the desired behavior of this daemon set. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status",
+	"status":   "Status is the current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status",
 }
 
 func (DaemonSet) SwaggerDoc() map[string]string {
@@ -58,7 +58,7 @@ func (DaemonSet) SwaggerDoc() map[string]string {
 
 var map_DaemonSetList = map[string]string{
 	"":         "DaemonSetList is a collection of daemon sets.",
-	"metadata": "Standard list metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata",
+	"metadata": "Standard list metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata",
 	"items":    "Items is a list of daemon sets.",
 }
 
@@ -68,8 +68,8 @@ func (DaemonSetList) SwaggerDoc() map[string]string {
 
 var map_DaemonSetSpec = map[string]string{
 	"":         "DaemonSetSpec is the specification of a daemon set.",
-	"selector": "Selector is a label query over pods that are managed by the daemon set. Must match in order to be controlled. If empty, defaulted to labels on Pod template. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md#label-selectors",
-	"template": "Template is the object that describes the pod that will be created. The DaemonSet will create exactly one copy of this pod on every node that matches the template's node selector (or on every node if no node selector is specified). More info: http://releases.k8s.io/v1.1.0/docs/user-guide/replication-controller.md#pod-template",
+	"selector": "Selector is a label query over pods that are managed by the daemon set. Must match in order to be controlled. If empty, defaulted to labels on Pod template. More info: http://releases.k8s.io/release-1.1/docs/user-guide/labels.md#label-selectors",
+	"template": "Template is the object that describes the pod that will be created. The DaemonSet will create exactly one copy of this pod on every node that matches the template's node selector (or on every node if no node selector is specified). More info: http://releases.k8s.io/release-1.1/docs/user-guide/replication-controller.md#pod-template",
 }
 
 func (DaemonSetSpec) SwaggerDoc() map[string]string {
@@ -78,9 +78,9 @@ func (DaemonSetSpec) SwaggerDoc() map[string]string {
 
 var map_DaemonSetStatus = map[string]string{
 	"": "DaemonSetStatus represents the current status of a daemon set.",
-	"currentNumberScheduled": "CurrentNumberScheduled is the number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. More info: http://releases.k8s.io/v1.1.0/docs/admin/daemon.md",
-	"numberMisscheduled":     "NumberMisscheduled is the number of nodes that are running the daemon pod, but are not supposed to run the daemon pod. More info: http://releases.k8s.io/v1.1.0/docs/admin/daemon.md",
-	"desiredNumberScheduled": "DesiredNumberScheduled is the total number of nodes that should be running the daemon pod (including nodes correctly running the daemon pod). More info: http://releases.k8s.io/v1.1.0/docs/admin/daemon.md",
+	"currentNumberScheduled": "CurrentNumberScheduled is the number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. More info: http://releases.k8s.io/release-1.1/docs/admin/daemon.md",
+	"numberMisscheduled":     "NumberMisscheduled is the number of nodes that are running the daemon pod, but are not supposed to run the daemon pod. More info: http://releases.k8s.io/release-1.1/docs/admin/daemon.md",
+	"desiredNumberScheduled": "DesiredNumberScheduled is the total number of nodes that should be running the daemon pod (including nodes correctly running the daemon pod). More info: http://releases.k8s.io/release-1.1/docs/admin/daemon.md",
 }
 
 func (DaemonSetStatus) SwaggerDoc() map[string]string {
@@ -162,8 +162,8 @@ func (HTTPIngressRuleValue) SwaggerDoc() map[string]string {
 
 var map_HorizontalPodAutoscaler = map[string]string{
 	"":         "configuration of a horizontal pod autoscaler.",
-	"metadata": "Standard object metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata",
-	"spec":     "behaviour of autoscaler. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status.",
+	"metadata": "Standard object metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata",
+	"spec":     "behaviour of autoscaler. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status.",
 	"status":   "current information about the autoscaler.",
 }
 
@@ -208,9 +208,9 @@ func (HorizontalPodAutoscalerStatus) SwaggerDoc() map[string]string {
 
 var map_Ingress = map[string]string{
 	"":         "Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.",
-	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata",
-	"spec":     "Spec is the desired state of the Ingress. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status",
-	"status":   "Status is the current state of the Ingress. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status",
+	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata",
+	"spec":     "Spec is the desired state of the Ingress. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status",
+	"status":   "Status is the current state of the Ingress. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status",
 }
 
 func (Ingress) SwaggerDoc() map[string]string {
@@ -229,7 +229,7 @@ func (IngressBackend) SwaggerDoc() map[string]string {
 
 var map_IngressList = map[string]string{
 	"":         "IngressList is a collection of Ingress.",
-	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata",
+	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata",
 	"items":    "Items is the list of Ingress.",
 }
 
@@ -276,9 +276,9 @@ func (IngressStatus) SwaggerDoc() map[string]string {
 
 var map_Job = map[string]string{
 	"":         "Job represents the configuration of a single job.",
-	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata",
-	"spec":     "Spec is a structure defining the expected behavior of a job. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status",
-	"status":   "Status is a structure describing current status of a job. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status",
+	"metadata": "Standard object's metadata. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata",
+	"spec":     "Spec is a structure defining the expected behavior of a job. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status",
+	"status":   "Status is a structure describing current status of a job. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status",
 }
 
 func (Job) SwaggerDoc() map[string]string {
@@ -301,7 +301,7 @@ func (JobCondition) SwaggerDoc() map[string]string {
 
 var map_JobList = map[string]string{
 	"":         "JobList is a collection of jobs.",
-	"metadata": "Standard list metadata More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata",
+	"metadata": "Standard list metadata More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata",
 	"items":    "Items is the list of Job.",
 }
 
@@ -311,10 +311,10 @@ func (JobList) SwaggerDoc() map[string]string {
 
 var map_JobSpec = map[string]string{
 	"":            "JobSpec describes how the job execution will look like.",
-	"parallelism": "Parallelism specifies the maximum desired number of pods the job should run at any given time. The actual number of pods running in steady state will be less than this number when ((.spec.completions - .status.successful) < .spec.parallelism), i.e. when the work left to do is less than max parallelism. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/jobs.md",
-	"completions": "Completions specifies the desired number of successfully finished pods the job should be run with. Defaults to 1. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/jobs.md",
-	"selector":    "Selector is a label query over pods that should match the pod count. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md#label-selectors",
-	"template":    "Template is the object that describes the pod that will be created when executing a job. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/jobs.md",
+	"parallelism": "Parallelism specifies the maximum desired number of pods the job should run at any given time. The actual number of pods running in steady state will be less than this number when ((.spec.completions - .status.successful) < .spec.parallelism), i.e. when the work left to do is less than max parallelism. More info: http://releases.k8s.io/release-1.1/docs/user-guide/jobs.md",
+	"completions": "Completions specifies the desired number of successfully finished pods the job should be run with. Defaults to 1. More info: http://releases.k8s.io/release-1.1/docs/user-guide/jobs.md",
+	"selector":    "Selector is a label query over pods that should match the pod count. More info: http://releases.k8s.io/release-1.1/docs/user-guide/labels.md#label-selectors",
+	"template":    "Template is the object that describes the pod that will be created when executing a job. More info: http://releases.k8s.io/release-1.1/docs/user-guide/jobs.md",
 }
 
 func (JobSpec) SwaggerDoc() map[string]string {
@@ -323,7 +323,7 @@ func (JobSpec) SwaggerDoc() map[string]string {
 
 var map_JobStatus = map[string]string{
 	"":               "JobStatus represents the current state of a Job.",
-	"conditions":     "Conditions represent the latest available observations of an object's current state. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/jobs.md",
+	"conditions":     "Conditions represent the latest available observations of an object's current state. More info: http://releases.k8s.io/release-1.1/docs/user-guide/jobs.md",
 	"startTime":      "StartTime represents time when the job was acknowledged by the Job Manager. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.",
 	"completionTime": "CompletionTime represents time when the job was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.",
 	"active":         "Active is the number of actively running pods.",
@@ -377,9 +377,9 @@ func (RollingUpdateDeployment) SwaggerDoc() map[string]string {
 
 var map_Scale = map[string]string{
 	"":         "represents a scaling request for a resource.",
-	"metadata": "Standard object metadata; More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata.",
-	"spec":     "defines the behavior of the scale. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status.",
-	"status":   "current status of the scale. More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#spec-and-status. Read-only.",
+	"metadata": "Standard object metadata; More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata.",
+	"spec":     "defines the behavior of the scale. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status.",
+	"status":   "current status of the scale. More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#spec-and-status. Read-only.",
 }
 
 func (Scale) SwaggerDoc() map[string]string {
@@ -398,7 +398,7 @@ func (ScaleSpec) SwaggerDoc() map[string]string {
 var map_ScaleStatus = map[string]string{
 	"":         "represents the current status of a scale subresource.",
 	"replicas": "actual number of observed instances of the scaled object.",
-	"selector": "label query over pods that should match the replicas count. More info: http://releases.k8s.io/v1.1.0/docs/user-guide/labels.md#label-selectors",
+	"selector": "label query over pods that should match the replicas count. More info: http://releases.k8s.io/release-1.1/docs/user-guide/labels.md#label-selectors",
 }
 
 func (ScaleStatus) SwaggerDoc() map[string]string {
@@ -407,9 +407,9 @@ func (ScaleStatus) SwaggerDoc() map[string]string {
 
 var map_SubresourceReference = map[string]string{
 	"":            "SubresourceReference contains enough information to let you inspect or modify the referred subresource.",
-	"kind":        "Kind of the referent; More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#types-kinds\"",
-	"namespace":   "Namespace of the referent; More info: http://releases.k8s.io/v1.1.0/docs/user-guide/namespaces.md",
-	"name":        "Name of the referent; More info: http://releases.k8s.io/v1.1.0/docs/user-guide/identifiers.md#names",
+	"kind":        "Kind of the referent; More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#types-kinds\"",
+	"namespace":   "Namespace of the referent; More info: http://releases.k8s.io/release-1.1/docs/user-guide/namespaces.md",
+	"name":        "Name of the referent; More info: http://releases.k8s.io/release-1.1/docs/user-guide/identifiers.md#names",
 	"apiVersion":  "API version of the referent",
 	"subresource": "Subresource name of the referent",
 }
@@ -441,7 +441,7 @@ func (ThirdPartyResourceData) SwaggerDoc() map[string]string {
 
 var map_ThirdPartyResourceDataList = map[string]string{
 	"":         "ThirdPartyResrouceDataList is a list of ThirdPartyResourceData.",
-	"metadata": "Standard list metadata More info: http://releases.k8s.io/v1.1.0/docs/devel/api-conventions.md#metadata",
+	"metadata": "Standard list metadata More info: http://releases.k8s.io/release-1.1/docs/devel/api-conventions.md#metadata",
 	"items":    "Items is the list of ThirdpartyResourceData.",
 }
 

--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -150,7 +150,7 @@ func printObjectSpecificMessage(obj runtime.Object, out io.Writer) {
 cluster.  If you want to expose this service to the external internet, you may
 need to set up firewall rules for the service port(s) (%s) to serve traffic.
 
-See http://releases.k8s.io/v1.1.0/docs/user-guide/services-firewalls.md for more details.
+See http://releases.k8s.io/release-1.1/docs/user-guide/services-firewalls.md for more details.
 `,
 				makePortsString(obj.Spec.Ports, true))
 			out.Write([]byte(msg))

--- a/pkg/kubectl/cmd/patch.go
+++ b/pkg/kubectl/cmd/patch.go
@@ -38,7 +38,7 @@ const (
 
 JSON and YAML formats are accepted.
 
-Please refer to the models in https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/blob/v1.1.0/docs/api-reference/v1/definitions.html to find if a field is mutable.`
+Please refer to the models in https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/release-1.1/docs/api-reference/v1/definitions.html to find if a field is mutable.`
 	patch_example = `
 # Partially update a node using strategic merge patch
 kubectl patch node k8s-node-1 -p '{"spec":{"unschedulable":true}}'

--- a/pkg/kubectl/cmd/replace.go
+++ b/pkg/kubectl/cmd/replace.go
@@ -44,7 +44,7 @@ JSON and YAML formats are accepted. If replacing an existing resource, the
 complete resource spec must be provided. This can be obtained by
 $ kubectl get TYPE NAME -o yaml
 
-Please refer to the models in https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/blob/v1.1.0/docs/api-reference/v1/definitions.html to find if a field is mutable.`
+Please refer to the models in https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/release-1.1/docs/api-reference/v1/definitions.html to find if a field is mutable.`
 	replace_example = `# Replace a pod using the data in pod.json.
 $ kubectl replace -f ./pod.json
 

--- a/pkg/kubectl/cmd/util/printing.go
+++ b/pkg/kubectl/cmd/util/printing.go
@@ -29,7 +29,7 @@ import (
 
 // AddPrinterFlags adds printing related flags to a command (e.g. output format, no headers, template path)
 func AddPrinterFlags(cmd *cobra.Command) {
-	cmd.Flags().StringP("output", "o", "", "Output format. One of: json|yaml|wide|name|go-template=...|go-template-file=...|jsonpath=...|jsonpath-file=... See golang template [http://golang.org/pkg/text/template/#pkg-overview] and jsonpath template [http://releases.k8s.io/v1.1.0/docs/user-guide/jsonpath.md].")
+	cmd.Flags().StringP("output", "o", "", "Output format. One of: json|yaml|wide|name|go-template=...|go-template-file=...|jsonpath=...|jsonpath-file=... See golang template [http://golang.org/pkg/text/template/#pkg-overview] and jsonpath template [http://releases.k8s.io/release-1.1/docs/user-guide/jsonpath.md].")
 	cmd.Flags().String("output-version", "", "Output the formatted object with the given version (default api-version).")
 	cmd.Flags().Bool("no-headers", false, "When using the default output, don't print headers.")
 	// template shorthand -t is deprecated to support -t for --tty


### PR DESCRIPTION
Manually fix #16522 on release branch. 

We need to fix our mark-new-version.sh to avoid a relapse.

This bug (https://github.com/kubernetes/kubernetes/pull/16486#discussion_r43350745) will be solved once we run the gh-pages doc importing tool again.

@nikhiljindal @janetkuo @bgrant0607 
