### PR TITLE
build kube-env in build-kube-env, not in verify-prereqs

### DIFF
--- a/cluster/gce/coreos/helper.sh
+++ b/cluster/gce/coreos/helper.sh
@@ -21,6 +21,8 @@ function build-kube-env {
   local master=$1
   local file=$2
 
+  build-runtime-config
+
   rm -f ${file}
   # TODO(dawnchen): master node is still running with debian image
   if [[ "${master}" == "true" ]]; then

--- a/cluster/gce/debian/helper.sh
+++ b/cluster/gce/debian/helper.sh
@@ -21,6 +21,8 @@ function build-kube-env {
   local master=$1
   local file=$2
 
+  build-runtime-config
+
   rm -f ${file}
   cat >$file <<EOF
 ENV_TIMESTAMP: $(yaml-quote $(date -u +%Y-%m-%dT%T%z))

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -48,33 +48,6 @@ function join_csv {
 
 # Verify prereqs
 function verify-prereqs {
-  if [[ "${ENABLE_EXPERIMENTAL_API}" == "true" ]]; then
-    if [[ -z "${RUNTIME_CONFIG}" ]]; then
-      RUNTIME_CONFIG="extensions/v1beta1=true"
-    else
-      # TODO: add checking if RUNTIME_CONFIG contains "extensions/v1beta1=false" and appending "extensions/v1beta1=true" if not.
-      if echo "${RUNTIME_CONFIG}" | grep -q -v "extensions/v1beta1=true"; then
-        echo "Experimental API should be turned on, but is not turned on in RUNTIME_CONFIG!" >&2
-        exit 1
-      fi
-    fi
-  fi
-  if [[ "${ENABLE_DEPLOYMENTS}" == "true" ]]; then
-    if [[ -z "${RUNTIME_CONFIG}" ]]; then
-      RUNTIME_CONFIG="extensions/v1beta1/deployments=true"
-    else
-      RUNTIME_CONFIG="${RUNTIME_CONFIG},extensions/v1beta1/deployments=true"
-    fi
-  fi
-  if [[ "${ENABLE_DAEMONSETS}" == "true" ]]; then
-    if [[ -z "${RUNTIME_CONFIG}" ]]; then
-      RUNTIME_CONFIG="extensions/v1beta1/daemonsets=true"
-    else
-      RUNTIME_CONFIG="${RUNTIME_CONFIG},extensions/v1beta1/daemonsets=true"
-    fi
-  fi
-
-
   local cmd
   for cmd in gcloud gsutil; do
     if ! which "${cmd}" >/dev/null; then
@@ -1254,4 +1227,33 @@ function restart-apiserver {
 # Perform preparations required to run e2e tests
 function prepare-e2e() {
   detect-project
+}
+
+# Builds the RUNTIME_CONFIG var from other feature enable options
+function build-runtime-config() {
+  if [[ "${ENABLE_EXPERIMENTAL_API}" == "true" ]]; then
+      if [[ -z "${RUNTIME_CONFIG}" ]]; then
+          RUNTIME_CONFIG="extensions/v1beta1=true"
+      else
+          # TODO: add checking if RUNTIME_CONFIG contains "extensions/v1beta1=false" and appending "extensions/v1beta1=true" if not.
+          if echo "${RUNTIME_CONFIG}" | grep -q -v "extensions/v1beta1=true"; then
+              echo "Experimental API should be turned on, but is not turned on in RUNTIME_CONFIG!" >&2
+              exit 1
+          fi
+      fi
+  fi
+  if [[ "${ENABLE_DEPLOYMENTS}" == "true" ]]; then
+      if [[ -z "${RUNTIME_CONFIG}" ]]; then
+          RUNTIME_CONFIG="extensions/v1beta1/deployments=true"
+      else
+          RUNTIME_CONFIG="${RUNTIME_CONFIG},extensions/v1beta1/deployments=true"
+      fi
+  fi
+  if [[ "${ENABLE_DAEMONSETS}" == "true" ]]; then
+      if [[ -z "${RUNTIME_CONFIG}" ]]; then
+          RUNTIME_CONFIG="extensions/v1beta1/daemonsets=true"
+      else
+          RUNTIME_CONFIG="${RUNTIME_CONFIG},extensions/v1beta1/daemonsets=true"
+      fi
+  fi
 }


### PR DESCRIPTION
cc @ihmccreery @zmerlynn 

ENABLE_\* is not respected right now unless verify-prereqs is called first
