### PR TITLE
Allow Docker container logs to be tail'd and follow'd

### DIFF
--- a/pkg/kubelet/dockertools/manager.go
+++ b/pkg/kubelet/dockertools/manager.go
@@ -290,7 +290,7 @@ func (dm *DockerManager) GetContainerLogs(pod *api.Pod, containerID kubecontaine
 		RawTerminal:  false,
 	}
 
-	if !logOptions.Follow && logOptions.TailLines != nil {
+	if logOptions.TailLines != nil {
 		opts.Tail = strconv.FormatInt(*logOptions.TailLines, 10)
 	}
 


### PR DESCRIPTION
Relaxes the very very ancient restriction we put in place to keep the
original API surface area PR small. Better to be consistent with actual
expected use of tail.

Fixes #16532
