### PR TITLE
Make rootscoped resources no namespace selectable field

### DIFF
--- a/pkg/registry/controller/strategy.go
+++ b/pkg/registry/controller/strategy.go
@@ -100,7 +100,7 @@ func (rcStrategy) AllowUnconditionalUpdate() bool {
 
 // ControllerToSelectableFields returns a field set that represents the object.
 func ControllerToSelectableFields(controller *api.ReplicationController) fields.Set {
-	objectMetaFieldsSet := generic.ObjectMetaFieldsSet(controller.ObjectMeta)
+	objectMetaFieldsSet := generic.ObjectMetaFieldsSet(controller.ObjectMeta, true)
 	controllerSpecificFieldsSet := fields.Set{
 		"status.replicas": strconv.Itoa(controller.Status.Replicas),
 	}

--- a/pkg/registry/daemonset/strategy.go
+++ b/pkg/registry/daemonset/strategy.go
@@ -102,7 +102,7 @@ func (daemonSetStrategy) AllowUnconditionalUpdate() bool {
 
 // DaemonSetToSelectableFields returns a field set that represents the object.
 func DaemonSetToSelectableFields(daemon *extensions.DaemonSet) fields.Set {
-	return generic.ObjectMetaFieldsSet(daemon.ObjectMeta)
+	return generic.ObjectMetaFieldsSet(daemon.ObjectMeta, true)
 }
 
 // MatchSetDaemon is the filter used by the generic etcd backend to route

--- a/pkg/registry/deployment/strategy.go
+++ b/pkg/registry/deployment/strategy.go
@@ -97,7 +97,7 @@ func (deploymentStatusStrategy) ValidateUpdate(ctx api.Context, obj, old runtime
 
 // DeploymentToSelectableFields returns a field set that represents the object.
 func DeploymentToSelectableFields(deployment *extensions.Deployment) fields.Set {
-	return generic.ObjectMetaFieldsSet(deployment.ObjectMeta)
+	return generic.ObjectMetaFieldsSet(deployment.ObjectMeta, true)
 }
 
 // MatchDeployment is the filter used by the generic etcd backend to route

--- a/pkg/registry/endpoint/strategy.go
+++ b/pkg/registry/endpoint/strategy.go
@@ -89,5 +89,5 @@ func EndpointsAttributes(obj runtime.Object) (objLabels labels.Set, objFields fi
 	if !ok {
 		return nil, nil, fmt.Errorf("invalid object type %#v", obj)
 	}
-	return endpoints.Labels, generic.ObjectMetaFieldsSet(endpoints.ObjectMeta), nil
+	return endpoints.Labels, generic.ObjectMetaFieldsSet(endpoints.ObjectMeta, true), nil
 }

--- a/pkg/registry/event/strategy.go
+++ b/pkg/registry/event/strategy.go
@@ -80,7 +80,7 @@ func getAttrs(obj runtime.Object) (objLabels labels.Set, objFields fields.Set, e
 		l = labels.Set{}
 	}
 
-	objectMetaFieldsSet := generic.ObjectMetaFieldsSet(event.ObjectMeta)
+	objectMetaFieldsSet := generic.ObjectMetaFieldsSet(event.ObjectMeta, true)
 	specificFieldsSet := fields.Set{
 		"involvedObject.kind":            event.InvolvedObject.Kind,
 		"involvedObject.namespace":       event.InvolvedObject.Namespace,

--- a/pkg/registry/generic/matcher.go
+++ b/pkg/registry/generic/matcher.go
@@ -27,7 +27,12 @@ import (
 type AttrFunc func(obj runtime.Object) (label labels.Set, field fields.Set, err error)
 
 // ObjectMetaFieldsSet returns a fields set that represents the ObjectMeta.
-func ObjectMetaFieldsSet(objectMeta api.ObjectMeta) fields.Set {
+func ObjectMetaFieldsSet(objectMeta api.ObjectMeta, hasNamespaceField bool) fields.Set {
+	if !hasNamespaceField {
+		return fields.Set{
+			"metadata.name": objectMeta.Name,
+		}
+	}
 	return fields.Set{
 		"metadata.name":      objectMeta.Name,
 		"metadata.namespace": objectMeta.Namespace,

--- a/pkg/registry/ingress/strategy.go
+++ b/pkg/registry/ingress/strategy.go
@@ -95,7 +95,7 @@ func (ingressStrategy) AllowUnconditionalUpdate() bool {
 
 // IngressToSelectableFields returns a field set that represents the object.
 func IngressToSelectableFields(ingress *extensions.Ingress) fields.Set {
-	return generic.ObjectMetaFieldsSet(ingress.ObjectMeta)
+	return generic.ObjectMetaFieldsSet(ingress.ObjectMeta, true)
 }
 
 // MatchIngress is the filter used by the generic etcd backend to ingress

--- a/pkg/registry/job/strategy.go
+++ b/pkg/registry/job/strategy.go
@@ -97,7 +97,7 @@ func (jobStatusStrategy) ValidateUpdate(ctx api.Context, obj, old runtime.Object
 
 // JobSelectableFields returns a field set that represents the object for matching purposes.
 func JobToSelectableFields(job *extensions.Job) fields.Set {
-	objectMetaFieldsSet := generic.ObjectMetaFieldsSet(job.ObjectMeta)
+	objectMetaFieldsSet := generic.ObjectMetaFieldsSet(job.ObjectMeta, true)
 	specificFieldsSet := fields.Set{
 		"status.successful": strconv.Itoa(job.Status.Succeeded),
 	}

--- a/pkg/registry/namespace/strategy.go
+++ b/pkg/registry/namespace/strategy.go
@@ -144,7 +144,7 @@ func MatchNamespace(label labels.Selector, field fields.Selector) generic.Matche
 
 // NamespaceToSelectableFields returns a label set that represents the object
 func NamespaceToSelectableFields(namespace *api.Namespace) labels.Set {
-	objectMetaFieldsSet := generic.ObjectMetaFieldsSet(namespace.ObjectMeta)
+	objectMetaFieldsSet := generic.ObjectMetaFieldsSet(namespace.ObjectMeta, false)
 	specificFieldsSet := fields.Set{
 		"status.phase": string(namespace.Status.Phase),
 		// This is a bug, but we need to support it for backward compatibility.

--- a/pkg/registry/node/strategy.go
+++ b/pkg/registry/node/strategy.go
@@ -114,10 +114,11 @@ type ResourceGetter interface {
 
 // NodeToSelectableFields returns a label set that represents the object.
 func NodeToSelectableFields(node *api.Node) fields.Set {
-	return fields.Set{
-		"metadata.name":      node.Name,
+	objectMetaFieldsSet := generic.ObjectMetaFieldsSet(node.ObjectMeta, false)
+	specificFieldsSet := fields.Set{
 		"spec.unschedulable": fmt.Sprint(node.Spec.Unschedulable),
 	}
+	return generic.MergeFieldsSets(objectMetaFieldsSet, specificFieldsSet)
 }
 
 // MatchNode returns a generic matcher for a given label and field selector.

--- a/pkg/registry/persistentvolume/strategy.go
+++ b/pkg/registry/persistentvolume/strategy.go
@@ -104,7 +104,7 @@ func MatchPersistentVolumes(label labels.Selector, field fields.Selector) generi
 
 // PersistentVolumeToSelectableFields returns a label set that represents the object
 func PersistentVolumeToSelectableFields(persistentvolume *api.PersistentVolume) labels.Set {
-	objectMetaFieldsSet := generic.ObjectMetaFieldsSet(persistentvolume.ObjectMeta)
+	objectMetaFieldsSet := generic.ObjectMetaFieldsSet(persistentvolume.ObjectMeta, false)
 	specificFieldsSet := fields.Set{
 		// This is a bug, but we need to support it for backward compatibility.
 		"name": persistentvolume.Name,

--- a/pkg/registry/persistentvolumeclaim/strategy.go
+++ b/pkg/registry/persistentvolumeclaim/strategy.go
@@ -104,7 +104,7 @@ func MatchPersistentVolumeClaim(label labels.Selector, field fields.Selector) ge
 
 // PersistentVolumeClaimToSelectableFields returns a label set that represents the object
 func PersistentVolumeClaimToSelectableFields(persistentvolumeclaim *api.PersistentVolumeClaim) labels.Set {
-	objectMetaFieldsSet := generic.ObjectMetaFieldsSet(persistentvolumeclaim.ObjectMeta)
+	objectMetaFieldsSet := generic.ObjectMetaFieldsSet(persistentvolumeclaim.ObjectMeta, true)
 	specificFieldsSet := fields.Set{
 		// This is a bug, but we need to support it for backward compatibility.
 		"name": persistentvolumeclaim.Name,

--- a/pkg/registry/pod/strategy.go
+++ b/pkg/registry/pod/strategy.go
@@ -166,7 +166,7 @@ func MatchPod(label labels.Selector, field fields.Selector) generic.Matcher {
 // PodToSelectableFields returns a field set that represents the object
 // TODO: fields are not labels, and the validation rules for them do not apply.
 func PodToSelectableFields(pod *api.Pod) fields.Set {
-	objectMetaFieldsSet := generic.ObjectMetaFieldsSet(pod.ObjectMeta)
+	objectMetaFieldsSet := generic.ObjectMetaFieldsSet(pod.ObjectMeta, true)
 	podSpecificFieldsSet := fields.Set{
 		"spec.nodeName": pod.Spec.NodeName,
 		"status.phase":  string(pod.Status.Phase),

--- a/pkg/registry/resourcequota/strategy.go
+++ b/pkg/registry/resourcequota/strategy.go
@@ -107,5 +107,5 @@ func MatchResourceQuota(label labels.Selector, field fields.Selector) generic.Ma
 
 // ResourceQuotaToSelectableFields returns a label set that represents the object
 func ResourceQuotaToSelectableFields(resourcequota *api.ResourceQuota) labels.Set {
-	return labels.Set(generic.ObjectMetaFieldsSet(resourcequota.ObjectMeta))
+	return labels.Set(generic.ObjectMetaFieldsSet(resourcequota.ObjectMeta, true))
 }

--- a/pkg/registry/serviceaccount/strategy.go
+++ b/pkg/registry/serviceaccount/strategy.go
@@ -86,5 +86,5 @@ func Matcher(label labels.Selector, field fields.Selector) generic.Matcher {
 
 // SelectableFields returns a label set that represents the object
 func SelectableFields(obj *api.ServiceAccount) labels.Set {
-	return labels.Set(generic.ObjectMetaFieldsSet(obj.ObjectMeta))
+	return labels.Set(generic.ObjectMetaFieldsSet(obj.ObjectMeta, true))
 }


### PR DESCRIPTION
Follow-up to #15766 
Ref #16509
Rootscoped resources has no namespace field, we shouldn't use namespace as a selectable field.
