### PR TITLE
Make the AWS provider target the metadata server for local data lookup

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -624,6 +624,24 @@ func (aws *AWSCloud) Routes() (cloudprovider.Routes, bool) {
 
 // NodeAddresses is an implementation of Instances.NodeAddresses.
 func (aws *AWSCloud) NodeAddresses(name string) ([]api.NodeAddress, error) {
+	self, err := aws.getSelfAWSInstance()
+	if err != nil {
+		return nil, err
+	}
+	if self.nodeName == name || len(name) == 0 {
+		internalIP, err := aws.metadata.GetMetadata("local-ipv4")
+		if err != nil {
+			return nil, err
+		}
+		externalIP, err := aws.metadata.GetMetadata("public-ipv4")
+		if err != nil {
+			return nil, err
+		}
+		return []api.NodeAddress{
+			{Type: api.NodeInternalIP, Address: internalIP},
+			{Type: api.NodeExternalIP, Address: externalIP},
+		}, nil
+	}
 	instance, err := aws.getInstanceByNodeName(name)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
@justinsb @davidopp @roberthbailey 

ref #16593 

This "fixes" 16593 in the sense that if you can't talk to the metadata server, you really are in trouble and we probably should delete your containers.
