### PR TITLE
[Fix for #16596] - Adapt nginx default path

### DIFF
--- a/docs/user-guide/persistent-volumes/simpletest/pod.yaml
+++ b/docs/user-guide/persistent-volumes/simpletest/pod.yaml
@@ -12,7 +12,7 @@ spec:
         - containerPort: 80
           name: "http-server"
       volumeMounts:
-      - mountPath: "/var/www/html"
+      - mountPath: "/usr/share/nginx/html"
         name: mypd
   volumes:
     - name: mypd


### PR DESCRIPTION
This fixes #16596 

As described on [docker hub](https://hub.docker.com/_/nginx/), the default path of the nginx container is `/usr/share/nginx/html` instead the used `/var/www/html`
