### PR TITLE
Fix centos get basicauth fail

### DIFF
--- a/cluster/centos/util.sh
+++ b/cluster/centos/util.sh
@@ -306,7 +306,7 @@ function kube-scp() {
 #   KUBE_USER
 #   KUBE_PASSWORD
 function get-password {
-  get-kubeconfig-basicauth
+  load-or-gen-kube-basicauth
   if [[ -z "${KUBE_USER}" || -z "${KUBE_PASSWORD}" ]]; then
     KUBE_USER=admin
     KUBE_PASSWORD=$(python -c 'import string,random; \


### PR DESCRIPTION
According to recently PR, We should use `load-or-gen-kube-basicauth` to replace `get-kubeconfig-basicauth`. 
