### PR TITLE
Avoid full sort when selecting host with highest priority.

### DIFF
--- a/plugin/pkg/scheduler/generic_scheduler.go
+++ b/plugin/pkg/scheduler/generic_scheduler.go
@@ -19,7 +19,6 @@ package scheduler
 import (
 	"fmt"
 	"math/rand"
-	"sort"
 	"strings"
 	"sync"
 
@@ -88,20 +87,32 @@ func (g *genericScheduler) Schedule(pod *api.Pod, nodeLister algorithm.NodeListe
 	return g.selectHost(priorityList)
 }
 
-// This method takes a prioritized list of nodes and sorts them in reverse order based on scores
-// and then picks one randomly from the nodes that had the highest score
+// This method takes a prioritized list of nodes, shuffles those with the highest scores to the
+// front of the list, and then picks one randomly from the nodes that had the highest score.
 func (g *genericScheduler) selectHost(priorityList algorithm.HostPriorityList) (string, error) {
 	if len(priorityList) == 0 {
 		return "", fmt.Errorf("empty priorityList")
 	}
-	sort.Sort(sort.Reverse(priorityList))
+	max := priorityList[0].Score
+	n := 0
+	for i, hostEntry := range priorityList {
+		if hostEntry.Score < max {
+			continue
+		}
+		if hostEntry.Score > max {
+			max = hostEntry.Score
+			n = 0
+		}
+		priorityList[i], priorityList[n] = priorityList[n], priorityList[i]
+		n++
+	}
+	if n == 1 {
+		return priorityList[0].Host, nil
+	}
 
-	hosts := getBestHosts(priorityList)
 	g.randomLock.Lock()
 	defer g.randomLock.Unlock()
-
-	ix := g.random.Int() % len(hosts)
-	return hosts[ix], nil
+	return priorityList[g.random.Intn(n)].Host, nil
 }
 
 // Filters the nodes to find the ones that fit based on the given predicate functions
@@ -177,18 +188,6 @@ func PrioritizeNodes(pod *api.Pod, podLister algorithm.PodLister, priorityConfig
 		result = append(result, algorithm.HostPriority{Host: host, Score: score})
 	}
 	return result, nil
-}
-
-func getBestHosts(list algorithm.HostPriorityList) []string {
-	result := []string{}
-	for _, hostEntry := range list {
-		if hostEntry.Score == list[0].Score {
-			result = append(result, hostEntry.Host)
-		} else {
-			break
-		}
-	}
-	return result
 }
 
 // EqualPriority is a prioritizer function that gives an equal weight of one to all nodes


### PR DESCRIPTION
I was reading through the scheduling code and figured I'd offer a little optimization when selecting the highest priority host.  I wouldn't argue that this is strictly needed, but I think it's a little better and not overly complicated.  There aren't added tests because the output is the same and already tested. 
- We can avoid a full sort of the list and find the top priority hosts with a single pass.
- We can avoid generating []string garbage from the top host names.
- We can avoid locking and generating a random number when there's one top host.
- We can avoid modulo bias in the random number.
