### PR TITLE
Move release-specific test env out of the kubekins-test image

### DIFF
--- a/hack/jenkins/gotest-dockerized.sh
+++ b/hack/jenkins/gotest-dockerized.sh
@@ -42,5 +42,5 @@ docker run --rm=true \
   -v "${REPO_DIR}":/go/src/k8s.io/kubernetes \
   -v "${KUBE_JUNIT_REPORT_DIR}":/workspace/artifacts \
   --env REPO_DIR="${REPO_DIR}" \
-  -i gcr.io/google_containers/kubekins-test:0.1 \
+  -i gcr.io/google_containers/kubekins-test:0.2 \
   bash -c "cd kubernetes && ./hack/jenkins/test-dockerized.sh"

--- a/hack/jenkins/test-dockerized.sh
+++ b/hack/jenkins/test-dockerized.sh
@@ -40,12 +40,14 @@ export KUBE_KEEP_VERBOSE_TEST_OUTPUT=y
 export KUBE_TIMEOUT='-timeout 300s'
 export KUBE_INTEGRATION_TEST_MAX_CONCURRENCY=4
 export LOG_LEVEL=4
+export KUBE_TEST_API_VERSIONS=v1,extensions/v1beta1
+export KUBE_TEST_ETCD_PREFIXES=registry
 
 ./hack/build-go.sh
 godep go install ./...
 ./hack/install-etcd.sh
 
-./hack/verify-all.sh
+./hack/verify-all.sh -v
 
 ./hack/test-go.sh -- -p=2
 ./hack/test-cmd.sh

--- a/hack/jenkins/test-image/Dockerfile
+++ b/hack/jenkins/test-image/Dockerfile
@@ -18,8 +18,6 @@
 FROM golang:1.4
 MAINTAINER  Jeff Lowdermilk <jeffml@google.com>
 
-ENV KUBE_TEST_API_VERSIONS  v1,extensions/v1beta1
-ENV KUBE_TEST_ETCD_PREFIXES registry
 ENV WORKSPACE               /workspace
 ENV TERM                    xterm
 

--- a/hack/jenkins/test-image/Makefile
+++ b/hack/jenkins/test-image/Makefile
@@ -1,6 +1,6 @@
 all: push
 
-TAG = 0.1
+TAG = 0.2
 
 container:
 	docker build -t gcr.io/google_containers/kubekins-test .


### PR DESCRIPTION
and put it in `test-dockerized.sh` which can be unique to the branch. Discovered while cherrypicking #16287 onto release-1.0, because `extension/v1beta1` isn't a valid api on that branch.
