### PR TITLE
Fix hpa escalation

### DIFF
--- a/api/swagger-spec/v1beta1.json
+++ b/api/swagger-spec/v1beta1.json
@@ -2513,10 +2513,6 @@
       "type": "string",
       "description": "Kind of the referent; More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds\""
      },
-     "namespace": {
-      "type": "string",
-      "description": "Namespace of the referent; More info: http://releases.k8s.io/HEAD/docs/user-guide/namespaces.md"
-     },
      "name": {
       "type": "string",
       "description": "Name of the referent; More info: http://releases.k8s.io/HEAD/docs/user-guide/identifiers.md#names"

--- a/docs/api-reference/extensions/v1beta1/definitions.html
+++ b/docs/api-reference/extensions/v1beta1/definitions.html
@@ -3998,13 +3998,6 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">namespace</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Namespace of the referent; More info: <a href="http://releases.k8s.io/HEAD/docs/user-guide/namespaces.md">http://releases.k8s.io/HEAD/docs/user-guide/namespaces.md</a></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
-<td class="tableblock halign-left valign-top"></td>
-</tr>
-<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">name</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Name of the referent; More info: <a href="http://releases.k8s.io/HEAD/docs/user-guide/identifiers.md#names">http://releases.k8s.io/HEAD/docs/user-guide/identifiers.md#names</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
@@ -4247,7 +4240,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2015-10-26 09:18:25 UTC
+Last updated 2015-11-02 14:28:45 UTC
 </div>
 </div>
 </body>

--- a/docs/api-reference/extensions/v1beta1/operations.html
+++ b/docs/api-reference/extensions/v1beta1/operations.html
@@ -5095,7 +5095,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2015-10-26 09:18:25 UTC
+Last updated 2015-11-02 14:28:45 UTC
 </div>
 </div>
 </body>

--- a/docs/api-reference/v1/definitions.html
+++ b/docs/api-reference/v1/definitions.html
@@ -6866,7 +6866,7 @@ The resulting set of endpoints can be viewed as:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2015-10-26 09:18:19 UTC
+Last updated 2015-11-02 14:28:36 UTC
 </div>
 </div>
 </body>

--- a/docs/api-reference/v1/operations.html
+++ b/docs/api-reference/v1/operations.html
@@ -23664,7 +23664,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2015-10-26 09:18:19 UTC
+Last updated 2015-11-02 14:28:36 UTC
 </div>
 </div>
 </body>

--- a/pkg/apis/extensions/deep_copy_generated.go
+++ b/pkg/apis/extensions/deep_copy_generated.go
@@ -1483,7 +1483,6 @@ func deepCopy_extensions_ScaleStatus(in ScaleStatus, out *ScaleStatus, c *conver
 
 func deepCopy_extensions_SubresourceReference(in SubresourceReference, out *SubresourceReference, c *conversion.Cloner) error {
 	out.Kind = in.Kind
-	out.Namespace = in.Namespace
 	out.Name = in.Name
 	out.APIVersion = in.APIVersion
 	out.Subresource = in.Subresource

--- a/pkg/apis/extensions/types.generated.go
+++ b/pkg/apis/extensions/types.generated.go
@@ -978,16 +978,15 @@ func (x *SubresourceReference) CodecEncodeSelf(e *codec1978.Encoder) {
 		} else {
 			yysep78 := !z.EncBinary()
 			yy2arr78 := z.EncBasicHandle().StructToArray
-			var yyq78 [5]bool
+			var yyq78 [4]bool
 			_, _, _ = yysep78, yyq78, yy2arr78
 			const yyr78 bool = false
 			yyq78[0] = x.Kind != ""
-			yyq78[1] = x.Namespace != ""
-			yyq78[2] = x.Name != ""
-			yyq78[3] = x.APIVersion != ""
-			yyq78[4] = x.Subresource != ""
+			yyq78[1] = x.Name != ""
+			yyq78[2] = x.APIVersion != ""
+			yyq78[3] = x.Subresource != ""
 			if yyr78 || yy2arr78 {
-				r.EncodeArrayStart(5)
+				r.EncodeArrayStart(4)
 			} else {
 				var yynn78 int = 0
 				for _, b := range yyq78 {
@@ -1025,19 +1024,19 @@ func (x *SubresourceReference) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym83
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Namespace))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq78[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("namespace"))
+					r.EncodeString(codecSelferC_UTF81234, string("name"))
 					yym84 := z.EncBinary()
 					_ = yym84
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Namespace))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 					}
 				}
 			}
@@ -1047,19 +1046,19 @@ func (x *SubresourceReference) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym86
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq78[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("name"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					yym87 := z.EncBinary()
 					_ = yym87
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -1069,38 +1068,16 @@ func (x *SubresourceReference) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym89
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq78[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym90 := z.EncBinary()
-					_ = yym90
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr78 || yy2arr78 {
-				if yyq78[4] {
-					yym92 := z.EncBinary()
-					_ = yym92
-					if false {
-					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Subresource))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq78[4] {
+				if yyq78[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("subresource"))
-					yym93 := z.EncBinary()
-					_ = yym93
+					yym90 := z.EncBinary()
+					_ = yym90
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Subresource))
@@ -1118,24 +1095,24 @@ func (x *SubresourceReference) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym94 := z.DecBinary()
-	_ = yym94
+	yym91 := z.DecBinary()
+	_ = yym91
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl95 := r.ReadMapStart()
-			if yyl95 == 0 {
+			yyl92 := r.ReadMapStart()
+			if yyl92 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl95, d)
+				x.codecDecodeSelfFromMap(yyl92, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl95 := r.ReadArrayStart()
-			if yyl95 == 0 {
+			yyl92 := r.ReadArrayStart()
+			if yyl92 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl95, d)
+				x.codecDecodeSelfFromArray(yyl92, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -1147,12 +1124,12 @@ func (x *SubresourceReference) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys96Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys96Slc
-	var yyhl96 bool = l >= 0
-	for yyj96 := 0; ; yyj96++ {
-		if yyhl96 {
-			if yyj96 >= l {
+	var yys93Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys93Slc
+	var yyhl93 bool = l >= 0
+	for yyj93 := 0; ; yyj93++ {
+		if yyhl93 {
+			if yyj93 >= l {
 				break
 			}
 		} else {
@@ -1160,20 +1137,14 @@ func (x *SubresourceReference) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
-		yys96Slc = r.DecodeBytes(yys96Slc, true, true)
-		yys96 := string(yys96Slc)
-		switch yys96 {
+		yys93Slc = r.DecodeBytes(yys93Slc, true, true)
+		yys93 := string(yys93Slc)
+		switch yys93 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
 			} else {
 				x.Kind = string(r.DecodeString())
-			}
-		case "namespace":
-			if r.TryDecodeAsNil() {
-				x.Namespace = ""
-			} else {
-				x.Namespace = string(r.DecodeString())
 			}
 		case "name":
 			if r.TryDecodeAsNil() {
@@ -1194,10 +1165,10 @@ func (x *SubresourceReference) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				x.Subresource = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys96)
-		} // end switch yys96
-	} // end for yyj96
-	if !yyhl96 {
+			z.DecStructFieldNotFound(-1, yys93)
+		} // end switch yys93
+	} // end for yyj93
+	if !yyhl93 {
 		r.ReadEnd()
 	}
 }
@@ -1206,16 +1177,16 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj102 int
-	var yyb102 bool
-	var yyhl102 bool = l >= 0
-	yyj102++
-	if yyhl102 {
-		yyb102 = yyj102 > l
+	var yyj98 int
+	var yyb98 bool
+	var yyhl98 bool = l >= 0
+	yyj98++
+	if yyhl98 {
+		yyb98 = yyj98 > l
 	} else {
-		yyb102 = r.CheckBreak()
+		yyb98 = r.CheckBreak()
 	}
-	if yyb102 {
+	if yyb98 {
 		r.ReadEnd()
 		return
 	}
@@ -1224,28 +1195,13 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj102++
-	if yyhl102 {
-		yyb102 = yyj102 > l
+	yyj98++
+	if yyhl98 {
+		yyb98 = yyj98 > l
 	} else {
-		yyb102 = r.CheckBreak()
+		yyb98 = r.CheckBreak()
 	}
-	if yyb102 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.Namespace = ""
-	} else {
-		x.Namespace = string(r.DecodeString())
-	}
-	yyj102++
-	if yyhl102 {
-		yyb102 = yyj102 > l
-	} else {
-		yyb102 = r.CheckBreak()
-	}
-	if yyb102 {
+	if yyb98 {
 		r.ReadEnd()
 		return
 	}
@@ -1254,13 +1210,13 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.Name = string(r.DecodeString())
 	}
-	yyj102++
-	if yyhl102 {
-		yyb102 = yyj102 > l
+	yyj98++
+	if yyhl98 {
+		yyb98 = yyj98 > l
 	} else {
-		yyb102 = r.CheckBreak()
+		yyb98 = r.CheckBreak()
 	}
-	if yyb102 {
+	if yyb98 {
 		r.ReadEnd()
 		return
 	}
@@ -1269,13 +1225,13 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj102++
-	if yyhl102 {
-		yyb102 = yyj102 > l
+	yyj98++
+	if yyhl98 {
+		yyb98 = yyj98 > l
 	} else {
-		yyb102 = r.CheckBreak()
+		yyb98 = r.CheckBreak()
 	}
-	if yyb102 {
+	if yyb98 {
 		r.ReadEnd()
 		return
 	}
@@ -1285,16 +1241,16 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		x.Subresource = string(r.DecodeString())
 	}
 	for {
-		yyj102++
-		if yyhl102 {
-			yyb102 = yyj102 > l
+		yyj98++
+		if yyhl98 {
+			yyb98 = yyj98 > l
 		} else {
-			yyb102 = r.CheckBreak()
+			yyb98 = r.CheckBreak()
 		}
-		if yyb102 {
+		if yyb98 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj102-1, "")
+		z.DecStructFieldNotFound(yyj98-1, "")
 	}
 	r.ReadEnd()
 }
@@ -1306,44 +1262,44 @@ func (x *CPUTargetUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym108 := z.EncBinary()
-		_ = yym108
+		yym103 := z.EncBinary()
+		_ = yym103
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep109 := !z.EncBinary()
-			yy2arr109 := z.EncBasicHandle().StructToArray
-			var yyq109 [1]bool
-			_, _, _ = yysep109, yyq109, yy2arr109
-			const yyr109 bool = false
-			if yyr109 || yy2arr109 {
+			yysep104 := !z.EncBinary()
+			yy2arr104 := z.EncBasicHandle().StructToArray
+			var yyq104 [1]bool
+			_, _, _ = yysep104, yyq104, yy2arr104
+			const yyr104 bool = false
+			if yyr104 || yy2arr104 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn109 int = 1
-				for _, b := range yyq109 {
+				var yynn104 int = 1
+				for _, b := range yyq104 {
 					if b {
-						yynn109++
+						yynn104++
 					}
 				}
-				r.EncodeMapStart(yynn109)
+				r.EncodeMapStart(yynn104)
 			}
-			if yyr109 || yy2arr109 {
-				yym111 := z.EncBinary()
-				_ = yym111
+			if yyr104 || yy2arr104 {
+				yym106 := z.EncBinary()
+				_ = yym106
 				if false {
 				} else {
 					r.EncodeInt(int64(x.TargetPercentage))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("targetPercentage"))
-				yym112 := z.EncBinary()
-				_ = yym112
+				yym107 := z.EncBinary()
+				_ = yym107
 				if false {
 				} else {
 					r.EncodeInt(int64(x.TargetPercentage))
 				}
 			}
-			if yysep109 {
+			if yysep104 {
 				r.EncodeEnd()
 			}
 		}
@@ -1354,24 +1310,24 @@ func (x *CPUTargetUtilization) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym113 := z.DecBinary()
-	_ = yym113
+	yym108 := z.DecBinary()
+	_ = yym108
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl114 := r.ReadMapStart()
-			if yyl114 == 0 {
+			yyl109 := r.ReadMapStart()
+			if yyl109 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl114, d)
+				x.codecDecodeSelfFromMap(yyl109, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl114 := r.ReadArrayStart()
-			if yyl114 == 0 {
+			yyl109 := r.ReadArrayStart()
+			if yyl109 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl114, d)
+				x.codecDecodeSelfFromArray(yyl109, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -1383,12 +1339,12 @@ func (x *CPUTargetUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys115Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys115Slc
-	var yyhl115 bool = l >= 0
-	for yyj115 := 0; ; yyj115++ {
-		if yyhl115 {
-			if yyj115 >= l {
+	var yys110Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys110Slc
+	var yyhl110 bool = l >= 0
+	for yyj110 := 0; ; yyj110++ {
+		if yyhl110 {
+			if yyj110 >= l {
 				break
 			}
 		} else {
@@ -1396,9 +1352,9 @@ func (x *CPUTargetUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
-		yys115Slc = r.DecodeBytes(yys115Slc, true, true)
-		yys115 := string(yys115Slc)
-		switch yys115 {
+		yys110Slc = r.DecodeBytes(yys110Slc, true, true)
+		yys110 := string(yys110Slc)
+		switch yys110 {
 		case "targetPercentage":
 			if r.TryDecodeAsNil() {
 				x.TargetPercentage = 0
@@ -1406,10 +1362,10 @@ func (x *CPUTargetUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				x.TargetPercentage = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys115)
-		} // end switch yys115
-	} // end for yyj115
-	if !yyhl115 {
+			z.DecStructFieldNotFound(-1, yys110)
+		} // end switch yys110
+	} // end for yyj110
+	if !yyhl110 {
 		r.ReadEnd()
 	}
 }
@@ -1418,16 +1374,16 @@ func (x *CPUTargetUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj117 int
-	var yyb117 bool
-	var yyhl117 bool = l >= 0
-	yyj117++
-	if yyhl117 {
-		yyb117 = yyj117 > l
+	var yyj112 int
+	var yyb112 bool
+	var yyhl112 bool = l >= 0
+	yyj112++
+	if yyhl112 {
+		yyb112 = yyj112 > l
 	} else {
-		yyb117 = r.CheckBreak()
+		yyb112 = r.CheckBreak()
 	}
-	if yyb117 {
+	if yyb112 {
 		r.ReadEnd()
 		return
 	}
@@ -1437,16 +1393,16 @@ func (x *CPUTargetUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		x.TargetPercentage = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj117++
-		if yyhl117 {
-			yyb117 = yyj117 > l
+		yyj112++
+		if yyhl112 {
+			yyb112 = yyj112 > l
 		} else {
-			yyb117 = r.CheckBreak()
+			yyb112 = r.CheckBreak()
 		}
-		if yyb117 {
+		if yyb112 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj117-1, "")
+		z.DecStructFieldNotFound(yyj112-1, "")
 	}
 	r.ReadEnd()
 }
@@ -1458,87 +1414,87 @@ func (x *HorizontalPodAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym119 := z.EncBinary()
-		_ = yym119
+		yym114 := z.EncBinary()
+		_ = yym114
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep120 := !z.EncBinary()
-			yy2arr120 := z.EncBasicHandle().StructToArray
-			var yyq120 [4]bool
-			_, _, _ = yysep120, yyq120, yy2arr120
-			const yyr120 bool = false
-			yyq120[1] = x.MinReplicas != nil
-			yyq120[3] = x.CPUUtilization != nil
-			if yyr120 || yy2arr120 {
+			yysep115 := !z.EncBinary()
+			yy2arr115 := z.EncBasicHandle().StructToArray
+			var yyq115 [4]bool
+			_, _, _ = yysep115, yyq115, yy2arr115
+			const yyr115 bool = false
+			yyq115[1] = x.MinReplicas != nil
+			yyq115[3] = x.CPUUtilization != nil
+			if yyr115 || yy2arr115 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn120 int = 2
-				for _, b := range yyq120 {
+				var yynn115 int = 2
+				for _, b := range yyq115 {
 					if b {
-						yynn120++
+						yynn115++
 					}
 				}
-				r.EncodeMapStart(yynn120)
+				r.EncodeMapStart(yynn115)
 			}
-			if yyr120 || yy2arr120 {
-				yy122 := &x.ScaleRef
-				yy122.CodecEncodeSelf(e)
+			if yyr115 || yy2arr115 {
+				yy117 := &x.ScaleRef
+				yy117.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("scaleRef"))
-				yy123 := &x.ScaleRef
-				yy123.CodecEncodeSelf(e)
+				yy118 := &x.ScaleRef
+				yy118.CodecEncodeSelf(e)
 			}
-			if yyr120 || yy2arr120 {
-				if yyq120[1] {
+			if yyr115 || yy2arr115 {
+				if yyq115[1] {
 					if x.MinReplicas == nil {
 						r.EncodeNil()
 					} else {
-						yy125 := *x.MinReplicas
-						yym126 := z.EncBinary()
-						_ = yym126
+						yy120 := *x.MinReplicas
+						yym121 := z.EncBinary()
+						_ = yym121
 						if false {
 						} else {
-							r.EncodeInt(int64(yy125))
+							r.EncodeInt(int64(yy120))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq120[1] {
+				if yyq115[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("minReplicas"))
 					if x.MinReplicas == nil {
 						r.EncodeNil()
 					} else {
-						yy127 := *x.MinReplicas
-						yym128 := z.EncBinary()
-						_ = yym128
+						yy122 := *x.MinReplicas
+						yym123 := z.EncBinary()
+						_ = yym123
 						if false {
 						} else {
-							r.EncodeInt(int64(yy127))
+							r.EncodeInt(int64(yy122))
 						}
 					}
 				}
 			}
-			if yyr120 || yy2arr120 {
-				yym130 := z.EncBinary()
-				_ = yym130
+			if yyr115 || yy2arr115 {
+				yym125 := z.EncBinary()
+				_ = yym125
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MaxReplicas))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("maxReplicas"))
-				yym131 := z.EncBinary()
-				_ = yym131
+				yym126 := z.EncBinary()
+				_ = yym126
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MaxReplicas))
 				}
 			}
-			if yyr120 || yy2arr120 {
-				if yyq120[3] {
+			if yyr115 || yy2arr115 {
+				if yyq115[3] {
 					if x.CPUUtilization == nil {
 						r.EncodeNil()
 					} else {
@@ -1548,7 +1504,7 @@ func (x *HorizontalPodAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq120[3] {
+				if yyq115[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("cpuUtilization"))
 					if x.CPUUtilization == nil {
 						r.EncodeNil()
@@ -1557,7 +1513,7 @@ func (x *HorizontalPodAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep120 {
+			if yysep115 {
 				r.EncodeEnd()
 			}
 		}
@@ -1568,24 +1524,24 @@ func (x *HorizontalPodAutoscalerSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym133 := z.DecBinary()
-	_ = yym133
+	yym128 := z.DecBinary()
+	_ = yym128
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl134 := r.ReadMapStart()
-			if yyl134 == 0 {
+			yyl129 := r.ReadMapStart()
+			if yyl129 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl134, d)
+				x.codecDecodeSelfFromMap(yyl129, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl134 := r.ReadArrayStart()
-			if yyl134 == 0 {
+			yyl129 := r.ReadArrayStart()
+			if yyl129 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl134, d)
+				x.codecDecodeSelfFromArray(yyl129, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -1597,12 +1553,12 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys135Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys135Slc
-	var yyhl135 bool = l >= 0
-	for yyj135 := 0; ; yyj135++ {
-		if yyhl135 {
-			if yyj135 >= l {
+	var yys130Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys130Slc
+	var yyhl130 bool = l >= 0
+	for yyj130 := 0; ; yyj130++ {
+		if yyhl130 {
+			if yyj130 >= l {
 				break
 			}
 		} else {
@@ -1610,15 +1566,15 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978
 				break
 			}
 		}
-		yys135Slc = r.DecodeBytes(yys135Slc, true, true)
-		yys135 := string(yys135Slc)
-		switch yys135 {
+		yys130Slc = r.DecodeBytes(yys130Slc, true, true)
+		yys130 := string(yys130Slc)
+		switch yys130 {
 		case "scaleRef":
 			if r.TryDecodeAsNil() {
 				x.ScaleRef = SubresourceReference{}
 			} else {
-				yyv136 := &x.ScaleRef
-				yyv136.CodecDecodeSelf(d)
+				yyv131 := &x.ScaleRef
+				yyv131.CodecDecodeSelf(d)
 			}
 		case "minReplicas":
 			if r.TryDecodeAsNil() {
@@ -1629,8 +1585,8 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978
 				if x.MinReplicas == nil {
 					x.MinReplicas = new(int)
 				}
-				yym138 := z.DecBinary()
-				_ = yym138
+				yym133 := z.DecBinary()
+				_ = yym133
 				if false {
 				} else {
 					*((*int)(x.MinReplicas)) = int(r.DecodeInt(codecSelferBitsize1234))
@@ -1654,10 +1610,10 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978
 				x.CPUUtilization.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys135)
-		} // end switch yys135
-	} // end for yyj135
-	if !yyhl135 {
+			z.DecStructFieldNotFound(-1, yys130)
+		} // end switch yys130
+	} // end for yyj130
+	if !yyhl130 {
 		r.ReadEnd()
 	}
 }
@@ -1666,32 +1622,32 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec19
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj141 int
-	var yyb141 bool
-	var yyhl141 bool = l >= 0
-	yyj141++
-	if yyhl141 {
-		yyb141 = yyj141 > l
+	var yyj136 int
+	var yyb136 bool
+	var yyhl136 bool = l >= 0
+	yyj136++
+	if yyhl136 {
+		yyb136 = yyj136 > l
 	} else {
-		yyb141 = r.CheckBreak()
+		yyb136 = r.CheckBreak()
 	}
-	if yyb141 {
+	if yyb136 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ScaleRef = SubresourceReference{}
 	} else {
-		yyv142 := &x.ScaleRef
-		yyv142.CodecDecodeSelf(d)
+		yyv137 := &x.ScaleRef
+		yyv137.CodecDecodeSelf(d)
 	}
-	yyj141++
-	if yyhl141 {
-		yyb141 = yyj141 > l
+	yyj136++
+	if yyhl136 {
+		yyb136 = yyj136 > l
 	} else {
-		yyb141 = r.CheckBreak()
+		yyb136 = r.CheckBreak()
 	}
-	if yyb141 {
+	if yyb136 {
 		r.ReadEnd()
 		return
 	}
@@ -1703,20 +1659,20 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec19
 		if x.MinReplicas == nil {
 			x.MinReplicas = new(int)
 		}
-		yym144 := z.DecBinary()
-		_ = yym144
+		yym139 := z.DecBinary()
+		_ = yym139
 		if false {
 		} else {
 			*((*int)(x.MinReplicas)) = int(r.DecodeInt(codecSelferBitsize1234))
 		}
 	}
-	yyj141++
-	if yyhl141 {
-		yyb141 = yyj141 > l
+	yyj136++
+	if yyhl136 {
+		yyb136 = yyj136 > l
 	} else {
-		yyb141 = r.CheckBreak()
+		yyb136 = r.CheckBreak()
 	}
-	if yyb141 {
+	if yyb136 {
 		r.ReadEnd()
 		return
 	}
@@ -1725,13 +1681,13 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec19
 	} else {
 		x.MaxReplicas = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj141++
-	if yyhl141 {
-		yyb141 = yyj141 > l
+	yyj136++
+	if yyhl136 {
+		yyb136 = yyj136 > l
 	} else {
-		yyb141 = r.CheckBreak()
+		yyb136 = r.CheckBreak()
 	}
-	if yyb141 {
+	if yyb136 {
 		r.ReadEnd()
 		return
 	}
@@ -1746,16 +1702,16 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec19
 		x.CPUUtilization.CodecDecodeSelf(d)
 	}
 	for {
-		yyj141++
-		if yyhl141 {
-			yyb141 = yyj141 > l
+		yyj136++
+		if yyhl136 {
+			yyb136 = yyj136 > l
 		} else {
-			yyb141 = r.CheckBreak()
+			yyb136 = r.CheckBreak()
 		}
-		if yyb141 {
+		if yyb136 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj141-1, "")
+		z.DecStructFieldNotFound(yyj136-1, "")
 	}
 	r.ReadEnd()
 }
@@ -1767,74 +1723,74 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym147 := z.EncBinary()
-		_ = yym147
+		yym142 := z.EncBinary()
+		_ = yym142
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep148 := !z.EncBinary()
-			yy2arr148 := z.EncBasicHandle().StructToArray
-			var yyq148 [5]bool
-			_, _, _ = yysep148, yyq148, yy2arr148
-			const yyr148 bool = false
-			yyq148[0] = x.ObservedGeneration != nil
-			yyq148[1] = x.LastScaleTime != nil
-			yyq148[4] = x.CurrentCPUUtilizationPercentage != nil
-			if yyr148 || yy2arr148 {
+			yysep143 := !z.EncBinary()
+			yy2arr143 := z.EncBasicHandle().StructToArray
+			var yyq143 [5]bool
+			_, _, _ = yysep143, yyq143, yy2arr143
+			const yyr143 bool = false
+			yyq143[0] = x.ObservedGeneration != nil
+			yyq143[1] = x.LastScaleTime != nil
+			yyq143[4] = x.CurrentCPUUtilizationPercentage != nil
+			if yyr143 || yy2arr143 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn148 int = 2
-				for _, b := range yyq148 {
+				var yynn143 int = 2
+				for _, b := range yyq143 {
 					if b {
-						yynn148++
+						yynn143++
 					}
 				}
-				r.EncodeMapStart(yynn148)
+				r.EncodeMapStart(yynn143)
 			}
-			if yyr148 || yy2arr148 {
-				if yyq148[0] {
+			if yyr143 || yy2arr143 {
+				if yyq143[0] {
 					if x.ObservedGeneration == nil {
 						r.EncodeNil()
 					} else {
-						yy150 := *x.ObservedGeneration
-						yym151 := z.EncBinary()
-						_ = yym151
+						yy145 := *x.ObservedGeneration
+						yym146 := z.EncBinary()
+						_ = yym146
 						if false {
 						} else {
-							r.EncodeInt(int64(yy150))
+							r.EncodeInt(int64(yy145))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq148[0] {
+				if yyq143[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("observedGeneration"))
 					if x.ObservedGeneration == nil {
 						r.EncodeNil()
 					} else {
-						yy152 := *x.ObservedGeneration
-						yym153 := z.EncBinary()
-						_ = yym153
+						yy147 := *x.ObservedGeneration
+						yym148 := z.EncBinary()
+						_ = yym148
 						if false {
 						} else {
-							r.EncodeInt(int64(yy152))
+							r.EncodeInt(int64(yy147))
 						}
 					}
 				}
 			}
-			if yyr148 || yy2arr148 {
-				if yyq148[1] {
+			if yyr143 || yy2arr143 {
+				if yyq143[1] {
 					if x.LastScaleTime == nil {
 						r.EncodeNil()
 					} else {
-						yym155 := z.EncBinary()
-						_ = yym155
+						yym150 := z.EncBinary()
+						_ = yym150
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.LastScaleTime) {
-						} else if yym155 {
+						} else if yym150 {
 							z.EncBinaryMarshal(x.LastScaleTime)
-						} else if !yym155 && z.IsJSONHandle() {
+						} else if !yym150 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.LastScaleTime)
 						} else {
 							z.EncFallback(x.LastScaleTime)
@@ -1844,18 +1800,18 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq148[1] {
+				if yyq143[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("lastScaleTime"))
 					if x.LastScaleTime == nil {
 						r.EncodeNil()
 					} else {
-						yym156 := z.EncBinary()
-						_ = yym156
+						yym151 := z.EncBinary()
+						_ = yym151
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.LastScaleTime) {
-						} else if yym156 {
+						} else if yym151 {
 							z.EncBinaryMarshal(x.LastScaleTime)
-						} else if !yym156 && z.IsJSONHandle() {
+						} else if !yym151 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.LastScaleTime)
 						} else {
 							z.EncFallback(x.LastScaleTime)
@@ -1863,71 +1819,71 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr148 || yy2arr148 {
-				yym158 := z.EncBinary()
-				_ = yym158
+			if yyr143 || yy2arr143 {
+				yym153 := z.EncBinary()
+				_ = yym153
 				if false {
 				} else {
 					r.EncodeInt(int64(x.CurrentReplicas))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("currentReplicas"))
-				yym159 := z.EncBinary()
-				_ = yym159
+				yym154 := z.EncBinary()
+				_ = yym154
 				if false {
 				} else {
 					r.EncodeInt(int64(x.CurrentReplicas))
 				}
 			}
-			if yyr148 || yy2arr148 {
-				yym161 := z.EncBinary()
-				_ = yym161
+			if yyr143 || yy2arr143 {
+				yym156 := z.EncBinary()
+				_ = yym156
 				if false {
 				} else {
 					r.EncodeInt(int64(x.DesiredReplicas))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("desiredReplicas"))
-				yym162 := z.EncBinary()
-				_ = yym162
+				yym157 := z.EncBinary()
+				_ = yym157
 				if false {
 				} else {
 					r.EncodeInt(int64(x.DesiredReplicas))
 				}
 			}
-			if yyr148 || yy2arr148 {
-				if yyq148[4] {
+			if yyr143 || yy2arr143 {
+				if yyq143[4] {
 					if x.CurrentCPUUtilizationPercentage == nil {
 						r.EncodeNil()
 					} else {
-						yy164 := *x.CurrentCPUUtilizationPercentage
-						yym165 := z.EncBinary()
-						_ = yym165
+						yy159 := *x.CurrentCPUUtilizationPercentage
+						yym160 := z.EncBinary()
+						_ = yym160
 						if false {
 						} else {
-							r.EncodeInt(int64(yy164))
+							r.EncodeInt(int64(yy159))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq148[4] {
+				if yyq143[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("currentCPUUtilizationPercentage"))
 					if x.CurrentCPUUtilizationPercentage == nil {
 						r.EncodeNil()
 					} else {
-						yy166 := *x.CurrentCPUUtilizationPercentage
-						yym167 := z.EncBinary()
-						_ = yym167
+						yy161 := *x.CurrentCPUUtilizationPercentage
+						yym162 := z.EncBinary()
+						_ = yym162
 						if false {
 						} else {
-							r.EncodeInt(int64(yy166))
+							r.EncodeInt(int64(yy161))
 						}
 					}
 				}
 			}
-			if yysep148 {
+			if yysep143 {
 				r.EncodeEnd()
 			}
 		}
@@ -1938,24 +1894,24 @@ func (x *HorizontalPodAutoscalerStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym168 := z.DecBinary()
-	_ = yym168
+	yym163 := z.DecBinary()
+	_ = yym163
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl169 := r.ReadMapStart()
-			if yyl169 == 0 {
+			yyl164 := r.ReadMapStart()
+			if yyl164 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl169, d)
+				x.codecDecodeSelfFromMap(yyl164, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl169 := r.ReadArrayStart()
-			if yyl169 == 0 {
+			yyl164 := r.ReadArrayStart()
+			if yyl164 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl169, d)
+				x.codecDecodeSelfFromArray(yyl164, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -1967,12 +1923,12 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromMap(l int, d *codec19
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys170Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys170Slc
-	var yyhl170 bool = l >= 0
-	for yyj170 := 0; ; yyj170++ {
-		if yyhl170 {
-			if yyj170 >= l {
+	var yys165Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys165Slc
+	var yyhl165 bool = l >= 0
+	for yyj165 := 0; ; yyj165++ {
+		if yyhl165 {
+			if yyj165 >= l {
 				break
 			}
 		} else {
@@ -1980,9 +1936,9 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromMap(l int, d *codec19
 				break
 			}
 		}
-		yys170Slc = r.DecodeBytes(yys170Slc, true, true)
-		yys170 := string(yys170Slc)
-		switch yys170 {
+		yys165Slc = r.DecodeBytes(yys165Slc, true, true)
+		yys165 := string(yys165Slc)
+		switch yys165 {
 		case "observedGeneration":
 			if r.TryDecodeAsNil() {
 				if x.ObservedGeneration != nil {
@@ -1992,8 +1948,8 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromMap(l int, d *codec19
 				if x.ObservedGeneration == nil {
 					x.ObservedGeneration = new(int64)
 				}
-				yym172 := z.DecBinary()
-				_ = yym172
+				yym167 := z.DecBinary()
+				_ = yym167
 				if false {
 				} else {
 					*((*int64)(x.ObservedGeneration)) = int64(r.DecodeInt(64))
@@ -2008,13 +1964,13 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromMap(l int, d *codec19
 				if x.LastScaleTime == nil {
 					x.LastScaleTime = new(pkg1_unversioned.Time)
 				}
-				yym174 := z.DecBinary()
-				_ = yym174
+				yym169 := z.DecBinary()
+				_ = yym169
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.LastScaleTime) {
-				} else if yym174 {
+				} else if yym169 {
 					z.DecBinaryUnmarshal(x.LastScaleTime)
-				} else if !yym174 && z.IsJSONHandle() {
+				} else if !yym169 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.LastScaleTime)
 				} else {
 					z.DecFallback(x.LastScaleTime, false)
@@ -2041,18 +1997,18 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromMap(l int, d *codec19
 				if x.CurrentCPUUtilizationPercentage == nil {
 					x.CurrentCPUUtilizationPercentage = new(int)
 				}
-				yym178 := z.DecBinary()
-				_ = yym178
+				yym173 := z.DecBinary()
+				_ = yym173
 				if false {
 				} else {
 					*((*int)(x.CurrentCPUUtilizationPercentage)) = int(r.DecodeInt(codecSelferBitsize1234))
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys170)
-		} // end switch yys170
-	} // end for yyj170
-	if !yyhl170 {
+			z.DecStructFieldNotFound(-1, yys165)
+		} // end switch yys165
+	} // end for yyj165
+	if !yyhl165 {
 		r.ReadEnd()
 	}
 }
@@ -2061,16 +2017,16 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj179 int
-	var yyb179 bool
-	var yyhl179 bool = l >= 0
-	yyj179++
-	if yyhl179 {
-		yyb179 = yyj179 > l
+	var yyj174 int
+	var yyb174 bool
+	var yyhl174 bool = l >= 0
+	yyj174++
+	if yyhl174 {
+		yyb174 = yyj174 > l
 	} else {
-		yyb179 = r.CheckBreak()
+		yyb174 = r.CheckBreak()
 	}
-	if yyb179 {
+	if yyb174 {
 		r.ReadEnd()
 		return
 	}
@@ -2082,20 +2038,20 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 		if x.ObservedGeneration == nil {
 			x.ObservedGeneration = new(int64)
 		}
-		yym181 := z.DecBinary()
-		_ = yym181
+		yym176 := z.DecBinary()
+		_ = yym176
 		if false {
 		} else {
 			*((*int64)(x.ObservedGeneration)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj179++
-	if yyhl179 {
-		yyb179 = yyj179 > l
+	yyj174++
+	if yyhl174 {
+		yyb174 = yyj174 > l
 	} else {
-		yyb179 = r.CheckBreak()
+		yyb174 = r.CheckBreak()
 	}
-	if yyb179 {
+	if yyb174 {
 		r.ReadEnd()
 		return
 	}
@@ -2107,25 +2063,25 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 		if x.LastScaleTime == nil {
 			x.LastScaleTime = new(pkg1_unversioned.Time)
 		}
-		yym183 := z.DecBinary()
-		_ = yym183
+		yym178 := z.DecBinary()
+		_ = yym178
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.LastScaleTime) {
-		} else if yym183 {
+		} else if yym178 {
 			z.DecBinaryUnmarshal(x.LastScaleTime)
-		} else if !yym183 && z.IsJSONHandle() {
+		} else if !yym178 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.LastScaleTime)
 		} else {
 			z.DecFallback(x.LastScaleTime, false)
 		}
 	}
-	yyj179++
-	if yyhl179 {
-		yyb179 = yyj179 > l
+	yyj174++
+	if yyhl174 {
+		yyb174 = yyj174 > l
 	} else {
-		yyb179 = r.CheckBreak()
+		yyb174 = r.CheckBreak()
 	}
-	if yyb179 {
+	if yyb174 {
 		r.ReadEnd()
 		return
 	}
@@ -2134,13 +2090,13 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 	} else {
 		x.CurrentReplicas = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj179++
-	if yyhl179 {
-		yyb179 = yyj179 > l
+	yyj174++
+	if yyhl174 {
+		yyb174 = yyj174 > l
 	} else {
-		yyb179 = r.CheckBreak()
+		yyb174 = r.CheckBreak()
 	}
-	if yyb179 {
+	if yyb174 {
 		r.ReadEnd()
 		return
 	}
@@ -2149,13 +2105,13 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 	} else {
 		x.DesiredReplicas = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj179++
-	if yyhl179 {
-		yyb179 = yyj179 > l
+	yyj174++
+	if yyhl174 {
+		yyb174 = yyj174 > l
 	} else {
-		yyb179 = r.CheckBreak()
+		yyb174 = r.CheckBreak()
 	}
-	if yyb179 {
+	if yyb174 {
 		r.ReadEnd()
 		return
 	}
@@ -2167,24 +2123,24 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 		if x.CurrentCPUUtilizationPercentage == nil {
 			x.CurrentCPUUtilizationPercentage = new(int)
 		}
-		yym187 := z.DecBinary()
-		_ = yym187
+		yym182 := z.DecBinary()
+		_ = yym182
 		if false {
 		} else {
 			*((*int)(x.CurrentCPUUtilizationPercentage)) = int(r.DecodeInt(codecSelferBitsize1234))
 		}
 	}
 	for {
-		yyj179++
-		if yyhl179 {
-			yyb179 = yyj179 > l
+		yyj174++
+		if yyhl174 {
+			yyb174 = yyj174 > l
 		} else {
-			yyb179 = r.CheckBreak()
+			yyb174 = r.CheckBreak()
 		}
-		if yyb179 {
+		if yyb174 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj179-1, "")
+		z.DecStructFieldNotFound(yyj174-1, "")
 	}
 	r.ReadEnd()
 }
@@ -2196,36 +2152,36 @@ func (x *HorizontalPodAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym188 := z.EncBinary()
-		_ = yym188
+		yym183 := z.EncBinary()
+		_ = yym183
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep189 := !z.EncBinary()
-			yy2arr189 := z.EncBasicHandle().StructToArray
-			var yyq189 [5]bool
-			_, _, _ = yysep189, yyq189, yy2arr189
-			const yyr189 bool = false
-			yyq189[0] = x.Kind != ""
-			yyq189[1] = x.APIVersion != ""
-			yyq189[2] = true
-			yyq189[3] = true
-			yyq189[4] = true
-			if yyr189 || yy2arr189 {
+			yysep184 := !z.EncBinary()
+			yy2arr184 := z.EncBasicHandle().StructToArray
+			var yyq184 [5]bool
+			_, _, _ = yysep184, yyq184, yy2arr184
+			const yyr184 bool = false
+			yyq184[0] = x.Kind != ""
+			yyq184[1] = x.APIVersion != ""
+			yyq184[2] = true
+			yyq184[3] = true
+			yyq184[4] = true
+			if yyr184 || yy2arr184 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn189 int = 0
-				for _, b := range yyq189 {
+				var yynn184 int = 0
+				for _, b := range yyq184 {
 					if b {
-						yynn189++
+						yynn184++
 					}
 				}
-				r.EncodeMapStart(yynn189)
+				r.EncodeMapStart(yynn184)
 			}
-			if yyr189 || yy2arr189 {
-				if yyq189[0] {
-					yym191 := z.EncBinary()
-					_ = yym191
+			if yyr184 || yy2arr184 {
+				if yyq184[0] {
+					yym186 := z.EncBinary()
+					_ = yym186
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -2234,20 +2190,20 @@ func (x *HorizontalPodAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq189[0] {
+				if yyq184[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym192 := z.EncBinary()
-					_ = yym192
+					yym187 := z.EncBinary()
+					_ = yym187
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr189 || yy2arr189 {
-				if yyq189[1] {
-					yym194 := z.EncBinary()
-					_ = yym194
+			if yyr184 || yy2arr184 {
+				if yyq184[1] {
+					yym189 := z.EncBinary()
+					_ = yym189
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -2256,59 +2212,59 @@ func (x *HorizontalPodAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq189[1] {
+				if yyq184[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym195 := z.EncBinary()
-					_ = yym195
+					yym190 := z.EncBinary()
+					_ = yym190
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr189 || yy2arr189 {
-				if yyq189[2] {
-					yy197 := &x.ObjectMeta
-					yy197.CodecEncodeSelf(e)
+			if yyr184 || yy2arr184 {
+				if yyq184[2] {
+					yy192 := &x.ObjectMeta
+					yy192.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq189[2] {
+				if yyq184[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy198 := &x.ObjectMeta
-					yy198.CodecEncodeSelf(e)
+					yy193 := &x.ObjectMeta
+					yy193.CodecEncodeSelf(e)
 				}
 			}
-			if yyr189 || yy2arr189 {
-				if yyq189[3] {
-					yy200 := &x.Spec
-					yy200.CodecEncodeSelf(e)
+			if yyr184 || yy2arr184 {
+				if yyq184[3] {
+					yy195 := &x.Spec
+					yy195.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq189[3] {
+				if yyq184[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy201 := &x.Spec
-					yy201.CodecEncodeSelf(e)
+					yy196 := &x.Spec
+					yy196.CodecEncodeSelf(e)
 				}
 			}
-			if yyr189 || yy2arr189 {
-				if yyq189[4] {
-					yy203 := &x.Status
-					yy203.CodecEncodeSelf(e)
+			if yyr184 || yy2arr184 {
+				if yyq184[4] {
+					yy198 := &x.Status
+					yy198.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq189[4] {
+				if yyq184[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy204 := &x.Status
-					yy204.CodecEncodeSelf(e)
+					yy199 := &x.Status
+					yy199.CodecEncodeSelf(e)
 				}
 			}
-			if yysep189 {
+			if yysep184 {
 				r.EncodeEnd()
 			}
 		}
@@ -2319,24 +2275,24 @@ func (x *HorizontalPodAutoscaler) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym205 := z.DecBinary()
-	_ = yym205
+	yym200 := z.DecBinary()
+	_ = yym200
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl206 := r.ReadMapStart()
-			if yyl206 == 0 {
+			yyl201 := r.ReadMapStart()
+			if yyl201 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl206, d)
+				x.codecDecodeSelfFromMap(yyl201, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl206 := r.ReadArrayStart()
-			if yyl206 == 0 {
+			yyl201 := r.ReadArrayStart()
+			if yyl201 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl206, d)
+				x.codecDecodeSelfFromArray(yyl201, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -2348,12 +2304,12 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys207Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys207Slc
-	var yyhl207 bool = l >= 0
-	for yyj207 := 0; ; yyj207++ {
-		if yyhl207 {
-			if yyj207 >= l {
+	var yys202Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys202Slc
+	var yyhl202 bool = l >= 0
+	for yyj202 := 0; ; yyj202++ {
+		if yyhl202 {
+			if yyj202 >= l {
 				break
 			}
 		} else {
@@ -2361,9 +2317,9 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				break
 			}
 		}
-		yys207Slc = r.DecodeBytes(yys207Slc, true, true)
-		yys207 := string(yys207Slc)
-		switch yys207 {
+		yys202Slc = r.DecodeBytes(yys202Slc, true, true)
+		yys202 := string(yys202Slc)
+		switch yys202 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -2380,28 +2336,28 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv210 := &x.ObjectMeta
-				yyv210.CodecDecodeSelf(d)
+				yyv205 := &x.ObjectMeta
+				yyv205.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = HorizontalPodAutoscalerSpec{}
 			} else {
-				yyv211 := &x.Spec
-				yyv211.CodecDecodeSelf(d)
+				yyv206 := &x.Spec
+				yyv206.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = HorizontalPodAutoscalerStatus{}
 			} else {
-				yyv212 := &x.Status
-				yyv212.CodecDecodeSelf(d)
+				yyv207 := &x.Status
+				yyv207.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys207)
-		} // end switch yys207
-	} // end for yyj207
-	if !yyhl207 {
+			z.DecStructFieldNotFound(-1, yys202)
+		} // end switch yys202
+	} // end for yyj202
+	if !yyhl202 {
 		r.ReadEnd()
 	}
 }
@@ -2410,16 +2366,16 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.D
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj213 int
-	var yyb213 bool
-	var yyhl213 bool = l >= 0
-	yyj213++
-	if yyhl213 {
-		yyb213 = yyj213 > l
+	var yyj208 int
+	var yyb208 bool
+	var yyhl208 bool = l >= 0
+	yyj208++
+	if yyhl208 {
+		yyb208 = yyj208 > l
 	} else {
-		yyb213 = r.CheckBreak()
+		yyb208 = r.CheckBreak()
 	}
-	if yyb213 {
+	if yyb208 {
 		r.ReadEnd()
 		return
 	}
@@ -2428,13 +2384,13 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.D
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj213++
-	if yyhl213 {
-		yyb213 = yyj213 > l
+	yyj208++
+	if yyhl208 {
+		yyb208 = yyj208 > l
 	} else {
-		yyb213 = r.CheckBreak()
+		yyb208 = r.CheckBreak()
 	}
-	if yyb213 {
+	if yyb208 {
 		r.ReadEnd()
 		return
 	}
@@ -2443,65 +2399,65 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.D
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj213++
-	if yyhl213 {
-		yyb213 = yyj213 > l
+	yyj208++
+	if yyhl208 {
+		yyb208 = yyj208 > l
 	} else {
-		yyb213 = r.CheckBreak()
+		yyb208 = r.CheckBreak()
 	}
-	if yyb213 {
+	if yyb208 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv216 := &x.ObjectMeta
-		yyv216.CodecDecodeSelf(d)
+		yyv211 := &x.ObjectMeta
+		yyv211.CodecDecodeSelf(d)
 	}
-	yyj213++
-	if yyhl213 {
-		yyb213 = yyj213 > l
+	yyj208++
+	if yyhl208 {
+		yyb208 = yyj208 > l
 	} else {
-		yyb213 = r.CheckBreak()
+		yyb208 = r.CheckBreak()
 	}
-	if yyb213 {
+	if yyb208 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = HorizontalPodAutoscalerSpec{}
 	} else {
-		yyv217 := &x.Spec
-		yyv217.CodecDecodeSelf(d)
+		yyv212 := &x.Spec
+		yyv212.CodecDecodeSelf(d)
 	}
-	yyj213++
-	if yyhl213 {
-		yyb213 = yyj213 > l
+	yyj208++
+	if yyhl208 {
+		yyb208 = yyj208 > l
 	} else {
-		yyb213 = r.CheckBreak()
+		yyb208 = r.CheckBreak()
 	}
-	if yyb213 {
+	if yyb208 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = HorizontalPodAutoscalerStatus{}
 	} else {
-		yyv218 := &x.Status
-		yyv218.CodecDecodeSelf(d)
+		yyv213 := &x.Status
+		yyv213.CodecDecodeSelf(d)
 	}
 	for {
-		yyj213++
-		if yyhl213 {
-			yyb213 = yyj213 > l
+		yyj208++
+		if yyhl208 {
+			yyb208 = yyj208 > l
 		} else {
-			yyb213 = r.CheckBreak()
+			yyb208 = r.CheckBreak()
 		}
-		if yyb213 {
+		if yyb208 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj213-1, "")
+		z.DecStructFieldNotFound(yyj208-1, "")
 	}
 	r.ReadEnd()
 }
@@ -2513,34 +2469,34 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym219 := z.EncBinary()
-		_ = yym219
+		yym214 := z.EncBinary()
+		_ = yym214
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep220 := !z.EncBinary()
-			yy2arr220 := z.EncBasicHandle().StructToArray
-			var yyq220 [4]bool
-			_, _, _ = yysep220, yyq220, yy2arr220
-			const yyr220 bool = false
-			yyq220[0] = x.Kind != ""
-			yyq220[1] = x.APIVersion != ""
-			yyq220[2] = true
-			if yyr220 || yy2arr220 {
+			yysep215 := !z.EncBinary()
+			yy2arr215 := z.EncBasicHandle().StructToArray
+			var yyq215 [4]bool
+			_, _, _ = yysep215, yyq215, yy2arr215
+			const yyr215 bool = false
+			yyq215[0] = x.Kind != ""
+			yyq215[1] = x.APIVersion != ""
+			yyq215[2] = true
+			if yyr215 || yy2arr215 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn220 int = 1
-				for _, b := range yyq220 {
+				var yynn215 int = 1
+				for _, b := range yyq215 {
 					if b {
-						yynn220++
+						yynn215++
 					}
 				}
-				r.EncodeMapStart(yynn220)
+				r.EncodeMapStart(yynn215)
 			}
-			if yyr220 || yy2arr220 {
-				if yyq220[0] {
-					yym222 := z.EncBinary()
-					_ = yym222
+			if yyr215 || yy2arr215 {
+				if yyq215[0] {
+					yym217 := z.EncBinary()
+					_ = yym217
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -2549,20 +2505,20 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq220[0] {
+				if yyq215[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym223 := z.EncBinary()
-					_ = yym223
+					yym218 := z.EncBinary()
+					_ = yym218
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr220 || yy2arr220 {
-				if yyq220[1] {
-					yym225 := z.EncBinary()
-					_ = yym225
+			if yyr215 || yy2arr215 {
+				if yyq215[1] {
+					yym220 := z.EncBinary()
+					_ = yym220
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -2571,48 +2527,48 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq220[1] {
+				if yyq215[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym221 := z.EncBinary()
+					_ = yym221
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr215 || yy2arr215 {
+				if yyq215[2] {
+					yy223 := &x.ListMeta
+					yym224 := z.EncBinary()
+					_ = yym224
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy223) {
+					} else {
+						z.EncFallback(yy223)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq215[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy225 := &x.ListMeta
 					yym226 := z.EncBinary()
 					_ = yym226
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy225) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						z.EncFallback(yy225)
 					}
 				}
 			}
-			if yyr220 || yy2arr220 {
-				if yyq220[2] {
-					yy228 := &x.ListMeta
-					yym229 := z.EncBinary()
-					_ = yym229
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy228) {
-					} else {
-						z.EncFallback(yy228)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq220[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy230 := &x.ListMeta
-					yym231 := z.EncBinary()
-					_ = yym231
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy230) {
-					} else {
-						z.EncFallback(yy230)
-					}
-				}
-			}
-			if yyr220 || yy2arr220 {
+			if yyr215 || yy2arr215 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym233 := z.EncBinary()
-					_ = yym233
+					yym228 := z.EncBinary()
+					_ = yym228
 					if false {
 					} else {
 						h.encSliceHorizontalPodAutoscaler(([]HorizontalPodAutoscaler)(x.Items), e)
@@ -2623,15 +2579,15 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym234 := z.EncBinary()
-					_ = yym234
+					yym229 := z.EncBinary()
+					_ = yym229
 					if false {
 					} else {
 						h.encSliceHorizontalPodAutoscaler(([]HorizontalPodAutoscaler)(x.Items), e)
 					}
 				}
 			}
-			if yysep220 {
+			if yysep215 {
 				r.EncodeEnd()
 			}
 		}
@@ -2642,24 +2598,24 @@ func (x *HorizontalPodAutoscalerList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym235 := z.DecBinary()
-	_ = yym235
+	yym230 := z.DecBinary()
+	_ = yym230
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl236 := r.ReadMapStart()
-			if yyl236 == 0 {
+			yyl231 := r.ReadMapStart()
+			if yyl231 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl236, d)
+				x.codecDecodeSelfFromMap(yyl231, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl236 := r.ReadArrayStart()
-			if yyl236 == 0 {
+			yyl231 := r.ReadArrayStart()
+			if yyl231 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl236, d)
+				x.codecDecodeSelfFromArray(yyl231, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -2671,12 +2627,12 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys237Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys237Slc
-	var yyhl237 bool = l >= 0
-	for yyj237 := 0; ; yyj237++ {
-		if yyhl237 {
-			if yyj237 >= l {
+	var yys232Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys232Slc
+	var yyhl232 bool = l >= 0
+	for yyj232 := 0; ; yyj232++ {
+		if yyhl232 {
+			if yyj232 >= l {
 				break
 			}
 		} else {
@@ -2684,9 +2640,9 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978
 				break
 			}
 		}
-		yys237Slc = r.DecodeBytes(yys237Slc, true, true)
-		yys237 := string(yys237Slc)
-		switch yys237 {
+		yys232Slc = r.DecodeBytes(yys232Slc, true, true)
+		yys232 := string(yys232Slc)
+		switch yys232 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -2703,32 +2659,32 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv240 := &x.ListMeta
-				yym241 := z.DecBinary()
-				_ = yym241
+				yyv235 := &x.ListMeta
+				yym236 := z.DecBinary()
+				_ = yym236
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv240) {
+				} else if z.HasExtensions() && z.DecExt(yyv235) {
 				} else {
-					z.DecFallback(yyv240, false)
+					z.DecFallback(yyv235, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv242 := &x.Items
-				yym243 := z.DecBinary()
-				_ = yym243
+				yyv237 := &x.Items
+				yym238 := z.DecBinary()
+				_ = yym238
 				if false {
 				} else {
-					h.decSliceHorizontalPodAutoscaler((*[]HorizontalPodAutoscaler)(yyv242), d)
+					h.decSliceHorizontalPodAutoscaler((*[]HorizontalPodAutoscaler)(yyv237), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys237)
-		} // end switch yys237
-	} // end for yyj237
-	if !yyhl237 {
+			z.DecStructFieldNotFound(-1, yys232)
+		} // end switch yys232
+	} // end for yyj232
+	if !yyhl232 {
 		r.ReadEnd()
 	}
 }
@@ -2737,16 +2693,16 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromArray(l int, d *codec19
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj244 int
-	var yyb244 bool
-	var yyhl244 bool = l >= 0
-	yyj244++
-	if yyhl244 {
-		yyb244 = yyj244 > l
+	var yyj239 int
+	var yyb239 bool
+	var yyhl239 bool = l >= 0
+	yyj239++
+	if yyhl239 {
+		yyb239 = yyj239 > l
 	} else {
-		yyb244 = r.CheckBreak()
+		yyb239 = r.CheckBreak()
 	}
-	if yyb244 {
+	if yyb239 {
 		r.ReadEnd()
 		return
 	}
@@ -2755,13 +2711,13 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromArray(l int, d *codec19
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj244++
-	if yyhl244 {
-		yyb244 = yyj244 > l
+	yyj239++
+	if yyhl239 {
+		yyb239 = yyj239 > l
 	} else {
-		yyb244 = r.CheckBreak()
+		yyb239 = r.CheckBreak()
 	}
-	if yyb244 {
+	if yyb239 {
 		r.ReadEnd()
 		return
 	}
@@ -2770,60 +2726,60 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromArray(l int, d *codec19
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj244++
-	if yyhl244 {
-		yyb244 = yyj244 > l
+	yyj239++
+	if yyhl239 {
+		yyb239 = yyj239 > l
 	} else {
-		yyb244 = r.CheckBreak()
+		yyb239 = r.CheckBreak()
 	}
-	if yyb244 {
+	if yyb239 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv247 := &x.ListMeta
-		yym248 := z.DecBinary()
-		_ = yym248
+		yyv242 := &x.ListMeta
+		yym243 := z.DecBinary()
+		_ = yym243
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv247) {
+		} else if z.HasExtensions() && z.DecExt(yyv242) {
 		} else {
-			z.DecFallback(yyv247, false)
+			z.DecFallback(yyv242, false)
 		}
 	}
-	yyj244++
-	if yyhl244 {
-		yyb244 = yyj244 > l
+	yyj239++
+	if yyhl239 {
+		yyb239 = yyj239 > l
 	} else {
-		yyb244 = r.CheckBreak()
+		yyb239 = r.CheckBreak()
 	}
-	if yyb244 {
+	if yyb239 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv249 := &x.Items
-		yym250 := z.DecBinary()
-		_ = yym250
+		yyv244 := &x.Items
+		yym245 := z.DecBinary()
+		_ = yym245
 		if false {
 		} else {
-			h.decSliceHorizontalPodAutoscaler((*[]HorizontalPodAutoscaler)(yyv249), d)
+			h.decSliceHorizontalPodAutoscaler((*[]HorizontalPodAutoscaler)(yyv244), d)
 		}
 	}
 	for {
-		yyj244++
-		if yyhl244 {
-			yyb244 = yyj244 > l
+		yyj239++
+		if yyhl239 {
+			yyb239 = yyj239 > l
 		} else {
-			yyb244 = r.CheckBreak()
+			yyb239 = r.CheckBreak()
 		}
-		if yyb244 {
+		if yyb239 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj244-1, "")
+		z.DecStructFieldNotFound(yyj239-1, "")
 	}
 	r.ReadEnd()
 }
@@ -2835,36 +2791,36 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym251 := z.EncBinary()
-		_ = yym251
+		yym246 := z.EncBinary()
+		_ = yym246
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep252 := !z.EncBinary()
-			yy2arr252 := z.EncBasicHandle().StructToArray
-			var yyq252 [5]bool
-			_, _, _ = yysep252, yyq252, yy2arr252
-			const yyr252 bool = false
-			yyq252[0] = x.Kind != ""
-			yyq252[1] = x.APIVersion != ""
-			yyq252[2] = true
-			yyq252[3] = x.Description != ""
-			yyq252[4] = len(x.Versions) != 0
-			if yyr252 || yy2arr252 {
+			yysep247 := !z.EncBinary()
+			yy2arr247 := z.EncBasicHandle().StructToArray
+			var yyq247 [5]bool
+			_, _, _ = yysep247, yyq247, yy2arr247
+			const yyr247 bool = false
+			yyq247[0] = x.Kind != ""
+			yyq247[1] = x.APIVersion != ""
+			yyq247[2] = true
+			yyq247[3] = x.Description != ""
+			yyq247[4] = len(x.Versions) != 0
+			if yyr247 || yy2arr247 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn252 int = 0
-				for _, b := range yyq252 {
+				var yynn247 int = 0
+				for _, b := range yyq247 {
 					if b {
-						yynn252++
+						yynn247++
 					}
 				}
-				r.EncodeMapStart(yynn252)
+				r.EncodeMapStart(yynn247)
 			}
-			if yyr252 || yy2arr252 {
-				if yyq252[0] {
-					yym254 := z.EncBinary()
-					_ = yym254
+			if yyr247 || yy2arr247 {
+				if yyq247[0] {
+					yym249 := z.EncBinary()
+					_ = yym249
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -2873,20 +2829,20 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq252[0] {
+				if yyq247[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym255 := z.EncBinary()
-					_ = yym255
+					yym250 := z.EncBinary()
+					_ = yym250
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr252 || yy2arr252 {
-				if yyq252[1] {
-					yym257 := z.EncBinary()
-					_ = yym257
+			if yyr247 || yy2arr247 {
+				if yyq247[1] {
+					yym252 := z.EncBinary()
+					_ = yym252
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -2895,59 +2851,59 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq252[1] {
+				if yyq247[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym253 := z.EncBinary()
+					_ = yym253
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr247 || yy2arr247 {
+				if yyq247[2] {
+					yy255 := &x.ObjectMeta
+					yy255.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq247[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy256 := &x.ObjectMeta
+					yy256.CodecEncodeSelf(e)
+				}
+			}
+			if yyr247 || yy2arr247 {
+				if yyq247[3] {
 					yym258 := z.EncBinary()
 					_ = yym258
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr252 || yy2arr252 {
-				if yyq252[2] {
-					yy260 := &x.ObjectMeta
-					yy260.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq252[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy261 := &x.ObjectMeta
-					yy261.CodecEncodeSelf(e)
-				}
-			}
-			if yyr252 || yy2arr252 {
-				if yyq252[3] {
-					yym263 := z.EncBinary()
-					_ = yym263
-					if false {
-					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Description))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq252[3] {
+				if yyq247[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("description"))
-					yym264 := z.EncBinary()
-					_ = yym264
+					yym259 := z.EncBinary()
+					_ = yym259
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Description))
 					}
 				}
 			}
-			if yyr252 || yy2arr252 {
-				if yyq252[4] {
+			if yyr247 || yy2arr247 {
+				if yyq247[4] {
 					if x.Versions == nil {
 						r.EncodeNil()
 					} else {
-						yym266 := z.EncBinary()
-						_ = yym266
+						yym261 := z.EncBinary()
+						_ = yym261
 						if false {
 						} else {
 							h.encSliceAPIVersion(([]APIVersion)(x.Versions), e)
@@ -2957,13 +2913,13 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq252[4] {
+				if yyq247[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("versions"))
 					if x.Versions == nil {
 						r.EncodeNil()
 					} else {
-						yym267 := z.EncBinary()
-						_ = yym267
+						yym262 := z.EncBinary()
+						_ = yym262
 						if false {
 						} else {
 							h.encSliceAPIVersion(([]APIVersion)(x.Versions), e)
@@ -2971,7 +2927,7 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep252 {
+			if yysep247 {
 				r.EncodeEnd()
 			}
 		}
@@ -2982,24 +2938,24 @@ func (x *ThirdPartyResource) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym268 := z.DecBinary()
-	_ = yym268
+	yym263 := z.DecBinary()
+	_ = yym263
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl269 := r.ReadMapStart()
-			if yyl269 == 0 {
+			yyl264 := r.ReadMapStart()
+			if yyl264 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl269, d)
+				x.codecDecodeSelfFromMap(yyl264, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl269 := r.ReadArrayStart()
-			if yyl269 == 0 {
+			yyl264 := r.ReadArrayStart()
+			if yyl264 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl269, d)
+				x.codecDecodeSelfFromArray(yyl264, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -3011,12 +2967,12 @@ func (x *ThirdPartyResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys270Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys270Slc
-	var yyhl270 bool = l >= 0
-	for yyj270 := 0; ; yyj270++ {
-		if yyhl270 {
-			if yyj270 >= l {
+	var yys265Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys265Slc
+	var yyhl265 bool = l >= 0
+	for yyj265 := 0; ; yyj265++ {
+		if yyhl265 {
+			if yyj265 >= l {
 				break
 			}
 		} else {
@@ -3024,9 +2980,9 @@ func (x *ThirdPartyResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
-		yys270Slc = r.DecodeBytes(yys270Slc, true, true)
-		yys270 := string(yys270Slc)
-		switch yys270 {
+		yys265Slc = r.DecodeBytes(yys265Slc, true, true)
+		yys265 := string(yys265Slc)
+		switch yys265 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -3043,8 +2999,8 @@ func (x *ThirdPartyResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv273 := &x.ObjectMeta
-				yyv273.CodecDecodeSelf(d)
+				yyv268 := &x.ObjectMeta
+				yyv268.CodecDecodeSelf(d)
 			}
 		case "description":
 			if r.TryDecodeAsNil() {
@@ -3056,19 +3012,19 @@ func (x *ThirdPartyResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			if r.TryDecodeAsNil() {
 				x.Versions = nil
 			} else {
-				yyv275 := &x.Versions
-				yym276 := z.DecBinary()
-				_ = yym276
+				yyv270 := &x.Versions
+				yym271 := z.DecBinary()
+				_ = yym271
 				if false {
 				} else {
-					h.decSliceAPIVersion((*[]APIVersion)(yyv275), d)
+					h.decSliceAPIVersion((*[]APIVersion)(yyv270), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys270)
-		} // end switch yys270
-	} // end for yyj270
-	if !yyhl270 {
+			z.DecStructFieldNotFound(-1, yys265)
+		} // end switch yys265
+	} // end for yyj265
+	if !yyhl265 {
 		r.ReadEnd()
 	}
 }
@@ -3077,16 +3033,16 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj277 int
-	var yyb277 bool
-	var yyhl277 bool = l >= 0
-	yyj277++
-	if yyhl277 {
-		yyb277 = yyj277 > l
+	var yyj272 int
+	var yyb272 bool
+	var yyhl272 bool = l >= 0
+	yyj272++
+	if yyhl272 {
+		yyb272 = yyj272 > l
 	} else {
-		yyb277 = r.CheckBreak()
+		yyb272 = r.CheckBreak()
 	}
-	if yyb277 {
+	if yyb272 {
 		r.ReadEnd()
 		return
 	}
@@ -3095,13 +3051,13 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj277++
-	if yyhl277 {
-		yyb277 = yyj277 > l
+	yyj272++
+	if yyhl272 {
+		yyb272 = yyj272 > l
 	} else {
-		yyb277 = r.CheckBreak()
+		yyb272 = r.CheckBreak()
 	}
-	if yyb277 {
+	if yyb272 {
 		r.ReadEnd()
 		return
 	}
@@ -3110,29 +3066,29 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj277++
-	if yyhl277 {
-		yyb277 = yyj277 > l
+	yyj272++
+	if yyhl272 {
+		yyb272 = yyj272 > l
 	} else {
-		yyb277 = r.CheckBreak()
+		yyb272 = r.CheckBreak()
 	}
-	if yyb277 {
+	if yyb272 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv280 := &x.ObjectMeta
-		yyv280.CodecDecodeSelf(d)
+		yyv275 := &x.ObjectMeta
+		yyv275.CodecDecodeSelf(d)
 	}
-	yyj277++
-	if yyhl277 {
-		yyb277 = yyj277 > l
+	yyj272++
+	if yyhl272 {
+		yyb272 = yyj272 > l
 	} else {
-		yyb277 = r.CheckBreak()
+		yyb272 = r.CheckBreak()
 	}
-	if yyb277 {
+	if yyb272 {
 		r.ReadEnd()
 		return
 	}
@@ -3141,38 +3097,38 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.Description = string(r.DecodeString())
 	}
-	yyj277++
-	if yyhl277 {
-		yyb277 = yyj277 > l
+	yyj272++
+	if yyhl272 {
+		yyb272 = yyj272 > l
 	} else {
-		yyb277 = r.CheckBreak()
+		yyb272 = r.CheckBreak()
 	}
-	if yyb277 {
+	if yyb272 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Versions = nil
 	} else {
-		yyv282 := &x.Versions
-		yym283 := z.DecBinary()
-		_ = yym283
+		yyv277 := &x.Versions
+		yym278 := z.DecBinary()
+		_ = yym278
 		if false {
 		} else {
-			h.decSliceAPIVersion((*[]APIVersion)(yyv282), d)
+			h.decSliceAPIVersion((*[]APIVersion)(yyv277), d)
 		}
 	}
 	for {
-		yyj277++
-		if yyhl277 {
-			yyb277 = yyj277 > l
+		yyj272++
+		if yyhl272 {
+			yyb272 = yyj272 > l
 		} else {
-			yyb277 = r.CheckBreak()
+			yyb272 = r.CheckBreak()
 		}
-		if yyb277 {
+		if yyb272 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj277-1, "")
+		z.DecStructFieldNotFound(yyj272-1, "")
 	}
 	r.ReadEnd()
 }
@@ -3184,34 +3140,34 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym284 := z.EncBinary()
-		_ = yym284
+		yym279 := z.EncBinary()
+		_ = yym279
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep285 := !z.EncBinary()
-			yy2arr285 := z.EncBasicHandle().StructToArray
-			var yyq285 [4]bool
-			_, _, _ = yysep285, yyq285, yy2arr285
-			const yyr285 bool = false
-			yyq285[0] = x.Kind != ""
-			yyq285[1] = x.APIVersion != ""
-			yyq285[2] = true
-			if yyr285 || yy2arr285 {
+			yysep280 := !z.EncBinary()
+			yy2arr280 := z.EncBasicHandle().StructToArray
+			var yyq280 [4]bool
+			_, _, _ = yysep280, yyq280, yy2arr280
+			const yyr280 bool = false
+			yyq280[0] = x.Kind != ""
+			yyq280[1] = x.APIVersion != ""
+			yyq280[2] = true
+			if yyr280 || yy2arr280 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn285 int = 1
-				for _, b := range yyq285 {
+				var yynn280 int = 1
+				for _, b := range yyq280 {
 					if b {
-						yynn285++
+						yynn280++
 					}
 				}
-				r.EncodeMapStart(yynn285)
+				r.EncodeMapStart(yynn280)
 			}
-			if yyr285 || yy2arr285 {
-				if yyq285[0] {
-					yym287 := z.EncBinary()
-					_ = yym287
+			if yyr280 || yy2arr280 {
+				if yyq280[0] {
+					yym282 := z.EncBinary()
+					_ = yym282
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -3220,20 +3176,20 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq285[0] {
+				if yyq280[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym288 := z.EncBinary()
-					_ = yym288
+					yym283 := z.EncBinary()
+					_ = yym283
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr285 || yy2arr285 {
-				if yyq285[1] {
-					yym290 := z.EncBinary()
-					_ = yym290
+			if yyr280 || yy2arr280 {
+				if yyq280[1] {
+					yym285 := z.EncBinary()
+					_ = yym285
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -3242,48 +3198,48 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq285[1] {
+				if yyq280[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym286 := z.EncBinary()
+					_ = yym286
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr280 || yy2arr280 {
+				if yyq280[2] {
+					yy288 := &x.ListMeta
+					yym289 := z.EncBinary()
+					_ = yym289
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy288) {
+					} else {
+						z.EncFallback(yy288)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq280[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy290 := &x.ListMeta
 					yym291 := z.EncBinary()
 					_ = yym291
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy290) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						z.EncFallback(yy290)
 					}
 				}
 			}
-			if yyr285 || yy2arr285 {
-				if yyq285[2] {
-					yy293 := &x.ListMeta
-					yym294 := z.EncBinary()
-					_ = yym294
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy293) {
-					} else {
-						z.EncFallback(yy293)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq285[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy295 := &x.ListMeta
-					yym296 := z.EncBinary()
-					_ = yym296
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy295) {
-					} else {
-						z.EncFallback(yy295)
-					}
-				}
-			}
-			if yyr285 || yy2arr285 {
+			if yyr280 || yy2arr280 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym298 := z.EncBinary()
-					_ = yym298
+					yym293 := z.EncBinary()
+					_ = yym293
 					if false {
 					} else {
 						h.encSliceThirdPartyResource(([]ThirdPartyResource)(x.Items), e)
@@ -3294,15 +3250,15 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym299 := z.EncBinary()
-					_ = yym299
+					yym294 := z.EncBinary()
+					_ = yym294
 					if false {
 					} else {
 						h.encSliceThirdPartyResource(([]ThirdPartyResource)(x.Items), e)
 					}
 				}
 			}
-			if yysep285 {
+			if yysep280 {
 				r.EncodeEnd()
 			}
 		}
@@ -3313,24 +3269,24 @@ func (x *ThirdPartyResourceList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym300 := z.DecBinary()
-	_ = yym300
+	yym295 := z.DecBinary()
+	_ = yym295
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl301 := r.ReadMapStart()
-			if yyl301 == 0 {
+			yyl296 := r.ReadMapStart()
+			if yyl296 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl301, d)
+				x.codecDecodeSelfFromMap(yyl296, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl301 := r.ReadArrayStart()
-			if yyl301 == 0 {
+			yyl296 := r.ReadArrayStart()
+			if yyl296 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl301, d)
+				x.codecDecodeSelfFromArray(yyl296, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -3342,12 +3298,12 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys302Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys302Slc
-	var yyhl302 bool = l >= 0
-	for yyj302 := 0; ; yyj302++ {
-		if yyhl302 {
-			if yyj302 >= l {
+	var yys297Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys297Slc
+	var yyhl297 bool = l >= 0
+	for yyj297 := 0; ; yyj297++ {
+		if yyhl297 {
+			if yyj297 >= l {
 				break
 			}
 		} else {
@@ -3355,9 +3311,9 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				break
 			}
 		}
-		yys302Slc = r.DecodeBytes(yys302Slc, true, true)
-		yys302 := string(yys302Slc)
-		switch yys302 {
+		yys297Slc = r.DecodeBytes(yys297Slc, true, true)
+		yys297 := string(yys297Slc)
+		switch yys297 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -3374,32 +3330,32 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv305 := &x.ListMeta
-				yym306 := z.DecBinary()
-				_ = yym306
+				yyv300 := &x.ListMeta
+				yym301 := z.DecBinary()
+				_ = yym301
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv305) {
+				} else if z.HasExtensions() && z.DecExt(yyv300) {
 				} else {
-					z.DecFallback(yyv305, false)
+					z.DecFallback(yyv300, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv307 := &x.Items
-				yym308 := z.DecBinary()
-				_ = yym308
+				yyv302 := &x.Items
+				yym303 := z.DecBinary()
+				_ = yym303
 				if false {
 				} else {
-					h.decSliceThirdPartyResource((*[]ThirdPartyResource)(yyv307), d)
+					h.decSliceThirdPartyResource((*[]ThirdPartyResource)(yyv302), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys302)
-		} // end switch yys302
-	} // end for yyj302
-	if !yyhl302 {
+			z.DecStructFieldNotFound(-1, yys297)
+		} // end switch yys297
+	} // end for yyj297
+	if !yyhl297 {
 		r.ReadEnd()
 	}
 }
@@ -3408,16 +3364,16 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromArray(l int, d *codec1978.De
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj309 int
-	var yyb309 bool
-	var yyhl309 bool = l >= 0
-	yyj309++
-	if yyhl309 {
-		yyb309 = yyj309 > l
+	var yyj304 int
+	var yyb304 bool
+	var yyhl304 bool = l >= 0
+	yyj304++
+	if yyhl304 {
+		yyb304 = yyj304 > l
 	} else {
-		yyb309 = r.CheckBreak()
+		yyb304 = r.CheckBreak()
 	}
-	if yyb309 {
+	if yyb304 {
 		r.ReadEnd()
 		return
 	}
@@ -3426,13 +3382,13 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromArray(l int, d *codec1978.De
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj309++
-	if yyhl309 {
-		yyb309 = yyj309 > l
+	yyj304++
+	if yyhl304 {
+		yyb304 = yyj304 > l
 	} else {
-		yyb309 = r.CheckBreak()
+		yyb304 = r.CheckBreak()
 	}
-	if yyb309 {
+	if yyb304 {
 		r.ReadEnd()
 		return
 	}
@@ -3441,60 +3397,60 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromArray(l int, d *codec1978.De
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj309++
-	if yyhl309 {
-		yyb309 = yyj309 > l
+	yyj304++
+	if yyhl304 {
+		yyb304 = yyj304 > l
 	} else {
-		yyb309 = r.CheckBreak()
+		yyb304 = r.CheckBreak()
 	}
-	if yyb309 {
+	if yyb304 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv312 := &x.ListMeta
-		yym313 := z.DecBinary()
-		_ = yym313
+		yyv307 := &x.ListMeta
+		yym308 := z.DecBinary()
+		_ = yym308
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv312) {
+		} else if z.HasExtensions() && z.DecExt(yyv307) {
 		} else {
-			z.DecFallback(yyv312, false)
+			z.DecFallback(yyv307, false)
 		}
 	}
-	yyj309++
-	if yyhl309 {
-		yyb309 = yyj309 > l
+	yyj304++
+	if yyhl304 {
+		yyb304 = yyj304 > l
 	} else {
-		yyb309 = r.CheckBreak()
+		yyb304 = r.CheckBreak()
 	}
-	if yyb309 {
+	if yyb304 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv314 := &x.Items
-		yym315 := z.DecBinary()
-		_ = yym315
+		yyv309 := &x.Items
+		yym310 := z.DecBinary()
+		_ = yym310
 		if false {
 		} else {
-			h.decSliceThirdPartyResource((*[]ThirdPartyResource)(yyv314), d)
+			h.decSliceThirdPartyResource((*[]ThirdPartyResource)(yyv309), d)
 		}
 	}
 	for {
-		yyj309++
-		if yyhl309 {
-			yyb309 = yyj309 > l
+		yyj304++
+		if yyhl304 {
+			yyb304 = yyj304 > l
 		} else {
-			yyb309 = r.CheckBreak()
+			yyb304 = r.CheckBreak()
 		}
-		if yyb309 {
+		if yyb304 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj309-1, "")
+		z.DecStructFieldNotFound(yyj304-1, "")
 	}
 	r.ReadEnd()
 }
@@ -3506,33 +3462,33 @@ func (x *APIVersion) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym316 := z.EncBinary()
-		_ = yym316
+		yym311 := z.EncBinary()
+		_ = yym311
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep317 := !z.EncBinary()
-			yy2arr317 := z.EncBasicHandle().StructToArray
-			var yyq317 [2]bool
-			_, _, _ = yysep317, yyq317, yy2arr317
-			const yyr317 bool = false
-			yyq317[0] = x.Name != ""
-			yyq317[1] = x.APIGroup != ""
-			if yyr317 || yy2arr317 {
+			yysep312 := !z.EncBinary()
+			yy2arr312 := z.EncBasicHandle().StructToArray
+			var yyq312 [2]bool
+			_, _, _ = yysep312, yyq312, yy2arr312
+			const yyr312 bool = false
+			yyq312[0] = x.Name != ""
+			yyq312[1] = x.APIGroup != ""
+			if yyr312 || yy2arr312 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn317 int = 0
-				for _, b := range yyq317 {
+				var yynn312 int = 0
+				for _, b := range yyq312 {
 					if b {
-						yynn317++
+						yynn312++
 					}
 				}
-				r.EncodeMapStart(yynn317)
+				r.EncodeMapStart(yynn312)
 			}
-			if yyr317 || yy2arr317 {
-				if yyq317[0] {
-					yym319 := z.EncBinary()
-					_ = yym319
+			if yyr312 || yy2arr312 {
+				if yyq312[0] {
+					yym314 := z.EncBinary()
+					_ = yym314
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
@@ -3541,20 +3497,20 @@ func (x *APIVersion) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq317[0] {
+				if yyq312[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("name"))
-					yym320 := z.EncBinary()
-					_ = yym320
+					yym315 := z.EncBinary()
+					_ = yym315
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 					}
 				}
 			}
-			if yyr317 || yy2arr317 {
-				if yyq317[1] {
-					yym322 := z.EncBinary()
-					_ = yym322
+			if yyr312 || yy2arr312 {
+				if yyq312[1] {
+					yym317 := z.EncBinary()
+					_ = yym317
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIGroup))
@@ -3563,17 +3519,17 @@ func (x *APIVersion) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq317[1] {
+				if yyq312[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiGroup"))
-					yym323 := z.EncBinary()
-					_ = yym323
+					yym318 := z.EncBinary()
+					_ = yym318
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIGroup))
 					}
 				}
 			}
-			if yysep317 {
+			if yysep312 {
 				r.EncodeEnd()
 			}
 		}
@@ -3584,24 +3540,24 @@ func (x *APIVersion) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym324 := z.DecBinary()
-	_ = yym324
+	yym319 := z.DecBinary()
+	_ = yym319
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl325 := r.ReadMapStart()
-			if yyl325 == 0 {
+			yyl320 := r.ReadMapStart()
+			if yyl320 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl325, d)
+				x.codecDecodeSelfFromMap(yyl320, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl325 := r.ReadArrayStart()
-			if yyl325 == 0 {
+			yyl320 := r.ReadArrayStart()
+			if yyl320 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl325, d)
+				x.codecDecodeSelfFromArray(yyl320, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -3613,12 +3569,12 @@ func (x *APIVersion) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys326Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys326Slc
-	var yyhl326 bool = l >= 0
-	for yyj326 := 0; ; yyj326++ {
-		if yyhl326 {
-			if yyj326 >= l {
+	var yys321Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys321Slc
+	var yyhl321 bool = l >= 0
+	for yyj321 := 0; ; yyj321++ {
+		if yyhl321 {
+			if yyj321 >= l {
 				break
 			}
 		} else {
@@ -3626,9 +3582,9 @@ func (x *APIVersion) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys326Slc = r.DecodeBytes(yys326Slc, true, true)
-		yys326 := string(yys326Slc)
-		switch yys326 {
+		yys321Slc = r.DecodeBytes(yys321Slc, true, true)
+		yys321 := string(yys321Slc)
+		switch yys321 {
 		case "name":
 			if r.TryDecodeAsNil() {
 				x.Name = ""
@@ -3642,10 +3598,10 @@ func (x *APIVersion) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIGroup = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys326)
-		} // end switch yys326
-	} // end for yyj326
-	if !yyhl326 {
+			z.DecStructFieldNotFound(-1, yys321)
+		} // end switch yys321
+	} // end for yyj321
+	if !yyhl321 {
 		r.ReadEnd()
 	}
 }
@@ -3654,16 +3610,16 @@ func (x *APIVersion) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj329 int
-	var yyb329 bool
-	var yyhl329 bool = l >= 0
-	yyj329++
-	if yyhl329 {
-		yyb329 = yyj329 > l
+	var yyj324 int
+	var yyb324 bool
+	var yyhl324 bool = l >= 0
+	yyj324++
+	if yyhl324 {
+		yyb324 = yyj324 > l
 	} else {
-		yyb329 = r.CheckBreak()
+		yyb324 = r.CheckBreak()
 	}
-	if yyb329 {
+	if yyb324 {
 		r.ReadEnd()
 		return
 	}
@@ -3672,13 +3628,13 @@ func (x *APIVersion) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Name = string(r.DecodeString())
 	}
-	yyj329++
-	if yyhl329 {
-		yyb329 = yyj329 > l
+	yyj324++
+	if yyhl324 {
+		yyb324 = yyj324 > l
 	} else {
-		yyb329 = r.CheckBreak()
+		yyb324 = r.CheckBreak()
 	}
-	if yyb329 {
+	if yyb324 {
 		r.ReadEnd()
 		return
 	}
@@ -3688,16 +3644,16 @@ func (x *APIVersion) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIGroup = string(r.DecodeString())
 	}
 	for {
-		yyj329++
-		if yyhl329 {
-			yyb329 = yyj329 > l
+		yyj324++
+		if yyhl324 {
+			yyb324 = yyj324 > l
 		} else {
-			yyb329 = r.CheckBreak()
+			yyb324 = r.CheckBreak()
 		}
-		if yyb329 {
+		if yyb324 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj329-1, "")
+		z.DecStructFieldNotFound(yyj324-1, "")
 	}
 	r.ReadEnd()
 }
@@ -3709,35 +3665,35 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym332 := z.EncBinary()
-		_ = yym332
+		yym327 := z.EncBinary()
+		_ = yym327
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep333 := !z.EncBinary()
-			yy2arr333 := z.EncBasicHandle().StructToArray
-			var yyq333 [4]bool
-			_, _, _ = yysep333, yyq333, yy2arr333
-			const yyr333 bool = false
-			yyq333[0] = x.Kind != ""
-			yyq333[1] = x.APIVersion != ""
-			yyq333[2] = true
-			yyq333[3] = len(x.Data) != 0
-			if yyr333 || yy2arr333 {
+			yysep328 := !z.EncBinary()
+			yy2arr328 := z.EncBasicHandle().StructToArray
+			var yyq328 [4]bool
+			_, _, _ = yysep328, yyq328, yy2arr328
+			const yyr328 bool = false
+			yyq328[0] = x.Kind != ""
+			yyq328[1] = x.APIVersion != ""
+			yyq328[2] = true
+			yyq328[3] = len(x.Data) != 0
+			if yyr328 || yy2arr328 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn333 int = 0
-				for _, b := range yyq333 {
+				var yynn328 int = 0
+				for _, b := range yyq328 {
 					if b {
-						yynn333++
+						yynn328++
 					}
 				}
-				r.EncodeMapStart(yynn333)
+				r.EncodeMapStart(yynn328)
 			}
-			if yyr333 || yy2arr333 {
-				if yyq333[0] {
-					yym335 := z.EncBinary()
-					_ = yym335
+			if yyr328 || yy2arr328 {
+				if yyq328[0] {
+					yym330 := z.EncBinary()
+					_ = yym330
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -3746,20 +3702,20 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq333[0] {
+				if yyq328[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym336 := z.EncBinary()
-					_ = yym336
+					yym331 := z.EncBinary()
+					_ = yym331
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr333 || yy2arr333 {
-				if yyq333[1] {
-					yym338 := z.EncBinary()
-					_ = yym338
+			if yyr328 || yy2arr328 {
+				if yyq328[1] {
+					yym333 := z.EncBinary()
+					_ = yym333
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -3768,37 +3724,37 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq333[1] {
+				if yyq328[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym339 := z.EncBinary()
-					_ = yym339
+					yym334 := z.EncBinary()
+					_ = yym334
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr333 || yy2arr333 {
-				if yyq333[2] {
-					yy341 := &x.ObjectMeta
-					yy341.CodecEncodeSelf(e)
+			if yyr328 || yy2arr328 {
+				if yyq328[2] {
+					yy336 := &x.ObjectMeta
+					yy336.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq333[2] {
+				if yyq328[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy342 := &x.ObjectMeta
-					yy342.CodecEncodeSelf(e)
+					yy337 := &x.ObjectMeta
+					yy337.CodecEncodeSelf(e)
 				}
 			}
-			if yyr333 || yy2arr333 {
-				if yyq333[3] {
+			if yyr328 || yy2arr328 {
+				if yyq328[3] {
 					if x.Data == nil {
 						r.EncodeNil()
 					} else {
-						yym344 := z.EncBinary()
-						_ = yym344
+						yym339 := z.EncBinary()
+						_ = yym339
 						if false {
 						} else {
 							r.EncodeStringBytes(codecSelferC_RAW1234, []byte(x.Data))
@@ -3808,13 +3764,13 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq333[3] {
+				if yyq328[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("name"))
 					if x.Data == nil {
 						r.EncodeNil()
 					} else {
-						yym345 := z.EncBinary()
-						_ = yym345
+						yym340 := z.EncBinary()
+						_ = yym340
 						if false {
 						} else {
 							r.EncodeStringBytes(codecSelferC_RAW1234, []byte(x.Data))
@@ -3822,7 +3778,7 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep333 {
+			if yysep328 {
 				r.EncodeEnd()
 			}
 		}
@@ -3833,24 +3789,24 @@ func (x *ThirdPartyResourceData) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym346 := z.DecBinary()
-	_ = yym346
+	yym341 := z.DecBinary()
+	_ = yym341
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl347 := r.ReadMapStart()
-			if yyl347 == 0 {
+			yyl342 := r.ReadMapStart()
+			if yyl342 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl347, d)
+				x.codecDecodeSelfFromMap(yyl342, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl347 := r.ReadArrayStart()
-			if yyl347 == 0 {
+			yyl342 := r.ReadArrayStart()
+			if yyl342 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl347, d)
+				x.codecDecodeSelfFromArray(yyl342, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -3862,12 +3818,12 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys348Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys348Slc
-	var yyhl348 bool = l >= 0
-	for yyj348 := 0; ; yyj348++ {
-		if yyhl348 {
-			if yyj348 >= l {
+	var yys343Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys343Slc
+	var yyhl343 bool = l >= 0
+	for yyj343 := 0; ; yyj343++ {
+		if yyhl343 {
+			if yyj343 >= l {
 				break
 			}
 		} else {
@@ -3875,9 +3831,9 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				break
 			}
 		}
-		yys348Slc = r.DecodeBytes(yys348Slc, true, true)
-		yys348 := string(yys348Slc)
-		switch yys348 {
+		yys343Slc = r.DecodeBytes(yys343Slc, true, true)
+		yys343 := string(yys343Slc)
+		switch yys343 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -3894,26 +3850,26 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv351 := &x.ObjectMeta
-				yyv351.CodecDecodeSelf(d)
+				yyv346 := &x.ObjectMeta
+				yyv346.CodecDecodeSelf(d)
 			}
 		case "name":
 			if r.TryDecodeAsNil() {
 				x.Data = nil
 			} else {
-				yyv352 := &x.Data
-				yym353 := z.DecBinary()
-				_ = yym353
+				yyv347 := &x.Data
+				yym348 := z.DecBinary()
+				_ = yym348
 				if false {
 				} else {
-					*yyv352 = r.DecodeBytes(*(*[]byte)(yyv352), false, false)
+					*yyv347 = r.DecodeBytes(*(*[]byte)(yyv347), false, false)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys348)
-		} // end switch yys348
-	} // end for yyj348
-	if !yyhl348 {
+			z.DecStructFieldNotFound(-1, yys343)
+		} // end switch yys343
+	} // end for yyj343
+	if !yyhl343 {
 		r.ReadEnd()
 	}
 }
@@ -3922,16 +3878,16 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromArray(l int, d *codec1978.De
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj354 int
-	var yyb354 bool
-	var yyhl354 bool = l >= 0
-	yyj354++
-	if yyhl354 {
-		yyb354 = yyj354 > l
+	var yyj349 int
+	var yyb349 bool
+	var yyhl349 bool = l >= 0
+	yyj349++
+	if yyhl349 {
+		yyb349 = yyj349 > l
 	} else {
-		yyb354 = r.CheckBreak()
+		yyb349 = r.CheckBreak()
 	}
-	if yyb354 {
+	if yyb349 {
 		r.ReadEnd()
 		return
 	}
@@ -3940,13 +3896,13 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromArray(l int, d *codec1978.De
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj354++
-	if yyhl354 {
-		yyb354 = yyj354 > l
+	yyj349++
+	if yyhl349 {
+		yyb349 = yyj349 > l
 	} else {
-		yyb354 = r.CheckBreak()
+		yyb349 = r.CheckBreak()
 	}
-	if yyb354 {
+	if yyb349 {
 		r.ReadEnd()
 		return
 	}
@@ -3955,54 +3911,54 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromArray(l int, d *codec1978.De
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj354++
-	if yyhl354 {
-		yyb354 = yyj354 > l
+	yyj349++
+	if yyhl349 {
+		yyb349 = yyj349 > l
 	} else {
-		yyb354 = r.CheckBreak()
+		yyb349 = r.CheckBreak()
 	}
-	if yyb354 {
+	if yyb349 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv357 := &x.ObjectMeta
-		yyv357.CodecDecodeSelf(d)
+		yyv352 := &x.ObjectMeta
+		yyv352.CodecDecodeSelf(d)
 	}
-	yyj354++
-	if yyhl354 {
-		yyb354 = yyj354 > l
+	yyj349++
+	if yyhl349 {
+		yyb349 = yyj349 > l
 	} else {
-		yyb354 = r.CheckBreak()
+		yyb349 = r.CheckBreak()
 	}
-	if yyb354 {
+	if yyb349 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Data = nil
 	} else {
-		yyv358 := &x.Data
-		yym359 := z.DecBinary()
-		_ = yym359
+		yyv353 := &x.Data
+		yym354 := z.DecBinary()
+		_ = yym354
 		if false {
 		} else {
-			*yyv358 = r.DecodeBytes(*(*[]byte)(yyv358), false, false)
+			*yyv353 = r.DecodeBytes(*(*[]byte)(yyv353), false, false)
 		}
 	}
 	for {
-		yyj354++
-		if yyhl354 {
-			yyb354 = yyj354 > l
+		yyj349++
+		if yyhl349 {
+			yyb349 = yyj349 > l
 		} else {
-			yyb354 = r.CheckBreak()
+			yyb349 = r.CheckBreak()
 		}
-		if yyb354 {
+		if yyb349 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj354-1, "")
+		z.DecStructFieldNotFound(yyj349-1, "")
 	}
 	r.ReadEnd()
 }
@@ -4014,36 +3970,36 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym360 := z.EncBinary()
-		_ = yym360
+		yym355 := z.EncBinary()
+		_ = yym355
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep361 := !z.EncBinary()
-			yy2arr361 := z.EncBasicHandle().StructToArray
-			var yyq361 [5]bool
-			_, _, _ = yysep361, yyq361, yy2arr361
-			const yyr361 bool = false
-			yyq361[0] = x.Kind != ""
-			yyq361[1] = x.APIVersion != ""
-			yyq361[2] = true
-			yyq361[3] = true
-			yyq361[4] = true
-			if yyr361 || yy2arr361 {
+			yysep356 := !z.EncBinary()
+			yy2arr356 := z.EncBasicHandle().StructToArray
+			var yyq356 [5]bool
+			_, _, _ = yysep356, yyq356, yy2arr356
+			const yyr356 bool = false
+			yyq356[0] = x.Kind != ""
+			yyq356[1] = x.APIVersion != ""
+			yyq356[2] = true
+			yyq356[3] = true
+			yyq356[4] = true
+			if yyr356 || yy2arr356 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn361 int = 0
-				for _, b := range yyq361 {
+				var yynn356 int = 0
+				for _, b := range yyq356 {
 					if b {
-						yynn361++
+						yynn356++
 					}
 				}
-				r.EncodeMapStart(yynn361)
+				r.EncodeMapStart(yynn356)
 			}
-			if yyr361 || yy2arr361 {
-				if yyq361[0] {
-					yym363 := z.EncBinary()
-					_ = yym363
+			if yyr356 || yy2arr356 {
+				if yyq356[0] {
+					yym358 := z.EncBinary()
+					_ = yym358
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -4052,20 +4008,20 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq361[0] {
+				if yyq356[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym364 := z.EncBinary()
-					_ = yym364
+					yym359 := z.EncBinary()
+					_ = yym359
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr361 || yy2arr361 {
-				if yyq361[1] {
-					yym366 := z.EncBinary()
-					_ = yym366
+			if yyr356 || yy2arr356 {
+				if yyq356[1] {
+					yym361 := z.EncBinary()
+					_ = yym361
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -4074,59 +4030,59 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq361[1] {
+				if yyq356[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym367 := z.EncBinary()
-					_ = yym367
+					yym362 := z.EncBinary()
+					_ = yym362
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr361 || yy2arr361 {
-				if yyq361[2] {
-					yy369 := &x.ObjectMeta
-					yy369.CodecEncodeSelf(e)
+			if yyr356 || yy2arr356 {
+				if yyq356[2] {
+					yy364 := &x.ObjectMeta
+					yy364.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq361[2] {
+				if yyq356[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy370 := &x.ObjectMeta
-					yy370.CodecEncodeSelf(e)
+					yy365 := &x.ObjectMeta
+					yy365.CodecEncodeSelf(e)
 				}
 			}
-			if yyr361 || yy2arr361 {
-				if yyq361[3] {
-					yy372 := &x.Spec
-					yy372.CodecEncodeSelf(e)
+			if yyr356 || yy2arr356 {
+				if yyq356[3] {
+					yy367 := &x.Spec
+					yy367.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq361[3] {
+				if yyq356[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy373 := &x.Spec
-					yy373.CodecEncodeSelf(e)
+					yy368 := &x.Spec
+					yy368.CodecEncodeSelf(e)
 				}
 			}
-			if yyr361 || yy2arr361 {
-				if yyq361[4] {
-					yy375 := &x.Status
-					yy375.CodecEncodeSelf(e)
+			if yyr356 || yy2arr356 {
+				if yyq356[4] {
+					yy370 := &x.Status
+					yy370.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq361[4] {
+				if yyq356[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy376 := &x.Status
-					yy376.CodecEncodeSelf(e)
+					yy371 := &x.Status
+					yy371.CodecEncodeSelf(e)
 				}
 			}
-			if yysep361 {
+			if yysep356 {
 				r.EncodeEnd()
 			}
 		}
@@ -4137,24 +4093,24 @@ func (x *Deployment) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym377 := z.DecBinary()
-	_ = yym377
+	yym372 := z.DecBinary()
+	_ = yym372
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl378 := r.ReadMapStart()
-			if yyl378 == 0 {
+			yyl373 := r.ReadMapStart()
+			if yyl373 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl378, d)
+				x.codecDecodeSelfFromMap(yyl373, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl378 := r.ReadArrayStart()
-			if yyl378 == 0 {
+			yyl373 := r.ReadArrayStart()
+			if yyl373 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl378, d)
+				x.codecDecodeSelfFromArray(yyl373, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4166,12 +4122,12 @@ func (x *Deployment) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys379Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys379Slc
-	var yyhl379 bool = l >= 0
-	for yyj379 := 0; ; yyj379++ {
-		if yyhl379 {
-			if yyj379 >= l {
+	var yys374Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys374Slc
+	var yyhl374 bool = l >= 0
+	for yyj374 := 0; ; yyj374++ {
+		if yyhl374 {
+			if yyj374 >= l {
 				break
 			}
 		} else {
@@ -4179,9 +4135,9 @@ func (x *Deployment) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys379Slc = r.DecodeBytes(yys379Slc, true, true)
-		yys379 := string(yys379Slc)
-		switch yys379 {
+		yys374Slc = r.DecodeBytes(yys374Slc, true, true)
+		yys374 := string(yys374Slc)
+		switch yys374 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -4198,28 +4154,28 @@ func (x *Deployment) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv382 := &x.ObjectMeta
-				yyv382.CodecDecodeSelf(d)
+				yyv377 := &x.ObjectMeta
+				yyv377.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = DeploymentSpec{}
 			} else {
-				yyv383 := &x.Spec
-				yyv383.CodecDecodeSelf(d)
+				yyv378 := &x.Spec
+				yyv378.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = DeploymentStatus{}
 			} else {
-				yyv384 := &x.Status
-				yyv384.CodecDecodeSelf(d)
+				yyv379 := &x.Status
+				yyv379.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys379)
-		} // end switch yys379
-	} // end for yyj379
-	if !yyhl379 {
+			z.DecStructFieldNotFound(-1, yys374)
+		} // end switch yys374
+	} // end for yyj374
+	if !yyhl374 {
 		r.ReadEnd()
 	}
 }
@@ -4228,16 +4184,16 @@ func (x *Deployment) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj385 int
-	var yyb385 bool
-	var yyhl385 bool = l >= 0
-	yyj385++
-	if yyhl385 {
-		yyb385 = yyj385 > l
+	var yyj380 int
+	var yyb380 bool
+	var yyhl380 bool = l >= 0
+	yyj380++
+	if yyhl380 {
+		yyb380 = yyj380 > l
 	} else {
-		yyb385 = r.CheckBreak()
+		yyb380 = r.CheckBreak()
 	}
-	if yyb385 {
+	if yyb380 {
 		r.ReadEnd()
 		return
 	}
@@ -4246,13 +4202,13 @@ func (x *Deployment) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj385++
-	if yyhl385 {
-		yyb385 = yyj385 > l
+	yyj380++
+	if yyhl380 {
+		yyb380 = yyj380 > l
 	} else {
-		yyb385 = r.CheckBreak()
+		yyb380 = r.CheckBreak()
 	}
-	if yyb385 {
+	if yyb380 {
 		r.ReadEnd()
 		return
 	}
@@ -4261,65 +4217,65 @@ func (x *Deployment) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj385++
-	if yyhl385 {
-		yyb385 = yyj385 > l
+	yyj380++
+	if yyhl380 {
+		yyb380 = yyj380 > l
 	} else {
-		yyb385 = r.CheckBreak()
+		yyb380 = r.CheckBreak()
 	}
-	if yyb385 {
+	if yyb380 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv388 := &x.ObjectMeta
-		yyv388.CodecDecodeSelf(d)
+		yyv383 := &x.ObjectMeta
+		yyv383.CodecDecodeSelf(d)
 	}
-	yyj385++
-	if yyhl385 {
-		yyb385 = yyj385 > l
+	yyj380++
+	if yyhl380 {
+		yyb380 = yyj380 > l
 	} else {
-		yyb385 = r.CheckBreak()
+		yyb380 = r.CheckBreak()
 	}
-	if yyb385 {
+	if yyb380 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = DeploymentSpec{}
 	} else {
-		yyv389 := &x.Spec
-		yyv389.CodecDecodeSelf(d)
+		yyv384 := &x.Spec
+		yyv384.CodecDecodeSelf(d)
 	}
-	yyj385++
-	if yyhl385 {
-		yyb385 = yyj385 > l
+	yyj380++
+	if yyhl380 {
+		yyb380 = yyj380 > l
 	} else {
-		yyb385 = r.CheckBreak()
+		yyb380 = r.CheckBreak()
 	}
-	if yyb385 {
+	if yyb380 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = DeploymentStatus{}
 	} else {
-		yyv390 := &x.Status
-		yyv390.CodecDecodeSelf(d)
+		yyv385 := &x.Status
+		yyv385.CodecDecodeSelf(d)
 	}
 	for {
-		yyj385++
-		if yyhl385 {
-			yyb385 = yyj385 > l
+		yyj380++
+		if yyhl380 {
+			yyb380 = yyj380 > l
 		} else {
-			yyb385 = r.CheckBreak()
+			yyb380 = r.CheckBreak()
 		}
-		if yyb385 {
+		if yyb380 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj385-1, "")
+		z.DecStructFieldNotFound(yyj380-1, "")
 	}
 	r.ReadEnd()
 }
@@ -4331,35 +4287,35 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym391 := z.EncBinary()
-		_ = yym391
+		yym386 := z.EncBinary()
+		_ = yym386
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep392 := !z.EncBinary()
-			yy2arr392 := z.EncBasicHandle().StructToArray
-			var yyq392 [5]bool
-			_, _, _ = yysep392, yyq392, yy2arr392
-			const yyr392 bool = false
-			yyq392[0] = x.Replicas != 0
-			yyq392[1] = len(x.Selector) != 0
-			yyq392[3] = true
-			yyq392[4] = x.UniqueLabelKey != ""
-			if yyr392 || yy2arr392 {
+			yysep387 := !z.EncBinary()
+			yy2arr387 := z.EncBasicHandle().StructToArray
+			var yyq387 [5]bool
+			_, _, _ = yysep387, yyq387, yy2arr387
+			const yyr387 bool = false
+			yyq387[0] = x.Replicas != 0
+			yyq387[1] = len(x.Selector) != 0
+			yyq387[3] = true
+			yyq387[4] = x.UniqueLabelKey != ""
+			if yyr387 || yy2arr387 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn392 int = 1
-				for _, b := range yyq392 {
+				var yynn387 int = 1
+				for _, b := range yyq387 {
 					if b {
-						yynn392++
+						yynn387++
 					}
 				}
-				r.EncodeMapStart(yynn392)
+				r.EncodeMapStart(yynn387)
 			}
-			if yyr392 || yy2arr392 {
-				if yyq392[0] {
-					yym394 := z.EncBinary()
-					_ = yym394
+			if yyr387 || yy2arr387 {
+				if yyq387[0] {
+					yym389 := z.EncBinary()
+					_ = yym389
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Replicas))
@@ -4368,23 +4324,23 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq392[0] {
+				if yyq387[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("replicas"))
-					yym395 := z.EncBinary()
-					_ = yym395
+					yym390 := z.EncBinary()
+					_ = yym390
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Replicas))
 					}
 				}
 			}
-			if yyr392 || yy2arr392 {
-				if yyq392[1] {
+			if yyr387 || yy2arr387 {
+				if yyq387[1] {
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
-						yym397 := z.EncBinary()
-						_ = yym397
+						yym392 := z.EncBinary()
+						_ = yym392
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.Selector, false, e)
@@ -4394,13 +4350,13 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq392[1] {
+				if yyq387[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
-						yym398 := z.EncBinary()
-						_ = yym398
+						yym393 := z.EncBinary()
+						_ = yym393
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.Selector, false, e)
@@ -4408,32 +4364,32 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr392 || yy2arr392 {
-				yy400 := &x.Template
-				yy400.CodecEncodeSelf(e)
+			if yyr387 || yy2arr387 {
+				yy395 := &x.Template
+				yy395.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("template"))
-				yy401 := &x.Template
-				yy401.CodecEncodeSelf(e)
+				yy396 := &x.Template
+				yy396.CodecEncodeSelf(e)
 			}
-			if yyr392 || yy2arr392 {
-				if yyq392[3] {
-					yy403 := &x.Strategy
-					yy403.CodecEncodeSelf(e)
+			if yyr387 || yy2arr387 {
+				if yyq387[3] {
+					yy398 := &x.Strategy
+					yy398.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq392[3] {
+				if yyq387[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("strategy"))
-					yy404 := &x.Strategy
-					yy404.CodecEncodeSelf(e)
+					yy399 := &x.Strategy
+					yy399.CodecEncodeSelf(e)
 				}
 			}
-			if yyr392 || yy2arr392 {
-				if yyq392[4] {
-					yym406 := z.EncBinary()
-					_ = yym406
+			if yyr387 || yy2arr387 {
+				if yyq387[4] {
+					yym401 := z.EncBinary()
+					_ = yym401
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.UniqueLabelKey))
@@ -4442,17 +4398,17 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq392[4] {
+				if yyq387[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("uniqueLabelKey"))
-					yym407 := z.EncBinary()
-					_ = yym407
+					yym402 := z.EncBinary()
+					_ = yym402
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.UniqueLabelKey))
 					}
 				}
 			}
-			if yysep392 {
+			if yysep387 {
 				r.EncodeEnd()
 			}
 		}
@@ -4463,24 +4419,24 @@ func (x *DeploymentSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym408 := z.DecBinary()
-	_ = yym408
+	yym403 := z.DecBinary()
+	_ = yym403
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl409 := r.ReadMapStart()
-			if yyl409 == 0 {
+			yyl404 := r.ReadMapStart()
+			if yyl404 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl409, d)
+				x.codecDecodeSelfFromMap(yyl404, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl409 := r.ReadArrayStart()
-			if yyl409 == 0 {
+			yyl404 := r.ReadArrayStart()
+			if yyl404 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl409, d)
+				x.codecDecodeSelfFromArray(yyl404, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4492,12 +4448,12 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys410Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys410Slc
-	var yyhl410 bool = l >= 0
-	for yyj410 := 0; ; yyj410++ {
-		if yyhl410 {
-			if yyj410 >= l {
+	var yys405Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys405Slc
+	var yyhl405 bool = l >= 0
+	for yyj405 := 0; ; yyj405++ {
+		if yyhl405 {
+			if yyj405 >= l {
 				break
 			}
 		} else {
@@ -4505,9 +4461,9 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys410Slc = r.DecodeBytes(yys410Slc, true, true)
-		yys410 := string(yys410Slc)
-		switch yys410 {
+		yys405Slc = r.DecodeBytes(yys405Slc, true, true)
+		yys405 := string(yys405Slc)
+		switch yys405 {
 		case "replicas":
 			if r.TryDecodeAsNil() {
 				x.Replicas = 0
@@ -4518,27 +4474,27 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Selector = nil
 			} else {
-				yyv412 := &x.Selector
-				yym413 := z.DecBinary()
-				_ = yym413
+				yyv407 := &x.Selector
+				yym408 := z.DecBinary()
+				_ = yym408
 				if false {
 				} else {
-					z.F.DecMapStringStringX(yyv412, false, d)
+					z.F.DecMapStringStringX(yyv407, false, d)
 				}
 			}
 		case "template":
 			if r.TryDecodeAsNil() {
 				x.Template = pkg2_api.PodTemplateSpec{}
 			} else {
-				yyv414 := &x.Template
-				yyv414.CodecDecodeSelf(d)
+				yyv409 := &x.Template
+				yyv409.CodecDecodeSelf(d)
 			}
 		case "strategy":
 			if r.TryDecodeAsNil() {
 				x.Strategy = DeploymentStrategy{}
 			} else {
-				yyv415 := &x.Strategy
-				yyv415.CodecDecodeSelf(d)
+				yyv410 := &x.Strategy
+				yyv410.CodecDecodeSelf(d)
 			}
 		case "uniqueLabelKey":
 			if r.TryDecodeAsNil() {
@@ -4547,10 +4503,10 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.UniqueLabelKey = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys410)
-		} // end switch yys410
-	} // end for yyj410
-	if !yyhl410 {
+			z.DecStructFieldNotFound(-1, yys405)
+		} // end switch yys405
+	} // end for yyj405
+	if !yyhl405 {
 		r.ReadEnd()
 	}
 }
@@ -4559,16 +4515,16 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj417 int
-	var yyb417 bool
-	var yyhl417 bool = l >= 0
-	yyj417++
-	if yyhl417 {
-		yyb417 = yyj417 > l
+	var yyj412 int
+	var yyb412 bool
+	var yyhl412 bool = l >= 0
+	yyj412++
+	if yyhl412 {
+		yyb412 = yyj412 > l
 	} else {
-		yyb417 = r.CheckBreak()
+		yyb412 = r.CheckBreak()
 	}
-	if yyb417 {
+	if yyb412 {
 		r.ReadEnd()
 		return
 	}
@@ -4577,66 +4533,66 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Replicas = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj417++
-	if yyhl417 {
-		yyb417 = yyj417 > l
+	yyj412++
+	if yyhl412 {
+		yyb412 = yyj412 > l
 	} else {
-		yyb417 = r.CheckBreak()
+		yyb412 = r.CheckBreak()
 	}
-	if yyb417 {
+	if yyb412 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Selector = nil
 	} else {
-		yyv419 := &x.Selector
-		yym420 := z.DecBinary()
-		_ = yym420
+		yyv414 := &x.Selector
+		yym415 := z.DecBinary()
+		_ = yym415
 		if false {
 		} else {
-			z.F.DecMapStringStringX(yyv419, false, d)
+			z.F.DecMapStringStringX(yyv414, false, d)
 		}
 	}
-	yyj417++
-	if yyhl417 {
-		yyb417 = yyj417 > l
+	yyj412++
+	if yyhl412 {
+		yyb412 = yyj412 > l
 	} else {
-		yyb417 = r.CheckBreak()
+		yyb412 = r.CheckBreak()
 	}
-	if yyb417 {
+	if yyb412 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Template = pkg2_api.PodTemplateSpec{}
 	} else {
-		yyv421 := &x.Template
-		yyv421.CodecDecodeSelf(d)
+		yyv416 := &x.Template
+		yyv416.CodecDecodeSelf(d)
 	}
-	yyj417++
-	if yyhl417 {
-		yyb417 = yyj417 > l
+	yyj412++
+	if yyhl412 {
+		yyb412 = yyj412 > l
 	} else {
-		yyb417 = r.CheckBreak()
+		yyb412 = r.CheckBreak()
 	}
-	if yyb417 {
+	if yyb412 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Strategy = DeploymentStrategy{}
 	} else {
-		yyv422 := &x.Strategy
-		yyv422.CodecDecodeSelf(d)
+		yyv417 := &x.Strategy
+		yyv417.CodecDecodeSelf(d)
 	}
-	yyj417++
-	if yyhl417 {
-		yyb417 = yyj417 > l
+	yyj412++
+	if yyhl412 {
+		yyb412 = yyj412 > l
 	} else {
-		yyb417 = r.CheckBreak()
+		yyb412 = r.CheckBreak()
 	}
-	if yyb417 {
+	if yyb412 {
 		r.ReadEnd()
 		return
 	}
@@ -4646,16 +4602,16 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.UniqueLabelKey = string(r.DecodeString())
 	}
 	for {
-		yyj417++
-		if yyhl417 {
-			yyb417 = yyj417 > l
+		yyj412++
+		if yyhl412 {
+			yyb412 = yyj412 > l
 		} else {
-			yyb417 = r.CheckBreak()
+			yyb412 = r.CheckBreak()
 		}
-		if yyb417 {
+		if yyb412 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj417-1, "")
+		z.DecStructFieldNotFound(yyj412-1, "")
 	}
 	r.ReadEnd()
 }
@@ -4667,43 +4623,43 @@ func (x *DeploymentStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym424 := z.EncBinary()
-		_ = yym424
+		yym419 := z.EncBinary()
+		_ = yym419
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep425 := !z.EncBinary()
-			yy2arr425 := z.EncBasicHandle().StructToArray
-			var yyq425 [2]bool
-			_, _, _ = yysep425, yyq425, yy2arr425
-			const yyr425 bool = false
-			yyq425[0] = x.Type != ""
-			yyq425[1] = x.RollingUpdate != nil
-			if yyr425 || yy2arr425 {
+			yysep420 := !z.EncBinary()
+			yy2arr420 := z.EncBasicHandle().StructToArray
+			var yyq420 [2]bool
+			_, _, _ = yysep420, yyq420, yy2arr420
+			const yyr420 bool = false
+			yyq420[0] = x.Type != ""
+			yyq420[1] = x.RollingUpdate != nil
+			if yyr420 || yy2arr420 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn425 int = 0
-				for _, b := range yyq425 {
+				var yynn420 int = 0
+				for _, b := range yyq420 {
 					if b {
-						yynn425++
+						yynn420++
 					}
 				}
-				r.EncodeMapStart(yynn425)
+				r.EncodeMapStart(yynn420)
 			}
-			if yyr425 || yy2arr425 {
-				if yyq425[0] {
+			if yyr420 || yy2arr420 {
+				if yyq420[0] {
 					x.Type.CodecEncodeSelf(e)
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq425[0] {
+				if yyq420[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("type"))
 					x.Type.CodecEncodeSelf(e)
 				}
 			}
-			if yyr425 || yy2arr425 {
-				if yyq425[1] {
+			if yyr420 || yy2arr420 {
+				if yyq420[1] {
 					if x.RollingUpdate == nil {
 						r.EncodeNil()
 					} else {
@@ -4713,7 +4669,7 @@ func (x *DeploymentStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq425[1] {
+				if yyq420[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("rollingUpdate"))
 					if x.RollingUpdate == nil {
 						r.EncodeNil()
@@ -4722,7 +4678,7 @@ func (x *DeploymentStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep425 {
+			if yysep420 {
 				r.EncodeEnd()
 			}
 		}
@@ -4733,24 +4689,24 @@ func (x *DeploymentStrategy) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym428 := z.DecBinary()
-	_ = yym428
+	yym423 := z.DecBinary()
+	_ = yym423
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl429 := r.ReadMapStart()
-			if yyl429 == 0 {
+			yyl424 := r.ReadMapStart()
+			if yyl424 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl429, d)
+				x.codecDecodeSelfFromMap(yyl424, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl429 := r.ReadArrayStart()
-			if yyl429 == 0 {
+			yyl424 := r.ReadArrayStart()
+			if yyl424 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl429, d)
+				x.codecDecodeSelfFromArray(yyl424, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4762,12 +4718,12 @@ func (x *DeploymentStrategy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys430Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys430Slc
-	var yyhl430 bool = l >= 0
-	for yyj430 := 0; ; yyj430++ {
-		if yyhl430 {
-			if yyj430 >= l {
+	var yys425Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys425Slc
+	var yyhl425 bool = l >= 0
+	for yyj425 := 0; ; yyj425++ {
+		if yyhl425 {
+			if yyj425 >= l {
 				break
 			}
 		} else {
@@ -4775,9 +4731,9 @@ func (x *DeploymentStrategy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
-		yys430Slc = r.DecodeBytes(yys430Slc, true, true)
-		yys430 := string(yys430Slc)
-		switch yys430 {
+		yys425Slc = r.DecodeBytes(yys425Slc, true, true)
+		yys425 := string(yys425Slc)
+		switch yys425 {
 		case "type":
 			if r.TryDecodeAsNil() {
 				x.Type = ""
@@ -4796,10 +4752,10 @@ func (x *DeploymentStrategy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				x.RollingUpdate.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys430)
-		} // end switch yys430
-	} // end for yyj430
-	if !yyhl430 {
+			z.DecStructFieldNotFound(-1, yys425)
+		} // end switch yys425
+	} // end for yyj425
+	if !yyhl425 {
 		r.ReadEnd()
 	}
 }
@@ -4808,16 +4764,16 @@ func (x *DeploymentStrategy) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj433 int
-	var yyb433 bool
-	var yyhl433 bool = l >= 0
-	yyj433++
-	if yyhl433 {
-		yyb433 = yyj433 > l
+	var yyj428 int
+	var yyb428 bool
+	var yyhl428 bool = l >= 0
+	yyj428++
+	if yyhl428 {
+		yyb428 = yyj428 > l
 	} else {
-		yyb433 = r.CheckBreak()
+		yyb428 = r.CheckBreak()
 	}
-	if yyb433 {
+	if yyb428 {
 		r.ReadEnd()
 		return
 	}
@@ -4826,13 +4782,13 @@ func (x *DeploymentStrategy) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.Type = DeploymentStrategyType(r.DecodeString())
 	}
-	yyj433++
-	if yyhl433 {
-		yyb433 = yyj433 > l
+	yyj428++
+	if yyhl428 {
+		yyb428 = yyj428 > l
 	} else {
-		yyb433 = r.CheckBreak()
+		yyb428 = r.CheckBreak()
 	}
-	if yyb433 {
+	if yyb428 {
 		r.ReadEnd()
 		return
 	}
@@ -4847,16 +4803,16 @@ func (x *DeploymentStrategy) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		x.RollingUpdate.CodecDecodeSelf(d)
 	}
 	for {
-		yyj433++
-		if yyhl433 {
-			yyb433 = yyj433 > l
+		yyj428++
+		if yyhl428 {
+			yyb428 = yyj428 > l
 		} else {
-			yyb433 = r.CheckBreak()
+			yyb428 = r.CheckBreak()
 		}
-		if yyb433 {
+		if yyb428 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj433-1, "")
+		z.DecStructFieldNotFound(yyj428-1, "")
 	}
 	r.ReadEnd()
 }
@@ -4865,8 +4821,8 @@ func (x DeploymentStrategyType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym436 := z.EncBinary()
-	_ = yym436
+	yym431 := z.EncBinary()
+	_ = yym431
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -4878,8 +4834,8 @@ func (x *DeploymentStrategyType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym437 := z.DecBinary()
-	_ = yym437
+	yym432 := z.DecBinary()
+	_ = yym432
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -4894,33 +4850,63 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym438 := z.EncBinary()
-		_ = yym438
+		yym433 := z.EncBinary()
+		_ = yym433
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep439 := !z.EncBinary()
-			yy2arr439 := z.EncBasicHandle().StructToArray
-			var yyq439 [3]bool
-			_, _, _ = yysep439, yyq439, yy2arr439
-			const yyr439 bool = false
-			yyq439[0] = true
-			yyq439[1] = true
-			yyq439[2] = x.MinReadySeconds != 0
-			if yyr439 || yy2arr439 {
+			yysep434 := !z.EncBinary()
+			yy2arr434 := z.EncBasicHandle().StructToArray
+			var yyq434 [3]bool
+			_, _, _ = yysep434, yyq434, yy2arr434
+			const yyr434 bool = false
+			yyq434[0] = true
+			yyq434[1] = true
+			yyq434[2] = x.MinReadySeconds != 0
+			if yyr434 || yy2arr434 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn439 int = 0
-				for _, b := range yyq439 {
+				var yynn434 int = 0
+				for _, b := range yyq434 {
 					if b {
-						yynn439++
+						yynn434++
 					}
 				}
-				r.EncodeMapStart(yynn439)
+				r.EncodeMapStart(yynn434)
 			}
-			if yyr439 || yy2arr439 {
-				if yyq439[0] {
-					yy441 := &x.MaxUnavailable
+			if yyr434 || yy2arr434 {
+				if yyq434[0] {
+					yy436 := &x.MaxUnavailable
+					yym437 := z.EncBinary()
+					_ = yym437
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy436) {
+					} else if !yym437 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy436)
+					} else {
+						z.EncFallback(yy436)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq434[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("maxUnavailable"))
+					yy438 := &x.MaxUnavailable
+					yym439 := z.EncBinary()
+					_ = yym439
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy438) {
+					} else if !yym439 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy438)
+					} else {
+						z.EncFallback(yy438)
+					}
+				}
+			}
+			if yyr434 || yy2arr434 {
+				if yyq434[1] {
+					yy441 := &x.MaxSurge
 					yym442 := z.EncBinary()
 					_ = yym442
 					if false {
@@ -4934,9 +4920,9 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq439[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("maxUnavailable"))
-					yy443 := &x.MaxUnavailable
+				if yyq434[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("maxSurge"))
+					yy443 := &x.MaxSurge
 					yym444 := z.EncBinary()
 					_ = yym444
 					if false {
@@ -4948,40 +4934,10 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr439 || yy2arr439 {
-				if yyq439[1] {
-					yy446 := &x.MaxSurge
-					yym447 := z.EncBinary()
-					_ = yym447
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy446) {
-					} else if !yym447 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy446)
-					} else {
-						z.EncFallback(yy446)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq439[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("maxSurge"))
-					yy448 := &x.MaxSurge
-					yym449 := z.EncBinary()
-					_ = yym449
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy448) {
-					} else if !yym449 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy448)
-					} else {
-						z.EncFallback(yy448)
-					}
-				}
-			}
-			if yyr439 || yy2arr439 {
-				if yyq439[2] {
-					yym451 := z.EncBinary()
-					_ = yym451
+			if yyr434 || yy2arr434 {
+				if yyq434[2] {
+					yym446 := z.EncBinary()
+					_ = yym446
 					if false {
 					} else {
 						r.EncodeInt(int64(x.MinReadySeconds))
@@ -4990,17 +4946,17 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq439[2] {
+				if yyq434[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("minReadySeconds"))
-					yym452 := z.EncBinary()
-					_ = yym452
+					yym447 := z.EncBinary()
+					_ = yym447
 					if false {
 					} else {
 						r.EncodeInt(int64(x.MinReadySeconds))
 					}
 				}
 			}
-			if yysep439 {
+			if yysep434 {
 				r.EncodeEnd()
 			}
 		}
@@ -5011,24 +4967,24 @@ func (x *RollingUpdateDeployment) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym453 := z.DecBinary()
-	_ = yym453
+	yym448 := z.DecBinary()
+	_ = yym448
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl454 := r.ReadMapStart()
-			if yyl454 == 0 {
+			yyl449 := r.ReadMapStart()
+			if yyl449 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl454, d)
+				x.codecDecodeSelfFromMap(yyl449, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl454 := r.ReadArrayStart()
-			if yyl454 == 0 {
+			yyl449 := r.ReadArrayStart()
+			if yyl449 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl454, d)
+				x.codecDecodeSelfFromArray(yyl449, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -5040,12 +4996,12 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys455Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys455Slc
-	var yyhl455 bool = l >= 0
-	for yyj455 := 0; ; yyj455++ {
-		if yyhl455 {
-			if yyj455 >= l {
+	var yys450Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys450Slc
+	var yyhl450 bool = l >= 0
+	for yyj450 := 0; ; yyj450++ {
+		if yyhl450 {
+			if yyj450 >= l {
 				break
 			}
 		} else {
@@ -5053,37 +5009,37 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				break
 			}
 		}
-		yys455Slc = r.DecodeBytes(yys455Slc, true, true)
-		yys455 := string(yys455Slc)
-		switch yys455 {
+		yys450Slc = r.DecodeBytes(yys450Slc, true, true)
+		yys450 := string(yys450Slc)
+		switch yys450 {
 		case "maxUnavailable":
 			if r.TryDecodeAsNil() {
 				x.MaxUnavailable = pkg6_util.IntOrString{}
 			} else {
-				yyv456 := &x.MaxUnavailable
-				yym457 := z.DecBinary()
-				_ = yym457
+				yyv451 := &x.MaxUnavailable
+				yym452 := z.DecBinary()
+				_ = yym452
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv456) {
-				} else if !yym457 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv456)
+				} else if z.HasExtensions() && z.DecExt(yyv451) {
+				} else if !yym452 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv451)
 				} else {
-					z.DecFallback(yyv456, false)
+					z.DecFallback(yyv451, false)
 				}
 			}
 		case "maxSurge":
 			if r.TryDecodeAsNil() {
 				x.MaxSurge = pkg6_util.IntOrString{}
 			} else {
-				yyv458 := &x.MaxSurge
-				yym459 := z.DecBinary()
-				_ = yym459
+				yyv453 := &x.MaxSurge
+				yym454 := z.DecBinary()
+				_ = yym454
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv458) {
-				} else if !yym459 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv458)
+				} else if z.HasExtensions() && z.DecExt(yyv453) {
+				} else if !yym454 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv453)
 				} else {
-					z.DecFallback(yyv458, false)
+					z.DecFallback(yyv453, false)
 				}
 			}
 		case "minReadySeconds":
@@ -5093,10 +5049,10 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				x.MinReadySeconds = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys455)
-		} // end switch yys455
-	} // end for yyj455
-	if !yyhl455 {
+			z.DecStructFieldNotFound(-1, yys450)
+		} // end switch yys450
+	} // end for yyj450
+	if !yyhl450 {
 		r.ReadEnd()
 	}
 }
@@ -5105,64 +5061,64 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromArray(l int, d *codec1978.D
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj461 int
-	var yyb461 bool
-	var yyhl461 bool = l >= 0
-	yyj461++
-	if yyhl461 {
-		yyb461 = yyj461 > l
+	var yyj456 int
+	var yyb456 bool
+	var yyhl456 bool = l >= 0
+	yyj456++
+	if yyhl456 {
+		yyb456 = yyj456 > l
 	} else {
-		yyb461 = r.CheckBreak()
+		yyb456 = r.CheckBreak()
 	}
-	if yyb461 {
+	if yyb456 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.MaxUnavailable = pkg6_util.IntOrString{}
 	} else {
-		yyv462 := &x.MaxUnavailable
-		yym463 := z.DecBinary()
-		_ = yym463
+		yyv457 := &x.MaxUnavailable
+		yym458 := z.DecBinary()
+		_ = yym458
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv462) {
-		} else if !yym463 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv462)
+		} else if z.HasExtensions() && z.DecExt(yyv457) {
+		} else if !yym458 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv457)
 		} else {
-			z.DecFallback(yyv462, false)
+			z.DecFallback(yyv457, false)
 		}
 	}
-	yyj461++
-	if yyhl461 {
-		yyb461 = yyj461 > l
+	yyj456++
+	if yyhl456 {
+		yyb456 = yyj456 > l
 	} else {
-		yyb461 = r.CheckBreak()
+		yyb456 = r.CheckBreak()
 	}
-	if yyb461 {
+	if yyb456 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.MaxSurge = pkg6_util.IntOrString{}
 	} else {
-		yyv464 := &x.MaxSurge
-		yym465 := z.DecBinary()
-		_ = yym465
+		yyv459 := &x.MaxSurge
+		yym460 := z.DecBinary()
+		_ = yym460
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv464) {
-		} else if !yym465 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv464)
+		} else if z.HasExtensions() && z.DecExt(yyv459) {
+		} else if !yym460 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv459)
 		} else {
-			z.DecFallback(yyv464, false)
+			z.DecFallback(yyv459, false)
 		}
 	}
-	yyj461++
-	if yyhl461 {
-		yyb461 = yyj461 > l
+	yyj456++
+	if yyhl456 {
+		yyb456 = yyj456 > l
 	} else {
-		yyb461 = r.CheckBreak()
+		yyb456 = r.CheckBreak()
 	}
-	if yyb461 {
+	if yyb456 {
 		r.ReadEnd()
 		return
 	}
@@ -5172,16 +5128,16 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromArray(l int, d *codec1978.D
 		x.MinReadySeconds = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj461++
-		if yyhl461 {
-			yyb461 = yyj461 > l
+		yyj456++
+		if yyhl456 {
+			yyb456 = yyj456 > l
 		} else {
-			yyb461 = r.CheckBreak()
+			yyb456 = r.CheckBreak()
 		}
-		if yyb461 {
+		if yyb456 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj461-1, "")
+		z.DecStructFieldNotFound(yyj456-1, "")
 	}
 	r.ReadEnd()
 }
@@ -5193,33 +5149,33 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym467 := z.EncBinary()
-		_ = yym467
+		yym462 := z.EncBinary()
+		_ = yym462
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep468 := !z.EncBinary()
-			yy2arr468 := z.EncBasicHandle().StructToArray
-			var yyq468 [2]bool
-			_, _, _ = yysep468, yyq468, yy2arr468
-			const yyr468 bool = false
-			yyq468[0] = x.Replicas != 0
-			yyq468[1] = x.UpdatedReplicas != 0
-			if yyr468 || yy2arr468 {
+			yysep463 := !z.EncBinary()
+			yy2arr463 := z.EncBasicHandle().StructToArray
+			var yyq463 [2]bool
+			_, _, _ = yysep463, yyq463, yy2arr463
+			const yyr463 bool = false
+			yyq463[0] = x.Replicas != 0
+			yyq463[1] = x.UpdatedReplicas != 0
+			if yyr463 || yy2arr463 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn468 int = 0
-				for _, b := range yyq468 {
+				var yynn463 int = 0
+				for _, b := range yyq463 {
 					if b {
-						yynn468++
+						yynn463++
 					}
 				}
-				r.EncodeMapStart(yynn468)
+				r.EncodeMapStart(yynn463)
 			}
-			if yyr468 || yy2arr468 {
-				if yyq468[0] {
-					yym470 := z.EncBinary()
-					_ = yym470
+			if yyr463 || yy2arr463 {
+				if yyq463[0] {
+					yym465 := z.EncBinary()
+					_ = yym465
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Replicas))
@@ -5228,20 +5184,20 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq468[0] {
+				if yyq463[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("replicas"))
-					yym471 := z.EncBinary()
-					_ = yym471
+					yym466 := z.EncBinary()
+					_ = yym466
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Replicas))
 					}
 				}
 			}
-			if yyr468 || yy2arr468 {
-				if yyq468[1] {
-					yym473 := z.EncBinary()
-					_ = yym473
+			if yyr463 || yy2arr463 {
+				if yyq463[1] {
+					yym468 := z.EncBinary()
+					_ = yym468
 					if false {
 					} else {
 						r.EncodeInt(int64(x.UpdatedReplicas))
@@ -5250,17 +5206,17 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq468[1] {
+				if yyq463[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("updatedReplicas"))
-					yym474 := z.EncBinary()
-					_ = yym474
+					yym469 := z.EncBinary()
+					_ = yym469
 					if false {
 					} else {
 						r.EncodeInt(int64(x.UpdatedReplicas))
 					}
 				}
 			}
-			if yysep468 {
+			if yysep463 {
 				r.EncodeEnd()
 			}
 		}
@@ -5271,24 +5227,24 @@ func (x *DeploymentStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym475 := z.DecBinary()
-	_ = yym475
+	yym470 := z.DecBinary()
+	_ = yym470
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl476 := r.ReadMapStart()
-			if yyl476 == 0 {
+			yyl471 := r.ReadMapStart()
+			if yyl471 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl476, d)
+				x.codecDecodeSelfFromMap(yyl471, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl476 := r.ReadArrayStart()
-			if yyl476 == 0 {
+			yyl471 := r.ReadArrayStart()
+			if yyl471 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl476, d)
+				x.codecDecodeSelfFromArray(yyl471, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -5300,12 +5256,12 @@ func (x *DeploymentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys477Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys477Slc
-	var yyhl477 bool = l >= 0
-	for yyj477 := 0; ; yyj477++ {
-		if yyhl477 {
-			if yyj477 >= l {
+	var yys472Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys472Slc
+	var yyhl472 bool = l >= 0
+	for yyj472 := 0; ; yyj472++ {
+		if yyhl472 {
+			if yyj472 >= l {
 				break
 			}
 		} else {
@@ -5313,9 +5269,9 @@ func (x *DeploymentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys477Slc = r.DecodeBytes(yys477Slc, true, true)
-		yys477 := string(yys477Slc)
-		switch yys477 {
+		yys472Slc = r.DecodeBytes(yys472Slc, true, true)
+		yys472 := string(yys472Slc)
+		switch yys472 {
 		case "replicas":
 			if r.TryDecodeAsNil() {
 				x.Replicas = 0
@@ -5329,10 +5285,10 @@ func (x *DeploymentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.UpdatedReplicas = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys477)
-		} // end switch yys477
-	} // end for yyj477
-	if !yyhl477 {
+			z.DecStructFieldNotFound(-1, yys472)
+		} // end switch yys472
+	} // end for yyj472
+	if !yyhl472 {
 		r.ReadEnd()
 	}
 }
@@ -5341,16 +5297,16 @@ func (x *DeploymentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj480 int
-	var yyb480 bool
-	var yyhl480 bool = l >= 0
-	yyj480++
-	if yyhl480 {
-		yyb480 = yyj480 > l
+	var yyj475 int
+	var yyb475 bool
+	var yyhl475 bool = l >= 0
+	yyj475++
+	if yyhl475 {
+		yyb475 = yyj475 > l
 	} else {
-		yyb480 = r.CheckBreak()
+		yyb475 = r.CheckBreak()
 	}
-	if yyb480 {
+	if yyb475 {
 		r.ReadEnd()
 		return
 	}
@@ -5359,13 +5315,13 @@ func (x *DeploymentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.Replicas = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj480++
-	if yyhl480 {
-		yyb480 = yyj480 > l
+	yyj475++
+	if yyhl475 {
+		yyb475 = yyj475 > l
 	} else {
-		yyb480 = r.CheckBreak()
+		yyb475 = r.CheckBreak()
 	}
-	if yyb480 {
+	if yyb475 {
 		r.ReadEnd()
 		return
 	}
@@ -5375,16 +5331,16 @@ func (x *DeploymentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		x.UpdatedReplicas = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj480++
-		if yyhl480 {
-			yyb480 = yyj480 > l
+		yyj475++
+		if yyhl475 {
+			yyb475 = yyj475 > l
 		} else {
-			yyb480 = r.CheckBreak()
+			yyb475 = r.CheckBreak()
 		}
-		if yyb480 {
+		if yyb475 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj480-1, "")
+		z.DecStructFieldNotFound(yyj475-1, "")
 	}
 	r.ReadEnd()
 }
@@ -5396,34 +5352,34 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym483 := z.EncBinary()
-		_ = yym483
+		yym478 := z.EncBinary()
+		_ = yym478
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep484 := !z.EncBinary()
-			yy2arr484 := z.EncBasicHandle().StructToArray
-			var yyq484 [4]bool
-			_, _, _ = yysep484, yyq484, yy2arr484
-			const yyr484 bool = false
-			yyq484[0] = x.Kind != ""
-			yyq484[1] = x.APIVersion != ""
-			yyq484[2] = true
-			if yyr484 || yy2arr484 {
+			yysep479 := !z.EncBinary()
+			yy2arr479 := z.EncBasicHandle().StructToArray
+			var yyq479 [4]bool
+			_, _, _ = yysep479, yyq479, yy2arr479
+			const yyr479 bool = false
+			yyq479[0] = x.Kind != ""
+			yyq479[1] = x.APIVersion != ""
+			yyq479[2] = true
+			if yyr479 || yy2arr479 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn484 int = 1
-				for _, b := range yyq484 {
+				var yynn479 int = 1
+				for _, b := range yyq479 {
 					if b {
-						yynn484++
+						yynn479++
 					}
 				}
-				r.EncodeMapStart(yynn484)
+				r.EncodeMapStart(yynn479)
 			}
-			if yyr484 || yy2arr484 {
-				if yyq484[0] {
-					yym486 := z.EncBinary()
-					_ = yym486
+			if yyr479 || yy2arr479 {
+				if yyq479[0] {
+					yym481 := z.EncBinary()
+					_ = yym481
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -5432,20 +5388,20 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq484[0] {
+				if yyq479[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym487 := z.EncBinary()
-					_ = yym487
+					yym482 := z.EncBinary()
+					_ = yym482
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr484 || yy2arr484 {
-				if yyq484[1] {
-					yym489 := z.EncBinary()
-					_ = yym489
+			if yyr479 || yy2arr479 {
+				if yyq479[1] {
+					yym484 := z.EncBinary()
+					_ = yym484
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -5454,48 +5410,48 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq484[1] {
+				if yyq479[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym485 := z.EncBinary()
+					_ = yym485
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr479 || yy2arr479 {
+				if yyq479[2] {
+					yy487 := &x.ListMeta
+					yym488 := z.EncBinary()
+					_ = yym488
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy487) {
+					} else {
+						z.EncFallback(yy487)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq479[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy489 := &x.ListMeta
 					yym490 := z.EncBinary()
 					_ = yym490
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy489) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						z.EncFallback(yy489)
 					}
 				}
 			}
-			if yyr484 || yy2arr484 {
-				if yyq484[2] {
-					yy492 := &x.ListMeta
-					yym493 := z.EncBinary()
-					_ = yym493
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy492) {
-					} else {
-						z.EncFallback(yy492)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq484[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy494 := &x.ListMeta
-					yym495 := z.EncBinary()
-					_ = yym495
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy494) {
-					} else {
-						z.EncFallback(yy494)
-					}
-				}
-			}
-			if yyr484 || yy2arr484 {
+			if yyr479 || yy2arr479 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym497 := z.EncBinary()
-					_ = yym497
+					yym492 := z.EncBinary()
+					_ = yym492
 					if false {
 					} else {
 						h.encSliceDeployment(([]Deployment)(x.Items), e)
@@ -5506,15 +5462,15 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym498 := z.EncBinary()
-					_ = yym498
+					yym493 := z.EncBinary()
+					_ = yym493
 					if false {
 					} else {
 						h.encSliceDeployment(([]Deployment)(x.Items), e)
 					}
 				}
 			}
-			if yysep484 {
+			if yysep479 {
 				r.EncodeEnd()
 			}
 		}
@@ -5525,24 +5481,24 @@ func (x *DeploymentList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym499 := z.DecBinary()
-	_ = yym499
+	yym494 := z.DecBinary()
+	_ = yym494
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl500 := r.ReadMapStart()
-			if yyl500 == 0 {
+			yyl495 := r.ReadMapStart()
+			if yyl495 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl500, d)
+				x.codecDecodeSelfFromMap(yyl495, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl500 := r.ReadArrayStart()
-			if yyl500 == 0 {
+			yyl495 := r.ReadArrayStart()
+			if yyl495 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl500, d)
+				x.codecDecodeSelfFromArray(yyl495, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -5554,12 +5510,12 @@ func (x *DeploymentList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys501Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys501Slc
-	var yyhl501 bool = l >= 0
-	for yyj501 := 0; ; yyj501++ {
-		if yyhl501 {
-			if yyj501 >= l {
+	var yys496Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys496Slc
+	var yyhl496 bool = l >= 0
+	for yyj496 := 0; ; yyj496++ {
+		if yyhl496 {
+			if yyj496 >= l {
 				break
 			}
 		} else {
@@ -5567,9 +5523,9 @@ func (x *DeploymentList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys501Slc = r.DecodeBytes(yys501Slc, true, true)
-		yys501 := string(yys501Slc)
-		switch yys501 {
+		yys496Slc = r.DecodeBytes(yys496Slc, true, true)
+		yys496 := string(yys496Slc)
+		switch yys496 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -5586,32 +5542,32 @@ func (x *DeploymentList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv504 := &x.ListMeta
-				yym505 := z.DecBinary()
-				_ = yym505
+				yyv499 := &x.ListMeta
+				yym500 := z.DecBinary()
+				_ = yym500
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv504) {
+				} else if z.HasExtensions() && z.DecExt(yyv499) {
 				} else {
-					z.DecFallback(yyv504, false)
+					z.DecFallback(yyv499, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv506 := &x.Items
-				yym507 := z.DecBinary()
-				_ = yym507
+				yyv501 := &x.Items
+				yym502 := z.DecBinary()
+				_ = yym502
 				if false {
 				} else {
-					h.decSliceDeployment((*[]Deployment)(yyv506), d)
+					h.decSliceDeployment((*[]Deployment)(yyv501), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys501)
-		} // end switch yys501
-	} // end for yyj501
-	if !yyhl501 {
+			z.DecStructFieldNotFound(-1, yys496)
+		} // end switch yys496
+	} // end for yyj496
+	if !yyhl496 {
 		r.ReadEnd()
 	}
 }
@@ -5620,16 +5576,16 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj508 int
-	var yyb508 bool
-	var yyhl508 bool = l >= 0
-	yyj508++
-	if yyhl508 {
-		yyb508 = yyj508 > l
+	var yyj503 int
+	var yyb503 bool
+	var yyhl503 bool = l >= 0
+	yyj503++
+	if yyhl503 {
+		yyb503 = yyj503 > l
 	} else {
-		yyb508 = r.CheckBreak()
+		yyb503 = r.CheckBreak()
 	}
-	if yyb508 {
+	if yyb503 {
 		r.ReadEnd()
 		return
 	}
@@ -5638,13 +5594,13 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj508++
-	if yyhl508 {
-		yyb508 = yyj508 > l
+	yyj503++
+	if yyhl503 {
+		yyb503 = yyj503 > l
 	} else {
-		yyb508 = r.CheckBreak()
+		yyb503 = r.CheckBreak()
 	}
-	if yyb508 {
+	if yyb503 {
 		r.ReadEnd()
 		return
 	}
@@ -5653,60 +5609,60 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj508++
-	if yyhl508 {
-		yyb508 = yyj508 > l
+	yyj503++
+	if yyhl503 {
+		yyb503 = yyj503 > l
 	} else {
-		yyb508 = r.CheckBreak()
+		yyb503 = r.CheckBreak()
 	}
-	if yyb508 {
+	if yyb503 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv511 := &x.ListMeta
-		yym512 := z.DecBinary()
-		_ = yym512
+		yyv506 := &x.ListMeta
+		yym507 := z.DecBinary()
+		_ = yym507
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv511) {
+		} else if z.HasExtensions() && z.DecExt(yyv506) {
 		} else {
-			z.DecFallback(yyv511, false)
+			z.DecFallback(yyv506, false)
 		}
 	}
-	yyj508++
-	if yyhl508 {
-		yyb508 = yyj508 > l
+	yyj503++
+	if yyhl503 {
+		yyb503 = yyj503 > l
 	} else {
-		yyb508 = r.CheckBreak()
+		yyb503 = r.CheckBreak()
 	}
-	if yyb508 {
+	if yyb503 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv513 := &x.Items
-		yym514 := z.DecBinary()
-		_ = yym514
+		yyv508 := &x.Items
+		yym509 := z.DecBinary()
+		_ = yym509
 		if false {
 		} else {
-			h.decSliceDeployment((*[]Deployment)(yyv513), d)
+			h.decSliceDeployment((*[]Deployment)(yyv508), d)
 		}
 	}
 	for {
-		yyj508++
-		if yyhl508 {
-			yyb508 = yyj508 > l
+		yyj503++
+		if yyhl503 {
+			yyb503 = yyj503 > l
 		} else {
-			yyb508 = r.CheckBreak()
+			yyb503 = r.CheckBreak()
 		}
-		if yyb508 {
+		if yyb503 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj508-1, "")
+		z.DecStructFieldNotFound(yyj503-1, "")
 	}
 	r.ReadEnd()
 }
@@ -5718,36 +5674,36 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym515 := z.EncBinary()
-		_ = yym515
+		yym510 := z.EncBinary()
+		_ = yym510
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep516 := !z.EncBinary()
-			yy2arr516 := z.EncBasicHandle().StructToArray
-			var yyq516 [2]bool
-			_, _, _ = yysep516, yyq516, yy2arr516
-			const yyr516 bool = false
-			yyq516[0] = len(x.Selector) != 0
-			yyq516[1] = x.Template != nil
-			if yyr516 || yy2arr516 {
+			yysep511 := !z.EncBinary()
+			yy2arr511 := z.EncBasicHandle().StructToArray
+			var yyq511 [2]bool
+			_, _, _ = yysep511, yyq511, yy2arr511
+			const yyr511 bool = false
+			yyq511[0] = len(x.Selector) != 0
+			yyq511[1] = x.Template != nil
+			if yyr511 || yy2arr511 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn516 int = 0
-				for _, b := range yyq516 {
+				var yynn511 int = 0
+				for _, b := range yyq511 {
 					if b {
-						yynn516++
+						yynn511++
 					}
 				}
-				r.EncodeMapStart(yynn516)
+				r.EncodeMapStart(yynn511)
 			}
-			if yyr516 || yy2arr516 {
-				if yyq516[0] {
+			if yyr511 || yy2arr511 {
+				if yyq511[0] {
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
-						yym518 := z.EncBinary()
-						_ = yym518
+						yym513 := z.EncBinary()
+						_ = yym513
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.Selector, false, e)
@@ -5757,13 +5713,13 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq516[0] {
+				if yyq511[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
-						yym519 := z.EncBinary()
-						_ = yym519
+						yym514 := z.EncBinary()
+						_ = yym514
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.Selector, false, e)
@@ -5771,8 +5727,8 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr516 || yy2arr516 {
-				if yyq516[1] {
+			if yyr511 || yy2arr511 {
+				if yyq511[1] {
 					if x.Template == nil {
 						r.EncodeNil()
 					} else {
@@ -5782,7 +5738,7 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq516[1] {
+				if yyq511[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("template"))
 					if x.Template == nil {
 						r.EncodeNil()
@@ -5791,7 +5747,7 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep516 {
+			if yysep511 {
 				r.EncodeEnd()
 			}
 		}
@@ -5802,24 +5758,24 @@ func (x *DaemonSetSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym521 := z.DecBinary()
-	_ = yym521
+	yym516 := z.DecBinary()
+	_ = yym516
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl522 := r.ReadMapStart()
-			if yyl522 == 0 {
+			yyl517 := r.ReadMapStart()
+			if yyl517 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl522, d)
+				x.codecDecodeSelfFromMap(yyl517, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl522 := r.ReadArrayStart()
-			if yyl522 == 0 {
+			yyl517 := r.ReadArrayStart()
+			if yyl517 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl522, d)
+				x.codecDecodeSelfFromArray(yyl517, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -5831,12 +5787,12 @@ func (x *DaemonSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys523Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys523Slc
-	var yyhl523 bool = l >= 0
-	for yyj523 := 0; ; yyj523++ {
-		if yyhl523 {
-			if yyj523 >= l {
+	var yys518Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys518Slc
+	var yyhl518 bool = l >= 0
+	for yyj518 := 0; ; yyj518++ {
+		if yyhl518 {
+			if yyj518 >= l {
 				break
 			}
 		} else {
@@ -5844,19 +5800,19 @@ func (x *DaemonSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys523Slc = r.DecodeBytes(yys523Slc, true, true)
-		yys523 := string(yys523Slc)
-		switch yys523 {
+		yys518Slc = r.DecodeBytes(yys518Slc, true, true)
+		yys518 := string(yys518Slc)
+		switch yys518 {
 		case "selector":
 			if r.TryDecodeAsNil() {
 				x.Selector = nil
 			} else {
-				yyv524 := &x.Selector
-				yym525 := z.DecBinary()
-				_ = yym525
+				yyv519 := &x.Selector
+				yym520 := z.DecBinary()
+				_ = yym520
 				if false {
 				} else {
-					z.F.DecMapStringStringX(yyv524, false, d)
+					z.F.DecMapStringStringX(yyv519, false, d)
 				}
 			}
 		case "template":
@@ -5871,10 +5827,10 @@ func (x *DaemonSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Template.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys523)
-		} // end switch yys523
-	} // end for yyj523
-	if !yyhl523 {
+			z.DecStructFieldNotFound(-1, yys518)
+		} // end switch yys518
+	} // end for yyj518
+	if !yyhl518 {
 		r.ReadEnd()
 	}
 }
@@ -5883,37 +5839,37 @@ func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj527 int
-	var yyb527 bool
-	var yyhl527 bool = l >= 0
-	yyj527++
-	if yyhl527 {
-		yyb527 = yyj527 > l
+	var yyj522 int
+	var yyb522 bool
+	var yyhl522 bool = l >= 0
+	yyj522++
+	if yyhl522 {
+		yyb522 = yyj522 > l
 	} else {
-		yyb527 = r.CheckBreak()
+		yyb522 = r.CheckBreak()
 	}
-	if yyb527 {
+	if yyb522 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Selector = nil
 	} else {
-		yyv528 := &x.Selector
-		yym529 := z.DecBinary()
-		_ = yym529
+		yyv523 := &x.Selector
+		yym524 := z.DecBinary()
+		_ = yym524
 		if false {
 		} else {
-			z.F.DecMapStringStringX(yyv528, false, d)
+			z.F.DecMapStringStringX(yyv523, false, d)
 		}
 	}
-	yyj527++
-	if yyhl527 {
-		yyb527 = yyj527 > l
+	yyj522++
+	if yyhl522 {
+		yyb522 = yyj522 > l
 	} else {
-		yyb527 = r.CheckBreak()
+		yyb522 = r.CheckBreak()
 	}
-	if yyb527 {
+	if yyb522 {
 		r.ReadEnd()
 		return
 	}
@@ -5928,16 +5884,16 @@ func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Template.CodecDecodeSelf(d)
 	}
 	for {
-		yyj527++
-		if yyhl527 {
-			yyb527 = yyj527 > l
+		yyj522++
+		if yyhl522 {
+			yyb522 = yyj522 > l
 		} else {
-			yyb527 = r.CheckBreak()
+			yyb522 = r.CheckBreak()
 		}
-		if yyb527 {
+		if yyb522 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj527-1, "")
+		z.DecStructFieldNotFound(yyj522-1, "")
 	}
 	r.ReadEnd()
 }
@@ -5949,76 +5905,76 @@ func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym531 := z.EncBinary()
-		_ = yym531
+		yym526 := z.EncBinary()
+		_ = yym526
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep532 := !z.EncBinary()
-			yy2arr532 := z.EncBasicHandle().StructToArray
-			var yyq532 [3]bool
-			_, _, _ = yysep532, yyq532, yy2arr532
-			const yyr532 bool = false
-			if yyr532 || yy2arr532 {
+			yysep527 := !z.EncBinary()
+			yy2arr527 := z.EncBasicHandle().StructToArray
+			var yyq527 [3]bool
+			_, _, _ = yysep527, yyq527, yy2arr527
+			const yyr527 bool = false
+			if yyr527 || yy2arr527 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn532 int = 3
-				for _, b := range yyq532 {
+				var yynn527 int = 3
+				for _, b := range yyq527 {
 					if b {
-						yynn532++
+						yynn527++
 					}
 				}
-				r.EncodeMapStart(yynn532)
+				r.EncodeMapStart(yynn527)
 			}
-			if yyr532 || yy2arr532 {
-				yym534 := z.EncBinary()
-				_ = yym534
+			if yyr527 || yy2arr527 {
+				yym529 := z.EncBinary()
+				_ = yym529
 				if false {
 				} else {
 					r.EncodeInt(int64(x.CurrentNumberScheduled))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("currentNumberScheduled"))
-				yym535 := z.EncBinary()
-				_ = yym535
+				yym530 := z.EncBinary()
+				_ = yym530
 				if false {
 				} else {
 					r.EncodeInt(int64(x.CurrentNumberScheduled))
 				}
 			}
-			if yyr532 || yy2arr532 {
-				yym537 := z.EncBinary()
-				_ = yym537
+			if yyr527 || yy2arr527 {
+				yym532 := z.EncBinary()
+				_ = yym532
 				if false {
 				} else {
 					r.EncodeInt(int64(x.NumberMisscheduled))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("numberMisscheduled"))
-				yym538 := z.EncBinary()
-				_ = yym538
+				yym533 := z.EncBinary()
+				_ = yym533
 				if false {
 				} else {
 					r.EncodeInt(int64(x.NumberMisscheduled))
 				}
 			}
-			if yyr532 || yy2arr532 {
-				yym540 := z.EncBinary()
-				_ = yym540
+			if yyr527 || yy2arr527 {
+				yym535 := z.EncBinary()
+				_ = yym535
 				if false {
 				} else {
 					r.EncodeInt(int64(x.DesiredNumberScheduled))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("desiredNumberScheduled"))
-				yym541 := z.EncBinary()
-				_ = yym541
+				yym536 := z.EncBinary()
+				_ = yym536
 				if false {
 				} else {
 					r.EncodeInt(int64(x.DesiredNumberScheduled))
 				}
 			}
-			if yysep532 {
+			if yysep527 {
 				r.EncodeEnd()
 			}
 		}
@@ -6029,24 +5985,24 @@ func (x *DaemonSetStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym542 := z.DecBinary()
-	_ = yym542
+	yym537 := z.DecBinary()
+	_ = yym537
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl543 := r.ReadMapStart()
-			if yyl543 == 0 {
+			yyl538 := r.ReadMapStart()
+			if yyl538 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl543, d)
+				x.codecDecodeSelfFromMap(yyl538, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl543 := r.ReadArrayStart()
-			if yyl543 == 0 {
+			yyl538 := r.ReadArrayStart()
+			if yyl538 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl543, d)
+				x.codecDecodeSelfFromArray(yyl538, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -6058,12 +6014,12 @@ func (x *DaemonSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys544Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys544Slc
-	var yyhl544 bool = l >= 0
-	for yyj544 := 0; ; yyj544++ {
-		if yyhl544 {
-			if yyj544 >= l {
+	var yys539Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys539Slc
+	var yyhl539 bool = l >= 0
+	for yyj539 := 0; ; yyj539++ {
+		if yyhl539 {
+			if yyj539 >= l {
 				break
 			}
 		} else {
@@ -6071,9 +6027,9 @@ func (x *DaemonSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys544Slc = r.DecodeBytes(yys544Slc, true, true)
-		yys544 := string(yys544Slc)
-		switch yys544 {
+		yys539Slc = r.DecodeBytes(yys539Slc, true, true)
+		yys539 := string(yys539Slc)
+		switch yys539 {
 		case "currentNumberScheduled":
 			if r.TryDecodeAsNil() {
 				x.CurrentNumberScheduled = 0
@@ -6093,10 +6049,10 @@ func (x *DaemonSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.DesiredNumberScheduled = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys544)
-		} // end switch yys544
-	} // end for yyj544
-	if !yyhl544 {
+			z.DecStructFieldNotFound(-1, yys539)
+		} // end switch yys539
+	} // end for yyj539
+	if !yyhl539 {
 		r.ReadEnd()
 	}
 }
@@ -6105,16 +6061,16 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj548 int
-	var yyb548 bool
-	var yyhl548 bool = l >= 0
-	yyj548++
-	if yyhl548 {
-		yyb548 = yyj548 > l
+	var yyj543 int
+	var yyb543 bool
+	var yyhl543 bool = l >= 0
+	yyj543++
+	if yyhl543 {
+		yyb543 = yyj543 > l
 	} else {
-		yyb548 = r.CheckBreak()
+		yyb543 = r.CheckBreak()
 	}
-	if yyb548 {
+	if yyb543 {
 		r.ReadEnd()
 		return
 	}
@@ -6123,13 +6079,13 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.CurrentNumberScheduled = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj548++
-	if yyhl548 {
-		yyb548 = yyj548 > l
+	yyj543++
+	if yyhl543 {
+		yyb543 = yyj543 > l
 	} else {
-		yyb548 = r.CheckBreak()
+		yyb543 = r.CheckBreak()
 	}
-	if yyb548 {
+	if yyb543 {
 		r.ReadEnd()
 		return
 	}
@@ -6138,13 +6094,13 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.NumberMisscheduled = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj548++
-	if yyhl548 {
-		yyb548 = yyj548 > l
+	yyj543++
+	if yyhl543 {
+		yyb543 = yyj543 > l
 	} else {
-		yyb548 = r.CheckBreak()
+		yyb543 = r.CheckBreak()
 	}
-	if yyb548 {
+	if yyb543 {
 		r.ReadEnd()
 		return
 	}
@@ -6154,16 +6110,16 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.DesiredNumberScheduled = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj548++
-		if yyhl548 {
-			yyb548 = yyj548 > l
+		yyj543++
+		if yyhl543 {
+			yyb543 = yyj543 > l
 		} else {
-			yyb548 = r.CheckBreak()
+			yyb543 = r.CheckBreak()
 		}
-		if yyb548 {
+		if yyb543 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj548-1, "")
+		z.DecStructFieldNotFound(yyj543-1, "")
 	}
 	r.ReadEnd()
 }
@@ -6175,36 +6131,36 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym552 := z.EncBinary()
-		_ = yym552
+		yym547 := z.EncBinary()
+		_ = yym547
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep553 := !z.EncBinary()
-			yy2arr553 := z.EncBasicHandle().StructToArray
-			var yyq553 [5]bool
-			_, _, _ = yysep553, yyq553, yy2arr553
-			const yyr553 bool = false
-			yyq553[0] = x.Kind != ""
-			yyq553[1] = x.APIVersion != ""
-			yyq553[2] = true
-			yyq553[3] = true
-			yyq553[4] = true
-			if yyr553 || yy2arr553 {
+			yysep548 := !z.EncBinary()
+			yy2arr548 := z.EncBasicHandle().StructToArray
+			var yyq548 [5]bool
+			_, _, _ = yysep548, yyq548, yy2arr548
+			const yyr548 bool = false
+			yyq548[0] = x.Kind != ""
+			yyq548[1] = x.APIVersion != ""
+			yyq548[2] = true
+			yyq548[3] = true
+			yyq548[4] = true
+			if yyr548 || yy2arr548 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn553 int = 0
-				for _, b := range yyq553 {
+				var yynn548 int = 0
+				for _, b := range yyq548 {
 					if b {
-						yynn553++
+						yynn548++
 					}
 				}
-				r.EncodeMapStart(yynn553)
+				r.EncodeMapStart(yynn548)
 			}
-			if yyr553 || yy2arr553 {
-				if yyq553[0] {
-					yym555 := z.EncBinary()
-					_ = yym555
+			if yyr548 || yy2arr548 {
+				if yyq548[0] {
+					yym550 := z.EncBinary()
+					_ = yym550
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -6213,20 +6169,20 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq553[0] {
+				if yyq548[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym556 := z.EncBinary()
-					_ = yym556
+					yym551 := z.EncBinary()
+					_ = yym551
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr553 || yy2arr553 {
-				if yyq553[1] {
-					yym558 := z.EncBinary()
-					_ = yym558
+			if yyr548 || yy2arr548 {
+				if yyq548[1] {
+					yym553 := z.EncBinary()
+					_ = yym553
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -6235,59 +6191,59 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq553[1] {
+				if yyq548[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym559 := z.EncBinary()
-					_ = yym559
+					yym554 := z.EncBinary()
+					_ = yym554
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr553 || yy2arr553 {
-				if yyq553[2] {
-					yy561 := &x.ObjectMeta
-					yy561.CodecEncodeSelf(e)
+			if yyr548 || yy2arr548 {
+				if yyq548[2] {
+					yy556 := &x.ObjectMeta
+					yy556.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq553[2] {
+				if yyq548[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy562 := &x.ObjectMeta
-					yy562.CodecEncodeSelf(e)
+					yy557 := &x.ObjectMeta
+					yy557.CodecEncodeSelf(e)
 				}
 			}
-			if yyr553 || yy2arr553 {
-				if yyq553[3] {
-					yy564 := &x.Spec
-					yy564.CodecEncodeSelf(e)
+			if yyr548 || yy2arr548 {
+				if yyq548[3] {
+					yy559 := &x.Spec
+					yy559.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq553[3] {
+				if yyq548[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy565 := &x.Spec
-					yy565.CodecEncodeSelf(e)
+					yy560 := &x.Spec
+					yy560.CodecEncodeSelf(e)
 				}
 			}
-			if yyr553 || yy2arr553 {
-				if yyq553[4] {
-					yy567 := &x.Status
-					yy567.CodecEncodeSelf(e)
+			if yyr548 || yy2arr548 {
+				if yyq548[4] {
+					yy562 := &x.Status
+					yy562.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq553[4] {
+				if yyq548[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy568 := &x.Status
-					yy568.CodecEncodeSelf(e)
+					yy563 := &x.Status
+					yy563.CodecEncodeSelf(e)
 				}
 			}
-			if yysep553 {
+			if yysep548 {
 				r.EncodeEnd()
 			}
 		}
@@ -6298,24 +6254,24 @@ func (x *DaemonSet) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym569 := z.DecBinary()
-	_ = yym569
+	yym564 := z.DecBinary()
+	_ = yym564
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl570 := r.ReadMapStart()
-			if yyl570 == 0 {
+			yyl565 := r.ReadMapStart()
+			if yyl565 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl570, d)
+				x.codecDecodeSelfFromMap(yyl565, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl570 := r.ReadArrayStart()
-			if yyl570 == 0 {
+			yyl565 := r.ReadArrayStart()
+			if yyl565 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl570, d)
+				x.codecDecodeSelfFromArray(yyl565, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -6327,12 +6283,12 @@ func (x *DaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys571Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys571Slc
-	var yyhl571 bool = l >= 0
-	for yyj571 := 0; ; yyj571++ {
-		if yyhl571 {
-			if yyj571 >= l {
+	var yys566Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys566Slc
+	var yyhl566 bool = l >= 0
+	for yyj566 := 0; ; yyj566++ {
+		if yyhl566 {
+			if yyj566 >= l {
 				break
 			}
 		} else {
@@ -6340,9 +6296,9 @@ func (x *DaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys571Slc = r.DecodeBytes(yys571Slc, true, true)
-		yys571 := string(yys571Slc)
-		switch yys571 {
+		yys566Slc = r.DecodeBytes(yys566Slc, true, true)
+		yys566 := string(yys566Slc)
+		switch yys566 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -6359,28 +6315,28 @@ func (x *DaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv574 := &x.ObjectMeta
-				yyv574.CodecDecodeSelf(d)
+				yyv569 := &x.ObjectMeta
+				yyv569.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = DaemonSetSpec{}
 			} else {
-				yyv575 := &x.Spec
-				yyv575.CodecDecodeSelf(d)
+				yyv570 := &x.Spec
+				yyv570.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = DaemonSetStatus{}
 			} else {
-				yyv576 := &x.Status
-				yyv576.CodecDecodeSelf(d)
+				yyv571 := &x.Status
+				yyv571.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys571)
-		} // end switch yys571
-	} // end for yyj571
-	if !yyhl571 {
+			z.DecStructFieldNotFound(-1, yys566)
+		} // end switch yys566
+	} // end for yyj566
+	if !yyhl566 {
 		r.ReadEnd()
 	}
 }
@@ -6389,16 +6345,16 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj577 int
-	var yyb577 bool
-	var yyhl577 bool = l >= 0
-	yyj577++
-	if yyhl577 {
-		yyb577 = yyj577 > l
+	var yyj572 int
+	var yyb572 bool
+	var yyhl572 bool = l >= 0
+	yyj572++
+	if yyhl572 {
+		yyb572 = yyj572 > l
 	} else {
-		yyb577 = r.CheckBreak()
+		yyb572 = r.CheckBreak()
 	}
-	if yyb577 {
+	if yyb572 {
 		r.ReadEnd()
 		return
 	}
@@ -6407,13 +6363,13 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj577++
-	if yyhl577 {
-		yyb577 = yyj577 > l
+	yyj572++
+	if yyhl572 {
+		yyb572 = yyj572 > l
 	} else {
-		yyb577 = r.CheckBreak()
+		yyb572 = r.CheckBreak()
 	}
-	if yyb577 {
+	if yyb572 {
 		r.ReadEnd()
 		return
 	}
@@ -6422,65 +6378,65 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj577++
-	if yyhl577 {
-		yyb577 = yyj577 > l
+	yyj572++
+	if yyhl572 {
+		yyb572 = yyj572 > l
 	} else {
-		yyb577 = r.CheckBreak()
+		yyb572 = r.CheckBreak()
 	}
-	if yyb577 {
+	if yyb572 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv580 := &x.ObjectMeta
-		yyv580.CodecDecodeSelf(d)
+		yyv575 := &x.ObjectMeta
+		yyv575.CodecDecodeSelf(d)
 	}
-	yyj577++
-	if yyhl577 {
-		yyb577 = yyj577 > l
+	yyj572++
+	if yyhl572 {
+		yyb572 = yyj572 > l
 	} else {
-		yyb577 = r.CheckBreak()
+		yyb572 = r.CheckBreak()
 	}
-	if yyb577 {
+	if yyb572 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = DaemonSetSpec{}
 	} else {
-		yyv581 := &x.Spec
-		yyv581.CodecDecodeSelf(d)
+		yyv576 := &x.Spec
+		yyv576.CodecDecodeSelf(d)
 	}
-	yyj577++
-	if yyhl577 {
-		yyb577 = yyj577 > l
+	yyj572++
+	if yyhl572 {
+		yyb572 = yyj572 > l
 	} else {
-		yyb577 = r.CheckBreak()
+		yyb572 = r.CheckBreak()
 	}
-	if yyb577 {
+	if yyb572 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = DaemonSetStatus{}
 	} else {
-		yyv582 := &x.Status
-		yyv582.CodecDecodeSelf(d)
+		yyv577 := &x.Status
+		yyv577.CodecDecodeSelf(d)
 	}
 	for {
-		yyj577++
-		if yyhl577 {
-			yyb577 = yyj577 > l
+		yyj572++
+		if yyhl572 {
+			yyb572 = yyj572 > l
 		} else {
-			yyb577 = r.CheckBreak()
+			yyb572 = r.CheckBreak()
 		}
-		if yyb577 {
+		if yyb572 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj577-1, "")
+		z.DecStructFieldNotFound(yyj572-1, "")
 	}
 	r.ReadEnd()
 }
@@ -6492,34 +6448,34 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym583 := z.EncBinary()
-		_ = yym583
+		yym578 := z.EncBinary()
+		_ = yym578
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep584 := !z.EncBinary()
-			yy2arr584 := z.EncBasicHandle().StructToArray
-			var yyq584 [4]bool
-			_, _, _ = yysep584, yyq584, yy2arr584
-			const yyr584 bool = false
-			yyq584[0] = x.Kind != ""
-			yyq584[1] = x.APIVersion != ""
-			yyq584[2] = true
-			if yyr584 || yy2arr584 {
+			yysep579 := !z.EncBinary()
+			yy2arr579 := z.EncBasicHandle().StructToArray
+			var yyq579 [4]bool
+			_, _, _ = yysep579, yyq579, yy2arr579
+			const yyr579 bool = false
+			yyq579[0] = x.Kind != ""
+			yyq579[1] = x.APIVersion != ""
+			yyq579[2] = true
+			if yyr579 || yy2arr579 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn584 int = 1
-				for _, b := range yyq584 {
+				var yynn579 int = 1
+				for _, b := range yyq579 {
 					if b {
-						yynn584++
+						yynn579++
 					}
 				}
-				r.EncodeMapStart(yynn584)
+				r.EncodeMapStart(yynn579)
 			}
-			if yyr584 || yy2arr584 {
-				if yyq584[0] {
-					yym586 := z.EncBinary()
-					_ = yym586
+			if yyr579 || yy2arr579 {
+				if yyq579[0] {
+					yym581 := z.EncBinary()
+					_ = yym581
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -6528,20 +6484,20 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq584[0] {
+				if yyq579[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym587 := z.EncBinary()
-					_ = yym587
+					yym582 := z.EncBinary()
+					_ = yym582
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr584 || yy2arr584 {
-				if yyq584[1] {
-					yym589 := z.EncBinary()
-					_ = yym589
+			if yyr579 || yy2arr579 {
+				if yyq579[1] {
+					yym584 := z.EncBinary()
+					_ = yym584
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -6550,48 +6506,48 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq584[1] {
+				if yyq579[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym585 := z.EncBinary()
+					_ = yym585
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr579 || yy2arr579 {
+				if yyq579[2] {
+					yy587 := &x.ListMeta
+					yym588 := z.EncBinary()
+					_ = yym588
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy587) {
+					} else {
+						z.EncFallback(yy587)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq579[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy589 := &x.ListMeta
 					yym590 := z.EncBinary()
 					_ = yym590
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy589) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						z.EncFallback(yy589)
 					}
 				}
 			}
-			if yyr584 || yy2arr584 {
-				if yyq584[2] {
-					yy592 := &x.ListMeta
-					yym593 := z.EncBinary()
-					_ = yym593
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy592) {
-					} else {
-						z.EncFallback(yy592)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq584[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy594 := &x.ListMeta
-					yym595 := z.EncBinary()
-					_ = yym595
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy594) {
-					} else {
-						z.EncFallback(yy594)
-					}
-				}
-			}
-			if yyr584 || yy2arr584 {
+			if yyr579 || yy2arr579 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym597 := z.EncBinary()
-					_ = yym597
+					yym592 := z.EncBinary()
+					_ = yym592
 					if false {
 					} else {
 						h.encSliceDaemonSet(([]DaemonSet)(x.Items), e)
@@ -6602,15 +6558,15 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym598 := z.EncBinary()
-					_ = yym598
+					yym593 := z.EncBinary()
+					_ = yym593
 					if false {
 					} else {
 						h.encSliceDaemonSet(([]DaemonSet)(x.Items), e)
 					}
 				}
 			}
-			if yysep584 {
+			if yysep579 {
 				r.EncodeEnd()
 			}
 		}
@@ -6621,24 +6577,24 @@ func (x *DaemonSetList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym599 := z.DecBinary()
-	_ = yym599
+	yym594 := z.DecBinary()
+	_ = yym594
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl600 := r.ReadMapStart()
-			if yyl600 == 0 {
+			yyl595 := r.ReadMapStart()
+			if yyl595 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl600, d)
+				x.codecDecodeSelfFromMap(yyl595, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl600 := r.ReadArrayStart()
-			if yyl600 == 0 {
+			yyl595 := r.ReadArrayStart()
+			if yyl595 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl600, d)
+				x.codecDecodeSelfFromArray(yyl595, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -6650,12 +6606,12 @@ func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys601Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys601Slc
-	var yyhl601 bool = l >= 0
-	for yyj601 := 0; ; yyj601++ {
-		if yyhl601 {
-			if yyj601 >= l {
+	var yys596Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys596Slc
+	var yyhl596 bool = l >= 0
+	for yyj596 := 0; ; yyj596++ {
+		if yyhl596 {
+			if yyj596 >= l {
 				break
 			}
 		} else {
@@ -6663,9 +6619,9 @@ func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys601Slc = r.DecodeBytes(yys601Slc, true, true)
-		yys601 := string(yys601Slc)
-		switch yys601 {
+		yys596Slc = r.DecodeBytes(yys596Slc, true, true)
+		yys596 := string(yys596Slc)
+		switch yys596 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -6682,32 +6638,32 @@ func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv604 := &x.ListMeta
-				yym605 := z.DecBinary()
-				_ = yym605
+				yyv599 := &x.ListMeta
+				yym600 := z.DecBinary()
+				_ = yym600
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv604) {
+				} else if z.HasExtensions() && z.DecExt(yyv599) {
 				} else {
-					z.DecFallback(yyv604, false)
+					z.DecFallback(yyv599, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv606 := &x.Items
-				yym607 := z.DecBinary()
-				_ = yym607
+				yyv601 := &x.Items
+				yym602 := z.DecBinary()
+				_ = yym602
 				if false {
 				} else {
-					h.decSliceDaemonSet((*[]DaemonSet)(yyv606), d)
+					h.decSliceDaemonSet((*[]DaemonSet)(yyv601), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys601)
-		} // end switch yys601
-	} // end for yyj601
-	if !yyhl601 {
+			z.DecStructFieldNotFound(-1, yys596)
+		} // end switch yys596
+	} // end for yyj596
+	if !yyhl596 {
 		r.ReadEnd()
 	}
 }
@@ -6716,16 +6672,16 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj608 int
-	var yyb608 bool
-	var yyhl608 bool = l >= 0
-	yyj608++
-	if yyhl608 {
-		yyb608 = yyj608 > l
+	var yyj603 int
+	var yyb603 bool
+	var yyhl603 bool = l >= 0
+	yyj603++
+	if yyhl603 {
+		yyb603 = yyj603 > l
 	} else {
-		yyb608 = r.CheckBreak()
+		yyb603 = r.CheckBreak()
 	}
-	if yyb608 {
+	if yyb603 {
 		r.ReadEnd()
 		return
 	}
@@ -6734,13 +6690,13 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj608++
-	if yyhl608 {
-		yyb608 = yyj608 > l
+	yyj603++
+	if yyhl603 {
+		yyb603 = yyj603 > l
 	} else {
-		yyb608 = r.CheckBreak()
+		yyb603 = r.CheckBreak()
 	}
-	if yyb608 {
+	if yyb603 {
 		r.ReadEnd()
 		return
 	}
@@ -6749,60 +6705,60 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj608++
-	if yyhl608 {
-		yyb608 = yyj608 > l
+	yyj603++
+	if yyhl603 {
+		yyb603 = yyj603 > l
 	} else {
-		yyb608 = r.CheckBreak()
+		yyb603 = r.CheckBreak()
 	}
-	if yyb608 {
+	if yyb603 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv611 := &x.ListMeta
-		yym612 := z.DecBinary()
-		_ = yym612
+		yyv606 := &x.ListMeta
+		yym607 := z.DecBinary()
+		_ = yym607
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv611) {
+		} else if z.HasExtensions() && z.DecExt(yyv606) {
 		} else {
-			z.DecFallback(yyv611, false)
+			z.DecFallback(yyv606, false)
 		}
 	}
-	yyj608++
-	if yyhl608 {
-		yyb608 = yyj608 > l
+	yyj603++
+	if yyhl603 {
+		yyb603 = yyj603 > l
 	} else {
-		yyb608 = r.CheckBreak()
+		yyb603 = r.CheckBreak()
 	}
-	if yyb608 {
+	if yyb603 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv613 := &x.Items
-		yym614 := z.DecBinary()
-		_ = yym614
+		yyv608 := &x.Items
+		yym609 := z.DecBinary()
+		_ = yym609
 		if false {
 		} else {
-			h.decSliceDaemonSet((*[]DaemonSet)(yyv613), d)
+			h.decSliceDaemonSet((*[]DaemonSet)(yyv608), d)
 		}
 	}
 	for {
-		yyj608++
-		if yyhl608 {
-			yyb608 = yyj608 > l
+		yyj603++
+		if yyhl603 {
+			yyb603 = yyj603 > l
 		} else {
-			yyb608 = r.CheckBreak()
+			yyb603 = r.CheckBreak()
 		}
-		if yyb608 {
+		if yyb603 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj608-1, "")
+		z.DecStructFieldNotFound(yyj603-1, "")
 	}
 	r.ReadEnd()
 }
@@ -6814,34 +6770,34 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym615 := z.EncBinary()
-		_ = yym615
+		yym610 := z.EncBinary()
+		_ = yym610
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep616 := !z.EncBinary()
-			yy2arr616 := z.EncBasicHandle().StructToArray
-			var yyq616 [4]bool
-			_, _, _ = yysep616, yyq616, yy2arr616
-			const yyr616 bool = false
-			yyq616[0] = x.Kind != ""
-			yyq616[1] = x.APIVersion != ""
-			yyq616[2] = true
-			if yyr616 || yy2arr616 {
+			yysep611 := !z.EncBinary()
+			yy2arr611 := z.EncBasicHandle().StructToArray
+			var yyq611 [4]bool
+			_, _, _ = yysep611, yyq611, yy2arr611
+			const yyr611 bool = false
+			yyq611[0] = x.Kind != ""
+			yyq611[1] = x.APIVersion != ""
+			yyq611[2] = true
+			if yyr611 || yy2arr611 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn616 int = 1
-				for _, b := range yyq616 {
+				var yynn611 int = 1
+				for _, b := range yyq611 {
 					if b {
-						yynn616++
+						yynn611++
 					}
 				}
-				r.EncodeMapStart(yynn616)
+				r.EncodeMapStart(yynn611)
 			}
-			if yyr616 || yy2arr616 {
-				if yyq616[0] {
-					yym618 := z.EncBinary()
-					_ = yym618
+			if yyr611 || yy2arr611 {
+				if yyq611[0] {
+					yym613 := z.EncBinary()
+					_ = yym613
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -6850,20 +6806,20 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq616[0] {
+				if yyq611[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym619 := z.EncBinary()
-					_ = yym619
+					yym614 := z.EncBinary()
+					_ = yym614
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr616 || yy2arr616 {
-				if yyq616[1] {
-					yym621 := z.EncBinary()
-					_ = yym621
+			if yyr611 || yy2arr611 {
+				if yyq611[1] {
+					yym616 := z.EncBinary()
+					_ = yym616
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -6872,48 +6828,48 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq616[1] {
+				if yyq611[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym617 := z.EncBinary()
+					_ = yym617
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr611 || yy2arr611 {
+				if yyq611[2] {
+					yy619 := &x.ListMeta
+					yym620 := z.EncBinary()
+					_ = yym620
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy619) {
+					} else {
+						z.EncFallback(yy619)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq611[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy621 := &x.ListMeta
 					yym622 := z.EncBinary()
 					_ = yym622
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy621) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						z.EncFallback(yy621)
 					}
 				}
 			}
-			if yyr616 || yy2arr616 {
-				if yyq616[2] {
-					yy624 := &x.ListMeta
-					yym625 := z.EncBinary()
-					_ = yym625
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy624) {
-					} else {
-						z.EncFallback(yy624)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq616[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy626 := &x.ListMeta
-					yym627 := z.EncBinary()
-					_ = yym627
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy626) {
-					} else {
-						z.EncFallback(yy626)
-					}
-				}
-			}
-			if yyr616 || yy2arr616 {
+			if yyr611 || yy2arr611 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym629 := z.EncBinary()
-					_ = yym629
+					yym624 := z.EncBinary()
+					_ = yym624
 					if false {
 					} else {
 						h.encSliceThirdPartyResourceData(([]ThirdPartyResourceData)(x.Items), e)
@@ -6924,15 +6880,15 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym630 := z.EncBinary()
-					_ = yym630
+					yym625 := z.EncBinary()
+					_ = yym625
 					if false {
 					} else {
 						h.encSliceThirdPartyResourceData(([]ThirdPartyResourceData)(x.Items), e)
 					}
 				}
 			}
-			if yysep616 {
+			if yysep611 {
 				r.EncodeEnd()
 			}
 		}
@@ -6943,24 +6899,24 @@ func (x *ThirdPartyResourceDataList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym631 := z.DecBinary()
-	_ = yym631
+	yym626 := z.DecBinary()
+	_ = yym626
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl632 := r.ReadMapStart()
-			if yyl632 == 0 {
+			yyl627 := r.ReadMapStart()
+			if yyl627 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl632, d)
+				x.codecDecodeSelfFromMap(yyl627, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl632 := r.ReadArrayStart()
-			if yyl632 == 0 {
+			yyl627 := r.ReadArrayStart()
+			if yyl627 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl632, d)
+				x.codecDecodeSelfFromArray(yyl627, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -6972,12 +6928,12 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys633Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys633Slc
-	var yyhl633 bool = l >= 0
-	for yyj633 := 0; ; yyj633++ {
-		if yyhl633 {
-			if yyj633 >= l {
+	var yys628Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys628Slc
+	var yyhl628 bool = l >= 0
+	for yyj628 := 0; ; yyj628++ {
+		if yyhl628 {
+			if yyj628 >= l {
 				break
 			}
 		} else {
@@ -6985,9 +6941,9 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.
 				break
 			}
 		}
-		yys633Slc = r.DecodeBytes(yys633Slc, true, true)
-		yys633 := string(yys633Slc)
-		switch yys633 {
+		yys628Slc = r.DecodeBytes(yys628Slc, true, true)
+		yys628 := string(yys628Slc)
+		switch yys628 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -7004,32 +6960,32 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv636 := &x.ListMeta
-				yym637 := z.DecBinary()
-				_ = yym637
+				yyv631 := &x.ListMeta
+				yym632 := z.DecBinary()
+				_ = yym632
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv636) {
+				} else if z.HasExtensions() && z.DecExt(yyv631) {
 				} else {
-					z.DecFallback(yyv636, false)
+					z.DecFallback(yyv631, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv638 := &x.Items
-				yym639 := z.DecBinary()
-				_ = yym639
+				yyv633 := &x.Items
+				yym634 := z.DecBinary()
+				_ = yym634
 				if false {
 				} else {
-					h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv638), d)
+					h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv633), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys633)
-		} // end switch yys633
-	} // end for yyj633
-	if !yyhl633 {
+			z.DecStructFieldNotFound(-1, yys628)
+		} // end switch yys628
+	} // end for yyj628
+	if !yyhl628 {
 		r.ReadEnd()
 	}
 }
@@ -7038,16 +6994,16 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj640 int
-	var yyb640 bool
-	var yyhl640 bool = l >= 0
-	yyj640++
-	if yyhl640 {
-		yyb640 = yyj640 > l
+	var yyj635 int
+	var yyb635 bool
+	var yyhl635 bool = l >= 0
+	yyj635++
+	if yyhl635 {
+		yyb635 = yyj635 > l
 	} else {
-		yyb640 = r.CheckBreak()
+		yyb635 = r.CheckBreak()
 	}
-	if yyb640 {
+	if yyb635 {
 		r.ReadEnd()
 		return
 	}
@@ -7056,13 +7012,13 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj640++
-	if yyhl640 {
-		yyb640 = yyj640 > l
+	yyj635++
+	if yyhl635 {
+		yyb635 = yyj635 > l
 	} else {
-		yyb640 = r.CheckBreak()
+		yyb635 = r.CheckBreak()
 	}
-	if yyb640 {
+	if yyb635 {
 		r.ReadEnd()
 		return
 	}
@@ -7071,60 +7027,60 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj640++
-	if yyhl640 {
-		yyb640 = yyj640 > l
+	yyj635++
+	if yyhl635 {
+		yyb635 = yyj635 > l
 	} else {
-		yyb640 = r.CheckBreak()
+		yyb635 = r.CheckBreak()
 	}
-	if yyb640 {
+	if yyb635 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv643 := &x.ListMeta
-		yym644 := z.DecBinary()
-		_ = yym644
+		yyv638 := &x.ListMeta
+		yym639 := z.DecBinary()
+		_ = yym639
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv643) {
+		} else if z.HasExtensions() && z.DecExt(yyv638) {
 		} else {
-			z.DecFallback(yyv643, false)
+			z.DecFallback(yyv638, false)
 		}
 	}
-	yyj640++
-	if yyhl640 {
-		yyb640 = yyj640 > l
+	yyj635++
+	if yyhl635 {
+		yyb635 = yyj635 > l
 	} else {
-		yyb640 = r.CheckBreak()
+		yyb635 = r.CheckBreak()
 	}
-	if yyb640 {
+	if yyb635 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv645 := &x.Items
-		yym646 := z.DecBinary()
-		_ = yym646
+		yyv640 := &x.Items
+		yym641 := z.DecBinary()
+		_ = yym641
 		if false {
 		} else {
-			h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv645), d)
+			h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv640), d)
 		}
 	}
 	for {
-		yyj640++
-		if yyhl640 {
-			yyb640 = yyj640 > l
+		yyj635++
+		if yyhl635 {
+			yyb635 = yyj635 > l
 		} else {
-			yyb640 = r.CheckBreak()
+			yyb635 = r.CheckBreak()
 		}
-		if yyb640 {
+		if yyb635 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj640-1, "")
+		z.DecStructFieldNotFound(yyj635-1, "")
 	}
 	r.ReadEnd()
 }
@@ -7136,36 +7092,36 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym647 := z.EncBinary()
-		_ = yym647
+		yym642 := z.EncBinary()
+		_ = yym642
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep648 := !z.EncBinary()
-			yy2arr648 := z.EncBasicHandle().StructToArray
-			var yyq648 [5]bool
-			_, _, _ = yysep648, yyq648, yy2arr648
-			const yyr648 bool = false
-			yyq648[0] = x.Kind != ""
-			yyq648[1] = x.APIVersion != ""
-			yyq648[2] = true
-			yyq648[3] = true
-			yyq648[4] = true
-			if yyr648 || yy2arr648 {
+			yysep643 := !z.EncBinary()
+			yy2arr643 := z.EncBasicHandle().StructToArray
+			var yyq643 [5]bool
+			_, _, _ = yysep643, yyq643, yy2arr643
+			const yyr643 bool = false
+			yyq643[0] = x.Kind != ""
+			yyq643[1] = x.APIVersion != ""
+			yyq643[2] = true
+			yyq643[3] = true
+			yyq643[4] = true
+			if yyr643 || yy2arr643 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn648 int = 0
-				for _, b := range yyq648 {
+				var yynn643 int = 0
+				for _, b := range yyq643 {
 					if b {
-						yynn648++
+						yynn643++
 					}
 				}
-				r.EncodeMapStart(yynn648)
+				r.EncodeMapStart(yynn643)
 			}
-			if yyr648 || yy2arr648 {
-				if yyq648[0] {
-					yym650 := z.EncBinary()
-					_ = yym650
+			if yyr643 || yy2arr643 {
+				if yyq643[0] {
+					yym645 := z.EncBinary()
+					_ = yym645
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -7174,20 +7130,20 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq648[0] {
+				if yyq643[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym651 := z.EncBinary()
-					_ = yym651
+					yym646 := z.EncBinary()
+					_ = yym646
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr648 || yy2arr648 {
-				if yyq648[1] {
-					yym653 := z.EncBinary()
-					_ = yym653
+			if yyr643 || yy2arr643 {
+				if yyq643[1] {
+					yym648 := z.EncBinary()
+					_ = yym648
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -7196,59 +7152,59 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq648[1] {
+				if yyq643[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym654 := z.EncBinary()
-					_ = yym654
+					yym649 := z.EncBinary()
+					_ = yym649
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr648 || yy2arr648 {
-				if yyq648[2] {
-					yy656 := &x.ObjectMeta
-					yy656.CodecEncodeSelf(e)
+			if yyr643 || yy2arr643 {
+				if yyq643[2] {
+					yy651 := &x.ObjectMeta
+					yy651.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq648[2] {
+				if yyq643[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy657 := &x.ObjectMeta
-					yy657.CodecEncodeSelf(e)
+					yy652 := &x.ObjectMeta
+					yy652.CodecEncodeSelf(e)
 				}
 			}
-			if yyr648 || yy2arr648 {
-				if yyq648[3] {
-					yy659 := &x.Spec
-					yy659.CodecEncodeSelf(e)
+			if yyr643 || yy2arr643 {
+				if yyq643[3] {
+					yy654 := &x.Spec
+					yy654.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq648[3] {
+				if yyq643[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy660 := &x.Spec
-					yy660.CodecEncodeSelf(e)
+					yy655 := &x.Spec
+					yy655.CodecEncodeSelf(e)
 				}
 			}
-			if yyr648 || yy2arr648 {
-				if yyq648[4] {
-					yy662 := &x.Status
-					yy662.CodecEncodeSelf(e)
+			if yyr643 || yy2arr643 {
+				if yyq643[4] {
+					yy657 := &x.Status
+					yy657.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq648[4] {
+				if yyq643[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy663 := &x.Status
-					yy663.CodecEncodeSelf(e)
+					yy658 := &x.Status
+					yy658.CodecEncodeSelf(e)
 				}
 			}
-			if yysep648 {
+			if yysep643 {
 				r.EncodeEnd()
 			}
 		}
@@ -7259,24 +7215,24 @@ func (x *Job) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym664 := z.DecBinary()
-	_ = yym664
+	yym659 := z.DecBinary()
+	_ = yym659
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl665 := r.ReadMapStart()
-			if yyl665 == 0 {
+			yyl660 := r.ReadMapStart()
+			if yyl660 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl665, d)
+				x.codecDecodeSelfFromMap(yyl660, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl665 := r.ReadArrayStart()
-			if yyl665 == 0 {
+			yyl660 := r.ReadArrayStart()
+			if yyl660 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl665, d)
+				x.codecDecodeSelfFromArray(yyl660, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -7288,12 +7244,12 @@ func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys666Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys666Slc
-	var yyhl666 bool = l >= 0
-	for yyj666 := 0; ; yyj666++ {
-		if yyhl666 {
-			if yyj666 >= l {
+	var yys661Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys661Slc
+	var yyhl661 bool = l >= 0
+	for yyj661 := 0; ; yyj661++ {
+		if yyhl661 {
+			if yyj661 >= l {
 				break
 			}
 		} else {
@@ -7301,9 +7257,9 @@ func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys666Slc = r.DecodeBytes(yys666Slc, true, true)
-		yys666 := string(yys666Slc)
-		switch yys666 {
+		yys661Slc = r.DecodeBytes(yys661Slc, true, true)
+		yys661 := string(yys661Slc)
+		switch yys661 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -7320,28 +7276,28 @@ func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv669 := &x.ObjectMeta
-				yyv669.CodecDecodeSelf(d)
+				yyv664 := &x.ObjectMeta
+				yyv664.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = JobSpec{}
 			} else {
-				yyv670 := &x.Spec
-				yyv670.CodecDecodeSelf(d)
+				yyv665 := &x.Spec
+				yyv665.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = JobStatus{}
 			} else {
-				yyv671 := &x.Status
-				yyv671.CodecDecodeSelf(d)
+				yyv666 := &x.Status
+				yyv666.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys666)
-		} // end switch yys666
-	} // end for yyj666
-	if !yyhl666 {
+			z.DecStructFieldNotFound(-1, yys661)
+		} // end switch yys661
+	} // end for yyj661
+	if !yyhl661 {
 		r.ReadEnd()
 	}
 }
@@ -7350,16 +7306,16 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj672 int
-	var yyb672 bool
-	var yyhl672 bool = l >= 0
-	yyj672++
-	if yyhl672 {
-		yyb672 = yyj672 > l
+	var yyj667 int
+	var yyb667 bool
+	var yyhl667 bool = l >= 0
+	yyj667++
+	if yyhl667 {
+		yyb667 = yyj667 > l
 	} else {
-		yyb672 = r.CheckBreak()
+		yyb667 = r.CheckBreak()
 	}
-	if yyb672 {
+	if yyb667 {
 		r.ReadEnd()
 		return
 	}
@@ -7368,13 +7324,13 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj672++
-	if yyhl672 {
-		yyb672 = yyj672 > l
+	yyj667++
+	if yyhl667 {
+		yyb667 = yyj667 > l
 	} else {
-		yyb672 = r.CheckBreak()
+		yyb667 = r.CheckBreak()
 	}
-	if yyb672 {
+	if yyb667 {
 		r.ReadEnd()
 		return
 	}
@@ -7383,65 +7339,65 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj672++
-	if yyhl672 {
-		yyb672 = yyj672 > l
+	yyj667++
+	if yyhl667 {
+		yyb667 = yyj667 > l
 	} else {
-		yyb672 = r.CheckBreak()
+		yyb667 = r.CheckBreak()
 	}
-	if yyb672 {
+	if yyb667 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv675 := &x.ObjectMeta
-		yyv675.CodecDecodeSelf(d)
+		yyv670 := &x.ObjectMeta
+		yyv670.CodecDecodeSelf(d)
 	}
-	yyj672++
-	if yyhl672 {
-		yyb672 = yyj672 > l
+	yyj667++
+	if yyhl667 {
+		yyb667 = yyj667 > l
 	} else {
-		yyb672 = r.CheckBreak()
+		yyb667 = r.CheckBreak()
 	}
-	if yyb672 {
+	if yyb667 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = JobSpec{}
 	} else {
-		yyv676 := &x.Spec
-		yyv676.CodecDecodeSelf(d)
+		yyv671 := &x.Spec
+		yyv671.CodecDecodeSelf(d)
 	}
-	yyj672++
-	if yyhl672 {
-		yyb672 = yyj672 > l
+	yyj667++
+	if yyhl667 {
+		yyb667 = yyj667 > l
 	} else {
-		yyb672 = r.CheckBreak()
+		yyb667 = r.CheckBreak()
 	}
-	if yyb672 {
+	if yyb667 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = JobStatus{}
 	} else {
-		yyv677 := &x.Status
-		yyv677.CodecDecodeSelf(d)
+		yyv672 := &x.Status
+		yyv672.CodecDecodeSelf(d)
 	}
 	for {
-		yyj672++
-		if yyhl672 {
-			yyb672 = yyj672 > l
+		yyj667++
+		if yyhl667 {
+			yyb667 = yyj667 > l
 		} else {
-			yyb672 = r.CheckBreak()
+			yyb667 = r.CheckBreak()
 		}
-		if yyb672 {
+		if yyb667 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj672-1, "")
+		z.DecStructFieldNotFound(yyj667-1, "")
 	}
 	r.ReadEnd()
 }
@@ -7453,34 +7409,34 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym678 := z.EncBinary()
-		_ = yym678
+		yym673 := z.EncBinary()
+		_ = yym673
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep679 := !z.EncBinary()
-			yy2arr679 := z.EncBasicHandle().StructToArray
-			var yyq679 [4]bool
-			_, _, _ = yysep679, yyq679, yy2arr679
-			const yyr679 bool = false
-			yyq679[0] = x.Kind != ""
-			yyq679[1] = x.APIVersion != ""
-			yyq679[2] = true
-			if yyr679 || yy2arr679 {
+			yysep674 := !z.EncBinary()
+			yy2arr674 := z.EncBasicHandle().StructToArray
+			var yyq674 [4]bool
+			_, _, _ = yysep674, yyq674, yy2arr674
+			const yyr674 bool = false
+			yyq674[0] = x.Kind != ""
+			yyq674[1] = x.APIVersion != ""
+			yyq674[2] = true
+			if yyr674 || yy2arr674 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn679 int = 1
-				for _, b := range yyq679 {
+				var yynn674 int = 1
+				for _, b := range yyq674 {
 					if b {
-						yynn679++
+						yynn674++
 					}
 				}
-				r.EncodeMapStart(yynn679)
+				r.EncodeMapStart(yynn674)
 			}
-			if yyr679 || yy2arr679 {
-				if yyq679[0] {
-					yym681 := z.EncBinary()
-					_ = yym681
+			if yyr674 || yy2arr674 {
+				if yyq674[0] {
+					yym676 := z.EncBinary()
+					_ = yym676
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -7489,20 +7445,20 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq679[0] {
+				if yyq674[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym682 := z.EncBinary()
-					_ = yym682
+					yym677 := z.EncBinary()
+					_ = yym677
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr679 || yy2arr679 {
-				if yyq679[1] {
-					yym684 := z.EncBinary()
-					_ = yym684
+			if yyr674 || yy2arr674 {
+				if yyq674[1] {
+					yym679 := z.EncBinary()
+					_ = yym679
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -7511,48 +7467,48 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq679[1] {
+				if yyq674[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym680 := z.EncBinary()
+					_ = yym680
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr674 || yy2arr674 {
+				if yyq674[2] {
+					yy682 := &x.ListMeta
+					yym683 := z.EncBinary()
+					_ = yym683
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy682) {
+					} else {
+						z.EncFallback(yy682)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq674[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy684 := &x.ListMeta
 					yym685 := z.EncBinary()
 					_ = yym685
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy684) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						z.EncFallback(yy684)
 					}
 				}
 			}
-			if yyr679 || yy2arr679 {
-				if yyq679[2] {
-					yy687 := &x.ListMeta
-					yym688 := z.EncBinary()
-					_ = yym688
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy687) {
-					} else {
-						z.EncFallback(yy687)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq679[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy689 := &x.ListMeta
-					yym690 := z.EncBinary()
-					_ = yym690
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy689) {
-					} else {
-						z.EncFallback(yy689)
-					}
-				}
-			}
-			if yyr679 || yy2arr679 {
+			if yyr674 || yy2arr674 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym692 := z.EncBinary()
-					_ = yym692
+					yym687 := z.EncBinary()
+					_ = yym687
 					if false {
 					} else {
 						h.encSliceJob(([]Job)(x.Items), e)
@@ -7563,15 +7519,15 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym693 := z.EncBinary()
-					_ = yym693
+					yym688 := z.EncBinary()
+					_ = yym688
 					if false {
 					} else {
 						h.encSliceJob(([]Job)(x.Items), e)
 					}
 				}
 			}
-			if yysep679 {
+			if yysep674 {
 				r.EncodeEnd()
 			}
 		}
@@ -7582,24 +7538,24 @@ func (x *JobList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym694 := z.DecBinary()
-	_ = yym694
+	yym689 := z.DecBinary()
+	_ = yym689
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl695 := r.ReadMapStart()
-			if yyl695 == 0 {
+			yyl690 := r.ReadMapStart()
+			if yyl690 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl695, d)
+				x.codecDecodeSelfFromMap(yyl690, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl695 := r.ReadArrayStart()
-			if yyl695 == 0 {
+			yyl690 := r.ReadArrayStart()
+			if yyl690 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl695, d)
+				x.codecDecodeSelfFromArray(yyl690, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -7611,12 +7567,12 @@ func (x *JobList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys696Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys696Slc
-	var yyhl696 bool = l >= 0
-	for yyj696 := 0; ; yyj696++ {
-		if yyhl696 {
-			if yyj696 >= l {
+	var yys691Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys691Slc
+	var yyhl691 bool = l >= 0
+	for yyj691 := 0; ; yyj691++ {
+		if yyhl691 {
+			if yyj691 >= l {
 				break
 			}
 		} else {
@@ -7624,9 +7580,9 @@ func (x *JobList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys696Slc = r.DecodeBytes(yys696Slc, true, true)
-		yys696 := string(yys696Slc)
-		switch yys696 {
+		yys691Slc = r.DecodeBytes(yys691Slc, true, true)
+		yys691 := string(yys691Slc)
+		switch yys691 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -7643,32 +7599,32 @@ func (x *JobList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv699 := &x.ListMeta
-				yym700 := z.DecBinary()
-				_ = yym700
+				yyv694 := &x.ListMeta
+				yym695 := z.DecBinary()
+				_ = yym695
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv699) {
+				} else if z.HasExtensions() && z.DecExt(yyv694) {
 				} else {
-					z.DecFallback(yyv699, false)
+					z.DecFallback(yyv694, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv701 := &x.Items
-				yym702 := z.DecBinary()
-				_ = yym702
+				yyv696 := &x.Items
+				yym697 := z.DecBinary()
+				_ = yym697
 				if false {
 				} else {
-					h.decSliceJob((*[]Job)(yyv701), d)
+					h.decSliceJob((*[]Job)(yyv696), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys696)
-		} // end switch yys696
-	} // end for yyj696
-	if !yyhl696 {
+			z.DecStructFieldNotFound(-1, yys691)
+		} // end switch yys691
+	} // end for yyj691
+	if !yyhl691 {
 		r.ReadEnd()
 	}
 }
@@ -7677,16 +7633,16 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj703 int
-	var yyb703 bool
-	var yyhl703 bool = l >= 0
-	yyj703++
-	if yyhl703 {
-		yyb703 = yyj703 > l
+	var yyj698 int
+	var yyb698 bool
+	var yyhl698 bool = l >= 0
+	yyj698++
+	if yyhl698 {
+		yyb698 = yyj698 > l
 	} else {
-		yyb703 = r.CheckBreak()
+		yyb698 = r.CheckBreak()
 	}
-	if yyb703 {
+	if yyb698 {
 		r.ReadEnd()
 		return
 	}
@@ -7695,13 +7651,13 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj703++
-	if yyhl703 {
-		yyb703 = yyj703 > l
+	yyj698++
+	if yyhl698 {
+		yyb698 = yyj698 > l
 	} else {
-		yyb703 = r.CheckBreak()
+		yyb698 = r.CheckBreak()
 	}
-	if yyb703 {
+	if yyb698 {
 		r.ReadEnd()
 		return
 	}
@@ -7710,60 +7666,60 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj703++
-	if yyhl703 {
-		yyb703 = yyj703 > l
+	yyj698++
+	if yyhl698 {
+		yyb698 = yyj698 > l
 	} else {
-		yyb703 = r.CheckBreak()
+		yyb698 = r.CheckBreak()
 	}
-	if yyb703 {
+	if yyb698 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv706 := &x.ListMeta
-		yym707 := z.DecBinary()
-		_ = yym707
+		yyv701 := &x.ListMeta
+		yym702 := z.DecBinary()
+		_ = yym702
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv706) {
+		} else if z.HasExtensions() && z.DecExt(yyv701) {
 		} else {
-			z.DecFallback(yyv706, false)
+			z.DecFallback(yyv701, false)
 		}
 	}
-	yyj703++
-	if yyhl703 {
-		yyb703 = yyj703 > l
+	yyj698++
+	if yyhl698 {
+		yyb698 = yyj698 > l
 	} else {
-		yyb703 = r.CheckBreak()
+		yyb698 = r.CheckBreak()
 	}
-	if yyb703 {
+	if yyb698 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv708 := &x.Items
-		yym709 := z.DecBinary()
-		_ = yym709
+		yyv703 := &x.Items
+		yym704 := z.DecBinary()
+		_ = yym704
 		if false {
 		} else {
-			h.decSliceJob((*[]Job)(yyv708), d)
+			h.decSliceJob((*[]Job)(yyv703), d)
 		}
 	}
 	for {
-		yyj703++
-		if yyhl703 {
-			yyb703 = yyj703 > l
+		yyj698++
+		if yyhl698 {
+			yyb698 = yyj698 > l
 		} else {
-			yyb703 = r.CheckBreak()
+			yyb698 = r.CheckBreak()
 		}
-		if yyb703 {
+		if yyb698 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj703-1, "")
+		z.DecStructFieldNotFound(yyj698-1, "")
 	}
 	r.ReadEnd()
 }
@@ -7775,36 +7731,68 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym710 := z.EncBinary()
-		_ = yym710
+		yym705 := z.EncBinary()
+		_ = yym705
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep711 := !z.EncBinary()
-			yy2arr711 := z.EncBasicHandle().StructToArray
-			var yyq711 [4]bool
-			_, _, _ = yysep711, yyq711, yy2arr711
-			const yyr711 bool = false
-			yyq711[0] = x.Parallelism != nil
-			yyq711[1] = x.Completions != nil
-			yyq711[2] = x.Selector != nil
-			if yyr711 || yy2arr711 {
+			yysep706 := !z.EncBinary()
+			yy2arr706 := z.EncBasicHandle().StructToArray
+			var yyq706 [4]bool
+			_, _, _ = yysep706, yyq706, yy2arr706
+			const yyr706 bool = false
+			yyq706[0] = x.Parallelism != nil
+			yyq706[1] = x.Completions != nil
+			yyq706[2] = x.Selector != nil
+			if yyr706 || yy2arr706 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn711 int = 1
-				for _, b := range yyq711 {
+				var yynn706 int = 1
+				for _, b := range yyq706 {
 					if b {
-						yynn711++
+						yynn706++
 					}
 				}
-				r.EncodeMapStart(yynn711)
+				r.EncodeMapStart(yynn706)
 			}
-			if yyr711 || yy2arr711 {
-				if yyq711[0] {
+			if yyr706 || yy2arr706 {
+				if yyq706[0] {
 					if x.Parallelism == nil {
 						r.EncodeNil()
 					} else {
-						yy713 := *x.Parallelism
+						yy708 := *x.Parallelism
+						yym709 := z.EncBinary()
+						_ = yym709
+						if false {
+						} else {
+							r.EncodeInt(int64(yy708))
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq706[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("parallelism"))
+					if x.Parallelism == nil {
+						r.EncodeNil()
+					} else {
+						yy710 := *x.Parallelism
+						yym711 := z.EncBinary()
+						_ = yym711
+						if false {
+						} else {
+							r.EncodeInt(int64(yy710))
+						}
+					}
+				}
+			}
+			if yyr706 || yy2arr706 {
+				if yyq706[1] {
+					if x.Completions == nil {
+						r.EncodeNil()
+					} else {
+						yy713 := *x.Completions
 						yym714 := z.EncBinary()
 						_ = yym714
 						if false {
@@ -7816,12 +7804,12 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq711[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("parallelism"))
-					if x.Parallelism == nil {
+				if yyq706[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("completions"))
+					if x.Completions == nil {
 						r.EncodeNil()
 					} else {
-						yy715 := *x.Parallelism
+						yy715 := *x.Completions
 						yym716 := z.EncBinary()
 						_ = yym716
 						if false {
@@ -7831,40 +7819,8 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr711 || yy2arr711 {
-				if yyq711[1] {
-					if x.Completions == nil {
-						r.EncodeNil()
-					} else {
-						yy718 := *x.Completions
-						yym719 := z.EncBinary()
-						_ = yym719
-						if false {
-						} else {
-							r.EncodeInt(int64(yy718))
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq711[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("completions"))
-					if x.Completions == nil {
-						r.EncodeNil()
-					} else {
-						yy720 := *x.Completions
-						yym721 := z.EncBinary()
-						_ = yym721
-						if false {
-						} else {
-							r.EncodeInt(int64(yy720))
-						}
-					}
-				}
-			}
-			if yyr711 || yy2arr711 {
-				if yyq711[2] {
+			if yyr706 || yy2arr706 {
+				if yyq706[2] {
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
@@ -7874,7 +7830,7 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq711[2] {
+				if yyq706[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
 					if x.Selector == nil {
 						r.EncodeNil()
@@ -7883,15 +7839,15 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr711 || yy2arr711 {
-				yy724 := &x.Template
-				yy724.CodecEncodeSelf(e)
+			if yyr706 || yy2arr706 {
+				yy719 := &x.Template
+				yy719.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("template"))
-				yy725 := &x.Template
-				yy725.CodecEncodeSelf(e)
+				yy720 := &x.Template
+				yy720.CodecEncodeSelf(e)
 			}
-			if yysep711 {
+			if yysep706 {
 				r.EncodeEnd()
 			}
 		}
@@ -7902,24 +7858,24 @@ func (x *JobSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym726 := z.DecBinary()
-	_ = yym726
+	yym721 := z.DecBinary()
+	_ = yym721
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl727 := r.ReadMapStart()
-			if yyl727 == 0 {
+			yyl722 := r.ReadMapStart()
+			if yyl722 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl727, d)
+				x.codecDecodeSelfFromMap(yyl722, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl727 := r.ReadArrayStart()
-			if yyl727 == 0 {
+			yyl722 := r.ReadArrayStart()
+			if yyl722 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl727, d)
+				x.codecDecodeSelfFromArray(yyl722, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -7931,12 +7887,12 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys728Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys728Slc
-	var yyhl728 bool = l >= 0
-	for yyj728 := 0; ; yyj728++ {
-		if yyhl728 {
-			if yyj728 >= l {
+	var yys723Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys723Slc
+	var yyhl723 bool = l >= 0
+	for yyj723 := 0; ; yyj723++ {
+		if yyhl723 {
+			if yyj723 >= l {
 				break
 			}
 		} else {
@@ -7944,9 +7900,9 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys728Slc = r.DecodeBytes(yys728Slc, true, true)
-		yys728 := string(yys728Slc)
-		switch yys728 {
+		yys723Slc = r.DecodeBytes(yys723Slc, true, true)
+		yys723 := string(yys723Slc)
+		switch yys723 {
 		case "parallelism":
 			if r.TryDecodeAsNil() {
 				if x.Parallelism != nil {
@@ -7956,8 +7912,8 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.Parallelism == nil {
 					x.Parallelism = new(int)
 				}
-				yym730 := z.DecBinary()
-				_ = yym730
+				yym725 := z.DecBinary()
+				_ = yym725
 				if false {
 				} else {
 					*((*int)(x.Parallelism)) = int(r.DecodeInt(codecSelferBitsize1234))
@@ -7972,8 +7928,8 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.Completions == nil {
 					x.Completions = new(int)
 				}
-				yym732 := z.DecBinary()
-				_ = yym732
+				yym727 := z.DecBinary()
+				_ = yym727
 				if false {
 				} else {
 					*((*int)(x.Completions)) = int(r.DecodeInt(codecSelferBitsize1234))
@@ -7994,14 +7950,14 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Template = pkg2_api.PodTemplateSpec{}
 			} else {
-				yyv734 := &x.Template
-				yyv734.CodecDecodeSelf(d)
+				yyv729 := &x.Template
+				yyv729.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys728)
-		} // end switch yys728
-	} // end for yyj728
-	if !yyhl728 {
+			z.DecStructFieldNotFound(-1, yys723)
+		} // end switch yys723
+	} // end for yyj723
+	if !yyhl723 {
 		r.ReadEnd()
 	}
 }
@@ -8010,16 +7966,16 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj735 int
-	var yyb735 bool
-	var yyhl735 bool = l >= 0
-	yyj735++
-	if yyhl735 {
-		yyb735 = yyj735 > l
+	var yyj730 int
+	var yyb730 bool
+	var yyhl730 bool = l >= 0
+	yyj730++
+	if yyhl730 {
+		yyb730 = yyj730 > l
 	} else {
-		yyb735 = r.CheckBreak()
+		yyb730 = r.CheckBreak()
 	}
-	if yyb735 {
+	if yyb730 {
 		r.ReadEnd()
 		return
 	}
@@ -8031,20 +7987,20 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.Parallelism == nil {
 			x.Parallelism = new(int)
 		}
-		yym737 := z.DecBinary()
-		_ = yym737
+		yym732 := z.DecBinary()
+		_ = yym732
 		if false {
 		} else {
 			*((*int)(x.Parallelism)) = int(r.DecodeInt(codecSelferBitsize1234))
 		}
 	}
-	yyj735++
-	if yyhl735 {
-		yyb735 = yyj735 > l
+	yyj730++
+	if yyhl730 {
+		yyb730 = yyj730 > l
 	} else {
-		yyb735 = r.CheckBreak()
+		yyb730 = r.CheckBreak()
 	}
-	if yyb735 {
+	if yyb730 {
 		r.ReadEnd()
 		return
 	}
@@ -8056,20 +8012,20 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.Completions == nil {
 			x.Completions = new(int)
 		}
-		yym739 := z.DecBinary()
-		_ = yym739
+		yym734 := z.DecBinary()
+		_ = yym734
 		if false {
 		} else {
 			*((*int)(x.Completions)) = int(r.DecodeInt(codecSelferBitsize1234))
 		}
 	}
-	yyj735++
-	if yyhl735 {
-		yyb735 = yyj735 > l
+	yyj730++
+	if yyhl730 {
+		yyb730 = yyj730 > l
 	} else {
-		yyb735 = r.CheckBreak()
+		yyb730 = r.CheckBreak()
 	}
-	if yyb735 {
+	if yyb730 {
 		r.ReadEnd()
 		return
 	}
@@ -8083,33 +8039,33 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.Selector.CodecDecodeSelf(d)
 	}
-	yyj735++
-	if yyhl735 {
-		yyb735 = yyj735 > l
+	yyj730++
+	if yyhl730 {
+		yyb730 = yyj730 > l
 	} else {
-		yyb735 = r.CheckBreak()
+		yyb730 = r.CheckBreak()
 	}
-	if yyb735 {
+	if yyb730 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Template = pkg2_api.PodTemplateSpec{}
 	} else {
-		yyv741 := &x.Template
-		yyv741.CodecDecodeSelf(d)
+		yyv736 := &x.Template
+		yyv736.CodecDecodeSelf(d)
 	}
 	for {
-		yyj735++
-		if yyhl735 {
-			yyb735 = yyj735 > l
+		yyj730++
+		if yyhl730 {
+			yyb730 = yyj730 > l
 		} else {
-			yyb735 = r.CheckBreak()
+			yyb730 = r.CheckBreak()
 		}
-		if yyb735 {
+		if yyb730 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj735-1, "")
+		z.DecStructFieldNotFound(yyj730-1, "")
 	}
 	r.ReadEnd()
 }
@@ -8121,40 +8077,40 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym742 := z.EncBinary()
-		_ = yym742
+		yym737 := z.EncBinary()
+		_ = yym737
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep743 := !z.EncBinary()
-			yy2arr743 := z.EncBasicHandle().StructToArray
-			var yyq743 [6]bool
-			_, _, _ = yysep743, yyq743, yy2arr743
-			const yyr743 bool = false
-			yyq743[0] = len(x.Conditions) != 0
-			yyq743[1] = x.StartTime != nil
-			yyq743[2] = x.CompletionTime != nil
-			yyq743[3] = x.Active != 0
-			yyq743[4] = x.Succeeded != 0
-			yyq743[5] = x.Failed != 0
-			if yyr743 || yy2arr743 {
+			yysep738 := !z.EncBinary()
+			yy2arr738 := z.EncBasicHandle().StructToArray
+			var yyq738 [6]bool
+			_, _, _ = yysep738, yyq738, yy2arr738
+			const yyr738 bool = false
+			yyq738[0] = len(x.Conditions) != 0
+			yyq738[1] = x.StartTime != nil
+			yyq738[2] = x.CompletionTime != nil
+			yyq738[3] = x.Active != 0
+			yyq738[4] = x.Succeeded != 0
+			yyq738[5] = x.Failed != 0
+			if yyr738 || yy2arr738 {
 				r.EncodeArrayStart(6)
 			} else {
-				var yynn743 int = 0
-				for _, b := range yyq743 {
+				var yynn738 int = 0
+				for _, b := range yyq738 {
 					if b {
-						yynn743++
+						yynn738++
 					}
 				}
-				r.EncodeMapStart(yynn743)
+				r.EncodeMapStart(yynn738)
 			}
-			if yyr743 || yy2arr743 {
-				if yyq743[0] {
+			if yyr738 || yy2arr738 {
+				if yyq738[0] {
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
-						yym745 := z.EncBinary()
-						_ = yym745
+						yym740 := z.EncBinary()
+						_ = yym740
 						if false {
 						} else {
 							h.encSliceJobCondition(([]JobCondition)(x.Conditions), e)
@@ -8164,72 +8120,72 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq743[0] {
+				if yyq738[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("conditions"))
 					if x.Conditions == nil {
+						r.EncodeNil()
+					} else {
+						yym741 := z.EncBinary()
+						_ = yym741
+						if false {
+						} else {
+							h.encSliceJobCondition(([]JobCondition)(x.Conditions), e)
+						}
+					}
+				}
+			}
+			if yyr738 || yy2arr738 {
+				if yyq738[1] {
+					if x.StartTime == nil {
+						r.EncodeNil()
+					} else {
+						yym743 := z.EncBinary()
+						_ = yym743
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.StartTime) {
+						} else if yym743 {
+							z.EncBinaryMarshal(x.StartTime)
+						} else if !yym743 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.StartTime)
+						} else {
+							z.EncFallback(x.StartTime)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq738[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("startTime"))
+					if x.StartTime == nil {
+						r.EncodeNil()
+					} else {
+						yym744 := z.EncBinary()
+						_ = yym744
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.StartTime) {
+						} else if yym744 {
+							z.EncBinaryMarshal(x.StartTime)
+						} else if !yym744 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.StartTime)
+						} else {
+							z.EncFallback(x.StartTime)
+						}
+					}
+				}
+			}
+			if yyr738 || yy2arr738 {
+				if yyq738[2] {
+					if x.CompletionTime == nil {
 						r.EncodeNil()
 					} else {
 						yym746 := z.EncBinary()
 						_ = yym746
 						if false {
-						} else {
-							h.encSliceJobCondition(([]JobCondition)(x.Conditions), e)
-						}
-					}
-				}
-			}
-			if yyr743 || yy2arr743 {
-				if yyq743[1] {
-					if x.StartTime == nil {
-						r.EncodeNil()
-					} else {
-						yym748 := z.EncBinary()
-						_ = yym748
-						if false {
-						} else if z.HasExtensions() && z.EncExt(x.StartTime) {
-						} else if yym748 {
-							z.EncBinaryMarshal(x.StartTime)
-						} else if !yym748 && z.IsJSONHandle() {
-							z.EncJSONMarshal(x.StartTime)
-						} else {
-							z.EncFallback(x.StartTime)
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq743[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("startTime"))
-					if x.StartTime == nil {
-						r.EncodeNil()
-					} else {
-						yym749 := z.EncBinary()
-						_ = yym749
-						if false {
-						} else if z.HasExtensions() && z.EncExt(x.StartTime) {
-						} else if yym749 {
-							z.EncBinaryMarshal(x.StartTime)
-						} else if !yym749 && z.IsJSONHandle() {
-							z.EncJSONMarshal(x.StartTime)
-						} else {
-							z.EncFallback(x.StartTime)
-						}
-					}
-				}
-			}
-			if yyr743 || yy2arr743 {
-				if yyq743[2] {
-					if x.CompletionTime == nil {
-						r.EncodeNil()
-					} else {
-						yym751 := z.EncBinary()
-						_ = yym751
-						if false {
 						} else if z.HasExtensions() && z.EncExt(x.CompletionTime) {
-						} else if yym751 {
+						} else if yym746 {
 							z.EncBinaryMarshal(x.CompletionTime)
-						} else if !yym751 && z.IsJSONHandle() {
+						} else if !yym746 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.CompletionTime)
 						} else {
 							z.EncFallback(x.CompletionTime)
@@ -8239,18 +8195,18 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq743[2] {
+				if yyq738[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("completionTime"))
 					if x.CompletionTime == nil {
 						r.EncodeNil()
 					} else {
-						yym752 := z.EncBinary()
-						_ = yym752
+						yym747 := z.EncBinary()
+						_ = yym747
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.CompletionTime) {
-						} else if yym752 {
+						} else if yym747 {
 							z.EncBinaryMarshal(x.CompletionTime)
-						} else if !yym752 && z.IsJSONHandle() {
+						} else if !yym747 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.CompletionTime)
 						} else {
 							z.EncFallback(x.CompletionTime)
@@ -8258,10 +8214,10 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr743 || yy2arr743 {
-				if yyq743[3] {
-					yym754 := z.EncBinary()
-					_ = yym754
+			if yyr738 || yy2arr738 {
+				if yyq738[3] {
+					yym749 := z.EncBinary()
+					_ = yym749
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Active))
@@ -8270,61 +8226,61 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq743[3] {
+				if yyq738[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("active"))
+					yym750 := z.EncBinary()
+					_ = yym750
+					if false {
+					} else {
+						r.EncodeInt(int64(x.Active))
+					}
+				}
+			}
+			if yyr738 || yy2arr738 {
+				if yyq738[4] {
+					yym752 := z.EncBinary()
+					_ = yym752
+					if false {
+					} else {
+						r.EncodeInt(int64(x.Succeeded))
+					}
+				} else {
+					r.EncodeInt(0)
+				}
+			} else {
+				if yyq738[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("succeeded"))
+					yym753 := z.EncBinary()
+					_ = yym753
+					if false {
+					} else {
+						r.EncodeInt(int64(x.Succeeded))
+					}
+				}
+			}
+			if yyr738 || yy2arr738 {
+				if yyq738[5] {
 					yym755 := z.EncBinary()
 					_ = yym755
 					if false {
 					} else {
-						r.EncodeInt(int64(x.Active))
-					}
-				}
-			}
-			if yyr743 || yy2arr743 {
-				if yyq743[4] {
-					yym757 := z.EncBinary()
-					_ = yym757
-					if false {
-					} else {
-						r.EncodeInt(int64(x.Succeeded))
-					}
-				} else {
-					r.EncodeInt(0)
-				}
-			} else {
-				if yyq743[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("succeeded"))
-					yym758 := z.EncBinary()
-					_ = yym758
-					if false {
-					} else {
-						r.EncodeInt(int64(x.Succeeded))
-					}
-				}
-			}
-			if yyr743 || yy2arr743 {
-				if yyq743[5] {
-					yym760 := z.EncBinary()
-					_ = yym760
-					if false {
-					} else {
 						r.EncodeInt(int64(x.Failed))
 					}
 				} else {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq743[5] {
+				if yyq738[5] {
 					r.EncodeString(codecSelferC_UTF81234, string("failed"))
-					yym761 := z.EncBinary()
-					_ = yym761
+					yym756 := z.EncBinary()
+					_ = yym756
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Failed))
 					}
 				}
 			}
-			if yysep743 {
+			if yysep738 {
 				r.EncodeEnd()
 			}
 		}
@@ -8335,24 +8291,24 @@ func (x *JobStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym762 := z.DecBinary()
-	_ = yym762
+	yym757 := z.DecBinary()
+	_ = yym757
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl763 := r.ReadMapStart()
-			if yyl763 == 0 {
+			yyl758 := r.ReadMapStart()
+			if yyl758 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl763, d)
+				x.codecDecodeSelfFromMap(yyl758, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl763 := r.ReadArrayStart()
-			if yyl763 == 0 {
+			yyl758 := r.ReadArrayStart()
+			if yyl758 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl763, d)
+				x.codecDecodeSelfFromArray(yyl758, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -8364,12 +8320,12 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys764Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys764Slc
-	var yyhl764 bool = l >= 0
-	for yyj764 := 0; ; yyj764++ {
-		if yyhl764 {
-			if yyj764 >= l {
+	var yys759Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys759Slc
+	var yyhl759 bool = l >= 0
+	for yyj759 := 0; ; yyj759++ {
+		if yyhl759 {
+			if yyj759 >= l {
 				break
 			}
 		} else {
@@ -8377,19 +8333,19 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys764Slc = r.DecodeBytes(yys764Slc, true, true)
-		yys764 := string(yys764Slc)
-		switch yys764 {
+		yys759Slc = r.DecodeBytes(yys759Slc, true, true)
+		yys759 := string(yys759Slc)
+		switch yys759 {
 		case "conditions":
 			if r.TryDecodeAsNil() {
 				x.Conditions = nil
 			} else {
-				yyv765 := &x.Conditions
-				yym766 := z.DecBinary()
-				_ = yym766
+				yyv760 := &x.Conditions
+				yym761 := z.DecBinary()
+				_ = yym761
 				if false {
 				} else {
-					h.decSliceJobCondition((*[]JobCondition)(yyv765), d)
+					h.decSliceJobCondition((*[]JobCondition)(yyv760), d)
 				}
 			}
 		case "startTime":
@@ -8401,13 +8357,13 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.StartTime == nil {
 					x.StartTime = new(pkg1_unversioned.Time)
 				}
-				yym768 := z.DecBinary()
-				_ = yym768
+				yym763 := z.DecBinary()
+				_ = yym763
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.StartTime) {
-				} else if yym768 {
+				} else if yym763 {
 					z.DecBinaryUnmarshal(x.StartTime)
-				} else if !yym768 && z.IsJSONHandle() {
+				} else if !yym763 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.StartTime)
 				} else {
 					z.DecFallback(x.StartTime, false)
@@ -8422,13 +8378,13 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.CompletionTime == nil {
 					x.CompletionTime = new(pkg1_unversioned.Time)
 				}
-				yym770 := z.DecBinary()
-				_ = yym770
+				yym765 := z.DecBinary()
+				_ = yym765
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.CompletionTime) {
-				} else if yym770 {
+				} else if yym765 {
 					z.DecBinaryUnmarshal(x.CompletionTime)
-				} else if !yym770 && z.IsJSONHandle() {
+				} else if !yym765 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.CompletionTime)
 				} else {
 					z.DecFallback(x.CompletionTime, false)
@@ -8453,10 +8409,10 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Failed = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys764)
-		} // end switch yys764
-	} // end for yyj764
-	if !yyhl764 {
+			z.DecStructFieldNotFound(-1, yys759)
+		} // end switch yys759
+	} // end for yyj759
+	if !yyhl759 {
 		r.ReadEnd()
 	}
 }
@@ -8465,37 +8421,37 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj774 int
-	var yyb774 bool
-	var yyhl774 bool = l >= 0
-	yyj774++
-	if yyhl774 {
-		yyb774 = yyj774 > l
+	var yyj769 int
+	var yyb769 bool
+	var yyhl769 bool = l >= 0
+	yyj769++
+	if yyhl769 {
+		yyb769 = yyj769 > l
 	} else {
-		yyb774 = r.CheckBreak()
+		yyb769 = r.CheckBreak()
 	}
-	if yyb774 {
+	if yyb769 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Conditions = nil
 	} else {
-		yyv775 := &x.Conditions
-		yym776 := z.DecBinary()
-		_ = yym776
+		yyv770 := &x.Conditions
+		yym771 := z.DecBinary()
+		_ = yym771
 		if false {
 		} else {
-			h.decSliceJobCondition((*[]JobCondition)(yyv775), d)
+			h.decSliceJobCondition((*[]JobCondition)(yyv770), d)
 		}
 	}
-	yyj774++
-	if yyhl774 {
-		yyb774 = yyj774 > l
+	yyj769++
+	if yyhl769 {
+		yyb769 = yyj769 > l
 	} else {
-		yyb774 = r.CheckBreak()
+		yyb769 = r.CheckBreak()
 	}
-	if yyb774 {
+	if yyb769 {
 		r.ReadEnd()
 		return
 	}
@@ -8507,25 +8463,25 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.StartTime == nil {
 			x.StartTime = new(pkg1_unversioned.Time)
 		}
-		yym778 := z.DecBinary()
-		_ = yym778
+		yym773 := z.DecBinary()
+		_ = yym773
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.StartTime) {
-		} else if yym778 {
+		} else if yym773 {
 			z.DecBinaryUnmarshal(x.StartTime)
-		} else if !yym778 && z.IsJSONHandle() {
+		} else if !yym773 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.StartTime)
 		} else {
 			z.DecFallback(x.StartTime, false)
 		}
 	}
-	yyj774++
-	if yyhl774 {
-		yyb774 = yyj774 > l
+	yyj769++
+	if yyhl769 {
+		yyb769 = yyj769 > l
 	} else {
-		yyb774 = r.CheckBreak()
+		yyb769 = r.CheckBreak()
 	}
-	if yyb774 {
+	if yyb769 {
 		r.ReadEnd()
 		return
 	}
@@ -8537,25 +8493,25 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.CompletionTime == nil {
 			x.CompletionTime = new(pkg1_unversioned.Time)
 		}
-		yym780 := z.DecBinary()
-		_ = yym780
+		yym775 := z.DecBinary()
+		_ = yym775
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.CompletionTime) {
-		} else if yym780 {
+		} else if yym775 {
 			z.DecBinaryUnmarshal(x.CompletionTime)
-		} else if !yym780 && z.IsJSONHandle() {
+		} else if !yym775 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.CompletionTime)
 		} else {
 			z.DecFallback(x.CompletionTime, false)
 		}
 	}
-	yyj774++
-	if yyhl774 {
-		yyb774 = yyj774 > l
+	yyj769++
+	if yyhl769 {
+		yyb769 = yyj769 > l
 	} else {
-		yyb774 = r.CheckBreak()
+		yyb769 = r.CheckBreak()
 	}
-	if yyb774 {
+	if yyb769 {
 		r.ReadEnd()
 		return
 	}
@@ -8564,13 +8520,13 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Active = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj774++
-	if yyhl774 {
-		yyb774 = yyj774 > l
+	yyj769++
+	if yyhl769 {
+		yyb769 = yyj769 > l
 	} else {
-		yyb774 = r.CheckBreak()
+		yyb769 = r.CheckBreak()
 	}
-	if yyb774 {
+	if yyb769 {
 		r.ReadEnd()
 		return
 	}
@@ -8579,13 +8535,13 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Succeeded = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj774++
-	if yyhl774 {
-		yyb774 = yyj774 > l
+	yyj769++
+	if yyhl769 {
+		yyb769 = yyj769 > l
 	} else {
-		yyb774 = r.CheckBreak()
+		yyb769 = r.CheckBreak()
 	}
-	if yyb774 {
+	if yyb769 {
 		r.ReadEnd()
 		return
 	}
@@ -8595,16 +8551,16 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Failed = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj774++
-		if yyhl774 {
-			yyb774 = yyj774 > l
+		yyj769++
+		if yyhl769 {
+			yyb769 = yyj769 > l
 		} else {
-			yyb774 = r.CheckBreak()
+			yyb769 = r.CheckBreak()
 		}
-		if yyb774 {
+		if yyb769 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj774-1, "")
+		z.DecStructFieldNotFound(yyj769-1, "")
 	}
 	r.ReadEnd()
 }
@@ -8613,8 +8569,8 @@ func (x JobConditionType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym784 := z.EncBinary()
-	_ = yym784
+	yym779 := z.EncBinary()
+	_ = yym779
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -8626,8 +8582,8 @@ func (x *JobConditionType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym785 := z.DecBinary()
-	_ = yym785
+	yym780 := z.DecBinary()
+	_ = yym780
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -8642,40 +8598,40 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym786 := z.EncBinary()
-		_ = yym786
+		yym781 := z.EncBinary()
+		_ = yym781
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep787 := !z.EncBinary()
-			yy2arr787 := z.EncBasicHandle().StructToArray
-			var yyq787 [6]bool
-			_, _, _ = yysep787, yyq787, yy2arr787
-			const yyr787 bool = false
-			yyq787[2] = true
-			yyq787[3] = true
-			yyq787[4] = x.Reason != ""
-			yyq787[5] = x.Message != ""
-			if yyr787 || yy2arr787 {
+			yysep782 := !z.EncBinary()
+			yy2arr782 := z.EncBasicHandle().StructToArray
+			var yyq782 [6]bool
+			_, _, _ = yysep782, yyq782, yy2arr782
+			const yyr782 bool = false
+			yyq782[2] = true
+			yyq782[3] = true
+			yyq782[4] = x.Reason != ""
+			yyq782[5] = x.Message != ""
+			if yyr782 || yy2arr782 {
 				r.EncodeArrayStart(6)
 			} else {
-				var yynn787 int = 2
-				for _, b := range yyq787 {
+				var yynn782 int = 2
+				for _, b := range yyq782 {
 					if b {
-						yynn787++
+						yynn782++
 					}
 				}
-				r.EncodeMapStart(yynn787)
+				r.EncodeMapStart(yynn782)
 			}
-			if yyr787 || yy2arr787 {
+			if yyr782 || yy2arr782 {
 				x.Type.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("type"))
 				x.Type.CodecEncodeSelf(e)
 			}
-			if yyr787 || yy2arr787 {
-				yym790 := z.EncBinary()
-				_ = yym790
+			if yyr782 || yy2arr782 {
+				yym785 := z.EncBinary()
+				_ = yym785
 				if false {
 				} else if z.HasExtensions() && z.EncExt(x.Status) {
 				} else {
@@ -8683,17 +8639,51 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("status"))
-				yym791 := z.EncBinary()
-				_ = yym791
+				yym786 := z.EncBinary()
+				_ = yym786
 				if false {
 				} else if z.HasExtensions() && z.EncExt(x.Status) {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Status))
 				}
 			}
-			if yyr787 || yy2arr787 {
-				if yyq787[2] {
-					yy793 := &x.LastProbeTime
+			if yyr782 || yy2arr782 {
+				if yyq782[2] {
+					yy788 := &x.LastProbeTime
+					yym789 := z.EncBinary()
+					_ = yym789
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy788) {
+					} else if yym789 {
+						z.EncBinaryMarshal(yy788)
+					} else if !yym789 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy788)
+					} else {
+						z.EncFallback(yy788)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq782[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("lastProbeTime"))
+					yy790 := &x.LastProbeTime
+					yym791 := z.EncBinary()
+					_ = yym791
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy790) {
+					} else if yym791 {
+						z.EncBinaryMarshal(yy790)
+					} else if !yym791 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy790)
+					} else {
+						z.EncFallback(yy790)
+					}
+				}
+			}
+			if yyr782 || yy2arr782 {
+				if yyq782[3] {
+					yy793 := &x.LastTransitionTime
 					yym794 := z.EncBinary()
 					_ = yym794
 					if false {
@@ -8709,9 +8699,9 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq787[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("lastProbeTime"))
-					yy795 := &x.LastProbeTime
+				if yyq782[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("lastTransitionTime"))
+					yy795 := &x.LastTransitionTime
 					yym796 := z.EncBinary()
 					_ = yym796
 					if false {
@@ -8725,67 +8715,33 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr787 || yy2arr787 {
-				if yyq787[3] {
-					yy798 := &x.LastTransitionTime
+			if yyr782 || yy2arr782 {
+				if yyq782[4] {
+					yym798 := z.EncBinary()
+					_ = yym798
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq782[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("reason"))
 					yym799 := z.EncBinary()
 					_ = yym799
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy798) {
-					} else if yym799 {
-						z.EncBinaryMarshal(yy798)
-					} else if !yym799 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy798)
 					} else {
-						z.EncFallback(yy798)
+						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
 					}
-				} else {
-					r.EncodeNil()
 				}
-			} else {
-				if yyq787[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("lastTransitionTime"))
-					yy800 := &x.LastTransitionTime
+			}
+			if yyr782 || yy2arr782 {
+				if yyq782[5] {
 					yym801 := z.EncBinary()
 					_ = yym801
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy800) {
-					} else if yym801 {
-						z.EncBinaryMarshal(yy800)
-					} else if !yym801 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy800)
-					} else {
-						z.EncFallback(yy800)
-					}
-				}
-			}
-			if yyr787 || yy2arr787 {
-				if yyq787[4] {
-					yym803 := z.EncBinary()
-					_ = yym803
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq787[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("reason"))
-					yym804 := z.EncBinary()
-					_ = yym804
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
-					}
-				}
-			}
-			if yyr787 || yy2arr787 {
-				if yyq787[5] {
-					yym806 := z.EncBinary()
-					_ = yym806
-					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
 					}
@@ -8793,17 +8749,17 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq787[5] {
+				if yyq782[5] {
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
-					yym807 := z.EncBinary()
-					_ = yym807
+					yym802 := z.EncBinary()
+					_ = yym802
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
 					}
 				}
 			}
-			if yysep787 {
+			if yysep782 {
 				r.EncodeEnd()
 			}
 		}
@@ -8814,24 +8770,24 @@ func (x *JobCondition) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym808 := z.DecBinary()
-	_ = yym808
+	yym803 := z.DecBinary()
+	_ = yym803
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl809 := r.ReadMapStart()
-			if yyl809 == 0 {
+			yyl804 := r.ReadMapStart()
+			if yyl804 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl809, d)
+				x.codecDecodeSelfFromMap(yyl804, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl809 := r.ReadArrayStart()
-			if yyl809 == 0 {
+			yyl804 := r.ReadArrayStart()
+			if yyl804 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl809, d)
+				x.codecDecodeSelfFromArray(yyl804, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -8843,12 +8799,12 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys810Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys810Slc
-	var yyhl810 bool = l >= 0
-	for yyj810 := 0; ; yyj810++ {
-		if yyhl810 {
-			if yyj810 >= l {
+	var yys805Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys805Slc
+	var yyhl805 bool = l >= 0
+	for yyj805 := 0; ; yyj805++ {
+		if yyhl805 {
+			if yyj805 >= l {
 				break
 			}
 		} else {
@@ -8856,9 +8812,9 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys810Slc = r.DecodeBytes(yys810Slc, true, true)
-		yys810 := string(yys810Slc)
-		switch yys810 {
+		yys805Slc = r.DecodeBytes(yys805Slc, true, true)
+		yys805 := string(yys805Slc)
+		switch yys805 {
 		case "type":
 			if r.TryDecodeAsNil() {
 				x.Type = ""
@@ -8875,34 +8831,34 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.LastProbeTime = pkg1_unversioned.Time{}
 			} else {
-				yyv813 := &x.LastProbeTime
-				yym814 := z.DecBinary()
-				_ = yym814
+				yyv808 := &x.LastProbeTime
+				yym809 := z.DecBinary()
+				_ = yym809
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv813) {
-				} else if yym814 {
-					z.DecBinaryUnmarshal(yyv813)
-				} else if !yym814 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv813)
+				} else if z.HasExtensions() && z.DecExt(yyv808) {
+				} else if yym809 {
+					z.DecBinaryUnmarshal(yyv808)
+				} else if !yym809 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv808)
 				} else {
-					z.DecFallback(yyv813, false)
+					z.DecFallback(yyv808, false)
 				}
 			}
 		case "lastTransitionTime":
 			if r.TryDecodeAsNil() {
 				x.LastTransitionTime = pkg1_unversioned.Time{}
 			} else {
-				yyv815 := &x.LastTransitionTime
-				yym816 := z.DecBinary()
-				_ = yym816
+				yyv810 := &x.LastTransitionTime
+				yym811 := z.DecBinary()
+				_ = yym811
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv815) {
-				} else if yym816 {
-					z.DecBinaryUnmarshal(yyv815)
-				} else if !yym816 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv815)
+				} else if z.HasExtensions() && z.DecExt(yyv810) {
+				} else if yym811 {
+					z.DecBinaryUnmarshal(yyv810)
+				} else if !yym811 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv810)
 				} else {
-					z.DecFallback(yyv815, false)
+					z.DecFallback(yyv810, false)
 				}
 			}
 		case "reason":
@@ -8918,10 +8874,10 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Message = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys810)
-		} // end switch yys810
-	} // end for yyj810
-	if !yyhl810 {
+			z.DecStructFieldNotFound(-1, yys805)
+		} // end switch yys805
+	} // end for yyj805
+	if !yyhl805 {
 		r.ReadEnd()
 	}
 }
@@ -8930,16 +8886,16 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj819 int
-	var yyb819 bool
-	var yyhl819 bool = l >= 0
-	yyj819++
-	if yyhl819 {
-		yyb819 = yyj819 > l
+	var yyj814 int
+	var yyb814 bool
+	var yyhl814 bool = l >= 0
+	yyj814++
+	if yyhl814 {
+		yyb814 = yyj814 > l
 	} else {
-		yyb819 = r.CheckBreak()
+		yyb814 = r.CheckBreak()
 	}
-	if yyb819 {
+	if yyb814 {
 		r.ReadEnd()
 		return
 	}
@@ -8948,13 +8904,13 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Type = JobConditionType(r.DecodeString())
 	}
-	yyj819++
-	if yyhl819 {
-		yyb819 = yyj819 > l
+	yyj814++
+	if yyhl814 {
+		yyb814 = yyj814 > l
 	} else {
-		yyb819 = r.CheckBreak()
+		yyb814 = r.CheckBreak()
 	}
-	if yyb819 {
+	if yyb814 {
 		r.ReadEnd()
 		return
 	}
@@ -8963,65 +8919,65 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Status = pkg2_api.ConditionStatus(r.DecodeString())
 	}
-	yyj819++
-	if yyhl819 {
-		yyb819 = yyj819 > l
+	yyj814++
+	if yyhl814 {
+		yyb814 = yyj814 > l
 	} else {
-		yyb819 = r.CheckBreak()
+		yyb814 = r.CheckBreak()
 	}
-	if yyb819 {
+	if yyb814 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.LastProbeTime = pkg1_unversioned.Time{}
 	} else {
-		yyv822 := &x.LastProbeTime
-		yym823 := z.DecBinary()
-		_ = yym823
+		yyv817 := &x.LastProbeTime
+		yym818 := z.DecBinary()
+		_ = yym818
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv822) {
-		} else if yym823 {
-			z.DecBinaryUnmarshal(yyv822)
-		} else if !yym823 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv822)
+		} else if z.HasExtensions() && z.DecExt(yyv817) {
+		} else if yym818 {
+			z.DecBinaryUnmarshal(yyv817)
+		} else if !yym818 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv817)
 		} else {
-			z.DecFallback(yyv822, false)
+			z.DecFallback(yyv817, false)
 		}
 	}
-	yyj819++
-	if yyhl819 {
-		yyb819 = yyj819 > l
+	yyj814++
+	if yyhl814 {
+		yyb814 = yyj814 > l
 	} else {
-		yyb819 = r.CheckBreak()
+		yyb814 = r.CheckBreak()
 	}
-	if yyb819 {
+	if yyb814 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.LastTransitionTime = pkg1_unversioned.Time{}
 	} else {
-		yyv824 := &x.LastTransitionTime
-		yym825 := z.DecBinary()
-		_ = yym825
+		yyv819 := &x.LastTransitionTime
+		yym820 := z.DecBinary()
+		_ = yym820
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv824) {
-		} else if yym825 {
-			z.DecBinaryUnmarshal(yyv824)
-		} else if !yym825 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv824)
+		} else if z.HasExtensions() && z.DecExt(yyv819) {
+		} else if yym820 {
+			z.DecBinaryUnmarshal(yyv819)
+		} else if !yym820 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv819)
 		} else {
-			z.DecFallback(yyv824, false)
+			z.DecFallback(yyv819, false)
 		}
 	}
-	yyj819++
-	if yyhl819 {
-		yyb819 = yyj819 > l
+	yyj814++
+	if yyhl814 {
+		yyb814 = yyj814 > l
 	} else {
-		yyb819 = r.CheckBreak()
+		yyb814 = r.CheckBreak()
 	}
-	if yyb819 {
+	if yyb814 {
 		r.ReadEnd()
 		return
 	}
@@ -9030,13 +8986,13 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Reason = string(r.DecodeString())
 	}
-	yyj819++
-	if yyhl819 {
-		yyb819 = yyj819 > l
+	yyj814++
+	if yyhl814 {
+		yyb814 = yyj814 > l
 	} else {
-		yyb819 = r.CheckBreak()
+		yyb814 = r.CheckBreak()
 	}
-	if yyb819 {
+	if yyb814 {
 		r.ReadEnd()
 		return
 	}
@@ -9046,16 +9002,16 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Message = string(r.DecodeString())
 	}
 	for {
-		yyj819++
-		if yyhl819 {
-			yyb819 = yyj819 > l
+		yyj814++
+		if yyhl814 {
+			yyb814 = yyj814 > l
 		} else {
-			yyb819 = r.CheckBreak()
+			yyb814 = r.CheckBreak()
 		}
-		if yyb819 {
+		if yyb814 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj819-1, "")
+		z.DecStructFieldNotFound(yyj814-1, "")
 	}
 	r.ReadEnd()
 }
@@ -9067,36 +9023,36 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym828 := z.EncBinary()
-		_ = yym828
+		yym823 := z.EncBinary()
+		_ = yym823
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep829 := !z.EncBinary()
-			yy2arr829 := z.EncBasicHandle().StructToArray
-			var yyq829 [5]bool
-			_, _, _ = yysep829, yyq829, yy2arr829
-			const yyr829 bool = false
-			yyq829[0] = x.Kind != ""
-			yyq829[1] = x.APIVersion != ""
-			yyq829[2] = true
-			yyq829[3] = true
-			yyq829[4] = true
-			if yyr829 || yy2arr829 {
+			yysep824 := !z.EncBinary()
+			yy2arr824 := z.EncBasicHandle().StructToArray
+			var yyq824 [5]bool
+			_, _, _ = yysep824, yyq824, yy2arr824
+			const yyr824 bool = false
+			yyq824[0] = x.Kind != ""
+			yyq824[1] = x.APIVersion != ""
+			yyq824[2] = true
+			yyq824[3] = true
+			yyq824[4] = true
+			if yyr824 || yy2arr824 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn829 int = 0
-				for _, b := range yyq829 {
+				var yynn824 int = 0
+				for _, b := range yyq824 {
 					if b {
-						yynn829++
+						yynn824++
 					}
 				}
-				r.EncodeMapStart(yynn829)
+				r.EncodeMapStart(yynn824)
 			}
-			if yyr829 || yy2arr829 {
-				if yyq829[0] {
-					yym831 := z.EncBinary()
-					_ = yym831
+			if yyr824 || yy2arr824 {
+				if yyq824[0] {
+					yym826 := z.EncBinary()
+					_ = yym826
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -9105,20 +9061,20 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq829[0] {
+				if yyq824[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym832 := z.EncBinary()
-					_ = yym832
+					yym827 := z.EncBinary()
+					_ = yym827
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr829 || yy2arr829 {
-				if yyq829[1] {
-					yym834 := z.EncBinary()
-					_ = yym834
+			if yyr824 || yy2arr824 {
+				if yyq824[1] {
+					yym829 := z.EncBinary()
+					_ = yym829
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -9127,59 +9083,59 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq829[1] {
+				if yyq824[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym835 := z.EncBinary()
-					_ = yym835
+					yym830 := z.EncBinary()
+					_ = yym830
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr829 || yy2arr829 {
-				if yyq829[2] {
-					yy837 := &x.ObjectMeta
-					yy837.CodecEncodeSelf(e)
+			if yyr824 || yy2arr824 {
+				if yyq824[2] {
+					yy832 := &x.ObjectMeta
+					yy832.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq829[2] {
+				if yyq824[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy838 := &x.ObjectMeta
-					yy838.CodecEncodeSelf(e)
+					yy833 := &x.ObjectMeta
+					yy833.CodecEncodeSelf(e)
 				}
 			}
-			if yyr829 || yy2arr829 {
-				if yyq829[3] {
-					yy840 := &x.Spec
-					yy840.CodecEncodeSelf(e)
+			if yyr824 || yy2arr824 {
+				if yyq824[3] {
+					yy835 := &x.Spec
+					yy835.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq829[3] {
+				if yyq824[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy841 := &x.Spec
-					yy841.CodecEncodeSelf(e)
+					yy836 := &x.Spec
+					yy836.CodecEncodeSelf(e)
 				}
 			}
-			if yyr829 || yy2arr829 {
-				if yyq829[4] {
-					yy843 := &x.Status
-					yy843.CodecEncodeSelf(e)
+			if yyr824 || yy2arr824 {
+				if yyq824[4] {
+					yy838 := &x.Status
+					yy838.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq829[4] {
+				if yyq824[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy844 := &x.Status
-					yy844.CodecEncodeSelf(e)
+					yy839 := &x.Status
+					yy839.CodecEncodeSelf(e)
 				}
 			}
-			if yysep829 {
+			if yysep824 {
 				r.EncodeEnd()
 			}
 		}
@@ -9190,24 +9146,24 @@ func (x *Ingress) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym845 := z.DecBinary()
-	_ = yym845
+	yym840 := z.DecBinary()
+	_ = yym840
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl846 := r.ReadMapStart()
-			if yyl846 == 0 {
+			yyl841 := r.ReadMapStart()
+			if yyl841 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl846, d)
+				x.codecDecodeSelfFromMap(yyl841, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl846 := r.ReadArrayStart()
-			if yyl846 == 0 {
+			yyl841 := r.ReadArrayStart()
+			if yyl841 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl846, d)
+				x.codecDecodeSelfFromArray(yyl841, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -9219,12 +9175,12 @@ func (x *Ingress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys847Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys847Slc
-	var yyhl847 bool = l >= 0
-	for yyj847 := 0; ; yyj847++ {
-		if yyhl847 {
-			if yyj847 >= l {
+	var yys842Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys842Slc
+	var yyhl842 bool = l >= 0
+	for yyj842 := 0; ; yyj842++ {
+		if yyhl842 {
+			if yyj842 >= l {
 				break
 			}
 		} else {
@@ -9232,9 +9188,9 @@ func (x *Ingress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys847Slc = r.DecodeBytes(yys847Slc, true, true)
-		yys847 := string(yys847Slc)
-		switch yys847 {
+		yys842Slc = r.DecodeBytes(yys842Slc, true, true)
+		yys842 := string(yys842Slc)
+		switch yys842 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -9251,28 +9207,28 @@ func (x *Ingress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv850 := &x.ObjectMeta
-				yyv850.CodecDecodeSelf(d)
+				yyv845 := &x.ObjectMeta
+				yyv845.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = IngressSpec{}
 			} else {
-				yyv851 := &x.Spec
-				yyv851.CodecDecodeSelf(d)
+				yyv846 := &x.Spec
+				yyv846.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = IngressStatus{}
 			} else {
-				yyv852 := &x.Status
-				yyv852.CodecDecodeSelf(d)
+				yyv847 := &x.Status
+				yyv847.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys847)
-		} // end switch yys847
-	} // end for yyj847
-	if !yyhl847 {
+			z.DecStructFieldNotFound(-1, yys842)
+		} // end switch yys842
+	} // end for yyj842
+	if !yyhl842 {
 		r.ReadEnd()
 	}
 }
@@ -9281,16 +9237,16 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj853 int
-	var yyb853 bool
-	var yyhl853 bool = l >= 0
-	yyj853++
-	if yyhl853 {
-		yyb853 = yyj853 > l
+	var yyj848 int
+	var yyb848 bool
+	var yyhl848 bool = l >= 0
+	yyj848++
+	if yyhl848 {
+		yyb848 = yyj848 > l
 	} else {
-		yyb853 = r.CheckBreak()
+		yyb848 = r.CheckBreak()
 	}
-	if yyb853 {
+	if yyb848 {
 		r.ReadEnd()
 		return
 	}
@@ -9299,13 +9255,13 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj853++
-	if yyhl853 {
-		yyb853 = yyj853 > l
+	yyj848++
+	if yyhl848 {
+		yyb848 = yyj848 > l
 	} else {
-		yyb853 = r.CheckBreak()
+		yyb848 = r.CheckBreak()
 	}
-	if yyb853 {
+	if yyb848 {
 		r.ReadEnd()
 		return
 	}
@@ -9314,65 +9270,65 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj853++
-	if yyhl853 {
-		yyb853 = yyj853 > l
+	yyj848++
+	if yyhl848 {
+		yyb848 = yyj848 > l
 	} else {
-		yyb853 = r.CheckBreak()
+		yyb848 = r.CheckBreak()
 	}
-	if yyb853 {
+	if yyb848 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv856 := &x.ObjectMeta
-		yyv856.CodecDecodeSelf(d)
+		yyv851 := &x.ObjectMeta
+		yyv851.CodecDecodeSelf(d)
 	}
-	yyj853++
-	if yyhl853 {
-		yyb853 = yyj853 > l
+	yyj848++
+	if yyhl848 {
+		yyb848 = yyj848 > l
 	} else {
-		yyb853 = r.CheckBreak()
+		yyb848 = r.CheckBreak()
 	}
-	if yyb853 {
+	if yyb848 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = IngressSpec{}
 	} else {
-		yyv857 := &x.Spec
-		yyv857.CodecDecodeSelf(d)
+		yyv852 := &x.Spec
+		yyv852.CodecDecodeSelf(d)
 	}
-	yyj853++
-	if yyhl853 {
-		yyb853 = yyj853 > l
+	yyj848++
+	if yyhl848 {
+		yyb848 = yyj848 > l
 	} else {
-		yyb853 = r.CheckBreak()
+		yyb848 = r.CheckBreak()
 	}
-	if yyb853 {
+	if yyb848 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = IngressStatus{}
 	} else {
-		yyv858 := &x.Status
-		yyv858.CodecDecodeSelf(d)
+		yyv853 := &x.Status
+		yyv853.CodecDecodeSelf(d)
 	}
 	for {
-		yyj853++
-		if yyhl853 {
-			yyb853 = yyj853 > l
+		yyj848++
+		if yyhl848 {
+			yyb848 = yyj848 > l
 		} else {
-			yyb853 = r.CheckBreak()
+			yyb848 = r.CheckBreak()
 		}
-		if yyb853 {
+		if yyb848 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj853-1, "")
+		z.DecStructFieldNotFound(yyj848-1, "")
 	}
 	r.ReadEnd()
 }
@@ -9384,34 +9340,34 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym859 := z.EncBinary()
-		_ = yym859
+		yym854 := z.EncBinary()
+		_ = yym854
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep860 := !z.EncBinary()
-			yy2arr860 := z.EncBasicHandle().StructToArray
-			var yyq860 [4]bool
-			_, _, _ = yysep860, yyq860, yy2arr860
-			const yyr860 bool = false
-			yyq860[0] = x.Kind != ""
-			yyq860[1] = x.APIVersion != ""
-			yyq860[2] = true
-			if yyr860 || yy2arr860 {
+			yysep855 := !z.EncBinary()
+			yy2arr855 := z.EncBasicHandle().StructToArray
+			var yyq855 [4]bool
+			_, _, _ = yysep855, yyq855, yy2arr855
+			const yyr855 bool = false
+			yyq855[0] = x.Kind != ""
+			yyq855[1] = x.APIVersion != ""
+			yyq855[2] = true
+			if yyr855 || yy2arr855 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn860 int = 1
-				for _, b := range yyq860 {
+				var yynn855 int = 1
+				for _, b := range yyq855 {
 					if b {
-						yynn860++
+						yynn855++
 					}
 				}
-				r.EncodeMapStart(yynn860)
+				r.EncodeMapStart(yynn855)
 			}
-			if yyr860 || yy2arr860 {
-				if yyq860[0] {
-					yym862 := z.EncBinary()
-					_ = yym862
+			if yyr855 || yy2arr855 {
+				if yyq855[0] {
+					yym857 := z.EncBinary()
+					_ = yym857
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -9420,20 +9376,20 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq860[0] {
+				if yyq855[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym863 := z.EncBinary()
-					_ = yym863
+					yym858 := z.EncBinary()
+					_ = yym858
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr860 || yy2arr860 {
-				if yyq860[1] {
-					yym865 := z.EncBinary()
-					_ = yym865
+			if yyr855 || yy2arr855 {
+				if yyq855[1] {
+					yym860 := z.EncBinary()
+					_ = yym860
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -9442,48 +9398,48 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq860[1] {
+				if yyq855[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym861 := z.EncBinary()
+					_ = yym861
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr855 || yy2arr855 {
+				if yyq855[2] {
+					yy863 := &x.ListMeta
+					yym864 := z.EncBinary()
+					_ = yym864
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy863) {
+					} else {
+						z.EncFallback(yy863)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq855[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy865 := &x.ListMeta
 					yym866 := z.EncBinary()
 					_ = yym866
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy865) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						z.EncFallback(yy865)
 					}
 				}
 			}
-			if yyr860 || yy2arr860 {
-				if yyq860[2] {
-					yy868 := &x.ListMeta
-					yym869 := z.EncBinary()
-					_ = yym869
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy868) {
-					} else {
-						z.EncFallback(yy868)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq860[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy870 := &x.ListMeta
-					yym871 := z.EncBinary()
-					_ = yym871
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy870) {
-					} else {
-						z.EncFallback(yy870)
-					}
-				}
-			}
-			if yyr860 || yy2arr860 {
+			if yyr855 || yy2arr855 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym873 := z.EncBinary()
-					_ = yym873
+					yym868 := z.EncBinary()
+					_ = yym868
 					if false {
 					} else {
 						h.encSliceIngress(([]Ingress)(x.Items), e)
@@ -9494,15 +9450,15 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym874 := z.EncBinary()
-					_ = yym874
+					yym869 := z.EncBinary()
+					_ = yym869
 					if false {
 					} else {
 						h.encSliceIngress(([]Ingress)(x.Items), e)
 					}
 				}
 			}
-			if yysep860 {
+			if yysep855 {
 				r.EncodeEnd()
 			}
 		}
@@ -9513,24 +9469,24 @@ func (x *IngressList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym875 := z.DecBinary()
-	_ = yym875
+	yym870 := z.DecBinary()
+	_ = yym870
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl876 := r.ReadMapStart()
-			if yyl876 == 0 {
+			yyl871 := r.ReadMapStart()
+			if yyl871 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl876, d)
+				x.codecDecodeSelfFromMap(yyl871, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl876 := r.ReadArrayStart()
-			if yyl876 == 0 {
+			yyl871 := r.ReadArrayStart()
+			if yyl871 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl876, d)
+				x.codecDecodeSelfFromArray(yyl871, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -9542,12 +9498,12 @@ func (x *IngressList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys877Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys877Slc
-	var yyhl877 bool = l >= 0
-	for yyj877 := 0; ; yyj877++ {
-		if yyhl877 {
-			if yyj877 >= l {
+	var yys872Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys872Slc
+	var yyhl872 bool = l >= 0
+	for yyj872 := 0; ; yyj872++ {
+		if yyhl872 {
+			if yyj872 >= l {
 				break
 			}
 		} else {
@@ -9555,9 +9511,9 @@ func (x *IngressList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys877Slc = r.DecodeBytes(yys877Slc, true, true)
-		yys877 := string(yys877Slc)
-		switch yys877 {
+		yys872Slc = r.DecodeBytes(yys872Slc, true, true)
+		yys872 := string(yys872Slc)
+		switch yys872 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -9574,32 +9530,32 @@ func (x *IngressList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv880 := &x.ListMeta
-				yym881 := z.DecBinary()
-				_ = yym881
+				yyv875 := &x.ListMeta
+				yym876 := z.DecBinary()
+				_ = yym876
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv880) {
+				} else if z.HasExtensions() && z.DecExt(yyv875) {
 				} else {
-					z.DecFallback(yyv880, false)
+					z.DecFallback(yyv875, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv882 := &x.Items
-				yym883 := z.DecBinary()
-				_ = yym883
+				yyv877 := &x.Items
+				yym878 := z.DecBinary()
+				_ = yym878
 				if false {
 				} else {
-					h.decSliceIngress((*[]Ingress)(yyv882), d)
+					h.decSliceIngress((*[]Ingress)(yyv877), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys877)
-		} // end switch yys877
-	} // end for yyj877
-	if !yyhl877 {
+			z.DecStructFieldNotFound(-1, yys872)
+		} // end switch yys872
+	} // end for yyj872
+	if !yyhl872 {
 		r.ReadEnd()
 	}
 }
@@ -9608,16 +9564,16 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj884 int
-	var yyb884 bool
-	var yyhl884 bool = l >= 0
-	yyj884++
-	if yyhl884 {
-		yyb884 = yyj884 > l
+	var yyj879 int
+	var yyb879 bool
+	var yyhl879 bool = l >= 0
+	yyj879++
+	if yyhl879 {
+		yyb879 = yyj879 > l
 	} else {
-		yyb884 = r.CheckBreak()
+		yyb879 = r.CheckBreak()
 	}
-	if yyb884 {
+	if yyb879 {
 		r.ReadEnd()
 		return
 	}
@@ -9626,13 +9582,13 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj884++
-	if yyhl884 {
-		yyb884 = yyj884 > l
+	yyj879++
+	if yyhl879 {
+		yyb879 = yyj879 > l
 	} else {
-		yyb884 = r.CheckBreak()
+		yyb879 = r.CheckBreak()
 	}
-	if yyb884 {
+	if yyb879 {
 		r.ReadEnd()
 		return
 	}
@@ -9641,60 +9597,60 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj884++
-	if yyhl884 {
-		yyb884 = yyj884 > l
+	yyj879++
+	if yyhl879 {
+		yyb879 = yyj879 > l
 	} else {
-		yyb884 = r.CheckBreak()
+		yyb879 = r.CheckBreak()
 	}
-	if yyb884 {
+	if yyb879 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv887 := &x.ListMeta
-		yym888 := z.DecBinary()
-		_ = yym888
+		yyv882 := &x.ListMeta
+		yym883 := z.DecBinary()
+		_ = yym883
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv887) {
+		} else if z.HasExtensions() && z.DecExt(yyv882) {
 		} else {
-			z.DecFallback(yyv887, false)
+			z.DecFallback(yyv882, false)
 		}
 	}
-	yyj884++
-	if yyhl884 {
-		yyb884 = yyj884 > l
+	yyj879++
+	if yyhl879 {
+		yyb879 = yyj879 > l
 	} else {
-		yyb884 = r.CheckBreak()
+		yyb879 = r.CheckBreak()
 	}
-	if yyb884 {
+	if yyb879 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv889 := &x.Items
-		yym890 := z.DecBinary()
-		_ = yym890
+		yyv884 := &x.Items
+		yym885 := z.DecBinary()
+		_ = yym885
 		if false {
 		} else {
-			h.decSliceIngress((*[]Ingress)(yyv889), d)
+			h.decSliceIngress((*[]Ingress)(yyv884), d)
 		}
 	}
 	for {
-		yyj884++
-		if yyhl884 {
-			yyb884 = yyj884 > l
+		yyj879++
+		if yyhl879 {
+			yyb879 = yyj879 > l
 		} else {
-			yyb884 = r.CheckBreak()
+			yyb879 = r.CheckBreak()
 		}
-		if yyb884 {
+		if yyb879 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj884-1, "")
+		z.DecStructFieldNotFound(yyj879-1, "")
 	}
 	r.ReadEnd()
 }
@@ -9706,31 +9662,31 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym891 := z.EncBinary()
-		_ = yym891
+		yym886 := z.EncBinary()
+		_ = yym886
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep892 := !z.EncBinary()
-			yy2arr892 := z.EncBasicHandle().StructToArray
-			var yyq892 [2]bool
-			_, _, _ = yysep892, yyq892, yy2arr892
-			const yyr892 bool = false
-			yyq892[0] = x.Backend != nil
-			yyq892[1] = len(x.Rules) != 0
-			if yyr892 || yy2arr892 {
+			yysep887 := !z.EncBinary()
+			yy2arr887 := z.EncBasicHandle().StructToArray
+			var yyq887 [2]bool
+			_, _, _ = yysep887, yyq887, yy2arr887
+			const yyr887 bool = false
+			yyq887[0] = x.Backend != nil
+			yyq887[1] = len(x.Rules) != 0
+			if yyr887 || yy2arr887 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn892 int = 0
-				for _, b := range yyq892 {
+				var yynn887 int = 0
+				for _, b := range yyq887 {
 					if b {
-						yynn892++
+						yynn887++
 					}
 				}
-				r.EncodeMapStart(yynn892)
+				r.EncodeMapStart(yynn887)
 			}
-			if yyr892 || yy2arr892 {
-				if yyq892[0] {
+			if yyr887 || yy2arr887 {
+				if yyq887[0] {
 					if x.Backend == nil {
 						r.EncodeNil()
 					} else {
@@ -9740,7 +9696,7 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq892[0] {
+				if yyq887[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("backend"))
 					if x.Backend == nil {
 						r.EncodeNil()
@@ -9749,13 +9705,13 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr892 || yy2arr892 {
-				if yyq892[1] {
+			if yyr887 || yy2arr887 {
+				if yyq887[1] {
 					if x.Rules == nil {
 						r.EncodeNil()
 					} else {
-						yym895 := z.EncBinary()
-						_ = yym895
+						yym890 := z.EncBinary()
+						_ = yym890
 						if false {
 						} else {
 							h.encSliceIngressRule(([]IngressRule)(x.Rules), e)
@@ -9765,13 +9721,13 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq892[1] {
+				if yyq887[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("rules"))
 					if x.Rules == nil {
 						r.EncodeNil()
 					} else {
-						yym896 := z.EncBinary()
-						_ = yym896
+						yym891 := z.EncBinary()
+						_ = yym891
 						if false {
 						} else {
 							h.encSliceIngressRule(([]IngressRule)(x.Rules), e)
@@ -9779,7 +9735,7 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep892 {
+			if yysep887 {
 				r.EncodeEnd()
 			}
 		}
@@ -9790,24 +9746,24 @@ func (x *IngressSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym897 := z.DecBinary()
-	_ = yym897
+	yym892 := z.DecBinary()
+	_ = yym892
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl898 := r.ReadMapStart()
-			if yyl898 == 0 {
+			yyl893 := r.ReadMapStart()
+			if yyl893 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl898, d)
+				x.codecDecodeSelfFromMap(yyl893, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl898 := r.ReadArrayStart()
-			if yyl898 == 0 {
+			yyl893 := r.ReadArrayStart()
+			if yyl893 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl898, d)
+				x.codecDecodeSelfFromArray(yyl893, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -9819,12 +9775,12 @@ func (x *IngressSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys899Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys899Slc
-	var yyhl899 bool = l >= 0
-	for yyj899 := 0; ; yyj899++ {
-		if yyhl899 {
-			if yyj899 >= l {
+	var yys894Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys894Slc
+	var yyhl894 bool = l >= 0
+	for yyj894 := 0; ; yyj894++ {
+		if yyhl894 {
+			if yyj894 >= l {
 				break
 			}
 		} else {
@@ -9832,9 +9788,9 @@ func (x *IngressSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys899Slc = r.DecodeBytes(yys899Slc, true, true)
-		yys899 := string(yys899Slc)
-		switch yys899 {
+		yys894Slc = r.DecodeBytes(yys894Slc, true, true)
+		yys894 := string(yys894Slc)
+		switch yys894 {
 		case "backend":
 			if r.TryDecodeAsNil() {
 				if x.Backend != nil {
@@ -9850,19 +9806,19 @@ func (x *IngressSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Rules = nil
 			} else {
-				yyv901 := &x.Rules
-				yym902 := z.DecBinary()
-				_ = yym902
+				yyv896 := &x.Rules
+				yym897 := z.DecBinary()
+				_ = yym897
 				if false {
 				} else {
-					h.decSliceIngressRule((*[]IngressRule)(yyv901), d)
+					h.decSliceIngressRule((*[]IngressRule)(yyv896), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys899)
-		} // end switch yys899
-	} // end for yyj899
-	if !yyhl899 {
+			z.DecStructFieldNotFound(-1, yys894)
+		} // end switch yys894
+	} // end for yyj894
+	if !yyhl894 {
 		r.ReadEnd()
 	}
 }
@@ -9871,16 +9827,16 @@ func (x *IngressSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj903 int
-	var yyb903 bool
-	var yyhl903 bool = l >= 0
-	yyj903++
-	if yyhl903 {
-		yyb903 = yyj903 > l
+	var yyj898 int
+	var yyb898 bool
+	var yyhl898 bool = l >= 0
+	yyj898++
+	if yyhl898 {
+		yyb898 = yyj898 > l
 	} else {
-		yyb903 = r.CheckBreak()
+		yyb898 = r.CheckBreak()
 	}
-	if yyb903 {
+	if yyb898 {
 		r.ReadEnd()
 		return
 	}
@@ -9894,38 +9850,38 @@ func (x *IngressSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.Backend.CodecDecodeSelf(d)
 	}
-	yyj903++
-	if yyhl903 {
-		yyb903 = yyj903 > l
+	yyj898++
+	if yyhl898 {
+		yyb898 = yyj898 > l
 	} else {
-		yyb903 = r.CheckBreak()
+		yyb898 = r.CheckBreak()
 	}
-	if yyb903 {
+	if yyb898 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Rules = nil
 	} else {
-		yyv905 := &x.Rules
-		yym906 := z.DecBinary()
-		_ = yym906
+		yyv900 := &x.Rules
+		yym901 := z.DecBinary()
+		_ = yym901
 		if false {
 		} else {
-			h.decSliceIngressRule((*[]IngressRule)(yyv905), d)
+			h.decSliceIngressRule((*[]IngressRule)(yyv900), d)
 		}
 	}
 	for {
-		yyj903++
-		if yyhl903 {
-			yyb903 = yyj903 > l
+		yyj898++
+		if yyhl898 {
+			yyb898 = yyj898 > l
 		} else {
-			yyb903 = r.CheckBreak()
+			yyb898 = r.CheckBreak()
 		}
-		if yyb903 {
+		if yyb898 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj903-1, "")
+		z.DecStructFieldNotFound(yyj898-1, "")
 	}
 	r.ReadEnd()
 }
@@ -9937,43 +9893,43 @@ func (x *IngressStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym907 := z.EncBinary()
-		_ = yym907
+		yym902 := z.EncBinary()
+		_ = yym902
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep908 := !z.EncBinary()
-			yy2arr908 := z.EncBasicHandle().StructToArray
-			var yyq908 [1]bool
-			_, _, _ = yysep908, yyq908, yy2arr908
-			const yyr908 bool = false
-			yyq908[0] = true
-			if yyr908 || yy2arr908 {
+			yysep903 := !z.EncBinary()
+			yy2arr903 := z.EncBasicHandle().StructToArray
+			var yyq903 [1]bool
+			_, _, _ = yysep903, yyq903, yy2arr903
+			const yyr903 bool = false
+			yyq903[0] = true
+			if yyr903 || yy2arr903 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn908 int = 0
-				for _, b := range yyq908 {
+				var yynn903 int = 0
+				for _, b := range yyq903 {
 					if b {
-						yynn908++
+						yynn903++
 					}
 				}
-				r.EncodeMapStart(yynn908)
+				r.EncodeMapStart(yynn903)
 			}
-			if yyr908 || yy2arr908 {
-				if yyq908[0] {
-					yy910 := &x.LoadBalancer
-					yy910.CodecEncodeSelf(e)
+			if yyr903 || yy2arr903 {
+				if yyq903[0] {
+					yy905 := &x.LoadBalancer
+					yy905.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq908[0] {
+				if yyq903[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("loadBalancer"))
-					yy911 := &x.LoadBalancer
-					yy911.CodecEncodeSelf(e)
+					yy906 := &x.LoadBalancer
+					yy906.CodecEncodeSelf(e)
 				}
 			}
-			if yysep908 {
+			if yysep903 {
 				r.EncodeEnd()
 			}
 		}
@@ -9984,24 +9940,24 @@ func (x *IngressStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym912 := z.DecBinary()
-	_ = yym912
+	yym907 := z.DecBinary()
+	_ = yym907
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl913 := r.ReadMapStart()
-			if yyl913 == 0 {
+			yyl908 := r.ReadMapStart()
+			if yyl908 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl913, d)
+				x.codecDecodeSelfFromMap(yyl908, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl913 := r.ReadArrayStart()
-			if yyl913 == 0 {
+			yyl908 := r.ReadArrayStart()
+			if yyl908 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl913, d)
+				x.codecDecodeSelfFromArray(yyl908, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10013,12 +9969,12 @@ func (x *IngressStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys914Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys914Slc
-	var yyhl914 bool = l >= 0
-	for yyj914 := 0; ; yyj914++ {
-		if yyhl914 {
-			if yyj914 >= l {
+	var yys909Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys909Slc
+	var yyhl909 bool = l >= 0
+	for yyj909 := 0; ; yyj909++ {
+		if yyhl909 {
+			if yyj909 >= l {
 				break
 			}
 		} else {
@@ -10026,21 +9982,21 @@ func (x *IngressStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys914Slc = r.DecodeBytes(yys914Slc, true, true)
-		yys914 := string(yys914Slc)
-		switch yys914 {
+		yys909Slc = r.DecodeBytes(yys909Slc, true, true)
+		yys909 := string(yys909Slc)
+		switch yys909 {
 		case "loadBalancer":
 			if r.TryDecodeAsNil() {
 				x.LoadBalancer = pkg2_api.LoadBalancerStatus{}
 			} else {
-				yyv915 := &x.LoadBalancer
-				yyv915.CodecDecodeSelf(d)
+				yyv910 := &x.LoadBalancer
+				yyv910.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys914)
-		} // end switch yys914
-	} // end for yyj914
-	if !yyhl914 {
+			z.DecStructFieldNotFound(-1, yys909)
+		} // end switch yys909
+	} // end for yyj909
+	if !yyhl909 {
 		r.ReadEnd()
 	}
 }
@@ -10049,36 +10005,36 @@ func (x *IngressStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj916 int
-	var yyb916 bool
-	var yyhl916 bool = l >= 0
-	yyj916++
-	if yyhl916 {
-		yyb916 = yyj916 > l
+	var yyj911 int
+	var yyb911 bool
+	var yyhl911 bool = l >= 0
+	yyj911++
+	if yyhl911 {
+		yyb911 = yyj911 > l
 	} else {
-		yyb916 = r.CheckBreak()
+		yyb911 = r.CheckBreak()
 	}
-	if yyb916 {
+	if yyb911 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.LoadBalancer = pkg2_api.LoadBalancerStatus{}
 	} else {
-		yyv917 := &x.LoadBalancer
-		yyv917.CodecDecodeSelf(d)
+		yyv912 := &x.LoadBalancer
+		yyv912.CodecDecodeSelf(d)
 	}
 	for {
-		yyj916++
-		if yyhl916 {
-			yyb916 = yyj916 > l
+		yyj911++
+		if yyhl911 {
+			yyb911 = yyj911 > l
 		} else {
-			yyb916 = r.CheckBreak()
+			yyb911 = r.CheckBreak()
 		}
-		if yyb916 {
+		if yyb911 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj916-1, "")
+		z.DecStructFieldNotFound(yyj911-1, "")
 	}
 	r.ReadEnd()
 }
@@ -10090,33 +10046,33 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym918 := z.EncBinary()
-		_ = yym918
+		yym913 := z.EncBinary()
+		_ = yym913
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep919 := !z.EncBinary()
-			yy2arr919 := z.EncBasicHandle().StructToArray
-			var yyq919 [2]bool
-			_, _, _ = yysep919, yyq919, yy2arr919
-			const yyr919 bool = false
-			yyq919[0] = x.Host != ""
-			yyq919[1] = x.IngressRuleValue.HTTP != nil && x.HTTP != nil
-			if yyr919 || yy2arr919 {
+			yysep914 := !z.EncBinary()
+			yy2arr914 := z.EncBasicHandle().StructToArray
+			var yyq914 [2]bool
+			_, _, _ = yysep914, yyq914, yy2arr914
+			const yyr914 bool = false
+			yyq914[0] = x.Host != ""
+			yyq914[1] = x.IngressRuleValue.HTTP != nil && x.HTTP != nil
+			if yyr914 || yy2arr914 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn919 int = 0
-				for _, b := range yyq919 {
+				var yynn914 int = 0
+				for _, b := range yyq914 {
 					if b {
-						yynn919++
+						yynn914++
 					}
 				}
-				r.EncodeMapStart(yynn919)
+				r.EncodeMapStart(yynn914)
 			}
-			if yyr919 || yy2arr919 {
-				if yyq919[0] {
-					yym921 := z.EncBinary()
-					_ = yym921
+			if yyr914 || yy2arr914 {
+				if yyq914[0] {
+					yym916 := z.EncBinary()
+					_ = yym916
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Host))
@@ -10125,27 +10081,27 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq919[0] {
+				if yyq914[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("host"))
-					yym922 := z.EncBinary()
-					_ = yym922
+					yym917 := z.EncBinary()
+					_ = yym917
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Host))
 					}
 				}
 			}
-			var yyn923 bool
+			var yyn918 bool
 			if x.IngressRuleValue.HTTP == nil {
-				yyn923 = true
-				goto LABEL923
+				yyn918 = true
+				goto LABEL918
 			}
-		LABEL923:
-			if yyr919 || yy2arr919 {
-				if yyn923 {
+		LABEL918:
+			if yyr914 || yy2arr914 {
+				if yyn918 {
 					r.EncodeNil()
 				} else {
-					if yyq919[1] {
+					if yyq914[1] {
 						if x.HTTP == nil {
 							r.EncodeNil()
 						} else {
@@ -10156,9 +10112,9 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
-				if yyq919[1] {
+				if yyq914[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("http"))
-					if yyn923 {
+					if yyn918 {
 						r.EncodeNil()
 					} else {
 						if x.HTTP == nil {
@@ -10169,7 +10125,7 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep919 {
+			if yysep914 {
 				r.EncodeEnd()
 			}
 		}
@@ -10180,24 +10136,24 @@ func (x *IngressRule) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym924 := z.DecBinary()
-	_ = yym924
+	yym919 := z.DecBinary()
+	_ = yym919
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl925 := r.ReadMapStart()
-			if yyl925 == 0 {
+			yyl920 := r.ReadMapStart()
+			if yyl920 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl925, d)
+				x.codecDecodeSelfFromMap(yyl920, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl925 := r.ReadArrayStart()
-			if yyl925 == 0 {
+			yyl920 := r.ReadArrayStart()
+			if yyl920 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl925, d)
+				x.codecDecodeSelfFromArray(yyl920, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10209,12 +10165,12 @@ func (x *IngressRule) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys926Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys926Slc
-	var yyhl926 bool = l >= 0
-	for yyj926 := 0; ; yyj926++ {
-		if yyhl926 {
-			if yyj926 >= l {
+	var yys921Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys921Slc
+	var yyhl921 bool = l >= 0
+	for yyj921 := 0; ; yyj921++ {
+		if yyhl921 {
+			if yyj921 >= l {
 				break
 			}
 		} else {
@@ -10222,9 +10178,9 @@ func (x *IngressRule) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys926Slc = r.DecodeBytes(yys926Slc, true, true)
-		yys926 := string(yys926Slc)
-		switch yys926 {
+		yys921Slc = r.DecodeBytes(yys921Slc, true, true)
+		yys921 := string(yys921Slc)
+		switch yys921 {
 		case "host":
 			if r.TryDecodeAsNil() {
 				x.Host = ""
@@ -10246,10 +10202,10 @@ func (x *IngressRule) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.HTTP.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys926)
-		} // end switch yys926
-	} // end for yyj926
-	if !yyhl926 {
+			z.DecStructFieldNotFound(-1, yys921)
+		} // end switch yys921
+	} // end for yyj921
+	if !yyhl921 {
 		r.ReadEnd()
 	}
 }
@@ -10258,16 +10214,16 @@ func (x *IngressRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj929 int
-	var yyb929 bool
-	var yyhl929 bool = l >= 0
-	yyj929++
-	if yyhl929 {
-		yyb929 = yyj929 > l
+	var yyj924 int
+	var yyb924 bool
+	var yyhl924 bool = l >= 0
+	yyj924++
+	if yyhl924 {
+		yyb924 = yyj924 > l
 	} else {
-		yyb929 = r.CheckBreak()
+		yyb924 = r.CheckBreak()
 	}
-	if yyb929 {
+	if yyb924 {
 		r.ReadEnd()
 		return
 	}
@@ -10276,13 +10232,13 @@ func (x *IngressRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Host = string(r.DecodeString())
 	}
-	yyj929++
-	if yyhl929 {
-		yyb929 = yyj929 > l
+	yyj924++
+	if yyhl924 {
+		yyb924 = yyj924 > l
 	} else {
-		yyb929 = r.CheckBreak()
+		yyb924 = r.CheckBreak()
 	}
-	if yyb929 {
+	if yyb924 {
 		r.ReadEnd()
 		return
 	}
@@ -10297,16 +10253,16 @@ func (x *IngressRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.HTTP.CodecDecodeSelf(d)
 	}
 	for {
-		yyj929++
-		if yyhl929 {
-			yyb929 = yyj929 > l
+		yyj924++
+		if yyhl924 {
+			yyb924 = yyj924 > l
 		} else {
-			yyb929 = r.CheckBreak()
+			yyb924 = r.CheckBreak()
 		}
-		if yyb929 {
+		if yyb924 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj929-1, "")
+		z.DecStructFieldNotFound(yyj924-1, "")
 	}
 	r.ReadEnd()
 }
@@ -10318,30 +10274,30 @@ func (x *IngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym932 := z.EncBinary()
-		_ = yym932
+		yym927 := z.EncBinary()
+		_ = yym927
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep933 := !z.EncBinary()
-			yy2arr933 := z.EncBasicHandle().StructToArray
-			var yyq933 [1]bool
-			_, _, _ = yysep933, yyq933, yy2arr933
-			const yyr933 bool = false
-			yyq933[0] = x.HTTP != nil
-			if yyr933 || yy2arr933 {
+			yysep928 := !z.EncBinary()
+			yy2arr928 := z.EncBasicHandle().StructToArray
+			var yyq928 [1]bool
+			_, _, _ = yysep928, yyq928, yy2arr928
+			const yyr928 bool = false
+			yyq928[0] = x.HTTP != nil
+			if yyr928 || yy2arr928 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn933 int = 0
-				for _, b := range yyq933 {
+				var yynn928 int = 0
+				for _, b := range yyq928 {
 					if b {
-						yynn933++
+						yynn928++
 					}
 				}
-				r.EncodeMapStart(yynn933)
+				r.EncodeMapStart(yynn928)
 			}
-			if yyr933 || yy2arr933 {
-				if yyq933[0] {
+			if yyr928 || yy2arr928 {
+				if yyq928[0] {
 					if x.HTTP == nil {
 						r.EncodeNil()
 					} else {
@@ -10351,7 +10307,7 @@ func (x *IngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq933[0] {
+				if yyq928[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("http"))
 					if x.HTTP == nil {
 						r.EncodeNil()
@@ -10360,7 +10316,7 @@ func (x *IngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep933 {
+			if yysep928 {
 				r.EncodeEnd()
 			}
 		}
@@ -10371,24 +10327,24 @@ func (x *IngressRuleValue) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym935 := z.DecBinary()
-	_ = yym935
+	yym930 := z.DecBinary()
+	_ = yym930
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl936 := r.ReadMapStart()
-			if yyl936 == 0 {
+			yyl931 := r.ReadMapStart()
+			if yyl931 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl936, d)
+				x.codecDecodeSelfFromMap(yyl931, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl936 := r.ReadArrayStart()
-			if yyl936 == 0 {
+			yyl931 := r.ReadArrayStart()
+			if yyl931 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl936, d)
+				x.codecDecodeSelfFromArray(yyl931, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10400,12 +10356,12 @@ func (x *IngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys937Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys937Slc
-	var yyhl937 bool = l >= 0
-	for yyj937 := 0; ; yyj937++ {
-		if yyhl937 {
-			if yyj937 >= l {
+	var yys932Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys932Slc
+	var yyhl932 bool = l >= 0
+	for yyj932 := 0; ; yyj932++ {
+		if yyhl932 {
+			if yyj932 >= l {
 				break
 			}
 		} else {
@@ -10413,9 +10369,9 @@ func (x *IngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys937Slc = r.DecodeBytes(yys937Slc, true, true)
-		yys937 := string(yys937Slc)
-		switch yys937 {
+		yys932Slc = r.DecodeBytes(yys932Slc, true, true)
+		yys932 := string(yys932Slc)
+		switch yys932 {
 		case "http":
 			if r.TryDecodeAsNil() {
 				if x.HTTP != nil {
@@ -10428,10 +10384,10 @@ func (x *IngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.HTTP.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys937)
-		} // end switch yys937
-	} // end for yyj937
-	if !yyhl937 {
+			z.DecStructFieldNotFound(-1, yys932)
+		} // end switch yys932
+	} // end for yyj932
+	if !yyhl932 {
 		r.ReadEnd()
 	}
 }
@@ -10440,16 +10396,16 @@ func (x *IngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj939 int
-	var yyb939 bool
-	var yyhl939 bool = l >= 0
-	yyj939++
-	if yyhl939 {
-		yyb939 = yyj939 > l
+	var yyj934 int
+	var yyb934 bool
+	var yyhl934 bool = l >= 0
+	yyj934++
+	if yyhl934 {
+		yyb934 = yyj934 > l
 	} else {
-		yyb939 = r.CheckBreak()
+		yyb934 = r.CheckBreak()
 	}
-	if yyb939 {
+	if yyb934 {
 		r.ReadEnd()
 		return
 	}
@@ -10464,16 +10420,16 @@ func (x *IngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		x.HTTP.CodecDecodeSelf(d)
 	}
 	for {
-		yyj939++
-		if yyhl939 {
-			yyb939 = yyj939 > l
+		yyj934++
+		if yyhl934 {
+			yyb934 = yyj934 > l
 		} else {
-			yyb939 = r.CheckBreak()
+			yyb934 = r.CheckBreak()
 		}
-		if yyb939 {
+		if yyb934 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj939-1, "")
+		z.DecStructFieldNotFound(yyj934-1, "")
 	}
 	r.ReadEnd()
 }
@@ -10485,33 +10441,33 @@ func (x *HTTPIngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym941 := z.EncBinary()
-		_ = yym941
+		yym936 := z.EncBinary()
+		_ = yym936
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep942 := !z.EncBinary()
-			yy2arr942 := z.EncBasicHandle().StructToArray
-			var yyq942 [1]bool
-			_, _, _ = yysep942, yyq942, yy2arr942
-			const yyr942 bool = false
-			if yyr942 || yy2arr942 {
+			yysep937 := !z.EncBinary()
+			yy2arr937 := z.EncBasicHandle().StructToArray
+			var yyq937 [1]bool
+			_, _, _ = yysep937, yyq937, yy2arr937
+			const yyr937 bool = false
+			if yyr937 || yy2arr937 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn942 int = 1
-				for _, b := range yyq942 {
+				var yynn937 int = 1
+				for _, b := range yyq937 {
 					if b {
-						yynn942++
+						yynn937++
 					}
 				}
-				r.EncodeMapStart(yynn942)
+				r.EncodeMapStart(yynn937)
 			}
-			if yyr942 || yy2arr942 {
+			if yyr937 || yy2arr937 {
 				if x.Paths == nil {
 					r.EncodeNil()
 				} else {
-					yym944 := z.EncBinary()
-					_ = yym944
+					yym939 := z.EncBinary()
+					_ = yym939
 					if false {
 					} else {
 						h.encSliceHTTPIngressPath(([]HTTPIngressPath)(x.Paths), e)
@@ -10522,15 +10478,15 @@ func (x *HTTPIngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Paths == nil {
 					r.EncodeNil()
 				} else {
-					yym945 := z.EncBinary()
-					_ = yym945
+					yym940 := z.EncBinary()
+					_ = yym940
 					if false {
 					} else {
 						h.encSliceHTTPIngressPath(([]HTTPIngressPath)(x.Paths), e)
 					}
 				}
 			}
-			if yysep942 {
+			if yysep937 {
 				r.EncodeEnd()
 			}
 		}
@@ -10541,24 +10497,24 @@ func (x *HTTPIngressRuleValue) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym946 := z.DecBinary()
-	_ = yym946
+	yym941 := z.DecBinary()
+	_ = yym941
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl947 := r.ReadMapStart()
-			if yyl947 == 0 {
+			yyl942 := r.ReadMapStart()
+			if yyl942 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl947, d)
+				x.codecDecodeSelfFromMap(yyl942, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl947 := r.ReadArrayStart()
-			if yyl947 == 0 {
+			yyl942 := r.ReadArrayStart()
+			if yyl942 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl947, d)
+				x.codecDecodeSelfFromArray(yyl942, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10570,12 +10526,12 @@ func (x *HTTPIngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys948Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys948Slc
-	var yyhl948 bool = l >= 0
-	for yyj948 := 0; ; yyj948++ {
-		if yyhl948 {
-			if yyj948 >= l {
+	var yys943Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys943Slc
+	var yyhl943 bool = l >= 0
+	for yyj943 := 0; ; yyj943++ {
+		if yyhl943 {
+			if yyj943 >= l {
 				break
 			}
 		} else {
@@ -10583,26 +10539,26 @@ func (x *HTTPIngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
-		yys948Slc = r.DecodeBytes(yys948Slc, true, true)
-		yys948 := string(yys948Slc)
-		switch yys948 {
+		yys943Slc = r.DecodeBytes(yys943Slc, true, true)
+		yys943 := string(yys943Slc)
+		switch yys943 {
 		case "paths":
 			if r.TryDecodeAsNil() {
 				x.Paths = nil
 			} else {
-				yyv949 := &x.Paths
-				yym950 := z.DecBinary()
-				_ = yym950
+				yyv944 := &x.Paths
+				yym945 := z.DecBinary()
+				_ = yym945
 				if false {
 				} else {
-					h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv949), d)
+					h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv944), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys948)
-		} // end switch yys948
-	} // end for yyj948
-	if !yyhl948 {
+			z.DecStructFieldNotFound(-1, yys943)
+		} // end switch yys943
+	} // end for yyj943
+	if !yyhl943 {
 		r.ReadEnd()
 	}
 }
@@ -10611,41 +10567,41 @@ func (x *HTTPIngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj951 int
-	var yyb951 bool
-	var yyhl951 bool = l >= 0
-	yyj951++
-	if yyhl951 {
-		yyb951 = yyj951 > l
+	var yyj946 int
+	var yyb946 bool
+	var yyhl946 bool = l >= 0
+	yyj946++
+	if yyhl946 {
+		yyb946 = yyj946 > l
 	} else {
-		yyb951 = r.CheckBreak()
+		yyb946 = r.CheckBreak()
 	}
-	if yyb951 {
+	if yyb946 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Paths = nil
 	} else {
-		yyv952 := &x.Paths
-		yym953 := z.DecBinary()
-		_ = yym953
+		yyv947 := &x.Paths
+		yym948 := z.DecBinary()
+		_ = yym948
 		if false {
 		} else {
-			h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv952), d)
+			h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv947), d)
 		}
 	}
 	for {
-		yyj951++
-		if yyhl951 {
-			yyb951 = yyj951 > l
+		yyj946++
+		if yyhl946 {
+			yyb946 = yyj946 > l
 		} else {
-			yyb951 = r.CheckBreak()
+			yyb946 = r.CheckBreak()
 		}
-		if yyb951 {
+		if yyb946 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj951-1, "")
+		z.DecStructFieldNotFound(yyj946-1, "")
 	}
 	r.ReadEnd()
 }
@@ -10657,32 +10613,32 @@ func (x *HTTPIngressPath) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym954 := z.EncBinary()
-		_ = yym954
+		yym949 := z.EncBinary()
+		_ = yym949
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep955 := !z.EncBinary()
-			yy2arr955 := z.EncBasicHandle().StructToArray
-			var yyq955 [2]bool
-			_, _, _ = yysep955, yyq955, yy2arr955
-			const yyr955 bool = false
-			yyq955[0] = x.Path != ""
-			if yyr955 || yy2arr955 {
+			yysep950 := !z.EncBinary()
+			yy2arr950 := z.EncBasicHandle().StructToArray
+			var yyq950 [2]bool
+			_, _, _ = yysep950, yyq950, yy2arr950
+			const yyr950 bool = false
+			yyq950[0] = x.Path != ""
+			if yyr950 || yy2arr950 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn955 int = 1
-				for _, b := range yyq955 {
+				var yynn950 int = 1
+				for _, b := range yyq950 {
 					if b {
-						yynn955++
+						yynn950++
 					}
 				}
-				r.EncodeMapStart(yynn955)
+				r.EncodeMapStart(yynn950)
 			}
-			if yyr955 || yy2arr955 {
-				if yyq955[0] {
-					yym957 := z.EncBinary()
-					_ = yym957
+			if yyr950 || yy2arr950 {
+				if yyq950[0] {
+					yym952 := z.EncBinary()
+					_ = yym952
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Path))
@@ -10691,25 +10647,25 @@ func (x *HTTPIngressPath) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq955[0] {
+				if yyq950[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("path"))
-					yym958 := z.EncBinary()
-					_ = yym958
+					yym953 := z.EncBinary()
+					_ = yym953
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 					}
 				}
 			}
-			if yyr955 || yy2arr955 {
-				yy960 := &x.Backend
-				yy960.CodecEncodeSelf(e)
+			if yyr950 || yy2arr950 {
+				yy955 := &x.Backend
+				yy955.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("backend"))
-				yy961 := &x.Backend
-				yy961.CodecEncodeSelf(e)
+				yy956 := &x.Backend
+				yy956.CodecEncodeSelf(e)
 			}
-			if yysep955 {
+			if yysep950 {
 				r.EncodeEnd()
 			}
 		}
@@ -10720,24 +10676,24 @@ func (x *HTTPIngressPath) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym962 := z.DecBinary()
-	_ = yym962
+	yym957 := z.DecBinary()
+	_ = yym957
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl963 := r.ReadMapStart()
-			if yyl963 == 0 {
+			yyl958 := r.ReadMapStart()
+			if yyl958 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl963, d)
+				x.codecDecodeSelfFromMap(yyl958, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl963 := r.ReadArrayStart()
-			if yyl963 == 0 {
+			yyl958 := r.ReadArrayStart()
+			if yyl958 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl963, d)
+				x.codecDecodeSelfFromArray(yyl958, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10749,12 +10705,12 @@ func (x *HTTPIngressPath) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys964Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys964Slc
-	var yyhl964 bool = l >= 0
-	for yyj964 := 0; ; yyj964++ {
-		if yyhl964 {
-			if yyj964 >= l {
+	var yys959Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys959Slc
+	var yyhl959 bool = l >= 0
+	for yyj959 := 0; ; yyj959++ {
+		if yyhl959 {
+			if yyj959 >= l {
 				break
 			}
 		} else {
@@ -10762,9 +10718,9 @@ func (x *HTTPIngressPath) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys964Slc = r.DecodeBytes(yys964Slc, true, true)
-		yys964 := string(yys964Slc)
-		switch yys964 {
+		yys959Slc = r.DecodeBytes(yys959Slc, true, true)
+		yys959 := string(yys959Slc)
+		switch yys959 {
 		case "path":
 			if r.TryDecodeAsNil() {
 				x.Path = ""
@@ -10775,14 +10731,14 @@ func (x *HTTPIngressPath) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Backend = IngressBackend{}
 			} else {
-				yyv966 := &x.Backend
-				yyv966.CodecDecodeSelf(d)
+				yyv961 := &x.Backend
+				yyv961.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys964)
-		} // end switch yys964
-	} // end for yyj964
-	if !yyhl964 {
+			z.DecStructFieldNotFound(-1, yys959)
+		} // end switch yys959
+	} // end for yyj959
+	if !yyhl959 {
 		r.ReadEnd()
 	}
 }
@@ -10791,16 +10747,16 @@ func (x *HTTPIngressPath) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj967 int
-	var yyb967 bool
-	var yyhl967 bool = l >= 0
-	yyj967++
-	if yyhl967 {
-		yyb967 = yyj967 > l
+	var yyj962 int
+	var yyb962 bool
+	var yyhl962 bool = l >= 0
+	yyj962++
+	if yyhl962 {
+		yyb962 = yyj962 > l
 	} else {
-		yyb967 = r.CheckBreak()
+		yyb962 = r.CheckBreak()
 	}
-	if yyb967 {
+	if yyb962 {
 		r.ReadEnd()
 		return
 	}
@@ -10809,33 +10765,33 @@ func (x *HTTPIngressPath) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Path = string(r.DecodeString())
 	}
-	yyj967++
-	if yyhl967 {
-		yyb967 = yyj967 > l
+	yyj962++
+	if yyhl962 {
+		yyb962 = yyj962 > l
 	} else {
-		yyb967 = r.CheckBreak()
+		yyb962 = r.CheckBreak()
 	}
-	if yyb967 {
+	if yyb962 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Backend = IngressBackend{}
 	} else {
-		yyv969 := &x.Backend
-		yyv969.CodecDecodeSelf(d)
+		yyv964 := &x.Backend
+		yyv964.CodecDecodeSelf(d)
 	}
 	for {
-		yyj967++
-		if yyhl967 {
-			yyb967 = yyj967 > l
+		yyj962++
+		if yyhl962 {
+			yyb962 = yyj962 > l
 		} else {
-			yyb967 = r.CheckBreak()
+			yyb962 = r.CheckBreak()
 		}
-		if yyb967 {
+		if yyb962 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj967-1, "")
+		z.DecStructFieldNotFound(yyj962-1, "")
 	}
 	r.ReadEnd()
 }
@@ -10847,68 +10803,68 @@ func (x *IngressBackend) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym970 := z.EncBinary()
-		_ = yym970
+		yym965 := z.EncBinary()
+		_ = yym965
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep971 := !z.EncBinary()
-			yy2arr971 := z.EncBasicHandle().StructToArray
-			var yyq971 [2]bool
-			_, _, _ = yysep971, yyq971, yy2arr971
-			const yyr971 bool = false
-			if yyr971 || yy2arr971 {
+			yysep966 := !z.EncBinary()
+			yy2arr966 := z.EncBasicHandle().StructToArray
+			var yyq966 [2]bool
+			_, _, _ = yysep966, yyq966, yy2arr966
+			const yyr966 bool = false
+			if yyr966 || yy2arr966 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn971 int = 2
-				for _, b := range yyq971 {
+				var yynn966 int = 2
+				for _, b := range yyq966 {
 					if b {
-						yynn971++
+						yynn966++
 					}
 				}
-				r.EncodeMapStart(yynn971)
+				r.EncodeMapStart(yynn966)
 			}
-			if yyr971 || yy2arr971 {
-				yym973 := z.EncBinary()
-				_ = yym973
+			if yyr966 || yy2arr966 {
+				yym968 := z.EncBinary()
+				_ = yym968
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ServiceName))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("serviceName"))
-				yym974 := z.EncBinary()
-				_ = yym974
+				yym969 := z.EncBinary()
+				_ = yym969
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ServiceName))
 				}
 			}
-			if yyr971 || yy2arr971 {
-				yy976 := &x.ServicePort
-				yym977 := z.EncBinary()
-				_ = yym977
+			if yyr966 || yy2arr966 {
+				yy971 := &x.ServicePort
+				yym972 := z.EncBinary()
+				_ = yym972
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy976) {
-				} else if !yym977 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy976)
+				} else if z.HasExtensions() && z.EncExt(yy971) {
+				} else if !yym972 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy971)
 				} else {
-					z.EncFallback(yy976)
+					z.EncFallback(yy971)
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("servicePort"))
-				yy978 := &x.ServicePort
-				yym979 := z.EncBinary()
-				_ = yym979
+				yy973 := &x.ServicePort
+				yym974 := z.EncBinary()
+				_ = yym974
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy978) {
-				} else if !yym979 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy978)
+				} else if z.HasExtensions() && z.EncExt(yy973) {
+				} else if !yym974 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy973)
 				} else {
-					z.EncFallback(yy978)
+					z.EncFallback(yy973)
 				}
 			}
-			if yysep971 {
+			if yysep966 {
 				r.EncodeEnd()
 			}
 		}
@@ -10919,24 +10875,24 @@ func (x *IngressBackend) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym980 := z.DecBinary()
-	_ = yym980
+	yym975 := z.DecBinary()
+	_ = yym975
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl981 := r.ReadMapStart()
-			if yyl981 == 0 {
+			yyl976 := r.ReadMapStart()
+			if yyl976 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl981, d)
+				x.codecDecodeSelfFromMap(yyl976, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl981 := r.ReadArrayStart()
-			if yyl981 == 0 {
+			yyl976 := r.ReadArrayStart()
+			if yyl976 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl981, d)
+				x.codecDecodeSelfFromArray(yyl976, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10948,12 +10904,12 @@ func (x *IngressBackend) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys982Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys982Slc
-	var yyhl982 bool = l >= 0
-	for yyj982 := 0; ; yyj982++ {
-		if yyhl982 {
-			if yyj982 >= l {
+	var yys977Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys977Slc
+	var yyhl977 bool = l >= 0
+	for yyj977 := 0; ; yyj977++ {
+		if yyhl977 {
+			if yyj977 >= l {
 				break
 			}
 		} else {
@@ -10961,9 +10917,9 @@ func (x *IngressBackend) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys982Slc = r.DecodeBytes(yys982Slc, true, true)
-		yys982 := string(yys982Slc)
-		switch yys982 {
+		yys977Slc = r.DecodeBytes(yys977Slc, true, true)
+		yys977 := string(yys977Slc)
+		switch yys977 {
 		case "serviceName":
 			if r.TryDecodeAsNil() {
 				x.ServiceName = ""
@@ -10974,22 +10930,22 @@ func (x *IngressBackend) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ServicePort = pkg6_util.IntOrString{}
 			} else {
-				yyv984 := &x.ServicePort
-				yym985 := z.DecBinary()
-				_ = yym985
+				yyv979 := &x.ServicePort
+				yym980 := z.DecBinary()
+				_ = yym980
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv984) {
-				} else if !yym985 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv984)
+				} else if z.HasExtensions() && z.DecExt(yyv979) {
+				} else if !yym980 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv979)
 				} else {
-					z.DecFallback(yyv984, false)
+					z.DecFallback(yyv979, false)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys982)
-		} // end switch yys982
-	} // end for yyj982
-	if !yyhl982 {
+			z.DecStructFieldNotFound(-1, yys977)
+		} // end switch yys977
+	} // end for yyj977
+	if !yyhl977 {
 		r.ReadEnd()
 	}
 }
@@ -10998,16 +10954,16 @@ func (x *IngressBackend) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj986 int
-	var yyb986 bool
-	var yyhl986 bool = l >= 0
-	yyj986++
-	if yyhl986 {
-		yyb986 = yyj986 > l
+	var yyj981 int
+	var yyb981 bool
+	var yyhl981 bool = l >= 0
+	yyj981++
+	if yyhl981 {
+		yyb981 = yyj981 > l
 	} else {
-		yyb986 = r.CheckBreak()
+		yyb981 = r.CheckBreak()
 	}
-	if yyb986 {
+	if yyb981 {
 		r.ReadEnd()
 		return
 	}
@@ -11016,41 +10972,41 @@ func (x *IngressBackend) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.ServiceName = string(r.DecodeString())
 	}
-	yyj986++
-	if yyhl986 {
-		yyb986 = yyj986 > l
+	yyj981++
+	if yyhl981 {
+		yyb981 = yyj981 > l
 	} else {
-		yyb986 = r.CheckBreak()
+		yyb981 = r.CheckBreak()
 	}
-	if yyb986 {
+	if yyb981 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ServicePort = pkg6_util.IntOrString{}
 	} else {
-		yyv988 := &x.ServicePort
-		yym989 := z.DecBinary()
-		_ = yym989
+		yyv983 := &x.ServicePort
+		yym984 := z.DecBinary()
+		_ = yym984
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv988) {
-		} else if !yym989 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv988)
+		} else if z.HasExtensions() && z.DecExt(yyv983) {
+		} else if !yym984 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv983)
 		} else {
-			z.DecFallback(yyv988, false)
+			z.DecFallback(yyv983, false)
 		}
 	}
 	for {
-		yyj986++
-		if yyhl986 {
-			yyb986 = yyj986 > l
+		yyj981++
+		if yyhl981 {
+			yyb981 = yyj981 > l
 		} else {
-			yyb986 = r.CheckBreak()
+			yyb981 = r.CheckBreak()
 		}
-		if yyb986 {
+		if yyb981 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj986-1, "")
+		z.DecStructFieldNotFound(yyj981-1, "")
 	}
 	r.ReadEnd()
 }
@@ -11059,8 +11015,8 @@ func (x NodeResource) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym990 := z.EncBinary()
-	_ = yym990
+	yym985 := z.EncBinary()
+	_ = yym985
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -11072,8 +11028,8 @@ func (x *NodeResource) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym991 := z.DecBinary()
-	_ = yym991
+	yym986 := z.DecBinary()
+	_ = yym986
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -11088,50 +11044,50 @@ func (x *NodeUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym992 := z.EncBinary()
-		_ = yym992
+		yym987 := z.EncBinary()
+		_ = yym987
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep993 := !z.EncBinary()
-			yy2arr993 := z.EncBasicHandle().StructToArray
-			var yyq993 [2]bool
-			_, _, _ = yysep993, yyq993, yy2arr993
-			const yyr993 bool = false
-			if yyr993 || yy2arr993 {
+			yysep988 := !z.EncBinary()
+			yy2arr988 := z.EncBasicHandle().StructToArray
+			var yyq988 [2]bool
+			_, _, _ = yysep988, yyq988, yy2arr988
+			const yyr988 bool = false
+			if yyr988 || yy2arr988 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn993 int = 2
-				for _, b := range yyq993 {
+				var yynn988 int = 2
+				for _, b := range yyq988 {
 					if b {
-						yynn993++
+						yynn988++
 					}
 				}
-				r.EncodeMapStart(yynn993)
+				r.EncodeMapStart(yynn988)
 			}
-			if yyr993 || yy2arr993 {
+			if yyr988 || yy2arr988 {
 				x.Resource.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("resource"))
 				x.Resource.CodecEncodeSelf(e)
 			}
-			if yyr993 || yy2arr993 {
-				yym996 := z.EncBinary()
-				_ = yym996
+			if yyr988 || yy2arr988 {
+				yym991 := z.EncBinary()
+				_ = yym991
 				if false {
 				} else {
 					r.EncodeFloat64(float64(x.Value))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("value"))
-				yym997 := z.EncBinary()
-				_ = yym997
+				yym992 := z.EncBinary()
+				_ = yym992
 				if false {
 				} else {
 					r.EncodeFloat64(float64(x.Value))
 				}
 			}
-			if yysep993 {
+			if yysep988 {
 				r.EncodeEnd()
 			}
 		}
@@ -11142,24 +11098,24 @@ func (x *NodeUtilization) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym998 := z.DecBinary()
-	_ = yym998
+	yym993 := z.DecBinary()
+	_ = yym993
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl999 := r.ReadMapStart()
-			if yyl999 == 0 {
+			yyl994 := r.ReadMapStart()
+			if yyl994 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl999, d)
+				x.codecDecodeSelfFromMap(yyl994, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl999 := r.ReadArrayStart()
-			if yyl999 == 0 {
+			yyl994 := r.ReadArrayStart()
+			if yyl994 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl999, d)
+				x.codecDecodeSelfFromArray(yyl994, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -11171,12 +11127,12 @@ func (x *NodeUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1000Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1000Slc
-	var yyhl1000 bool = l >= 0
-	for yyj1000 := 0; ; yyj1000++ {
-		if yyhl1000 {
-			if yyj1000 >= l {
+	var yys995Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys995Slc
+	var yyhl995 bool = l >= 0
+	for yyj995 := 0; ; yyj995++ {
+		if yyhl995 {
+			if yyj995 >= l {
 				break
 			}
 		} else {
@@ -11184,9 +11140,9 @@ func (x *NodeUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys1000Slc = r.DecodeBytes(yys1000Slc, true, true)
-		yys1000 := string(yys1000Slc)
-		switch yys1000 {
+		yys995Slc = r.DecodeBytes(yys995Slc, true, true)
+		yys995 := string(yys995Slc)
+		switch yys995 {
 		case "resource":
 			if r.TryDecodeAsNil() {
 				x.Resource = ""
@@ -11200,10 +11156,10 @@ func (x *NodeUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Value = float64(r.DecodeFloat(false))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1000)
-		} // end switch yys1000
-	} // end for yyj1000
-	if !yyhl1000 {
+			z.DecStructFieldNotFound(-1, yys995)
+		} // end switch yys995
+	} // end for yyj995
+	if !yyhl995 {
 		r.ReadEnd()
 	}
 }
@@ -11212,16 +11168,16 @@ func (x *NodeUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1003 int
-	var yyb1003 bool
-	var yyhl1003 bool = l >= 0
-	yyj1003++
-	if yyhl1003 {
-		yyb1003 = yyj1003 > l
+	var yyj998 int
+	var yyb998 bool
+	var yyhl998 bool = l >= 0
+	yyj998++
+	if yyhl998 {
+		yyb998 = yyj998 > l
 	} else {
-		yyb1003 = r.CheckBreak()
+		yyb998 = r.CheckBreak()
 	}
-	if yyb1003 {
+	if yyb998 {
 		r.ReadEnd()
 		return
 	}
@@ -11230,13 +11186,13 @@ func (x *NodeUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Resource = NodeResource(r.DecodeString())
 	}
-	yyj1003++
-	if yyhl1003 {
-		yyb1003 = yyj1003 > l
+	yyj998++
+	if yyhl998 {
+		yyb998 = yyj998 > l
 	} else {
-		yyb1003 = r.CheckBreak()
+		yyb998 = r.CheckBreak()
 	}
-	if yyb1003 {
+	if yyb998 {
 		r.ReadEnd()
 		return
 	}
@@ -11246,16 +11202,16 @@ func (x *NodeUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.Value = float64(r.DecodeFloat(false))
 	}
 	for {
-		yyj1003++
-		if yyhl1003 {
-			yyb1003 = yyj1003 > l
+		yyj998++
+		if yyhl998 {
+			yyb998 = yyj998 > l
 		} else {
-			yyb1003 = r.CheckBreak()
+			yyb998 = r.CheckBreak()
 		}
-		if yyb1003 {
+		if yyb998 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1003-1, "")
+		z.DecStructFieldNotFound(yyj998-1, "")
 	}
 	r.ReadEnd()
 }
@@ -11267,65 +11223,65 @@ func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1006 := z.EncBinary()
-		_ = yym1006
+		yym1001 := z.EncBinary()
+		_ = yym1001
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1007 := !z.EncBinary()
-			yy2arr1007 := z.EncBasicHandle().StructToArray
-			var yyq1007 [3]bool
-			_, _, _ = yysep1007, yyq1007, yy2arr1007
-			const yyr1007 bool = false
-			if yyr1007 || yy2arr1007 {
+			yysep1002 := !z.EncBinary()
+			yy2arr1002 := z.EncBasicHandle().StructToArray
+			var yyq1002 [3]bool
+			_, _, _ = yysep1002, yyq1002, yy2arr1002
+			const yyr1002 bool = false
+			if yyr1002 || yy2arr1002 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn1007 int = 3
-				for _, b := range yyq1007 {
+				var yynn1002 int = 3
+				for _, b := range yyq1002 {
 					if b {
-						yynn1007++
+						yynn1002++
 					}
 				}
-				r.EncodeMapStart(yynn1007)
+				r.EncodeMapStart(yynn1002)
 			}
-			if yyr1007 || yy2arr1007 {
-				yym1009 := z.EncBinary()
-				_ = yym1009
+			if yyr1002 || yy2arr1002 {
+				yym1004 := z.EncBinary()
+				_ = yym1004
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MinNodes))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("minNodes"))
-				yym1010 := z.EncBinary()
-				_ = yym1010
+				yym1005 := z.EncBinary()
+				_ = yym1005
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MinNodes))
 				}
 			}
-			if yyr1007 || yy2arr1007 {
-				yym1012 := z.EncBinary()
-				_ = yym1012
+			if yyr1002 || yy2arr1002 {
+				yym1007 := z.EncBinary()
+				_ = yym1007
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MaxNodes))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("maxNodes"))
-				yym1013 := z.EncBinary()
-				_ = yym1013
+				yym1008 := z.EncBinary()
+				_ = yym1008
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MaxNodes))
 				}
 			}
-			if yyr1007 || yy2arr1007 {
+			if yyr1002 || yy2arr1002 {
 				if x.TargetUtilization == nil {
 					r.EncodeNil()
 				} else {
-					yym1015 := z.EncBinary()
-					_ = yym1015
+					yym1010 := z.EncBinary()
+					_ = yym1010
 					if false {
 					} else {
 						h.encSliceNodeUtilization(([]NodeUtilization)(x.TargetUtilization), e)
@@ -11336,15 +11292,15 @@ func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.TargetUtilization == nil {
 					r.EncodeNil()
 				} else {
-					yym1016 := z.EncBinary()
-					_ = yym1016
+					yym1011 := z.EncBinary()
+					_ = yym1011
 					if false {
 					} else {
 						h.encSliceNodeUtilization(([]NodeUtilization)(x.TargetUtilization), e)
 					}
 				}
 			}
-			if yysep1007 {
+			if yysep1002 {
 				r.EncodeEnd()
 			}
 		}
@@ -11355,24 +11311,24 @@ func (x *ClusterAutoscalerSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1017 := z.DecBinary()
-	_ = yym1017
+	yym1012 := z.DecBinary()
+	_ = yym1012
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1018 := r.ReadMapStart()
-			if yyl1018 == 0 {
+			yyl1013 := r.ReadMapStart()
+			if yyl1013 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1018, d)
+				x.codecDecodeSelfFromMap(yyl1013, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1018 := r.ReadArrayStart()
-			if yyl1018 == 0 {
+			yyl1013 := r.ReadArrayStart()
+			if yyl1013 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1018, d)
+				x.codecDecodeSelfFromArray(yyl1013, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -11384,12 +11340,12 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1019Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1019Slc
-	var yyhl1019 bool = l >= 0
-	for yyj1019 := 0; ; yyj1019++ {
-		if yyhl1019 {
-			if yyj1019 >= l {
+	var yys1014Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1014Slc
+	var yyhl1014 bool = l >= 0
+	for yyj1014 := 0; ; yyj1014++ {
+		if yyhl1014 {
+			if yyj1014 >= l {
 				break
 			}
 		} else {
@@ -11397,9 +11353,9 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				break
 			}
 		}
-		yys1019Slc = r.DecodeBytes(yys1019Slc, true, true)
-		yys1019 := string(yys1019Slc)
-		switch yys1019 {
+		yys1014Slc = r.DecodeBytes(yys1014Slc, true, true)
+		yys1014 := string(yys1014Slc)
+		switch yys1014 {
 		case "minNodes":
 			if r.TryDecodeAsNil() {
 				x.MinNodes = 0
@@ -11416,19 +11372,19 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			if r.TryDecodeAsNil() {
 				x.TargetUtilization = nil
 			} else {
-				yyv1022 := &x.TargetUtilization
-				yym1023 := z.DecBinary()
-				_ = yym1023
+				yyv1017 := &x.TargetUtilization
+				yym1018 := z.DecBinary()
+				_ = yym1018
 				if false {
 				} else {
-					h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1022), d)
+					h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1017), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1019)
-		} // end switch yys1019
-	} // end for yyj1019
-	if !yyhl1019 {
+			z.DecStructFieldNotFound(-1, yys1014)
+		} // end switch yys1014
+	} // end for yyj1014
+	if !yyhl1014 {
 		r.ReadEnd()
 	}
 }
@@ -11437,16 +11393,16 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1024 int
-	var yyb1024 bool
-	var yyhl1024 bool = l >= 0
-	yyj1024++
-	if yyhl1024 {
-		yyb1024 = yyj1024 > l
+	var yyj1019 int
+	var yyb1019 bool
+	var yyhl1019 bool = l >= 0
+	yyj1019++
+	if yyhl1019 {
+		yyb1019 = yyj1019 > l
 	} else {
-		yyb1024 = r.CheckBreak()
+		yyb1019 = r.CheckBreak()
 	}
-	if yyb1024 {
+	if yyb1019 {
 		r.ReadEnd()
 		return
 	}
@@ -11455,13 +11411,13 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.MinNodes = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj1024++
-	if yyhl1024 {
-		yyb1024 = yyj1024 > l
+	yyj1019++
+	if yyhl1019 {
+		yyb1019 = yyj1019 > l
 	} else {
-		yyb1024 = r.CheckBreak()
+		yyb1019 = r.CheckBreak()
 	}
-	if yyb1024 {
+	if yyb1019 {
 		r.ReadEnd()
 		return
 	}
@@ -11470,38 +11426,38 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.MaxNodes = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj1024++
-	if yyhl1024 {
-		yyb1024 = yyj1024 > l
+	yyj1019++
+	if yyhl1019 {
+		yyb1019 = yyj1019 > l
 	} else {
-		yyb1024 = r.CheckBreak()
+		yyb1019 = r.CheckBreak()
 	}
-	if yyb1024 {
+	if yyb1019 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.TargetUtilization = nil
 	} else {
-		yyv1027 := &x.TargetUtilization
-		yym1028 := z.DecBinary()
-		_ = yym1028
+		yyv1022 := &x.TargetUtilization
+		yym1023 := z.DecBinary()
+		_ = yym1023
 		if false {
 		} else {
-			h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1027), d)
+			h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1022), d)
 		}
 	}
 	for {
-		yyj1024++
-		if yyhl1024 {
-			yyb1024 = yyj1024 > l
+		yyj1019++
+		if yyhl1019 {
+			yyb1019 = yyj1019 > l
 		} else {
-			yyb1024 = r.CheckBreak()
+			yyb1019 = r.CheckBreak()
 		}
-		if yyb1024 {
+		if yyb1019 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1024-1, "")
+		z.DecStructFieldNotFound(yyj1019-1, "")
 	}
 	r.ReadEnd()
 }
@@ -11513,35 +11469,35 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1029 := z.EncBinary()
-		_ = yym1029
+		yym1024 := z.EncBinary()
+		_ = yym1024
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1030 := !z.EncBinary()
-			yy2arr1030 := z.EncBasicHandle().StructToArray
-			var yyq1030 [4]bool
-			_, _, _ = yysep1030, yyq1030, yy2arr1030
-			const yyr1030 bool = false
-			yyq1030[0] = x.Kind != ""
-			yyq1030[1] = x.APIVersion != ""
-			yyq1030[2] = true
-			yyq1030[3] = true
-			if yyr1030 || yy2arr1030 {
+			yysep1025 := !z.EncBinary()
+			yy2arr1025 := z.EncBasicHandle().StructToArray
+			var yyq1025 [4]bool
+			_, _, _ = yysep1025, yyq1025, yy2arr1025
+			const yyr1025 bool = false
+			yyq1025[0] = x.Kind != ""
+			yyq1025[1] = x.APIVersion != ""
+			yyq1025[2] = true
+			yyq1025[3] = true
+			if yyr1025 || yy2arr1025 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1030 int = 0
-				for _, b := range yyq1030 {
+				var yynn1025 int = 0
+				for _, b := range yyq1025 {
 					if b {
-						yynn1030++
+						yynn1025++
 					}
 				}
-				r.EncodeMapStart(yynn1030)
+				r.EncodeMapStart(yynn1025)
 			}
-			if yyr1030 || yy2arr1030 {
-				if yyq1030[0] {
-					yym1032 := z.EncBinary()
-					_ = yym1032
+			if yyr1025 || yy2arr1025 {
+				if yyq1025[0] {
+					yym1027 := z.EncBinary()
+					_ = yym1027
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -11550,20 +11506,20 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1030[0] {
+				if yyq1025[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym1033 := z.EncBinary()
-					_ = yym1033
+					yym1028 := z.EncBinary()
+					_ = yym1028
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1030 || yy2arr1030 {
-				if yyq1030[1] {
-					yym1035 := z.EncBinary()
-					_ = yym1035
+			if yyr1025 || yy2arr1025 {
+				if yyq1025[1] {
+					yym1030 := z.EncBinary()
+					_ = yym1030
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -11572,45 +11528,45 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1030[1] {
+				if yyq1025[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym1036 := z.EncBinary()
-					_ = yym1036
+					yym1031 := z.EncBinary()
+					_ = yym1031
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1030 || yy2arr1030 {
-				if yyq1030[2] {
-					yy1038 := &x.ObjectMeta
-					yy1038.CodecEncodeSelf(e)
+			if yyr1025 || yy2arr1025 {
+				if yyq1025[2] {
+					yy1033 := &x.ObjectMeta
+					yy1033.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1030[2] {
+				if yyq1025[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy1039 := &x.ObjectMeta
-					yy1039.CodecEncodeSelf(e)
+					yy1034 := &x.ObjectMeta
+					yy1034.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1030 || yy2arr1030 {
-				if yyq1030[3] {
-					yy1041 := &x.Spec
-					yy1041.CodecEncodeSelf(e)
+			if yyr1025 || yy2arr1025 {
+				if yyq1025[3] {
+					yy1036 := &x.Spec
+					yy1036.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1030[3] {
+				if yyq1025[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy1042 := &x.Spec
-					yy1042.CodecEncodeSelf(e)
+					yy1037 := &x.Spec
+					yy1037.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1030 {
+			if yysep1025 {
 				r.EncodeEnd()
 			}
 		}
@@ -11621,24 +11577,24 @@ func (x *ClusterAutoscaler) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1043 := z.DecBinary()
-	_ = yym1043
+	yym1038 := z.DecBinary()
+	_ = yym1038
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1044 := r.ReadMapStart()
-			if yyl1044 == 0 {
+			yyl1039 := r.ReadMapStart()
+			if yyl1039 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1044, d)
+				x.codecDecodeSelfFromMap(yyl1039, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1044 := r.ReadArrayStart()
-			if yyl1044 == 0 {
+			yyl1039 := r.ReadArrayStart()
+			if yyl1039 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1044, d)
+				x.codecDecodeSelfFromArray(yyl1039, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -11650,12 +11606,12 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1045Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1045Slc
-	var yyhl1045 bool = l >= 0
-	for yyj1045 := 0; ; yyj1045++ {
-		if yyhl1045 {
-			if yyj1045 >= l {
+	var yys1040Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1040Slc
+	var yyhl1040 bool = l >= 0
+	for yyj1040 := 0; ; yyj1040++ {
+		if yyhl1040 {
+			if yyj1040 >= l {
 				break
 			}
 		} else {
@@ -11663,9 +11619,9 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				break
 			}
 		}
-		yys1045Slc = r.DecodeBytes(yys1045Slc, true, true)
-		yys1045 := string(yys1045Slc)
-		switch yys1045 {
+		yys1040Slc = r.DecodeBytes(yys1040Slc, true, true)
+		yys1040 := string(yys1040Slc)
+		switch yys1040 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -11682,21 +11638,21 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_api.ObjectMeta{}
 			} else {
-				yyv1048 := &x.ObjectMeta
-				yyv1048.CodecDecodeSelf(d)
+				yyv1043 := &x.ObjectMeta
+				yyv1043.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = ClusterAutoscalerSpec{}
 			} else {
-				yyv1049 := &x.Spec
-				yyv1049.CodecDecodeSelf(d)
+				yyv1044 := &x.Spec
+				yyv1044.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1045)
-		} // end switch yys1045
-	} // end for yyj1045
-	if !yyhl1045 {
+			z.DecStructFieldNotFound(-1, yys1040)
+		} // end switch yys1040
+	} // end for yyj1040
+	if !yyhl1040 {
 		r.ReadEnd()
 	}
 }
@@ -11705,16 +11661,16 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1050 int
-	var yyb1050 bool
-	var yyhl1050 bool = l >= 0
-	yyj1050++
-	if yyhl1050 {
-		yyb1050 = yyj1050 > l
+	var yyj1045 int
+	var yyb1045 bool
+	var yyhl1045 bool = l >= 0
+	yyj1045++
+	if yyhl1045 {
+		yyb1045 = yyj1045 > l
 	} else {
-		yyb1050 = r.CheckBreak()
+		yyb1045 = r.CheckBreak()
 	}
-	if yyb1050 {
+	if yyb1045 {
 		r.ReadEnd()
 		return
 	}
@@ -11723,13 +11679,13 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1050++
-	if yyhl1050 {
-		yyb1050 = yyj1050 > l
+	yyj1045++
+	if yyhl1045 {
+		yyb1045 = yyj1045 > l
 	} else {
-		yyb1050 = r.CheckBreak()
+		yyb1045 = r.CheckBreak()
 	}
-	if yyb1050 {
+	if yyb1045 {
 		r.ReadEnd()
 		return
 	}
@@ -11738,49 +11694,49 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj1050++
-	if yyhl1050 {
-		yyb1050 = yyj1050 > l
+	yyj1045++
+	if yyhl1045 {
+		yyb1045 = yyj1045 > l
 	} else {
-		yyb1050 = r.CheckBreak()
+		yyb1045 = r.CheckBreak()
 	}
-	if yyb1050 {
+	if yyb1045 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_api.ObjectMeta{}
 	} else {
-		yyv1053 := &x.ObjectMeta
-		yyv1053.CodecDecodeSelf(d)
+		yyv1048 := &x.ObjectMeta
+		yyv1048.CodecDecodeSelf(d)
 	}
-	yyj1050++
-	if yyhl1050 {
-		yyb1050 = yyj1050 > l
+	yyj1045++
+	if yyhl1045 {
+		yyb1045 = yyj1045 > l
 	} else {
-		yyb1050 = r.CheckBreak()
+		yyb1045 = r.CheckBreak()
 	}
-	if yyb1050 {
+	if yyb1045 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = ClusterAutoscalerSpec{}
 	} else {
-		yyv1054 := &x.Spec
-		yyv1054.CodecDecodeSelf(d)
+		yyv1049 := &x.Spec
+		yyv1049.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1050++
-		if yyhl1050 {
-			yyb1050 = yyj1050 > l
+		yyj1045++
+		if yyhl1045 {
+			yyb1045 = yyj1045 > l
 		} else {
-			yyb1050 = r.CheckBreak()
+			yyb1045 = r.CheckBreak()
 		}
-		if yyb1050 {
+		if yyb1045 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1050-1, "")
+		z.DecStructFieldNotFound(yyj1045-1, "")
 	}
 	r.ReadEnd()
 }
@@ -11792,34 +11748,34 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1055 := z.EncBinary()
-		_ = yym1055
+		yym1050 := z.EncBinary()
+		_ = yym1050
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1056 := !z.EncBinary()
-			yy2arr1056 := z.EncBasicHandle().StructToArray
-			var yyq1056 [4]bool
-			_, _, _ = yysep1056, yyq1056, yy2arr1056
-			const yyr1056 bool = false
-			yyq1056[0] = x.Kind != ""
-			yyq1056[1] = x.APIVersion != ""
-			yyq1056[2] = true
-			if yyr1056 || yy2arr1056 {
+			yysep1051 := !z.EncBinary()
+			yy2arr1051 := z.EncBasicHandle().StructToArray
+			var yyq1051 [4]bool
+			_, _, _ = yysep1051, yyq1051, yy2arr1051
+			const yyr1051 bool = false
+			yyq1051[0] = x.Kind != ""
+			yyq1051[1] = x.APIVersion != ""
+			yyq1051[2] = true
+			if yyr1051 || yy2arr1051 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1056 int = 1
-				for _, b := range yyq1056 {
+				var yynn1051 int = 1
+				for _, b := range yyq1051 {
 					if b {
-						yynn1056++
+						yynn1051++
 					}
 				}
-				r.EncodeMapStart(yynn1056)
+				r.EncodeMapStart(yynn1051)
 			}
-			if yyr1056 || yy2arr1056 {
-				if yyq1056[0] {
-					yym1058 := z.EncBinary()
-					_ = yym1058
+			if yyr1051 || yy2arr1051 {
+				if yyq1051[0] {
+					yym1053 := z.EncBinary()
+					_ = yym1053
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -11828,20 +11784,20 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1056[0] {
+				if yyq1051[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym1059 := z.EncBinary()
-					_ = yym1059
+					yym1054 := z.EncBinary()
+					_ = yym1054
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1056 || yy2arr1056 {
-				if yyq1056[1] {
-					yym1061 := z.EncBinary()
-					_ = yym1061
+			if yyr1051 || yy2arr1051 {
+				if yyq1051[1] {
+					yym1056 := z.EncBinary()
+					_ = yym1056
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -11850,48 +11806,48 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1056[1] {
+				if yyq1051[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym1057 := z.EncBinary()
+					_ = yym1057
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr1051 || yy2arr1051 {
+				if yyq1051[2] {
+					yy1059 := &x.ListMeta
+					yym1060 := z.EncBinary()
+					_ = yym1060
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1059) {
+					} else {
+						z.EncFallback(yy1059)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1051[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy1061 := &x.ListMeta
 					yym1062 := z.EncBinary()
 					_ = yym1062
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1061) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						z.EncFallback(yy1061)
 					}
 				}
 			}
-			if yyr1056 || yy2arr1056 {
-				if yyq1056[2] {
-					yy1064 := &x.ListMeta
-					yym1065 := z.EncBinary()
-					_ = yym1065
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1064) {
-					} else {
-						z.EncFallback(yy1064)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1056[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy1066 := &x.ListMeta
-					yym1067 := z.EncBinary()
-					_ = yym1067
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1066) {
-					} else {
-						z.EncFallback(yy1066)
-					}
-				}
-			}
-			if yyr1056 || yy2arr1056 {
+			if yyr1051 || yy2arr1051 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1069 := z.EncBinary()
-					_ = yym1069
+					yym1064 := z.EncBinary()
+					_ = yym1064
 					if false {
 					} else {
 						h.encSliceClusterAutoscaler(([]ClusterAutoscaler)(x.Items), e)
@@ -11902,15 +11858,15 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1070 := z.EncBinary()
-					_ = yym1070
+					yym1065 := z.EncBinary()
+					_ = yym1065
 					if false {
 					} else {
 						h.encSliceClusterAutoscaler(([]ClusterAutoscaler)(x.Items), e)
 					}
 				}
 			}
-			if yysep1056 {
+			if yysep1051 {
 				r.EncodeEnd()
 			}
 		}
@@ -11921,24 +11877,24 @@ func (x *ClusterAutoscalerList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1071 := z.DecBinary()
-	_ = yym1071
+	yym1066 := z.DecBinary()
+	_ = yym1066
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1072 := r.ReadMapStart()
-			if yyl1072 == 0 {
+			yyl1067 := r.ReadMapStart()
+			if yyl1067 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1072, d)
+				x.codecDecodeSelfFromMap(yyl1067, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1072 := r.ReadArrayStart()
-			if yyl1072 == 0 {
+			yyl1067 := r.ReadArrayStart()
+			if yyl1067 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1072, d)
+				x.codecDecodeSelfFromArray(yyl1067, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -11950,12 +11906,12 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1073Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1073Slc
-	var yyhl1073 bool = l >= 0
-	for yyj1073 := 0; ; yyj1073++ {
-		if yyhl1073 {
-			if yyj1073 >= l {
+	var yys1068Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1068Slc
+	var yyhl1068 bool = l >= 0
+	for yyj1068 := 0; ; yyj1068++ {
+		if yyhl1068 {
+			if yyj1068 >= l {
 				break
 			}
 		} else {
@@ -11963,9 +11919,9 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				break
 			}
 		}
-		yys1073Slc = r.DecodeBytes(yys1073Slc, true, true)
-		yys1073 := string(yys1073Slc)
-		switch yys1073 {
+		yys1068Slc = r.DecodeBytes(yys1068Slc, true, true)
+		yys1068 := string(yys1068Slc)
+		switch yys1068 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -11982,32 +11938,32 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv1076 := &x.ListMeta
-				yym1077 := z.DecBinary()
-				_ = yym1077
+				yyv1071 := &x.ListMeta
+				yym1072 := z.DecBinary()
+				_ = yym1072
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1076) {
+				} else if z.HasExtensions() && z.DecExt(yyv1071) {
 				} else {
-					z.DecFallback(yyv1076, false)
+					z.DecFallback(yyv1071, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv1078 := &x.Items
-				yym1079 := z.DecBinary()
-				_ = yym1079
+				yyv1073 := &x.Items
+				yym1074 := z.DecBinary()
+				_ = yym1074
 				if false {
 				} else {
-					h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1078), d)
+					h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1073), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1073)
-		} // end switch yys1073
-	} // end for yyj1073
-	if !yyhl1073 {
+			z.DecStructFieldNotFound(-1, yys1068)
+		} // end switch yys1068
+	} // end for yyj1068
+	if !yyhl1068 {
 		r.ReadEnd()
 	}
 }
@@ -12016,16 +11972,16 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1080 int
-	var yyb1080 bool
-	var yyhl1080 bool = l >= 0
-	yyj1080++
-	if yyhl1080 {
-		yyb1080 = yyj1080 > l
+	var yyj1075 int
+	var yyb1075 bool
+	var yyhl1075 bool = l >= 0
+	yyj1075++
+	if yyhl1075 {
+		yyb1075 = yyj1075 > l
 	} else {
-		yyb1080 = r.CheckBreak()
+		yyb1075 = r.CheckBreak()
 	}
-	if yyb1080 {
+	if yyb1075 {
 		r.ReadEnd()
 		return
 	}
@@ -12034,13 +11990,13 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1080++
-	if yyhl1080 {
-		yyb1080 = yyj1080 > l
+	yyj1075++
+	if yyhl1075 {
+		yyb1075 = yyj1075 > l
 	} else {
-		yyb1080 = r.CheckBreak()
+		yyb1075 = r.CheckBreak()
 	}
-	if yyb1080 {
+	if yyb1075 {
 		r.ReadEnd()
 		return
 	}
@@ -12049,60 +12005,60 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj1080++
-	if yyhl1080 {
-		yyb1080 = yyj1080 > l
+	yyj1075++
+	if yyhl1075 {
+		yyb1075 = yyj1075 > l
 	} else {
-		yyb1080 = r.CheckBreak()
+		yyb1075 = r.CheckBreak()
 	}
-	if yyb1080 {
+	if yyb1075 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv1083 := &x.ListMeta
-		yym1084 := z.DecBinary()
-		_ = yym1084
+		yyv1078 := &x.ListMeta
+		yym1079 := z.DecBinary()
+		_ = yym1079
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1083) {
+		} else if z.HasExtensions() && z.DecExt(yyv1078) {
 		} else {
-			z.DecFallback(yyv1083, false)
+			z.DecFallback(yyv1078, false)
 		}
 	}
-	yyj1080++
-	if yyhl1080 {
-		yyb1080 = yyj1080 > l
+	yyj1075++
+	if yyhl1075 {
+		yyb1075 = yyj1075 > l
 	} else {
-		yyb1080 = r.CheckBreak()
+		yyb1075 = r.CheckBreak()
 	}
-	if yyb1080 {
+	if yyb1075 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv1085 := &x.Items
-		yym1086 := z.DecBinary()
-		_ = yym1086
+		yyv1080 := &x.Items
+		yym1081 := z.DecBinary()
+		_ = yym1081
 		if false {
 		} else {
-			h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1085), d)
+			h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1080), d)
 		}
 	}
 	for {
-		yyj1080++
-		if yyhl1080 {
-			yyb1080 = yyj1080 > l
+		yyj1075++
+		if yyhl1075 {
+			yyb1075 = yyj1075 > l
 		} else {
-			yyb1080 = r.CheckBreak()
+			yyb1075 = r.CheckBreak()
 		}
-		if yyb1080 {
+		if yyb1075 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1080-1, "")
+		z.DecStructFieldNotFound(yyj1075-1, "")
 	}
 	r.ReadEnd()
 }
@@ -12114,36 +12070,36 @@ func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1087 := z.EncBinary()
-		_ = yym1087
+		yym1082 := z.EncBinary()
+		_ = yym1082
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1088 := !z.EncBinary()
-			yy2arr1088 := z.EncBasicHandle().StructToArray
-			var yyq1088 [2]bool
-			_, _, _ = yysep1088, yyq1088, yy2arr1088
-			const yyr1088 bool = false
-			yyq1088[0] = len(x.MatchLabels) != 0
-			yyq1088[1] = len(x.MatchExpressions) != 0
-			if yyr1088 || yy2arr1088 {
+			yysep1083 := !z.EncBinary()
+			yy2arr1083 := z.EncBasicHandle().StructToArray
+			var yyq1083 [2]bool
+			_, _, _ = yysep1083, yyq1083, yy2arr1083
+			const yyr1083 bool = false
+			yyq1083[0] = len(x.MatchLabels) != 0
+			yyq1083[1] = len(x.MatchExpressions) != 0
+			if yyr1083 || yy2arr1083 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn1088 int = 0
-				for _, b := range yyq1088 {
+				var yynn1083 int = 0
+				for _, b := range yyq1083 {
 					if b {
-						yynn1088++
+						yynn1083++
 					}
 				}
-				r.EncodeMapStart(yynn1088)
+				r.EncodeMapStart(yynn1083)
 			}
-			if yyr1088 || yy2arr1088 {
-				if yyq1088[0] {
+			if yyr1083 || yy2arr1083 {
+				if yyq1083[0] {
 					if x.MatchLabels == nil {
 						r.EncodeNil()
 					} else {
-						yym1090 := z.EncBinary()
-						_ = yym1090
+						yym1085 := z.EncBinary()
+						_ = yym1085
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.MatchLabels, false, e)
@@ -12153,13 +12109,13 @@ func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1088[0] {
+				if yyq1083[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("matchLabels"))
 					if x.MatchLabels == nil {
 						r.EncodeNil()
 					} else {
-						yym1091 := z.EncBinary()
-						_ = yym1091
+						yym1086 := z.EncBinary()
+						_ = yym1086
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.MatchLabels, false, e)
@@ -12167,13 +12123,13 @@ func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1088 || yy2arr1088 {
-				if yyq1088[1] {
+			if yyr1083 || yy2arr1083 {
+				if yyq1083[1] {
 					if x.MatchExpressions == nil {
 						r.EncodeNil()
 					} else {
-						yym1093 := z.EncBinary()
-						_ = yym1093
+						yym1088 := z.EncBinary()
+						_ = yym1088
 						if false {
 						} else {
 							h.encSlicePodSelectorRequirement(([]PodSelectorRequirement)(x.MatchExpressions), e)
@@ -12183,13 +12139,13 @@ func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1088[1] {
+				if yyq1083[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("matchExpressions"))
 					if x.MatchExpressions == nil {
 						r.EncodeNil()
 					} else {
-						yym1094 := z.EncBinary()
-						_ = yym1094
+						yym1089 := z.EncBinary()
+						_ = yym1089
 						if false {
 						} else {
 							h.encSlicePodSelectorRequirement(([]PodSelectorRequirement)(x.MatchExpressions), e)
@@ -12197,7 +12153,7 @@ func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1088 {
+			if yysep1083 {
 				r.EncodeEnd()
 			}
 		}
@@ -12208,24 +12164,24 @@ func (x *PodSelector) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1095 := z.DecBinary()
-	_ = yym1095
+	yym1090 := z.DecBinary()
+	_ = yym1090
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1096 := r.ReadMapStart()
-			if yyl1096 == 0 {
+			yyl1091 := r.ReadMapStart()
+			if yyl1091 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1096, d)
+				x.codecDecodeSelfFromMap(yyl1091, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1096 := r.ReadArrayStart()
-			if yyl1096 == 0 {
+			yyl1091 := r.ReadArrayStart()
+			if yyl1091 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1096, d)
+				x.codecDecodeSelfFromArray(yyl1091, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -12237,12 +12193,12 @@ func (x *PodSelector) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1097Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1097Slc
-	var yyhl1097 bool = l >= 0
-	for yyj1097 := 0; ; yyj1097++ {
-		if yyhl1097 {
-			if yyj1097 >= l {
+	var yys1092Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1092Slc
+	var yyhl1092 bool = l >= 0
+	for yyj1092 := 0; ; yyj1092++ {
+		if yyhl1092 {
+			if yyj1092 >= l {
 				break
 			}
 		} else {
@@ -12250,38 +12206,38 @@ func (x *PodSelector) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys1097Slc = r.DecodeBytes(yys1097Slc, true, true)
-		yys1097 := string(yys1097Slc)
-		switch yys1097 {
+		yys1092Slc = r.DecodeBytes(yys1092Slc, true, true)
+		yys1092 := string(yys1092Slc)
+		switch yys1092 {
 		case "matchLabels":
 			if r.TryDecodeAsNil() {
 				x.MatchLabels = nil
 			} else {
-				yyv1098 := &x.MatchLabels
-				yym1099 := z.DecBinary()
-				_ = yym1099
+				yyv1093 := &x.MatchLabels
+				yym1094 := z.DecBinary()
+				_ = yym1094
 				if false {
 				} else {
-					z.F.DecMapStringStringX(yyv1098, false, d)
+					z.F.DecMapStringStringX(yyv1093, false, d)
 				}
 			}
 		case "matchExpressions":
 			if r.TryDecodeAsNil() {
 				x.MatchExpressions = nil
 			} else {
-				yyv1100 := &x.MatchExpressions
-				yym1101 := z.DecBinary()
-				_ = yym1101
+				yyv1095 := &x.MatchExpressions
+				yym1096 := z.DecBinary()
+				_ = yym1096
 				if false {
 				} else {
-					h.decSlicePodSelectorRequirement((*[]PodSelectorRequirement)(yyv1100), d)
+					h.decSlicePodSelectorRequirement((*[]PodSelectorRequirement)(yyv1095), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1097)
-		} // end switch yys1097
-	} // end for yyj1097
-	if !yyhl1097 {
+			z.DecStructFieldNotFound(-1, yys1092)
+		} // end switch yys1092
+	} // end for yyj1092
+	if !yyhl1092 {
 		r.ReadEnd()
 	}
 }
@@ -12290,62 +12246,62 @@ func (x *PodSelector) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1102 int
-	var yyb1102 bool
-	var yyhl1102 bool = l >= 0
-	yyj1102++
-	if yyhl1102 {
-		yyb1102 = yyj1102 > l
+	var yyj1097 int
+	var yyb1097 bool
+	var yyhl1097 bool = l >= 0
+	yyj1097++
+	if yyhl1097 {
+		yyb1097 = yyj1097 > l
 	} else {
-		yyb1102 = r.CheckBreak()
+		yyb1097 = r.CheckBreak()
 	}
-	if yyb1102 {
+	if yyb1097 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.MatchLabels = nil
 	} else {
-		yyv1103 := &x.MatchLabels
-		yym1104 := z.DecBinary()
-		_ = yym1104
+		yyv1098 := &x.MatchLabels
+		yym1099 := z.DecBinary()
+		_ = yym1099
 		if false {
 		} else {
-			z.F.DecMapStringStringX(yyv1103, false, d)
+			z.F.DecMapStringStringX(yyv1098, false, d)
 		}
 	}
-	yyj1102++
-	if yyhl1102 {
-		yyb1102 = yyj1102 > l
+	yyj1097++
+	if yyhl1097 {
+		yyb1097 = yyj1097 > l
 	} else {
-		yyb1102 = r.CheckBreak()
+		yyb1097 = r.CheckBreak()
 	}
-	if yyb1102 {
+	if yyb1097 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.MatchExpressions = nil
 	} else {
-		yyv1105 := &x.MatchExpressions
-		yym1106 := z.DecBinary()
-		_ = yym1106
+		yyv1100 := &x.MatchExpressions
+		yym1101 := z.DecBinary()
+		_ = yym1101
 		if false {
 		} else {
-			h.decSlicePodSelectorRequirement((*[]PodSelectorRequirement)(yyv1105), d)
+			h.decSlicePodSelectorRequirement((*[]PodSelectorRequirement)(yyv1100), d)
 		}
 	}
 	for {
-		yyj1102++
-		if yyhl1102 {
-			yyb1102 = yyj1102 > l
+		yyj1097++
+		if yyhl1097 {
+			yyb1097 = yyj1097 > l
 		} else {
-			yyb1102 = r.CheckBreak()
+			yyb1097 = r.CheckBreak()
 		}
-		if yyb1102 {
+		if yyb1097 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1102-1, "")
+		z.DecStructFieldNotFound(yyj1097-1, "")
 	}
 	r.ReadEnd()
 }
@@ -12357,57 +12313,57 @@ func (x *PodSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1107 := z.EncBinary()
-		_ = yym1107
+		yym1102 := z.EncBinary()
+		_ = yym1102
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1108 := !z.EncBinary()
-			yy2arr1108 := z.EncBasicHandle().StructToArray
-			var yyq1108 [3]bool
-			_, _, _ = yysep1108, yyq1108, yy2arr1108
-			const yyr1108 bool = false
-			yyq1108[2] = len(x.Values) != 0
-			if yyr1108 || yy2arr1108 {
+			yysep1103 := !z.EncBinary()
+			yy2arr1103 := z.EncBasicHandle().StructToArray
+			var yyq1103 [3]bool
+			_, _, _ = yysep1103, yyq1103, yy2arr1103
+			const yyr1103 bool = false
+			yyq1103[2] = len(x.Values) != 0
+			if yyr1103 || yy2arr1103 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn1108 int = 2
-				for _, b := range yyq1108 {
+				var yynn1103 int = 2
+				for _, b := range yyq1103 {
 					if b {
-						yynn1108++
+						yynn1103++
 					}
 				}
-				r.EncodeMapStart(yynn1108)
+				r.EncodeMapStart(yynn1103)
 			}
-			if yyr1108 || yy2arr1108 {
-				yym1110 := z.EncBinary()
-				_ = yym1110
+			if yyr1103 || yy2arr1103 {
+				yym1105 := z.EncBinary()
+				_ = yym1105
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("key"))
-				yym1111 := z.EncBinary()
-				_ = yym1111
+				yym1106 := z.EncBinary()
+				_ = yym1106
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
 				}
 			}
-			if yyr1108 || yy2arr1108 {
+			if yyr1103 || yy2arr1103 {
 				x.Operator.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("operator"))
 				x.Operator.CodecEncodeSelf(e)
 			}
-			if yyr1108 || yy2arr1108 {
-				if yyq1108[2] {
+			if yyr1103 || yy2arr1103 {
+				if yyq1103[2] {
 					if x.Values == nil {
 						r.EncodeNil()
 					} else {
-						yym1114 := z.EncBinary()
-						_ = yym1114
+						yym1109 := z.EncBinary()
+						_ = yym1109
 						if false {
 						} else {
 							z.F.EncSliceStringV(x.Values, false, e)
@@ -12417,13 +12373,13 @@ func (x *PodSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1108[2] {
+				if yyq1103[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("values"))
 					if x.Values == nil {
 						r.EncodeNil()
 					} else {
-						yym1115 := z.EncBinary()
-						_ = yym1115
+						yym1110 := z.EncBinary()
+						_ = yym1110
 						if false {
 						} else {
 							z.F.EncSliceStringV(x.Values, false, e)
@@ -12431,7 +12387,7 @@ func (x *PodSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1108 {
+			if yysep1103 {
 				r.EncodeEnd()
 			}
 		}
@@ -12442,24 +12398,24 @@ func (x *PodSelectorRequirement) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1116 := z.DecBinary()
-	_ = yym1116
+	yym1111 := z.DecBinary()
+	_ = yym1111
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1117 := r.ReadMapStart()
-			if yyl1117 == 0 {
+			yyl1112 := r.ReadMapStart()
+			if yyl1112 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1117, d)
+				x.codecDecodeSelfFromMap(yyl1112, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1117 := r.ReadArrayStart()
-			if yyl1117 == 0 {
+			yyl1112 := r.ReadArrayStart()
+			if yyl1112 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1117, d)
+				x.codecDecodeSelfFromArray(yyl1112, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -12471,12 +12427,12 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1118Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1118Slc
-	var yyhl1118 bool = l >= 0
-	for yyj1118 := 0; ; yyj1118++ {
-		if yyhl1118 {
-			if yyj1118 >= l {
+	var yys1113Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1113Slc
+	var yyhl1113 bool = l >= 0
+	for yyj1113 := 0; ; yyj1113++ {
+		if yyhl1113 {
+			if yyj1113 >= l {
 				break
 			}
 		} else {
@@ -12484,9 +12440,9 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				break
 			}
 		}
-		yys1118Slc = r.DecodeBytes(yys1118Slc, true, true)
-		yys1118 := string(yys1118Slc)
-		switch yys1118 {
+		yys1113Slc = r.DecodeBytes(yys1113Slc, true, true)
+		yys1113 := string(yys1113Slc)
+		switch yys1113 {
 		case "key":
 			if r.TryDecodeAsNil() {
 				x.Key = ""
@@ -12503,19 +12459,19 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			if r.TryDecodeAsNil() {
 				x.Values = nil
 			} else {
-				yyv1121 := &x.Values
-				yym1122 := z.DecBinary()
-				_ = yym1122
+				yyv1116 := &x.Values
+				yym1117 := z.DecBinary()
+				_ = yym1117
 				if false {
 				} else {
-					z.F.DecSliceStringX(yyv1121, false, d)
+					z.F.DecSliceStringX(yyv1116, false, d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1118)
-		} // end switch yys1118
-	} // end for yyj1118
-	if !yyhl1118 {
+			z.DecStructFieldNotFound(-1, yys1113)
+		} // end switch yys1113
+	} // end for yyj1113
+	if !yyhl1113 {
 		r.ReadEnd()
 	}
 }
@@ -12524,16 +12480,16 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromArray(l int, d *codec1978.De
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1123 int
-	var yyb1123 bool
-	var yyhl1123 bool = l >= 0
-	yyj1123++
-	if yyhl1123 {
-		yyb1123 = yyj1123 > l
+	var yyj1118 int
+	var yyb1118 bool
+	var yyhl1118 bool = l >= 0
+	yyj1118++
+	if yyhl1118 {
+		yyb1118 = yyj1118 > l
 	} else {
-		yyb1123 = r.CheckBreak()
+		yyb1118 = r.CheckBreak()
 	}
-	if yyb1123 {
+	if yyb1118 {
 		r.ReadEnd()
 		return
 	}
@@ -12542,13 +12498,13 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromArray(l int, d *codec1978.De
 	} else {
 		x.Key = string(r.DecodeString())
 	}
-	yyj1123++
-	if yyhl1123 {
-		yyb1123 = yyj1123 > l
+	yyj1118++
+	if yyhl1118 {
+		yyb1118 = yyj1118 > l
 	} else {
-		yyb1123 = r.CheckBreak()
+		yyb1118 = r.CheckBreak()
 	}
-	if yyb1123 {
+	if yyb1118 {
 		r.ReadEnd()
 		return
 	}
@@ -12557,38 +12513,38 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromArray(l int, d *codec1978.De
 	} else {
 		x.Operator = PodSelectorOperator(r.DecodeString())
 	}
-	yyj1123++
-	if yyhl1123 {
-		yyb1123 = yyj1123 > l
+	yyj1118++
+	if yyhl1118 {
+		yyb1118 = yyj1118 > l
 	} else {
-		yyb1123 = r.CheckBreak()
+		yyb1118 = r.CheckBreak()
 	}
-	if yyb1123 {
+	if yyb1118 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Values = nil
 	} else {
-		yyv1126 := &x.Values
-		yym1127 := z.DecBinary()
-		_ = yym1127
+		yyv1121 := &x.Values
+		yym1122 := z.DecBinary()
+		_ = yym1122
 		if false {
 		} else {
-			z.F.DecSliceStringX(yyv1126, false, d)
+			z.F.DecSliceStringX(yyv1121, false, d)
 		}
 	}
 	for {
-		yyj1123++
-		if yyhl1123 {
-			yyb1123 = yyj1123 > l
+		yyj1118++
+		if yyhl1118 {
+			yyb1118 = yyj1118 > l
 		} else {
-			yyb1123 = r.CheckBreak()
+			yyb1118 = r.CheckBreak()
 		}
-		if yyb1123 {
+		if yyb1118 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1123-1, "")
+		z.DecStructFieldNotFound(yyj1118-1, "")
 	}
 	r.ReadEnd()
 }
@@ -12597,8 +12553,8 @@ func (x PodSelectorOperator) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym1128 := z.EncBinary()
-	_ = yym1128
+	yym1123 := z.EncBinary()
+	_ = yym1123
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -12610,8 +12566,8 @@ func (x *PodSelectorOperator) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1129 := z.DecBinary()
-	_ = yym1129
+	yym1124 := z.DecBinary()
+	_ = yym1124
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -12624,9 +12580,9 @@ func (x codecSelfer1234) encSliceHorizontalPodAutoscaler(v []HorizontalPodAutosc
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1130 := range v {
-		yy1131 := &yyv1130
-		yy1131.CodecEncodeSelf(e)
+	for _, yyv1125 := range v {
+		yy1126 := &yyv1125
+		yy1126.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -12636,75 +12592,75 @@ func (x codecSelfer1234) decSliceHorizontalPodAutoscaler(v *[]HorizontalPodAutos
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1132 := *v
-	yyh1132, yyl1132 := z.DecSliceHelperStart()
+	yyv1127 := *v
+	yyh1127, yyl1127 := z.DecSliceHelperStart()
 
-	var yyrr1132, yyrl1132 int
-	var yyc1132, yyrt1132 bool
-	_, _, _ = yyc1132, yyrt1132, yyrl1132
-	yyrr1132 = yyl1132
+	var yyrr1127, yyrl1127 int
+	var yyc1127, yyrt1127 bool
+	_, _, _ = yyc1127, yyrt1127, yyrl1127
+	yyrr1127 = yyl1127
 
-	if yyv1132 == nil {
-		if yyrl1132, yyrt1132 = z.DecInferLen(yyl1132, z.DecBasicHandle().MaxInitLen, 336); yyrt1132 {
-			yyrr1132 = yyrl1132
+	if yyv1127 == nil {
+		if yyrl1127, yyrt1127 = z.DecInferLen(yyl1127, z.DecBasicHandle().MaxInitLen, 320); yyrt1127 {
+			yyrr1127 = yyrl1127
 		}
-		yyv1132 = make([]HorizontalPodAutoscaler, yyrl1132)
-		yyc1132 = true
+		yyv1127 = make([]HorizontalPodAutoscaler, yyrl1127)
+		yyc1127 = true
 	}
 
-	if yyl1132 == 0 {
-		if len(yyv1132) != 0 {
-			yyv1132 = yyv1132[:0]
-			yyc1132 = true
+	if yyl1127 == 0 {
+		if len(yyv1127) != 0 {
+			yyv1127 = yyv1127[:0]
+			yyc1127 = true
 		}
-	} else if yyl1132 > 0 {
+	} else if yyl1127 > 0 {
 
-		if yyl1132 > cap(yyv1132) {
-			yyrl1132, yyrt1132 = z.DecInferLen(yyl1132, z.DecBasicHandle().MaxInitLen, 336)
-			yyv1132 = make([]HorizontalPodAutoscaler, yyrl1132)
-			yyc1132 = true
+		if yyl1127 > cap(yyv1127) {
+			yyrl1127, yyrt1127 = z.DecInferLen(yyl1127, z.DecBasicHandle().MaxInitLen, 320)
+			yyv1127 = make([]HorizontalPodAutoscaler, yyrl1127)
+			yyc1127 = true
 
-			yyrr1132 = len(yyv1132)
-		} else if yyl1132 != len(yyv1132) {
-			yyv1132 = yyv1132[:yyl1132]
-			yyc1132 = true
+			yyrr1127 = len(yyv1127)
+		} else if yyl1127 != len(yyv1127) {
+			yyv1127 = yyv1127[:yyl1127]
+			yyc1127 = true
 		}
-		yyj1132 := 0
-		for ; yyj1132 < yyrr1132; yyj1132++ {
+		yyj1127 := 0
+		for ; yyj1127 < yyrr1127; yyj1127++ {
 			if r.TryDecodeAsNil() {
-				yyv1132[yyj1132] = HorizontalPodAutoscaler{}
+				yyv1127[yyj1127] = HorizontalPodAutoscaler{}
 			} else {
-				yyv1133 := &yyv1132[yyj1132]
-				yyv1133.CodecDecodeSelf(d)
+				yyv1128 := &yyv1127[yyj1127]
+				yyv1128.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1132 {
-			for ; yyj1132 < yyl1132; yyj1132++ {
-				yyv1132 = append(yyv1132, HorizontalPodAutoscaler{})
+		if yyrt1127 {
+			for ; yyj1127 < yyl1127; yyj1127++ {
+				yyv1127 = append(yyv1127, HorizontalPodAutoscaler{})
 				if r.TryDecodeAsNil() {
-					yyv1132[yyj1132] = HorizontalPodAutoscaler{}
+					yyv1127[yyj1127] = HorizontalPodAutoscaler{}
 				} else {
-					yyv1134 := &yyv1132[yyj1132]
-					yyv1134.CodecDecodeSelf(d)
+					yyv1129 := &yyv1127[yyj1127]
+					yyv1129.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1132 := 0; !r.CheckBreak(); yyj1132++ {
-			if yyj1132 >= len(yyv1132) {
-				yyv1132 = append(yyv1132, HorizontalPodAutoscaler{}) // var yyz1132 HorizontalPodAutoscaler
-				yyc1132 = true
+		for yyj1127 := 0; !r.CheckBreak(); yyj1127++ {
+			if yyj1127 >= len(yyv1127) {
+				yyv1127 = append(yyv1127, HorizontalPodAutoscaler{}) // var yyz1127 HorizontalPodAutoscaler
+				yyc1127 = true
 			}
 
-			if yyj1132 < len(yyv1132) {
+			if yyj1127 < len(yyv1127) {
 				if r.TryDecodeAsNil() {
-					yyv1132[yyj1132] = HorizontalPodAutoscaler{}
+					yyv1127[yyj1127] = HorizontalPodAutoscaler{}
 				} else {
-					yyv1135 := &yyv1132[yyj1132]
-					yyv1135.CodecDecodeSelf(d)
+					yyv1130 := &yyv1127[yyj1127]
+					yyv1130.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -12712,10 +12668,10 @@ func (x codecSelfer1234) decSliceHorizontalPodAutoscaler(v *[]HorizontalPodAutos
 			}
 
 		}
-		yyh1132.End()
+		yyh1127.End()
 	}
-	if yyc1132 {
-		*v = yyv1132
+	if yyc1127 {
+		*v = yyv1127
 	}
 
 }
@@ -12725,9 +12681,9 @@ func (x codecSelfer1234) encSliceAPIVersion(v []APIVersion, e *codec1978.Encoder
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1136 := range v {
-		yy1137 := &yyv1136
-		yy1137.CodecEncodeSelf(e)
+	for _, yyv1131 := range v {
+		yy1132 := &yyv1131
+		yy1132.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -12737,75 +12693,75 @@ func (x codecSelfer1234) decSliceAPIVersion(v *[]APIVersion, d *codec1978.Decode
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1138 := *v
-	yyh1138, yyl1138 := z.DecSliceHelperStart()
+	yyv1133 := *v
+	yyh1133, yyl1133 := z.DecSliceHelperStart()
 
-	var yyrr1138, yyrl1138 int
-	var yyc1138, yyrt1138 bool
-	_, _, _ = yyc1138, yyrt1138, yyrl1138
-	yyrr1138 = yyl1138
+	var yyrr1133, yyrl1133 int
+	var yyc1133, yyrt1133 bool
+	_, _, _ = yyc1133, yyrt1133, yyrl1133
+	yyrr1133 = yyl1133
 
-	if yyv1138 == nil {
-		if yyrl1138, yyrt1138 = z.DecInferLen(yyl1138, z.DecBasicHandle().MaxInitLen, 32); yyrt1138 {
-			yyrr1138 = yyrl1138
+	if yyv1133 == nil {
+		if yyrl1133, yyrt1133 = z.DecInferLen(yyl1133, z.DecBasicHandle().MaxInitLen, 32); yyrt1133 {
+			yyrr1133 = yyrl1133
 		}
-		yyv1138 = make([]APIVersion, yyrl1138)
-		yyc1138 = true
+		yyv1133 = make([]APIVersion, yyrl1133)
+		yyc1133 = true
 	}
 
-	if yyl1138 == 0 {
-		if len(yyv1138) != 0 {
-			yyv1138 = yyv1138[:0]
-			yyc1138 = true
+	if yyl1133 == 0 {
+		if len(yyv1133) != 0 {
+			yyv1133 = yyv1133[:0]
+			yyc1133 = true
 		}
-	} else if yyl1138 > 0 {
+	} else if yyl1133 > 0 {
 
-		if yyl1138 > cap(yyv1138) {
-			yyrl1138, yyrt1138 = z.DecInferLen(yyl1138, z.DecBasicHandle().MaxInitLen, 32)
-			yyv1138 = make([]APIVersion, yyrl1138)
-			yyc1138 = true
+		if yyl1133 > cap(yyv1133) {
+			yyrl1133, yyrt1133 = z.DecInferLen(yyl1133, z.DecBasicHandle().MaxInitLen, 32)
+			yyv1133 = make([]APIVersion, yyrl1133)
+			yyc1133 = true
 
-			yyrr1138 = len(yyv1138)
-		} else if yyl1138 != len(yyv1138) {
-			yyv1138 = yyv1138[:yyl1138]
-			yyc1138 = true
+			yyrr1133 = len(yyv1133)
+		} else if yyl1133 != len(yyv1133) {
+			yyv1133 = yyv1133[:yyl1133]
+			yyc1133 = true
 		}
-		yyj1138 := 0
-		for ; yyj1138 < yyrr1138; yyj1138++ {
+		yyj1133 := 0
+		for ; yyj1133 < yyrr1133; yyj1133++ {
 			if r.TryDecodeAsNil() {
-				yyv1138[yyj1138] = APIVersion{}
+				yyv1133[yyj1133] = APIVersion{}
 			} else {
-				yyv1139 := &yyv1138[yyj1138]
-				yyv1139.CodecDecodeSelf(d)
+				yyv1134 := &yyv1133[yyj1133]
+				yyv1134.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1138 {
-			for ; yyj1138 < yyl1138; yyj1138++ {
-				yyv1138 = append(yyv1138, APIVersion{})
+		if yyrt1133 {
+			for ; yyj1133 < yyl1133; yyj1133++ {
+				yyv1133 = append(yyv1133, APIVersion{})
 				if r.TryDecodeAsNil() {
-					yyv1138[yyj1138] = APIVersion{}
+					yyv1133[yyj1133] = APIVersion{}
 				} else {
-					yyv1140 := &yyv1138[yyj1138]
-					yyv1140.CodecDecodeSelf(d)
+					yyv1135 := &yyv1133[yyj1133]
+					yyv1135.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1138 := 0; !r.CheckBreak(); yyj1138++ {
-			if yyj1138 >= len(yyv1138) {
-				yyv1138 = append(yyv1138, APIVersion{}) // var yyz1138 APIVersion
-				yyc1138 = true
+		for yyj1133 := 0; !r.CheckBreak(); yyj1133++ {
+			if yyj1133 >= len(yyv1133) {
+				yyv1133 = append(yyv1133, APIVersion{}) // var yyz1133 APIVersion
+				yyc1133 = true
 			}
 
-			if yyj1138 < len(yyv1138) {
+			if yyj1133 < len(yyv1133) {
 				if r.TryDecodeAsNil() {
-					yyv1138[yyj1138] = APIVersion{}
+					yyv1133[yyj1133] = APIVersion{}
 				} else {
-					yyv1141 := &yyv1138[yyj1138]
-					yyv1141.CodecDecodeSelf(d)
+					yyv1136 := &yyv1133[yyj1133]
+					yyv1136.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -12813,10 +12769,10 @@ func (x codecSelfer1234) decSliceAPIVersion(v *[]APIVersion, d *codec1978.Decode
 			}
 
 		}
-		yyh1138.End()
+		yyh1133.End()
 	}
-	if yyc1138 {
-		*v = yyv1138
+	if yyc1133 {
+		*v = yyv1133
 	}
 
 }
@@ -12826,9 +12782,9 @@ func (x codecSelfer1234) encSliceThirdPartyResource(v []ThirdPartyResource, e *c
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1142 := range v {
-		yy1143 := &yyv1142
-		yy1143.CodecEncodeSelf(e)
+	for _, yyv1137 := range v {
+		yy1138 := &yyv1137
+		yy1138.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -12838,75 +12794,75 @@ func (x codecSelfer1234) decSliceThirdPartyResource(v *[]ThirdPartyResource, d *
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1144 := *v
-	yyh1144, yyl1144 := z.DecSliceHelperStart()
+	yyv1139 := *v
+	yyh1139, yyl1139 := z.DecSliceHelperStart()
 
-	var yyrr1144, yyrl1144 int
-	var yyc1144, yyrt1144 bool
-	_, _, _ = yyc1144, yyrt1144, yyrl1144
-	yyrr1144 = yyl1144
+	var yyrr1139, yyrl1139 int
+	var yyc1139, yyrt1139 bool
+	_, _, _ = yyc1139, yyrt1139, yyrl1139
+	yyrr1139 = yyl1139
 
-	if yyv1144 == nil {
-		if yyrl1144, yyrt1144 = z.DecInferLen(yyl1144, z.DecBasicHandle().MaxInitLen, 232); yyrt1144 {
-			yyrr1144 = yyrl1144
+	if yyv1139 == nil {
+		if yyrl1139, yyrt1139 = z.DecInferLen(yyl1139, z.DecBasicHandle().MaxInitLen, 232); yyrt1139 {
+			yyrr1139 = yyrl1139
 		}
-		yyv1144 = make([]ThirdPartyResource, yyrl1144)
-		yyc1144 = true
+		yyv1139 = make([]ThirdPartyResource, yyrl1139)
+		yyc1139 = true
 	}
 
-	if yyl1144 == 0 {
-		if len(yyv1144) != 0 {
-			yyv1144 = yyv1144[:0]
-			yyc1144 = true
+	if yyl1139 == 0 {
+		if len(yyv1139) != 0 {
+			yyv1139 = yyv1139[:0]
+			yyc1139 = true
 		}
-	} else if yyl1144 > 0 {
+	} else if yyl1139 > 0 {
 
-		if yyl1144 > cap(yyv1144) {
-			yyrl1144, yyrt1144 = z.DecInferLen(yyl1144, z.DecBasicHandle().MaxInitLen, 232)
-			yyv1144 = make([]ThirdPartyResource, yyrl1144)
-			yyc1144 = true
+		if yyl1139 > cap(yyv1139) {
+			yyrl1139, yyrt1139 = z.DecInferLen(yyl1139, z.DecBasicHandle().MaxInitLen, 232)
+			yyv1139 = make([]ThirdPartyResource, yyrl1139)
+			yyc1139 = true
 
-			yyrr1144 = len(yyv1144)
-		} else if yyl1144 != len(yyv1144) {
-			yyv1144 = yyv1144[:yyl1144]
-			yyc1144 = true
+			yyrr1139 = len(yyv1139)
+		} else if yyl1139 != len(yyv1139) {
+			yyv1139 = yyv1139[:yyl1139]
+			yyc1139 = true
 		}
-		yyj1144 := 0
-		for ; yyj1144 < yyrr1144; yyj1144++ {
+		yyj1139 := 0
+		for ; yyj1139 < yyrr1139; yyj1139++ {
 			if r.TryDecodeAsNil() {
-				yyv1144[yyj1144] = ThirdPartyResource{}
+				yyv1139[yyj1139] = ThirdPartyResource{}
 			} else {
-				yyv1145 := &yyv1144[yyj1144]
-				yyv1145.CodecDecodeSelf(d)
+				yyv1140 := &yyv1139[yyj1139]
+				yyv1140.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1144 {
-			for ; yyj1144 < yyl1144; yyj1144++ {
-				yyv1144 = append(yyv1144, ThirdPartyResource{})
+		if yyrt1139 {
+			for ; yyj1139 < yyl1139; yyj1139++ {
+				yyv1139 = append(yyv1139, ThirdPartyResource{})
 				if r.TryDecodeAsNil() {
-					yyv1144[yyj1144] = ThirdPartyResource{}
+					yyv1139[yyj1139] = ThirdPartyResource{}
 				} else {
-					yyv1146 := &yyv1144[yyj1144]
-					yyv1146.CodecDecodeSelf(d)
+					yyv1141 := &yyv1139[yyj1139]
+					yyv1141.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1144 := 0; !r.CheckBreak(); yyj1144++ {
-			if yyj1144 >= len(yyv1144) {
-				yyv1144 = append(yyv1144, ThirdPartyResource{}) // var yyz1144 ThirdPartyResource
-				yyc1144 = true
+		for yyj1139 := 0; !r.CheckBreak(); yyj1139++ {
+			if yyj1139 >= len(yyv1139) {
+				yyv1139 = append(yyv1139, ThirdPartyResource{}) // var yyz1139 ThirdPartyResource
+				yyc1139 = true
 			}
 
-			if yyj1144 < len(yyv1144) {
+			if yyj1139 < len(yyv1139) {
 				if r.TryDecodeAsNil() {
-					yyv1144[yyj1144] = ThirdPartyResource{}
+					yyv1139[yyj1139] = ThirdPartyResource{}
 				} else {
-					yyv1147 := &yyv1144[yyj1144]
-					yyv1147.CodecDecodeSelf(d)
+					yyv1142 := &yyv1139[yyj1139]
+					yyv1142.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -12914,10 +12870,10 @@ func (x codecSelfer1234) decSliceThirdPartyResource(v *[]ThirdPartyResource, d *
 			}
 
 		}
-		yyh1144.End()
+		yyh1139.End()
 	}
-	if yyc1144 {
-		*v = yyv1144
+	if yyc1139 {
+		*v = yyv1139
 	}
 
 }
@@ -12927,9 +12883,9 @@ func (x codecSelfer1234) encSliceDeployment(v []Deployment, e *codec1978.Encoder
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1148 := range v {
-		yy1149 := &yyv1148
-		yy1149.CodecEncodeSelf(e)
+	for _, yyv1143 := range v {
+		yy1144 := &yyv1143
+		yy1144.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -12939,75 +12895,75 @@ func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decode
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1150 := *v
-	yyh1150, yyl1150 := z.DecSliceHelperStart()
+	yyv1145 := *v
+	yyh1145, yyl1145 := z.DecSliceHelperStart()
 
-	var yyrr1150, yyrl1150 int
-	var yyc1150, yyrt1150 bool
-	_, _, _ = yyc1150, yyrt1150, yyrl1150
-	yyrr1150 = yyl1150
+	var yyrr1145, yyrl1145 int
+	var yyc1145, yyrt1145 bool
+	_, _, _ = yyc1145, yyrt1145, yyrl1145
+	yyrr1145 = yyl1145
 
-	if yyv1150 == nil {
-		if yyrl1150, yyrt1150 = z.DecInferLen(yyl1150, z.DecBasicHandle().MaxInitLen, 592); yyrt1150 {
-			yyrr1150 = yyrl1150
+	if yyv1145 == nil {
+		if yyrl1145, yyrt1145 = z.DecInferLen(yyl1145, z.DecBasicHandle().MaxInitLen, 592); yyrt1145 {
+			yyrr1145 = yyrl1145
 		}
-		yyv1150 = make([]Deployment, yyrl1150)
-		yyc1150 = true
+		yyv1145 = make([]Deployment, yyrl1145)
+		yyc1145 = true
 	}
 
-	if yyl1150 == 0 {
-		if len(yyv1150) != 0 {
-			yyv1150 = yyv1150[:0]
-			yyc1150 = true
+	if yyl1145 == 0 {
+		if len(yyv1145) != 0 {
+			yyv1145 = yyv1145[:0]
+			yyc1145 = true
 		}
-	} else if yyl1150 > 0 {
+	} else if yyl1145 > 0 {
 
-		if yyl1150 > cap(yyv1150) {
-			yyrl1150, yyrt1150 = z.DecInferLen(yyl1150, z.DecBasicHandle().MaxInitLen, 592)
-			yyv1150 = make([]Deployment, yyrl1150)
-			yyc1150 = true
+		if yyl1145 > cap(yyv1145) {
+			yyrl1145, yyrt1145 = z.DecInferLen(yyl1145, z.DecBasicHandle().MaxInitLen, 592)
+			yyv1145 = make([]Deployment, yyrl1145)
+			yyc1145 = true
 
-			yyrr1150 = len(yyv1150)
-		} else if yyl1150 != len(yyv1150) {
-			yyv1150 = yyv1150[:yyl1150]
-			yyc1150 = true
+			yyrr1145 = len(yyv1145)
+		} else if yyl1145 != len(yyv1145) {
+			yyv1145 = yyv1145[:yyl1145]
+			yyc1145 = true
 		}
-		yyj1150 := 0
-		for ; yyj1150 < yyrr1150; yyj1150++ {
+		yyj1145 := 0
+		for ; yyj1145 < yyrr1145; yyj1145++ {
 			if r.TryDecodeAsNil() {
-				yyv1150[yyj1150] = Deployment{}
+				yyv1145[yyj1145] = Deployment{}
 			} else {
-				yyv1151 := &yyv1150[yyj1150]
-				yyv1151.CodecDecodeSelf(d)
+				yyv1146 := &yyv1145[yyj1145]
+				yyv1146.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1150 {
-			for ; yyj1150 < yyl1150; yyj1150++ {
-				yyv1150 = append(yyv1150, Deployment{})
+		if yyrt1145 {
+			for ; yyj1145 < yyl1145; yyj1145++ {
+				yyv1145 = append(yyv1145, Deployment{})
 				if r.TryDecodeAsNil() {
-					yyv1150[yyj1150] = Deployment{}
+					yyv1145[yyj1145] = Deployment{}
 				} else {
-					yyv1152 := &yyv1150[yyj1150]
-					yyv1152.CodecDecodeSelf(d)
+					yyv1147 := &yyv1145[yyj1145]
+					yyv1147.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1150 := 0; !r.CheckBreak(); yyj1150++ {
-			if yyj1150 >= len(yyv1150) {
-				yyv1150 = append(yyv1150, Deployment{}) // var yyz1150 Deployment
-				yyc1150 = true
+		for yyj1145 := 0; !r.CheckBreak(); yyj1145++ {
+			if yyj1145 >= len(yyv1145) {
+				yyv1145 = append(yyv1145, Deployment{}) // var yyz1145 Deployment
+				yyc1145 = true
 			}
 
-			if yyj1150 < len(yyv1150) {
+			if yyj1145 < len(yyv1145) {
 				if r.TryDecodeAsNil() {
-					yyv1150[yyj1150] = Deployment{}
+					yyv1145[yyj1145] = Deployment{}
 				} else {
-					yyv1153 := &yyv1150[yyj1150]
-					yyv1153.CodecDecodeSelf(d)
+					yyv1148 := &yyv1145[yyj1145]
+					yyv1148.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13015,10 +12971,10 @@ func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decode
 			}
 
 		}
-		yyh1150.End()
+		yyh1145.End()
 	}
-	if yyc1150 {
-		*v = yyv1150
+	if yyc1145 {
+		*v = yyv1145
 	}
 
 }
@@ -13028,9 +12984,9 @@ func (x codecSelfer1234) encSliceDaemonSet(v []DaemonSet, e *codec1978.Encoder) 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1154 := range v {
-		yy1155 := &yyv1154
-		yy1155.CodecEncodeSelf(e)
+	for _, yyv1149 := range v {
+		yy1150 := &yyv1149
+		yy1150.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13040,75 +12996,75 @@ func (x codecSelfer1234) decSliceDaemonSet(v *[]DaemonSet, d *codec1978.Decoder)
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1156 := *v
-	yyh1156, yyl1156 := z.DecSliceHelperStart()
+	yyv1151 := *v
+	yyh1151, yyl1151 := z.DecSliceHelperStart()
 
-	var yyrr1156, yyrl1156 int
-	var yyc1156, yyrt1156 bool
-	_, _, _ = yyc1156, yyrt1156, yyrl1156
-	yyrr1156 = yyl1156
+	var yyrr1151, yyrl1151 int
+	var yyc1151, yyrt1151 bool
+	_, _, _ = yyc1151, yyrt1151, yyrl1151
+	yyrr1151 = yyl1151
 
-	if yyv1156 == nil {
-		if yyrl1156, yyrt1156 = z.DecInferLen(yyl1156, z.DecBasicHandle().MaxInitLen, 232); yyrt1156 {
-			yyrr1156 = yyrl1156
+	if yyv1151 == nil {
+		if yyrl1151, yyrt1151 = z.DecInferLen(yyl1151, z.DecBasicHandle().MaxInitLen, 232); yyrt1151 {
+			yyrr1151 = yyrl1151
 		}
-		yyv1156 = make([]DaemonSet, yyrl1156)
-		yyc1156 = true
+		yyv1151 = make([]DaemonSet, yyrl1151)
+		yyc1151 = true
 	}
 
-	if yyl1156 == 0 {
-		if len(yyv1156) != 0 {
-			yyv1156 = yyv1156[:0]
-			yyc1156 = true
+	if yyl1151 == 0 {
+		if len(yyv1151) != 0 {
+			yyv1151 = yyv1151[:0]
+			yyc1151 = true
 		}
-	} else if yyl1156 > 0 {
+	} else if yyl1151 > 0 {
 
-		if yyl1156 > cap(yyv1156) {
-			yyrl1156, yyrt1156 = z.DecInferLen(yyl1156, z.DecBasicHandle().MaxInitLen, 232)
-			yyv1156 = make([]DaemonSet, yyrl1156)
-			yyc1156 = true
+		if yyl1151 > cap(yyv1151) {
+			yyrl1151, yyrt1151 = z.DecInferLen(yyl1151, z.DecBasicHandle().MaxInitLen, 232)
+			yyv1151 = make([]DaemonSet, yyrl1151)
+			yyc1151 = true
 
-			yyrr1156 = len(yyv1156)
-		} else if yyl1156 != len(yyv1156) {
-			yyv1156 = yyv1156[:yyl1156]
-			yyc1156 = true
+			yyrr1151 = len(yyv1151)
+		} else if yyl1151 != len(yyv1151) {
+			yyv1151 = yyv1151[:yyl1151]
+			yyc1151 = true
 		}
-		yyj1156 := 0
-		for ; yyj1156 < yyrr1156; yyj1156++ {
+		yyj1151 := 0
+		for ; yyj1151 < yyrr1151; yyj1151++ {
 			if r.TryDecodeAsNil() {
-				yyv1156[yyj1156] = DaemonSet{}
+				yyv1151[yyj1151] = DaemonSet{}
 			} else {
-				yyv1157 := &yyv1156[yyj1156]
-				yyv1157.CodecDecodeSelf(d)
+				yyv1152 := &yyv1151[yyj1151]
+				yyv1152.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1156 {
-			for ; yyj1156 < yyl1156; yyj1156++ {
-				yyv1156 = append(yyv1156, DaemonSet{})
+		if yyrt1151 {
+			for ; yyj1151 < yyl1151; yyj1151++ {
+				yyv1151 = append(yyv1151, DaemonSet{})
 				if r.TryDecodeAsNil() {
-					yyv1156[yyj1156] = DaemonSet{}
+					yyv1151[yyj1151] = DaemonSet{}
 				} else {
-					yyv1158 := &yyv1156[yyj1156]
-					yyv1158.CodecDecodeSelf(d)
+					yyv1153 := &yyv1151[yyj1151]
+					yyv1153.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1156 := 0; !r.CheckBreak(); yyj1156++ {
-			if yyj1156 >= len(yyv1156) {
-				yyv1156 = append(yyv1156, DaemonSet{}) // var yyz1156 DaemonSet
-				yyc1156 = true
+		for yyj1151 := 0; !r.CheckBreak(); yyj1151++ {
+			if yyj1151 >= len(yyv1151) {
+				yyv1151 = append(yyv1151, DaemonSet{}) // var yyz1151 DaemonSet
+				yyc1151 = true
 			}
 
-			if yyj1156 < len(yyv1156) {
+			if yyj1151 < len(yyv1151) {
 				if r.TryDecodeAsNil() {
-					yyv1156[yyj1156] = DaemonSet{}
+					yyv1151[yyj1151] = DaemonSet{}
 				} else {
-					yyv1159 := &yyv1156[yyj1156]
-					yyv1159.CodecDecodeSelf(d)
+					yyv1154 := &yyv1151[yyj1151]
+					yyv1154.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13116,10 +13072,10 @@ func (x codecSelfer1234) decSliceDaemonSet(v *[]DaemonSet, d *codec1978.Decoder)
 			}
 
 		}
-		yyh1156.End()
+		yyh1151.End()
 	}
-	if yyc1156 {
-		*v = yyv1156
+	if yyc1151 {
+		*v = yyv1151
 	}
 
 }
@@ -13129,9 +13085,9 @@ func (x codecSelfer1234) encSliceThirdPartyResourceData(v []ThirdPartyResourceDa
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1160 := range v {
-		yy1161 := &yyv1160
-		yy1161.CodecEncodeSelf(e)
+	for _, yyv1155 := range v {
+		yy1156 := &yyv1155
+		yy1156.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13141,75 +13097,75 @@ func (x codecSelfer1234) decSliceThirdPartyResourceData(v *[]ThirdPartyResourceD
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1162 := *v
-	yyh1162, yyl1162 := z.DecSliceHelperStart()
+	yyv1157 := *v
+	yyh1157, yyl1157 := z.DecSliceHelperStart()
 
-	var yyrr1162, yyrl1162 int
-	var yyc1162, yyrt1162 bool
-	_, _, _ = yyc1162, yyrt1162, yyrl1162
-	yyrr1162 = yyl1162
+	var yyrr1157, yyrl1157 int
+	var yyc1157, yyrt1157 bool
+	_, _, _ = yyc1157, yyrt1157, yyrl1157
+	yyrr1157 = yyl1157
 
-	if yyv1162 == nil {
-		if yyrl1162, yyrt1162 = z.DecInferLen(yyl1162, z.DecBasicHandle().MaxInitLen, 216); yyrt1162 {
-			yyrr1162 = yyrl1162
+	if yyv1157 == nil {
+		if yyrl1157, yyrt1157 = z.DecInferLen(yyl1157, z.DecBasicHandle().MaxInitLen, 216); yyrt1157 {
+			yyrr1157 = yyrl1157
 		}
-		yyv1162 = make([]ThirdPartyResourceData, yyrl1162)
-		yyc1162 = true
+		yyv1157 = make([]ThirdPartyResourceData, yyrl1157)
+		yyc1157 = true
 	}
 
-	if yyl1162 == 0 {
-		if len(yyv1162) != 0 {
-			yyv1162 = yyv1162[:0]
-			yyc1162 = true
+	if yyl1157 == 0 {
+		if len(yyv1157) != 0 {
+			yyv1157 = yyv1157[:0]
+			yyc1157 = true
 		}
-	} else if yyl1162 > 0 {
+	} else if yyl1157 > 0 {
 
-		if yyl1162 > cap(yyv1162) {
-			yyrl1162, yyrt1162 = z.DecInferLen(yyl1162, z.DecBasicHandle().MaxInitLen, 216)
-			yyv1162 = make([]ThirdPartyResourceData, yyrl1162)
-			yyc1162 = true
+		if yyl1157 > cap(yyv1157) {
+			yyrl1157, yyrt1157 = z.DecInferLen(yyl1157, z.DecBasicHandle().MaxInitLen, 216)
+			yyv1157 = make([]ThirdPartyResourceData, yyrl1157)
+			yyc1157 = true
 
-			yyrr1162 = len(yyv1162)
-		} else if yyl1162 != len(yyv1162) {
-			yyv1162 = yyv1162[:yyl1162]
-			yyc1162 = true
+			yyrr1157 = len(yyv1157)
+		} else if yyl1157 != len(yyv1157) {
+			yyv1157 = yyv1157[:yyl1157]
+			yyc1157 = true
 		}
-		yyj1162 := 0
-		for ; yyj1162 < yyrr1162; yyj1162++ {
+		yyj1157 := 0
+		for ; yyj1157 < yyrr1157; yyj1157++ {
 			if r.TryDecodeAsNil() {
-				yyv1162[yyj1162] = ThirdPartyResourceData{}
+				yyv1157[yyj1157] = ThirdPartyResourceData{}
 			} else {
-				yyv1163 := &yyv1162[yyj1162]
-				yyv1163.CodecDecodeSelf(d)
+				yyv1158 := &yyv1157[yyj1157]
+				yyv1158.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1162 {
-			for ; yyj1162 < yyl1162; yyj1162++ {
-				yyv1162 = append(yyv1162, ThirdPartyResourceData{})
+		if yyrt1157 {
+			for ; yyj1157 < yyl1157; yyj1157++ {
+				yyv1157 = append(yyv1157, ThirdPartyResourceData{})
 				if r.TryDecodeAsNil() {
-					yyv1162[yyj1162] = ThirdPartyResourceData{}
+					yyv1157[yyj1157] = ThirdPartyResourceData{}
 				} else {
-					yyv1164 := &yyv1162[yyj1162]
-					yyv1164.CodecDecodeSelf(d)
+					yyv1159 := &yyv1157[yyj1157]
+					yyv1159.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1162 := 0; !r.CheckBreak(); yyj1162++ {
-			if yyj1162 >= len(yyv1162) {
-				yyv1162 = append(yyv1162, ThirdPartyResourceData{}) // var yyz1162 ThirdPartyResourceData
-				yyc1162 = true
+		for yyj1157 := 0; !r.CheckBreak(); yyj1157++ {
+			if yyj1157 >= len(yyv1157) {
+				yyv1157 = append(yyv1157, ThirdPartyResourceData{}) // var yyz1157 ThirdPartyResourceData
+				yyc1157 = true
 			}
 
-			if yyj1162 < len(yyv1162) {
+			if yyj1157 < len(yyv1157) {
 				if r.TryDecodeAsNil() {
-					yyv1162[yyj1162] = ThirdPartyResourceData{}
+					yyv1157[yyj1157] = ThirdPartyResourceData{}
 				} else {
-					yyv1165 := &yyv1162[yyj1162]
-					yyv1165.CodecDecodeSelf(d)
+					yyv1160 := &yyv1157[yyj1157]
+					yyv1160.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13217,10 +13173,10 @@ func (x codecSelfer1234) decSliceThirdPartyResourceData(v *[]ThirdPartyResourceD
 			}
 
 		}
-		yyh1162.End()
+		yyh1157.End()
 	}
-	if yyc1162 {
-		*v = yyv1162
+	if yyc1157 {
+		*v = yyv1157
 	}
 
 }
@@ -13230,9 +13186,9 @@ func (x codecSelfer1234) encSliceJob(v []Job, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1166 := range v {
-		yy1167 := &yyv1166
-		yy1167.CodecEncodeSelf(e)
+	for _, yyv1161 := range v {
+		yy1162 := &yyv1161
+		yy1162.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13242,75 +13198,75 @@ func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1168 := *v
-	yyh1168, yyl1168 := z.DecSliceHelperStart()
+	yyv1163 := *v
+	yyh1163, yyl1163 := z.DecSliceHelperStart()
 
-	var yyrr1168, yyrl1168 int
-	var yyc1168, yyrt1168 bool
-	_, _, _ = yyc1168, yyrt1168, yyrl1168
-	yyrr1168 = yyl1168
+	var yyrr1163, yyrl1163 int
+	var yyc1163, yyrt1163 bool
+	_, _, _ = yyc1163, yyrt1163, yyrl1163
+	yyrr1163 = yyl1163
 
-	if yyv1168 == nil {
-		if yyrl1168, yyrt1168 = z.DecInferLen(yyl1168, z.DecBasicHandle().MaxInitLen, 608); yyrt1168 {
-			yyrr1168 = yyrl1168
+	if yyv1163 == nil {
+		if yyrl1163, yyrt1163 = z.DecInferLen(yyl1163, z.DecBasicHandle().MaxInitLen, 608); yyrt1163 {
+			yyrr1163 = yyrl1163
 		}
-		yyv1168 = make([]Job, yyrl1168)
-		yyc1168 = true
+		yyv1163 = make([]Job, yyrl1163)
+		yyc1163 = true
 	}
 
-	if yyl1168 == 0 {
-		if len(yyv1168) != 0 {
-			yyv1168 = yyv1168[:0]
-			yyc1168 = true
+	if yyl1163 == 0 {
+		if len(yyv1163) != 0 {
+			yyv1163 = yyv1163[:0]
+			yyc1163 = true
 		}
-	} else if yyl1168 > 0 {
+	} else if yyl1163 > 0 {
 
-		if yyl1168 > cap(yyv1168) {
-			yyrl1168, yyrt1168 = z.DecInferLen(yyl1168, z.DecBasicHandle().MaxInitLen, 608)
-			yyv1168 = make([]Job, yyrl1168)
-			yyc1168 = true
+		if yyl1163 > cap(yyv1163) {
+			yyrl1163, yyrt1163 = z.DecInferLen(yyl1163, z.DecBasicHandle().MaxInitLen, 608)
+			yyv1163 = make([]Job, yyrl1163)
+			yyc1163 = true
 
-			yyrr1168 = len(yyv1168)
-		} else if yyl1168 != len(yyv1168) {
-			yyv1168 = yyv1168[:yyl1168]
-			yyc1168 = true
+			yyrr1163 = len(yyv1163)
+		} else if yyl1163 != len(yyv1163) {
+			yyv1163 = yyv1163[:yyl1163]
+			yyc1163 = true
 		}
-		yyj1168 := 0
-		for ; yyj1168 < yyrr1168; yyj1168++ {
+		yyj1163 := 0
+		for ; yyj1163 < yyrr1163; yyj1163++ {
 			if r.TryDecodeAsNil() {
-				yyv1168[yyj1168] = Job{}
+				yyv1163[yyj1163] = Job{}
 			} else {
-				yyv1169 := &yyv1168[yyj1168]
-				yyv1169.CodecDecodeSelf(d)
+				yyv1164 := &yyv1163[yyj1163]
+				yyv1164.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1168 {
-			for ; yyj1168 < yyl1168; yyj1168++ {
-				yyv1168 = append(yyv1168, Job{})
+		if yyrt1163 {
+			for ; yyj1163 < yyl1163; yyj1163++ {
+				yyv1163 = append(yyv1163, Job{})
 				if r.TryDecodeAsNil() {
-					yyv1168[yyj1168] = Job{}
+					yyv1163[yyj1163] = Job{}
 				} else {
-					yyv1170 := &yyv1168[yyj1168]
-					yyv1170.CodecDecodeSelf(d)
+					yyv1165 := &yyv1163[yyj1163]
+					yyv1165.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1168 := 0; !r.CheckBreak(); yyj1168++ {
-			if yyj1168 >= len(yyv1168) {
-				yyv1168 = append(yyv1168, Job{}) // var yyz1168 Job
-				yyc1168 = true
+		for yyj1163 := 0; !r.CheckBreak(); yyj1163++ {
+			if yyj1163 >= len(yyv1163) {
+				yyv1163 = append(yyv1163, Job{}) // var yyz1163 Job
+				yyc1163 = true
 			}
 
-			if yyj1168 < len(yyv1168) {
+			if yyj1163 < len(yyv1163) {
 				if r.TryDecodeAsNil() {
-					yyv1168[yyj1168] = Job{}
+					yyv1163[yyj1163] = Job{}
 				} else {
-					yyv1171 := &yyv1168[yyj1168]
-					yyv1171.CodecDecodeSelf(d)
+					yyv1166 := &yyv1163[yyj1163]
+					yyv1166.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13318,10 +13274,10 @@ func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh1168.End()
+		yyh1163.End()
 	}
-	if yyc1168 {
-		*v = yyv1168
+	if yyc1163 {
+		*v = yyv1163
 	}
 
 }
@@ -13331,9 +13287,9 @@ func (x codecSelfer1234) encSliceJobCondition(v []JobCondition, e *codec1978.Enc
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1172 := range v {
-		yy1173 := &yyv1172
-		yy1173.CodecEncodeSelf(e)
+	for _, yyv1167 := range v {
+		yy1168 := &yyv1167
+		yy1168.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13343,75 +13299,75 @@ func (x codecSelfer1234) decSliceJobCondition(v *[]JobCondition, d *codec1978.De
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1174 := *v
-	yyh1174, yyl1174 := z.DecSliceHelperStart()
+	yyv1169 := *v
+	yyh1169, yyl1169 := z.DecSliceHelperStart()
 
-	var yyrr1174, yyrl1174 int
-	var yyc1174, yyrt1174 bool
-	_, _, _ = yyc1174, yyrt1174, yyrl1174
-	yyrr1174 = yyl1174
+	var yyrr1169, yyrl1169 int
+	var yyc1169, yyrt1169 bool
+	_, _, _ = yyc1169, yyrt1169, yyrl1169
+	yyrr1169 = yyl1169
 
-	if yyv1174 == nil {
-		if yyrl1174, yyrt1174 = z.DecInferLen(yyl1174, z.DecBasicHandle().MaxInitLen, 112); yyrt1174 {
-			yyrr1174 = yyrl1174
+	if yyv1169 == nil {
+		if yyrl1169, yyrt1169 = z.DecInferLen(yyl1169, z.DecBasicHandle().MaxInitLen, 112); yyrt1169 {
+			yyrr1169 = yyrl1169
 		}
-		yyv1174 = make([]JobCondition, yyrl1174)
-		yyc1174 = true
+		yyv1169 = make([]JobCondition, yyrl1169)
+		yyc1169 = true
 	}
 
-	if yyl1174 == 0 {
-		if len(yyv1174) != 0 {
-			yyv1174 = yyv1174[:0]
-			yyc1174 = true
+	if yyl1169 == 0 {
+		if len(yyv1169) != 0 {
+			yyv1169 = yyv1169[:0]
+			yyc1169 = true
 		}
-	} else if yyl1174 > 0 {
+	} else if yyl1169 > 0 {
 
-		if yyl1174 > cap(yyv1174) {
-			yyrl1174, yyrt1174 = z.DecInferLen(yyl1174, z.DecBasicHandle().MaxInitLen, 112)
-			yyv1174 = make([]JobCondition, yyrl1174)
-			yyc1174 = true
+		if yyl1169 > cap(yyv1169) {
+			yyrl1169, yyrt1169 = z.DecInferLen(yyl1169, z.DecBasicHandle().MaxInitLen, 112)
+			yyv1169 = make([]JobCondition, yyrl1169)
+			yyc1169 = true
 
-			yyrr1174 = len(yyv1174)
-		} else if yyl1174 != len(yyv1174) {
-			yyv1174 = yyv1174[:yyl1174]
-			yyc1174 = true
+			yyrr1169 = len(yyv1169)
+		} else if yyl1169 != len(yyv1169) {
+			yyv1169 = yyv1169[:yyl1169]
+			yyc1169 = true
 		}
-		yyj1174 := 0
-		for ; yyj1174 < yyrr1174; yyj1174++ {
+		yyj1169 := 0
+		for ; yyj1169 < yyrr1169; yyj1169++ {
 			if r.TryDecodeAsNil() {
-				yyv1174[yyj1174] = JobCondition{}
+				yyv1169[yyj1169] = JobCondition{}
 			} else {
-				yyv1175 := &yyv1174[yyj1174]
-				yyv1175.CodecDecodeSelf(d)
+				yyv1170 := &yyv1169[yyj1169]
+				yyv1170.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1174 {
-			for ; yyj1174 < yyl1174; yyj1174++ {
-				yyv1174 = append(yyv1174, JobCondition{})
+		if yyrt1169 {
+			for ; yyj1169 < yyl1169; yyj1169++ {
+				yyv1169 = append(yyv1169, JobCondition{})
 				if r.TryDecodeAsNil() {
-					yyv1174[yyj1174] = JobCondition{}
+					yyv1169[yyj1169] = JobCondition{}
 				} else {
-					yyv1176 := &yyv1174[yyj1174]
-					yyv1176.CodecDecodeSelf(d)
+					yyv1171 := &yyv1169[yyj1169]
+					yyv1171.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1174 := 0; !r.CheckBreak(); yyj1174++ {
-			if yyj1174 >= len(yyv1174) {
-				yyv1174 = append(yyv1174, JobCondition{}) // var yyz1174 JobCondition
-				yyc1174 = true
+		for yyj1169 := 0; !r.CheckBreak(); yyj1169++ {
+			if yyj1169 >= len(yyv1169) {
+				yyv1169 = append(yyv1169, JobCondition{}) // var yyz1169 JobCondition
+				yyc1169 = true
 			}
 
-			if yyj1174 < len(yyv1174) {
+			if yyj1169 < len(yyv1169) {
 				if r.TryDecodeAsNil() {
-					yyv1174[yyj1174] = JobCondition{}
+					yyv1169[yyj1169] = JobCondition{}
 				} else {
-					yyv1177 := &yyv1174[yyj1174]
-					yyv1177.CodecDecodeSelf(d)
+					yyv1172 := &yyv1169[yyj1169]
+					yyv1172.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13419,10 +13375,10 @@ func (x codecSelfer1234) decSliceJobCondition(v *[]JobCondition, d *codec1978.De
 			}
 
 		}
-		yyh1174.End()
+		yyh1169.End()
 	}
-	if yyc1174 {
-		*v = yyv1174
+	if yyc1169 {
+		*v = yyv1169
 	}
 
 }
@@ -13432,9 +13388,9 @@ func (x codecSelfer1234) encSliceIngress(v []Ingress, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1178 := range v {
-		yy1179 := &yyv1178
-		yy1179.CodecEncodeSelf(e)
+	for _, yyv1173 := range v {
+		yy1174 := &yyv1173
+		yy1174.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13444,75 +13400,75 @@ func (x codecSelfer1234) decSliceIngress(v *[]Ingress, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1180 := *v
-	yyh1180, yyl1180 := z.DecSliceHelperStart()
+	yyv1175 := *v
+	yyh1175, yyl1175 := z.DecSliceHelperStart()
 
-	var yyrr1180, yyrl1180 int
-	var yyc1180, yyrt1180 bool
-	_, _, _ = yyc1180, yyrt1180, yyrl1180
-	yyrr1180 = yyl1180
+	var yyrr1175, yyrl1175 int
+	var yyc1175, yyrt1175 bool
+	_, _, _ = yyc1175, yyrt1175, yyrl1175
+	yyrr1175 = yyl1175
 
-	if yyv1180 == nil {
-		if yyrl1180, yyrt1180 = z.DecInferLen(yyl1180, z.DecBasicHandle().MaxInitLen, 248); yyrt1180 {
-			yyrr1180 = yyrl1180
+	if yyv1175 == nil {
+		if yyrl1175, yyrt1175 = z.DecInferLen(yyl1175, z.DecBasicHandle().MaxInitLen, 248); yyrt1175 {
+			yyrr1175 = yyrl1175
 		}
-		yyv1180 = make([]Ingress, yyrl1180)
-		yyc1180 = true
+		yyv1175 = make([]Ingress, yyrl1175)
+		yyc1175 = true
 	}
 
-	if yyl1180 == 0 {
-		if len(yyv1180) != 0 {
-			yyv1180 = yyv1180[:0]
-			yyc1180 = true
+	if yyl1175 == 0 {
+		if len(yyv1175) != 0 {
+			yyv1175 = yyv1175[:0]
+			yyc1175 = true
 		}
-	} else if yyl1180 > 0 {
+	} else if yyl1175 > 0 {
 
-		if yyl1180 > cap(yyv1180) {
-			yyrl1180, yyrt1180 = z.DecInferLen(yyl1180, z.DecBasicHandle().MaxInitLen, 248)
-			yyv1180 = make([]Ingress, yyrl1180)
-			yyc1180 = true
+		if yyl1175 > cap(yyv1175) {
+			yyrl1175, yyrt1175 = z.DecInferLen(yyl1175, z.DecBasicHandle().MaxInitLen, 248)
+			yyv1175 = make([]Ingress, yyrl1175)
+			yyc1175 = true
 
-			yyrr1180 = len(yyv1180)
-		} else if yyl1180 != len(yyv1180) {
-			yyv1180 = yyv1180[:yyl1180]
-			yyc1180 = true
+			yyrr1175 = len(yyv1175)
+		} else if yyl1175 != len(yyv1175) {
+			yyv1175 = yyv1175[:yyl1175]
+			yyc1175 = true
 		}
-		yyj1180 := 0
-		for ; yyj1180 < yyrr1180; yyj1180++ {
+		yyj1175 := 0
+		for ; yyj1175 < yyrr1175; yyj1175++ {
 			if r.TryDecodeAsNil() {
-				yyv1180[yyj1180] = Ingress{}
+				yyv1175[yyj1175] = Ingress{}
 			} else {
-				yyv1181 := &yyv1180[yyj1180]
-				yyv1181.CodecDecodeSelf(d)
+				yyv1176 := &yyv1175[yyj1175]
+				yyv1176.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1180 {
-			for ; yyj1180 < yyl1180; yyj1180++ {
-				yyv1180 = append(yyv1180, Ingress{})
+		if yyrt1175 {
+			for ; yyj1175 < yyl1175; yyj1175++ {
+				yyv1175 = append(yyv1175, Ingress{})
 				if r.TryDecodeAsNil() {
-					yyv1180[yyj1180] = Ingress{}
+					yyv1175[yyj1175] = Ingress{}
 				} else {
-					yyv1182 := &yyv1180[yyj1180]
-					yyv1182.CodecDecodeSelf(d)
+					yyv1177 := &yyv1175[yyj1175]
+					yyv1177.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1180 := 0; !r.CheckBreak(); yyj1180++ {
-			if yyj1180 >= len(yyv1180) {
-				yyv1180 = append(yyv1180, Ingress{}) // var yyz1180 Ingress
-				yyc1180 = true
+		for yyj1175 := 0; !r.CheckBreak(); yyj1175++ {
+			if yyj1175 >= len(yyv1175) {
+				yyv1175 = append(yyv1175, Ingress{}) // var yyz1175 Ingress
+				yyc1175 = true
 			}
 
-			if yyj1180 < len(yyv1180) {
+			if yyj1175 < len(yyv1175) {
 				if r.TryDecodeAsNil() {
-					yyv1180[yyj1180] = Ingress{}
+					yyv1175[yyj1175] = Ingress{}
 				} else {
-					yyv1183 := &yyv1180[yyj1180]
-					yyv1183.CodecDecodeSelf(d)
+					yyv1178 := &yyv1175[yyj1175]
+					yyv1178.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13520,10 +13476,10 @@ func (x codecSelfer1234) decSliceIngress(v *[]Ingress, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh1180.End()
+		yyh1175.End()
 	}
-	if yyc1180 {
-		*v = yyv1180
+	if yyc1175 {
+		*v = yyv1175
 	}
 
 }
@@ -13533,9 +13489,9 @@ func (x codecSelfer1234) encSliceIngressRule(v []IngressRule, e *codec1978.Encod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1184 := range v {
-		yy1185 := &yyv1184
-		yy1185.CodecEncodeSelf(e)
+	for _, yyv1179 := range v {
+		yy1180 := &yyv1179
+		yy1180.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13545,75 +13501,75 @@ func (x codecSelfer1234) decSliceIngressRule(v *[]IngressRule, d *codec1978.Deco
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1186 := *v
-	yyh1186, yyl1186 := z.DecSliceHelperStart()
+	yyv1181 := *v
+	yyh1181, yyl1181 := z.DecSliceHelperStart()
 
-	var yyrr1186, yyrl1186 int
-	var yyc1186, yyrt1186 bool
-	_, _, _ = yyc1186, yyrt1186, yyrl1186
-	yyrr1186 = yyl1186
+	var yyrr1181, yyrl1181 int
+	var yyc1181, yyrt1181 bool
+	_, _, _ = yyc1181, yyrt1181, yyrl1181
+	yyrr1181 = yyl1181
 
-	if yyv1186 == nil {
-		if yyrl1186, yyrt1186 = z.DecInferLen(yyl1186, z.DecBasicHandle().MaxInitLen, 24); yyrt1186 {
-			yyrr1186 = yyrl1186
+	if yyv1181 == nil {
+		if yyrl1181, yyrt1181 = z.DecInferLen(yyl1181, z.DecBasicHandle().MaxInitLen, 24); yyrt1181 {
+			yyrr1181 = yyrl1181
 		}
-		yyv1186 = make([]IngressRule, yyrl1186)
-		yyc1186 = true
+		yyv1181 = make([]IngressRule, yyrl1181)
+		yyc1181 = true
 	}
 
-	if yyl1186 == 0 {
-		if len(yyv1186) != 0 {
-			yyv1186 = yyv1186[:0]
-			yyc1186 = true
+	if yyl1181 == 0 {
+		if len(yyv1181) != 0 {
+			yyv1181 = yyv1181[:0]
+			yyc1181 = true
 		}
-	} else if yyl1186 > 0 {
+	} else if yyl1181 > 0 {
 
-		if yyl1186 > cap(yyv1186) {
-			yyrl1186, yyrt1186 = z.DecInferLen(yyl1186, z.DecBasicHandle().MaxInitLen, 24)
-			yyv1186 = make([]IngressRule, yyrl1186)
-			yyc1186 = true
+		if yyl1181 > cap(yyv1181) {
+			yyrl1181, yyrt1181 = z.DecInferLen(yyl1181, z.DecBasicHandle().MaxInitLen, 24)
+			yyv1181 = make([]IngressRule, yyrl1181)
+			yyc1181 = true
 
-			yyrr1186 = len(yyv1186)
-		} else if yyl1186 != len(yyv1186) {
-			yyv1186 = yyv1186[:yyl1186]
-			yyc1186 = true
+			yyrr1181 = len(yyv1181)
+		} else if yyl1181 != len(yyv1181) {
+			yyv1181 = yyv1181[:yyl1181]
+			yyc1181 = true
 		}
-		yyj1186 := 0
-		for ; yyj1186 < yyrr1186; yyj1186++ {
+		yyj1181 := 0
+		for ; yyj1181 < yyrr1181; yyj1181++ {
 			if r.TryDecodeAsNil() {
-				yyv1186[yyj1186] = IngressRule{}
+				yyv1181[yyj1181] = IngressRule{}
 			} else {
-				yyv1187 := &yyv1186[yyj1186]
-				yyv1187.CodecDecodeSelf(d)
+				yyv1182 := &yyv1181[yyj1181]
+				yyv1182.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1186 {
-			for ; yyj1186 < yyl1186; yyj1186++ {
-				yyv1186 = append(yyv1186, IngressRule{})
+		if yyrt1181 {
+			for ; yyj1181 < yyl1181; yyj1181++ {
+				yyv1181 = append(yyv1181, IngressRule{})
 				if r.TryDecodeAsNil() {
-					yyv1186[yyj1186] = IngressRule{}
+					yyv1181[yyj1181] = IngressRule{}
 				} else {
-					yyv1188 := &yyv1186[yyj1186]
-					yyv1188.CodecDecodeSelf(d)
+					yyv1183 := &yyv1181[yyj1181]
+					yyv1183.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1186 := 0; !r.CheckBreak(); yyj1186++ {
-			if yyj1186 >= len(yyv1186) {
-				yyv1186 = append(yyv1186, IngressRule{}) // var yyz1186 IngressRule
-				yyc1186 = true
+		for yyj1181 := 0; !r.CheckBreak(); yyj1181++ {
+			if yyj1181 >= len(yyv1181) {
+				yyv1181 = append(yyv1181, IngressRule{}) // var yyz1181 IngressRule
+				yyc1181 = true
 			}
 
-			if yyj1186 < len(yyv1186) {
+			if yyj1181 < len(yyv1181) {
 				if r.TryDecodeAsNil() {
-					yyv1186[yyj1186] = IngressRule{}
+					yyv1181[yyj1181] = IngressRule{}
 				} else {
-					yyv1189 := &yyv1186[yyj1186]
-					yyv1189.CodecDecodeSelf(d)
+					yyv1184 := &yyv1181[yyj1181]
+					yyv1184.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13621,10 +13577,10 @@ func (x codecSelfer1234) decSliceIngressRule(v *[]IngressRule, d *codec1978.Deco
 			}
 
 		}
-		yyh1186.End()
+		yyh1181.End()
 	}
-	if yyc1186 {
-		*v = yyv1186
+	if yyc1181 {
+		*v = yyv1181
 	}
 
 }
@@ -13634,9 +13590,9 @@ func (x codecSelfer1234) encSliceHTTPIngressPath(v []HTTPIngressPath, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1190 := range v {
-		yy1191 := &yyv1190
-		yy1191.CodecEncodeSelf(e)
+	for _, yyv1185 := range v {
+		yy1186 := &yyv1185
+		yy1186.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13646,75 +13602,75 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1192 := *v
-	yyh1192, yyl1192 := z.DecSliceHelperStart()
+	yyv1187 := *v
+	yyh1187, yyl1187 := z.DecSliceHelperStart()
 
-	var yyrr1192, yyrl1192 int
-	var yyc1192, yyrt1192 bool
-	_, _, _ = yyc1192, yyrt1192, yyrl1192
-	yyrr1192 = yyl1192
+	var yyrr1187, yyrl1187 int
+	var yyc1187, yyrt1187 bool
+	_, _, _ = yyc1187, yyrt1187, yyrl1187
+	yyrr1187 = yyl1187
 
-	if yyv1192 == nil {
-		if yyrl1192, yyrt1192 = z.DecInferLen(yyl1192, z.DecBasicHandle().MaxInitLen, 64); yyrt1192 {
-			yyrr1192 = yyrl1192
+	if yyv1187 == nil {
+		if yyrl1187, yyrt1187 = z.DecInferLen(yyl1187, z.DecBasicHandle().MaxInitLen, 64); yyrt1187 {
+			yyrr1187 = yyrl1187
 		}
-		yyv1192 = make([]HTTPIngressPath, yyrl1192)
-		yyc1192 = true
+		yyv1187 = make([]HTTPIngressPath, yyrl1187)
+		yyc1187 = true
 	}
 
-	if yyl1192 == 0 {
-		if len(yyv1192) != 0 {
-			yyv1192 = yyv1192[:0]
-			yyc1192 = true
+	if yyl1187 == 0 {
+		if len(yyv1187) != 0 {
+			yyv1187 = yyv1187[:0]
+			yyc1187 = true
 		}
-	} else if yyl1192 > 0 {
+	} else if yyl1187 > 0 {
 
-		if yyl1192 > cap(yyv1192) {
-			yyrl1192, yyrt1192 = z.DecInferLen(yyl1192, z.DecBasicHandle().MaxInitLen, 64)
-			yyv1192 = make([]HTTPIngressPath, yyrl1192)
-			yyc1192 = true
+		if yyl1187 > cap(yyv1187) {
+			yyrl1187, yyrt1187 = z.DecInferLen(yyl1187, z.DecBasicHandle().MaxInitLen, 64)
+			yyv1187 = make([]HTTPIngressPath, yyrl1187)
+			yyc1187 = true
 
-			yyrr1192 = len(yyv1192)
-		} else if yyl1192 != len(yyv1192) {
-			yyv1192 = yyv1192[:yyl1192]
-			yyc1192 = true
+			yyrr1187 = len(yyv1187)
+		} else if yyl1187 != len(yyv1187) {
+			yyv1187 = yyv1187[:yyl1187]
+			yyc1187 = true
 		}
-		yyj1192 := 0
-		for ; yyj1192 < yyrr1192; yyj1192++ {
+		yyj1187 := 0
+		for ; yyj1187 < yyrr1187; yyj1187++ {
 			if r.TryDecodeAsNil() {
-				yyv1192[yyj1192] = HTTPIngressPath{}
+				yyv1187[yyj1187] = HTTPIngressPath{}
 			} else {
-				yyv1193 := &yyv1192[yyj1192]
-				yyv1193.CodecDecodeSelf(d)
+				yyv1188 := &yyv1187[yyj1187]
+				yyv1188.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1192 {
-			for ; yyj1192 < yyl1192; yyj1192++ {
-				yyv1192 = append(yyv1192, HTTPIngressPath{})
+		if yyrt1187 {
+			for ; yyj1187 < yyl1187; yyj1187++ {
+				yyv1187 = append(yyv1187, HTTPIngressPath{})
 				if r.TryDecodeAsNil() {
-					yyv1192[yyj1192] = HTTPIngressPath{}
+					yyv1187[yyj1187] = HTTPIngressPath{}
 				} else {
-					yyv1194 := &yyv1192[yyj1192]
-					yyv1194.CodecDecodeSelf(d)
+					yyv1189 := &yyv1187[yyj1187]
+					yyv1189.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1192 := 0; !r.CheckBreak(); yyj1192++ {
-			if yyj1192 >= len(yyv1192) {
-				yyv1192 = append(yyv1192, HTTPIngressPath{}) // var yyz1192 HTTPIngressPath
-				yyc1192 = true
+		for yyj1187 := 0; !r.CheckBreak(); yyj1187++ {
+			if yyj1187 >= len(yyv1187) {
+				yyv1187 = append(yyv1187, HTTPIngressPath{}) // var yyz1187 HTTPIngressPath
+				yyc1187 = true
 			}
 
-			if yyj1192 < len(yyv1192) {
+			if yyj1187 < len(yyv1187) {
 				if r.TryDecodeAsNil() {
-					yyv1192[yyj1192] = HTTPIngressPath{}
+					yyv1187[yyj1187] = HTTPIngressPath{}
 				} else {
-					yyv1195 := &yyv1192[yyj1192]
-					yyv1195.CodecDecodeSelf(d)
+					yyv1190 := &yyv1187[yyj1187]
+					yyv1190.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13722,10 +13678,10 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 			}
 
 		}
-		yyh1192.End()
+		yyh1187.End()
 	}
-	if yyc1192 {
-		*v = yyv1192
+	if yyc1187 {
+		*v = yyv1187
 	}
 
 }
@@ -13735,9 +13691,9 @@ func (x codecSelfer1234) encSliceNodeUtilization(v []NodeUtilization, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1196 := range v {
-		yy1197 := &yyv1196
-		yy1197.CodecEncodeSelf(e)
+	for _, yyv1191 := range v {
+		yy1192 := &yyv1191
+		yy1192.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13747,75 +13703,75 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1198 := *v
-	yyh1198, yyl1198 := z.DecSliceHelperStart()
+	yyv1193 := *v
+	yyh1193, yyl1193 := z.DecSliceHelperStart()
 
-	var yyrr1198, yyrl1198 int
-	var yyc1198, yyrt1198 bool
-	_, _, _ = yyc1198, yyrt1198, yyrl1198
-	yyrr1198 = yyl1198
+	var yyrr1193, yyrl1193 int
+	var yyc1193, yyrt1193 bool
+	_, _, _ = yyc1193, yyrt1193, yyrl1193
+	yyrr1193 = yyl1193
 
-	if yyv1198 == nil {
-		if yyrl1198, yyrt1198 = z.DecInferLen(yyl1198, z.DecBasicHandle().MaxInitLen, 24); yyrt1198 {
-			yyrr1198 = yyrl1198
+	if yyv1193 == nil {
+		if yyrl1193, yyrt1193 = z.DecInferLen(yyl1193, z.DecBasicHandle().MaxInitLen, 24); yyrt1193 {
+			yyrr1193 = yyrl1193
 		}
-		yyv1198 = make([]NodeUtilization, yyrl1198)
-		yyc1198 = true
+		yyv1193 = make([]NodeUtilization, yyrl1193)
+		yyc1193 = true
 	}
 
-	if yyl1198 == 0 {
-		if len(yyv1198) != 0 {
-			yyv1198 = yyv1198[:0]
-			yyc1198 = true
+	if yyl1193 == 0 {
+		if len(yyv1193) != 0 {
+			yyv1193 = yyv1193[:0]
+			yyc1193 = true
 		}
-	} else if yyl1198 > 0 {
+	} else if yyl1193 > 0 {
 
-		if yyl1198 > cap(yyv1198) {
-			yyrl1198, yyrt1198 = z.DecInferLen(yyl1198, z.DecBasicHandle().MaxInitLen, 24)
-			yyv1198 = make([]NodeUtilization, yyrl1198)
-			yyc1198 = true
+		if yyl1193 > cap(yyv1193) {
+			yyrl1193, yyrt1193 = z.DecInferLen(yyl1193, z.DecBasicHandle().MaxInitLen, 24)
+			yyv1193 = make([]NodeUtilization, yyrl1193)
+			yyc1193 = true
 
-			yyrr1198 = len(yyv1198)
-		} else if yyl1198 != len(yyv1198) {
-			yyv1198 = yyv1198[:yyl1198]
-			yyc1198 = true
+			yyrr1193 = len(yyv1193)
+		} else if yyl1193 != len(yyv1193) {
+			yyv1193 = yyv1193[:yyl1193]
+			yyc1193 = true
 		}
-		yyj1198 := 0
-		for ; yyj1198 < yyrr1198; yyj1198++ {
+		yyj1193 := 0
+		for ; yyj1193 < yyrr1193; yyj1193++ {
 			if r.TryDecodeAsNil() {
-				yyv1198[yyj1198] = NodeUtilization{}
+				yyv1193[yyj1193] = NodeUtilization{}
 			} else {
-				yyv1199 := &yyv1198[yyj1198]
-				yyv1199.CodecDecodeSelf(d)
+				yyv1194 := &yyv1193[yyj1193]
+				yyv1194.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1198 {
-			for ; yyj1198 < yyl1198; yyj1198++ {
-				yyv1198 = append(yyv1198, NodeUtilization{})
+		if yyrt1193 {
+			for ; yyj1193 < yyl1193; yyj1193++ {
+				yyv1193 = append(yyv1193, NodeUtilization{})
 				if r.TryDecodeAsNil() {
-					yyv1198[yyj1198] = NodeUtilization{}
+					yyv1193[yyj1193] = NodeUtilization{}
 				} else {
-					yyv1200 := &yyv1198[yyj1198]
-					yyv1200.CodecDecodeSelf(d)
+					yyv1195 := &yyv1193[yyj1193]
+					yyv1195.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1198 := 0; !r.CheckBreak(); yyj1198++ {
-			if yyj1198 >= len(yyv1198) {
-				yyv1198 = append(yyv1198, NodeUtilization{}) // var yyz1198 NodeUtilization
-				yyc1198 = true
+		for yyj1193 := 0; !r.CheckBreak(); yyj1193++ {
+			if yyj1193 >= len(yyv1193) {
+				yyv1193 = append(yyv1193, NodeUtilization{}) // var yyz1193 NodeUtilization
+				yyc1193 = true
 			}
 
-			if yyj1198 < len(yyv1198) {
+			if yyj1193 < len(yyv1193) {
 				if r.TryDecodeAsNil() {
-					yyv1198[yyj1198] = NodeUtilization{}
+					yyv1193[yyj1193] = NodeUtilization{}
 				} else {
-					yyv1201 := &yyv1198[yyj1198]
-					yyv1201.CodecDecodeSelf(d)
+					yyv1196 := &yyv1193[yyj1193]
+					yyv1196.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13823,10 +13779,10 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 			}
 
 		}
-		yyh1198.End()
+		yyh1193.End()
 	}
-	if yyc1198 {
-		*v = yyv1198
+	if yyc1193 {
+		*v = yyv1193
 	}
 
 }
@@ -13836,9 +13792,9 @@ func (x codecSelfer1234) encSliceClusterAutoscaler(v []ClusterAutoscaler, e *cod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1202 := range v {
-		yy1203 := &yyv1202
-		yy1203.CodecEncodeSelf(e)
+	for _, yyv1197 := range v {
+		yy1198 := &yyv1197
+		yy1198.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13848,75 +13804,75 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1204 := *v
-	yyh1204, yyl1204 := z.DecSliceHelperStart()
+	yyv1199 := *v
+	yyh1199, yyl1199 := z.DecSliceHelperStart()
 
-	var yyrr1204, yyrl1204 int
-	var yyc1204, yyrt1204 bool
-	_, _, _ = yyc1204, yyrt1204, yyrl1204
-	yyrr1204 = yyl1204
+	var yyrr1199, yyrl1199 int
+	var yyc1199, yyrt1199 bool
+	_, _, _ = yyc1199, yyrt1199, yyrl1199
+	yyrr1199 = yyl1199
 
-	if yyv1204 == nil {
-		if yyrl1204, yyrt1204 = z.DecInferLen(yyl1204, z.DecBasicHandle().MaxInitLen, 232); yyrt1204 {
-			yyrr1204 = yyrl1204
+	if yyv1199 == nil {
+		if yyrl1199, yyrt1199 = z.DecInferLen(yyl1199, z.DecBasicHandle().MaxInitLen, 232); yyrt1199 {
+			yyrr1199 = yyrl1199
 		}
-		yyv1204 = make([]ClusterAutoscaler, yyrl1204)
-		yyc1204 = true
+		yyv1199 = make([]ClusterAutoscaler, yyrl1199)
+		yyc1199 = true
 	}
 
-	if yyl1204 == 0 {
-		if len(yyv1204) != 0 {
-			yyv1204 = yyv1204[:0]
-			yyc1204 = true
+	if yyl1199 == 0 {
+		if len(yyv1199) != 0 {
+			yyv1199 = yyv1199[:0]
+			yyc1199 = true
 		}
-	} else if yyl1204 > 0 {
+	} else if yyl1199 > 0 {
 
-		if yyl1204 > cap(yyv1204) {
-			yyrl1204, yyrt1204 = z.DecInferLen(yyl1204, z.DecBasicHandle().MaxInitLen, 232)
-			yyv1204 = make([]ClusterAutoscaler, yyrl1204)
-			yyc1204 = true
+		if yyl1199 > cap(yyv1199) {
+			yyrl1199, yyrt1199 = z.DecInferLen(yyl1199, z.DecBasicHandle().MaxInitLen, 232)
+			yyv1199 = make([]ClusterAutoscaler, yyrl1199)
+			yyc1199 = true
 
-			yyrr1204 = len(yyv1204)
-		} else if yyl1204 != len(yyv1204) {
-			yyv1204 = yyv1204[:yyl1204]
-			yyc1204 = true
+			yyrr1199 = len(yyv1199)
+		} else if yyl1199 != len(yyv1199) {
+			yyv1199 = yyv1199[:yyl1199]
+			yyc1199 = true
 		}
-		yyj1204 := 0
-		for ; yyj1204 < yyrr1204; yyj1204++ {
+		yyj1199 := 0
+		for ; yyj1199 < yyrr1199; yyj1199++ {
 			if r.TryDecodeAsNil() {
-				yyv1204[yyj1204] = ClusterAutoscaler{}
+				yyv1199[yyj1199] = ClusterAutoscaler{}
 			} else {
-				yyv1205 := &yyv1204[yyj1204]
-				yyv1205.CodecDecodeSelf(d)
+				yyv1200 := &yyv1199[yyj1199]
+				yyv1200.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1204 {
-			for ; yyj1204 < yyl1204; yyj1204++ {
-				yyv1204 = append(yyv1204, ClusterAutoscaler{})
+		if yyrt1199 {
+			for ; yyj1199 < yyl1199; yyj1199++ {
+				yyv1199 = append(yyv1199, ClusterAutoscaler{})
 				if r.TryDecodeAsNil() {
-					yyv1204[yyj1204] = ClusterAutoscaler{}
+					yyv1199[yyj1199] = ClusterAutoscaler{}
 				} else {
-					yyv1206 := &yyv1204[yyj1204]
-					yyv1206.CodecDecodeSelf(d)
+					yyv1201 := &yyv1199[yyj1199]
+					yyv1201.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1204 := 0; !r.CheckBreak(); yyj1204++ {
-			if yyj1204 >= len(yyv1204) {
-				yyv1204 = append(yyv1204, ClusterAutoscaler{}) // var yyz1204 ClusterAutoscaler
-				yyc1204 = true
+		for yyj1199 := 0; !r.CheckBreak(); yyj1199++ {
+			if yyj1199 >= len(yyv1199) {
+				yyv1199 = append(yyv1199, ClusterAutoscaler{}) // var yyz1199 ClusterAutoscaler
+				yyc1199 = true
 			}
 
-			if yyj1204 < len(yyv1204) {
+			if yyj1199 < len(yyv1199) {
 				if r.TryDecodeAsNil() {
-					yyv1204[yyj1204] = ClusterAutoscaler{}
+					yyv1199[yyj1199] = ClusterAutoscaler{}
 				} else {
-					yyv1207 := &yyv1204[yyj1204]
-					yyv1207.CodecDecodeSelf(d)
+					yyv1202 := &yyv1199[yyj1199]
+					yyv1202.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13924,10 +13880,10 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 			}
 
 		}
-		yyh1204.End()
+		yyh1199.End()
 	}
-	if yyc1204 {
-		*v = yyv1204
+	if yyc1199 {
+		*v = yyv1199
 	}
 
 }
@@ -13937,9 +13893,9 @@ func (x codecSelfer1234) encSlicePodSelectorRequirement(v []PodSelectorRequireme
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1208 := range v {
-		yy1209 := &yyv1208
-		yy1209.CodecEncodeSelf(e)
+	for _, yyv1203 := range v {
+		yy1204 := &yyv1203
+		yy1204.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13949,75 +13905,75 @@ func (x codecSelfer1234) decSlicePodSelectorRequirement(v *[]PodSelectorRequirem
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1210 := *v
-	yyh1210, yyl1210 := z.DecSliceHelperStart()
+	yyv1205 := *v
+	yyh1205, yyl1205 := z.DecSliceHelperStart()
 
-	var yyrr1210, yyrl1210 int
-	var yyc1210, yyrt1210 bool
-	_, _, _ = yyc1210, yyrt1210, yyrl1210
-	yyrr1210 = yyl1210
+	var yyrr1205, yyrl1205 int
+	var yyc1205, yyrt1205 bool
+	_, _, _ = yyc1205, yyrt1205, yyrl1205
+	yyrr1205 = yyl1205
 
-	if yyv1210 == nil {
-		if yyrl1210, yyrt1210 = z.DecInferLen(yyl1210, z.DecBasicHandle().MaxInitLen, 56); yyrt1210 {
-			yyrr1210 = yyrl1210
+	if yyv1205 == nil {
+		if yyrl1205, yyrt1205 = z.DecInferLen(yyl1205, z.DecBasicHandle().MaxInitLen, 56); yyrt1205 {
+			yyrr1205 = yyrl1205
 		}
-		yyv1210 = make([]PodSelectorRequirement, yyrl1210)
-		yyc1210 = true
+		yyv1205 = make([]PodSelectorRequirement, yyrl1205)
+		yyc1205 = true
 	}
 
-	if yyl1210 == 0 {
-		if len(yyv1210) != 0 {
-			yyv1210 = yyv1210[:0]
-			yyc1210 = true
+	if yyl1205 == 0 {
+		if len(yyv1205) != 0 {
+			yyv1205 = yyv1205[:0]
+			yyc1205 = true
 		}
-	} else if yyl1210 > 0 {
+	} else if yyl1205 > 0 {
 
-		if yyl1210 > cap(yyv1210) {
-			yyrl1210, yyrt1210 = z.DecInferLen(yyl1210, z.DecBasicHandle().MaxInitLen, 56)
-			yyv1210 = make([]PodSelectorRequirement, yyrl1210)
-			yyc1210 = true
+		if yyl1205 > cap(yyv1205) {
+			yyrl1205, yyrt1205 = z.DecInferLen(yyl1205, z.DecBasicHandle().MaxInitLen, 56)
+			yyv1205 = make([]PodSelectorRequirement, yyrl1205)
+			yyc1205 = true
 
-			yyrr1210 = len(yyv1210)
-		} else if yyl1210 != len(yyv1210) {
-			yyv1210 = yyv1210[:yyl1210]
-			yyc1210 = true
+			yyrr1205 = len(yyv1205)
+		} else if yyl1205 != len(yyv1205) {
+			yyv1205 = yyv1205[:yyl1205]
+			yyc1205 = true
 		}
-		yyj1210 := 0
-		for ; yyj1210 < yyrr1210; yyj1210++ {
+		yyj1205 := 0
+		for ; yyj1205 < yyrr1205; yyj1205++ {
 			if r.TryDecodeAsNil() {
-				yyv1210[yyj1210] = PodSelectorRequirement{}
+				yyv1205[yyj1205] = PodSelectorRequirement{}
 			} else {
-				yyv1211 := &yyv1210[yyj1210]
-				yyv1211.CodecDecodeSelf(d)
+				yyv1206 := &yyv1205[yyj1205]
+				yyv1206.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1210 {
-			for ; yyj1210 < yyl1210; yyj1210++ {
-				yyv1210 = append(yyv1210, PodSelectorRequirement{})
+		if yyrt1205 {
+			for ; yyj1205 < yyl1205; yyj1205++ {
+				yyv1205 = append(yyv1205, PodSelectorRequirement{})
 				if r.TryDecodeAsNil() {
-					yyv1210[yyj1210] = PodSelectorRequirement{}
+					yyv1205[yyj1205] = PodSelectorRequirement{}
 				} else {
-					yyv1212 := &yyv1210[yyj1210]
-					yyv1212.CodecDecodeSelf(d)
+					yyv1207 := &yyv1205[yyj1205]
+					yyv1207.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1210 := 0; !r.CheckBreak(); yyj1210++ {
-			if yyj1210 >= len(yyv1210) {
-				yyv1210 = append(yyv1210, PodSelectorRequirement{}) // var yyz1210 PodSelectorRequirement
-				yyc1210 = true
+		for yyj1205 := 0; !r.CheckBreak(); yyj1205++ {
+			if yyj1205 >= len(yyv1205) {
+				yyv1205 = append(yyv1205, PodSelectorRequirement{}) // var yyz1205 PodSelectorRequirement
+				yyc1205 = true
 			}
 
-			if yyj1210 < len(yyv1210) {
+			if yyj1205 < len(yyv1205) {
 				if r.TryDecodeAsNil() {
-					yyv1210[yyj1210] = PodSelectorRequirement{}
+					yyv1205[yyj1205] = PodSelectorRequirement{}
 				} else {
-					yyv1213 := &yyv1210[yyj1210]
-					yyv1213.CodecDecodeSelf(d)
+					yyv1208 := &yyv1205[yyj1205]
+					yyv1208.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -14025,10 +13981,10 @@ func (x codecSelfer1234) decSlicePodSelectorRequirement(v *[]PodSelectorRequirem
 			}
 
 		}
-		yyh1210.End()
+		yyh1205.End()
 	}
-	if yyc1210 {
-		*v = yyv1210
+	if yyc1205 {
+		*v = yyv1205
 	}
 
 }

--- a/pkg/apis/extensions/types.go
+++ b/pkg/apis/extensions/types.go
@@ -71,8 +71,6 @@ type ReplicationControllerDummy struct {
 type SubresourceReference struct {
 	// Kind of the referent; More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
 	Kind string `json:"kind,omitempty"`
-	// Namespace of the referent; More info: http://releases.k8s.io/HEAD/docs/user-guide/namespaces.md
-	Namespace string `json:"namespace,omitempty"`
 	// Name of the referent; More info: http://releases.k8s.io/HEAD/docs/user-guide/identifiers.md#names
 	Name string `json:"name,omitempty"`
 	// API version of the referent

--- a/pkg/apis/extensions/v1beta1/conversion_generated.go
+++ b/pkg/apis/extensions/v1beta1/conversion_generated.go
@@ -3019,7 +3019,6 @@ func autoconvert_extensions_SubresourceReference_To_v1beta1_SubresourceReference
 		defaulting.(func(*extensions.SubresourceReference))(in)
 	}
 	out.Kind = in.Kind
-	out.Namespace = in.Namespace
 	out.Name = in.Name
 	out.APIVersion = in.APIVersion
 	out.Subresource = in.Subresource
@@ -3983,7 +3982,6 @@ func autoconvert_v1beta1_SubresourceReference_To_extensions_SubresourceReference
 		defaulting.(func(*SubresourceReference))(in)
 	}
 	out.Kind = in.Kind
-	out.Namespace = in.Namespace
 	out.Name = in.Name
 	out.APIVersion = in.APIVersion
 	out.Subresource = in.Subresource

--- a/pkg/apis/extensions/v1beta1/deep_copy_generated.go
+++ b/pkg/apis/extensions/v1beta1/deep_copy_generated.go
@@ -1505,7 +1505,6 @@ func deepCopy_v1beta1_ScaleStatus(in ScaleStatus, out *ScaleStatus, c *conversio
 
 func deepCopy_v1beta1_SubresourceReference(in SubresourceReference, out *SubresourceReference, c *conversion.Cloner) error {
 	out.Kind = in.Kind
-	out.Namespace = in.Namespace
 	out.Name = in.Name
 	out.APIVersion = in.APIVersion
 	out.Subresource = in.Subresource

--- a/pkg/apis/extensions/v1beta1/types.generated.go
+++ b/pkg/apis/extensions/v1beta1/types.generated.go
@@ -978,16 +978,15 @@ func (x *SubresourceReference) CodecEncodeSelf(e *codec1978.Encoder) {
 		} else {
 			yysep78 := !z.EncBinary()
 			yy2arr78 := z.EncBasicHandle().StructToArray
-			var yyq78 [5]bool
+			var yyq78 [4]bool
 			_, _, _ = yysep78, yyq78, yy2arr78
 			const yyr78 bool = false
 			yyq78[0] = x.Kind != ""
-			yyq78[1] = x.Namespace != ""
-			yyq78[2] = x.Name != ""
-			yyq78[3] = x.APIVersion != ""
-			yyq78[4] = x.Subresource != ""
+			yyq78[1] = x.Name != ""
+			yyq78[2] = x.APIVersion != ""
+			yyq78[3] = x.Subresource != ""
 			if yyr78 || yy2arr78 {
-				r.EncodeArrayStart(5)
+				r.EncodeArrayStart(4)
 			} else {
 				var yynn78 int = 0
 				for _, b := range yyq78 {
@@ -1025,19 +1024,19 @@ func (x *SubresourceReference) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym83
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Namespace))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq78[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("namespace"))
+					r.EncodeString(codecSelferC_UTF81234, string("name"))
 					yym84 := z.EncBinary()
 					_ = yym84
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Namespace))
+						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 					}
 				}
 			}
@@ -1047,19 +1046,19 @@ func (x *SubresourceReference) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym86
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
 				if yyq78[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("name"))
+					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
 					yym87 := z.EncBinary()
 					_ = yym87
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
@@ -1069,38 +1068,16 @@ func (x *SubresourceReference) CodecEncodeSelf(e *codec1978.Encoder) {
 					_ = yym89
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq78[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym90 := z.EncBinary()
-					_ = yym90
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr78 || yy2arr78 {
-				if yyq78[4] {
-					yym92 := z.EncBinary()
-					_ = yym92
-					if false {
-					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Subresource))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq78[4] {
+				if yyq78[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("subresource"))
-					yym93 := z.EncBinary()
-					_ = yym93
+					yym90 := z.EncBinary()
+					_ = yym90
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Subresource))
@@ -1118,24 +1095,24 @@ func (x *SubresourceReference) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym94 := z.DecBinary()
-	_ = yym94
+	yym91 := z.DecBinary()
+	_ = yym91
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl95 := r.ReadMapStart()
-			if yyl95 == 0 {
+			yyl92 := r.ReadMapStart()
+			if yyl92 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl95, d)
+				x.codecDecodeSelfFromMap(yyl92, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl95 := r.ReadArrayStart()
-			if yyl95 == 0 {
+			yyl92 := r.ReadArrayStart()
+			if yyl92 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl95, d)
+				x.codecDecodeSelfFromArray(yyl92, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -1147,12 +1124,12 @@ func (x *SubresourceReference) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys96Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys96Slc
-	var yyhl96 bool = l >= 0
-	for yyj96 := 0; ; yyj96++ {
-		if yyhl96 {
-			if yyj96 >= l {
+	var yys93Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys93Slc
+	var yyhl93 bool = l >= 0
+	for yyj93 := 0; ; yyj93++ {
+		if yyhl93 {
+			if yyj93 >= l {
 				break
 			}
 		} else {
@@ -1160,20 +1137,14 @@ func (x *SubresourceReference) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
-		yys96Slc = r.DecodeBytes(yys96Slc, true, true)
-		yys96 := string(yys96Slc)
-		switch yys96 {
+		yys93Slc = r.DecodeBytes(yys93Slc, true, true)
+		yys93 := string(yys93Slc)
+		switch yys93 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
 			} else {
 				x.Kind = string(r.DecodeString())
-			}
-		case "namespace":
-			if r.TryDecodeAsNil() {
-				x.Namespace = ""
-			} else {
-				x.Namespace = string(r.DecodeString())
 			}
 		case "name":
 			if r.TryDecodeAsNil() {
@@ -1194,10 +1165,10 @@ func (x *SubresourceReference) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				x.Subresource = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys96)
-		} // end switch yys96
-	} // end for yyj96
-	if !yyhl96 {
+			z.DecStructFieldNotFound(-1, yys93)
+		} // end switch yys93
+	} // end for yyj93
+	if !yyhl93 {
 		r.ReadEnd()
 	}
 }
@@ -1206,16 +1177,16 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj102 int
-	var yyb102 bool
-	var yyhl102 bool = l >= 0
-	yyj102++
-	if yyhl102 {
-		yyb102 = yyj102 > l
+	var yyj98 int
+	var yyb98 bool
+	var yyhl98 bool = l >= 0
+	yyj98++
+	if yyhl98 {
+		yyb98 = yyj98 > l
 	} else {
-		yyb102 = r.CheckBreak()
+		yyb98 = r.CheckBreak()
 	}
-	if yyb102 {
+	if yyb98 {
 		r.ReadEnd()
 		return
 	}
@@ -1224,28 +1195,13 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj102++
-	if yyhl102 {
-		yyb102 = yyj102 > l
+	yyj98++
+	if yyhl98 {
+		yyb98 = yyj98 > l
 	} else {
-		yyb102 = r.CheckBreak()
+		yyb98 = r.CheckBreak()
 	}
-	if yyb102 {
-		r.ReadEnd()
-		return
-	}
-	if r.TryDecodeAsNil() {
-		x.Namespace = ""
-	} else {
-		x.Namespace = string(r.DecodeString())
-	}
-	yyj102++
-	if yyhl102 {
-		yyb102 = yyj102 > l
-	} else {
-		yyb102 = r.CheckBreak()
-	}
-	if yyb102 {
+	if yyb98 {
 		r.ReadEnd()
 		return
 	}
@@ -1254,13 +1210,13 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.Name = string(r.DecodeString())
 	}
-	yyj102++
-	if yyhl102 {
-		yyb102 = yyj102 > l
+	yyj98++
+	if yyhl98 {
+		yyb98 = yyj98 > l
 	} else {
-		yyb102 = r.CheckBreak()
+		yyb98 = r.CheckBreak()
 	}
-	if yyb102 {
+	if yyb98 {
 		r.ReadEnd()
 		return
 	}
@@ -1269,13 +1225,13 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj102++
-	if yyhl102 {
-		yyb102 = yyj102 > l
+	yyj98++
+	if yyhl98 {
+		yyb98 = yyj98 > l
 	} else {
-		yyb102 = r.CheckBreak()
+		yyb98 = r.CheckBreak()
 	}
-	if yyb102 {
+	if yyb98 {
 		r.ReadEnd()
 		return
 	}
@@ -1285,16 +1241,16 @@ func (x *SubresourceReference) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		x.Subresource = string(r.DecodeString())
 	}
 	for {
-		yyj102++
-		if yyhl102 {
-			yyb102 = yyj102 > l
+		yyj98++
+		if yyhl98 {
+			yyb98 = yyj98 > l
 		} else {
-			yyb102 = r.CheckBreak()
+			yyb98 = r.CheckBreak()
 		}
-		if yyb102 {
+		if yyb98 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj102-1, "")
+		z.DecStructFieldNotFound(yyj98-1, "")
 	}
 	r.ReadEnd()
 }
@@ -1306,44 +1262,44 @@ func (x *CPUTargetUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym108 := z.EncBinary()
-		_ = yym108
+		yym103 := z.EncBinary()
+		_ = yym103
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep109 := !z.EncBinary()
-			yy2arr109 := z.EncBasicHandle().StructToArray
-			var yyq109 [1]bool
-			_, _, _ = yysep109, yyq109, yy2arr109
-			const yyr109 bool = false
-			if yyr109 || yy2arr109 {
+			yysep104 := !z.EncBinary()
+			yy2arr104 := z.EncBasicHandle().StructToArray
+			var yyq104 [1]bool
+			_, _, _ = yysep104, yyq104, yy2arr104
+			const yyr104 bool = false
+			if yyr104 || yy2arr104 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn109 int = 1
-				for _, b := range yyq109 {
+				var yynn104 int = 1
+				for _, b := range yyq104 {
 					if b {
-						yynn109++
+						yynn104++
 					}
 				}
-				r.EncodeMapStart(yynn109)
+				r.EncodeMapStart(yynn104)
 			}
-			if yyr109 || yy2arr109 {
-				yym111 := z.EncBinary()
-				_ = yym111
+			if yyr104 || yy2arr104 {
+				yym106 := z.EncBinary()
+				_ = yym106
 				if false {
 				} else {
 					r.EncodeInt(int64(x.TargetPercentage))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("targetPercentage"))
-				yym112 := z.EncBinary()
-				_ = yym112
+				yym107 := z.EncBinary()
+				_ = yym107
 				if false {
 				} else {
 					r.EncodeInt(int64(x.TargetPercentage))
 				}
 			}
-			if yysep109 {
+			if yysep104 {
 				r.EncodeEnd()
 			}
 		}
@@ -1354,24 +1310,24 @@ func (x *CPUTargetUtilization) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym113 := z.DecBinary()
-	_ = yym113
+	yym108 := z.DecBinary()
+	_ = yym108
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl114 := r.ReadMapStart()
-			if yyl114 == 0 {
+			yyl109 := r.ReadMapStart()
+			if yyl109 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl114, d)
+				x.codecDecodeSelfFromMap(yyl109, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl114 := r.ReadArrayStart()
-			if yyl114 == 0 {
+			yyl109 := r.ReadArrayStart()
+			if yyl109 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl114, d)
+				x.codecDecodeSelfFromArray(yyl109, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -1383,12 +1339,12 @@ func (x *CPUTargetUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys115Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys115Slc
-	var yyhl115 bool = l >= 0
-	for yyj115 := 0; ; yyj115++ {
-		if yyhl115 {
-			if yyj115 >= l {
+	var yys110Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys110Slc
+	var yyhl110 bool = l >= 0
+	for yyj110 := 0; ; yyj110++ {
+		if yyhl110 {
+			if yyj110 >= l {
 				break
 			}
 		} else {
@@ -1396,9 +1352,9 @@ func (x *CPUTargetUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
-		yys115Slc = r.DecodeBytes(yys115Slc, true, true)
-		yys115 := string(yys115Slc)
-		switch yys115 {
+		yys110Slc = r.DecodeBytes(yys110Slc, true, true)
+		yys110 := string(yys110Slc)
+		switch yys110 {
 		case "targetPercentage":
 			if r.TryDecodeAsNil() {
 				x.TargetPercentage = 0
@@ -1406,10 +1362,10 @@ func (x *CPUTargetUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				x.TargetPercentage = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys115)
-		} // end switch yys115
-	} // end for yyj115
-	if !yyhl115 {
+			z.DecStructFieldNotFound(-1, yys110)
+		} // end switch yys110
+	} // end for yyj110
+	if !yyhl110 {
 		r.ReadEnd()
 	}
 }
@@ -1418,16 +1374,16 @@ func (x *CPUTargetUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj117 int
-	var yyb117 bool
-	var yyhl117 bool = l >= 0
-	yyj117++
-	if yyhl117 {
-		yyb117 = yyj117 > l
+	var yyj112 int
+	var yyb112 bool
+	var yyhl112 bool = l >= 0
+	yyj112++
+	if yyhl112 {
+		yyb112 = yyj112 > l
 	} else {
-		yyb117 = r.CheckBreak()
+		yyb112 = r.CheckBreak()
 	}
-	if yyb117 {
+	if yyb112 {
 		r.ReadEnd()
 		return
 	}
@@ -1437,16 +1393,16 @@ func (x *CPUTargetUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 		x.TargetPercentage = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj117++
-		if yyhl117 {
-			yyb117 = yyj117 > l
+		yyj112++
+		if yyhl112 {
+			yyb112 = yyj112 > l
 		} else {
-			yyb117 = r.CheckBreak()
+			yyb112 = r.CheckBreak()
 		}
-		if yyb117 {
+		if yyb112 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj117-1, "")
+		z.DecStructFieldNotFound(yyj112-1, "")
 	}
 	r.ReadEnd()
 }
@@ -1458,87 +1414,87 @@ func (x *HorizontalPodAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym119 := z.EncBinary()
-		_ = yym119
+		yym114 := z.EncBinary()
+		_ = yym114
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep120 := !z.EncBinary()
-			yy2arr120 := z.EncBasicHandle().StructToArray
-			var yyq120 [4]bool
-			_, _, _ = yysep120, yyq120, yy2arr120
-			const yyr120 bool = false
-			yyq120[1] = x.MinReplicas != nil
-			yyq120[3] = x.CPUUtilization != nil
-			if yyr120 || yy2arr120 {
+			yysep115 := !z.EncBinary()
+			yy2arr115 := z.EncBasicHandle().StructToArray
+			var yyq115 [4]bool
+			_, _, _ = yysep115, yyq115, yy2arr115
+			const yyr115 bool = false
+			yyq115[1] = x.MinReplicas != nil
+			yyq115[3] = x.CPUUtilization != nil
+			if yyr115 || yy2arr115 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn120 int = 2
-				for _, b := range yyq120 {
+				var yynn115 int = 2
+				for _, b := range yyq115 {
 					if b {
-						yynn120++
+						yynn115++
 					}
 				}
-				r.EncodeMapStart(yynn120)
+				r.EncodeMapStart(yynn115)
 			}
-			if yyr120 || yy2arr120 {
-				yy122 := &x.ScaleRef
-				yy122.CodecEncodeSelf(e)
+			if yyr115 || yy2arr115 {
+				yy117 := &x.ScaleRef
+				yy117.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("scaleRef"))
-				yy123 := &x.ScaleRef
-				yy123.CodecEncodeSelf(e)
+				yy118 := &x.ScaleRef
+				yy118.CodecEncodeSelf(e)
 			}
-			if yyr120 || yy2arr120 {
-				if yyq120[1] {
+			if yyr115 || yy2arr115 {
+				if yyq115[1] {
 					if x.MinReplicas == nil {
 						r.EncodeNil()
 					} else {
-						yy125 := *x.MinReplicas
-						yym126 := z.EncBinary()
-						_ = yym126
+						yy120 := *x.MinReplicas
+						yym121 := z.EncBinary()
+						_ = yym121
 						if false {
 						} else {
-							r.EncodeInt(int64(yy125))
+							r.EncodeInt(int64(yy120))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq120[1] {
+				if yyq115[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("minReplicas"))
 					if x.MinReplicas == nil {
 						r.EncodeNil()
 					} else {
-						yy127 := *x.MinReplicas
-						yym128 := z.EncBinary()
-						_ = yym128
+						yy122 := *x.MinReplicas
+						yym123 := z.EncBinary()
+						_ = yym123
 						if false {
 						} else {
-							r.EncodeInt(int64(yy127))
+							r.EncodeInt(int64(yy122))
 						}
 					}
 				}
 			}
-			if yyr120 || yy2arr120 {
-				yym130 := z.EncBinary()
-				_ = yym130
+			if yyr115 || yy2arr115 {
+				yym125 := z.EncBinary()
+				_ = yym125
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MaxReplicas))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("maxReplicas"))
-				yym131 := z.EncBinary()
-				_ = yym131
+				yym126 := z.EncBinary()
+				_ = yym126
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MaxReplicas))
 				}
 			}
-			if yyr120 || yy2arr120 {
-				if yyq120[3] {
+			if yyr115 || yy2arr115 {
+				if yyq115[3] {
 					if x.CPUUtilization == nil {
 						r.EncodeNil()
 					} else {
@@ -1548,7 +1504,7 @@ func (x *HorizontalPodAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq120[3] {
+				if yyq115[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("cpuUtilization"))
 					if x.CPUUtilization == nil {
 						r.EncodeNil()
@@ -1557,7 +1513,7 @@ func (x *HorizontalPodAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep120 {
+			if yysep115 {
 				r.EncodeEnd()
 			}
 		}
@@ -1568,24 +1524,24 @@ func (x *HorizontalPodAutoscalerSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym133 := z.DecBinary()
-	_ = yym133
+	yym128 := z.DecBinary()
+	_ = yym128
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl134 := r.ReadMapStart()
-			if yyl134 == 0 {
+			yyl129 := r.ReadMapStart()
+			if yyl129 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl134, d)
+				x.codecDecodeSelfFromMap(yyl129, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl134 := r.ReadArrayStart()
-			if yyl134 == 0 {
+			yyl129 := r.ReadArrayStart()
+			if yyl129 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl134, d)
+				x.codecDecodeSelfFromArray(yyl129, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -1597,12 +1553,12 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys135Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys135Slc
-	var yyhl135 bool = l >= 0
-	for yyj135 := 0; ; yyj135++ {
-		if yyhl135 {
-			if yyj135 >= l {
+	var yys130Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys130Slc
+	var yyhl130 bool = l >= 0
+	for yyj130 := 0; ; yyj130++ {
+		if yyhl130 {
+			if yyj130 >= l {
 				break
 			}
 		} else {
@@ -1610,15 +1566,15 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978
 				break
 			}
 		}
-		yys135Slc = r.DecodeBytes(yys135Slc, true, true)
-		yys135 := string(yys135Slc)
-		switch yys135 {
+		yys130Slc = r.DecodeBytes(yys130Slc, true, true)
+		yys130 := string(yys130Slc)
+		switch yys130 {
 		case "scaleRef":
 			if r.TryDecodeAsNil() {
 				x.ScaleRef = SubresourceReference{}
 			} else {
-				yyv136 := &x.ScaleRef
-				yyv136.CodecDecodeSelf(d)
+				yyv131 := &x.ScaleRef
+				yyv131.CodecDecodeSelf(d)
 			}
 		case "minReplicas":
 			if r.TryDecodeAsNil() {
@@ -1629,8 +1585,8 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978
 				if x.MinReplicas == nil {
 					x.MinReplicas = new(int)
 				}
-				yym138 := z.DecBinary()
-				_ = yym138
+				yym133 := z.DecBinary()
+				_ = yym133
 				if false {
 				} else {
 					*((*int)(x.MinReplicas)) = int(r.DecodeInt(codecSelferBitsize1234))
@@ -1654,10 +1610,10 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978
 				x.CPUUtilization.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys135)
-		} // end switch yys135
-	} // end for yyj135
-	if !yyhl135 {
+			z.DecStructFieldNotFound(-1, yys130)
+		} // end switch yys130
+	} // end for yyj130
+	if !yyhl130 {
 		r.ReadEnd()
 	}
 }
@@ -1666,32 +1622,32 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec19
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj141 int
-	var yyb141 bool
-	var yyhl141 bool = l >= 0
-	yyj141++
-	if yyhl141 {
-		yyb141 = yyj141 > l
+	var yyj136 int
+	var yyb136 bool
+	var yyhl136 bool = l >= 0
+	yyj136++
+	if yyhl136 {
+		yyb136 = yyj136 > l
 	} else {
-		yyb141 = r.CheckBreak()
+		yyb136 = r.CheckBreak()
 	}
-	if yyb141 {
+	if yyb136 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ScaleRef = SubresourceReference{}
 	} else {
-		yyv142 := &x.ScaleRef
-		yyv142.CodecDecodeSelf(d)
+		yyv137 := &x.ScaleRef
+		yyv137.CodecDecodeSelf(d)
 	}
-	yyj141++
-	if yyhl141 {
-		yyb141 = yyj141 > l
+	yyj136++
+	if yyhl136 {
+		yyb136 = yyj136 > l
 	} else {
-		yyb141 = r.CheckBreak()
+		yyb136 = r.CheckBreak()
 	}
-	if yyb141 {
+	if yyb136 {
 		r.ReadEnd()
 		return
 	}
@@ -1703,20 +1659,20 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec19
 		if x.MinReplicas == nil {
 			x.MinReplicas = new(int)
 		}
-		yym144 := z.DecBinary()
-		_ = yym144
+		yym139 := z.DecBinary()
+		_ = yym139
 		if false {
 		} else {
 			*((*int)(x.MinReplicas)) = int(r.DecodeInt(codecSelferBitsize1234))
 		}
 	}
-	yyj141++
-	if yyhl141 {
-		yyb141 = yyj141 > l
+	yyj136++
+	if yyhl136 {
+		yyb136 = yyj136 > l
 	} else {
-		yyb141 = r.CheckBreak()
+		yyb136 = r.CheckBreak()
 	}
-	if yyb141 {
+	if yyb136 {
 		r.ReadEnd()
 		return
 	}
@@ -1725,13 +1681,13 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec19
 	} else {
 		x.MaxReplicas = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj141++
-	if yyhl141 {
-		yyb141 = yyj141 > l
+	yyj136++
+	if yyhl136 {
+		yyb136 = yyj136 > l
 	} else {
-		yyb141 = r.CheckBreak()
+		yyb136 = r.CheckBreak()
 	}
-	if yyb141 {
+	if yyb136 {
 		r.ReadEnd()
 		return
 	}
@@ -1746,16 +1702,16 @@ func (x *HorizontalPodAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec19
 		x.CPUUtilization.CodecDecodeSelf(d)
 	}
 	for {
-		yyj141++
-		if yyhl141 {
-			yyb141 = yyj141 > l
+		yyj136++
+		if yyhl136 {
+			yyb136 = yyj136 > l
 		} else {
-			yyb141 = r.CheckBreak()
+			yyb136 = r.CheckBreak()
 		}
-		if yyb141 {
+		if yyb136 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj141-1, "")
+		z.DecStructFieldNotFound(yyj136-1, "")
 	}
 	r.ReadEnd()
 }
@@ -1767,74 +1723,74 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym147 := z.EncBinary()
-		_ = yym147
+		yym142 := z.EncBinary()
+		_ = yym142
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep148 := !z.EncBinary()
-			yy2arr148 := z.EncBasicHandle().StructToArray
-			var yyq148 [5]bool
-			_, _, _ = yysep148, yyq148, yy2arr148
-			const yyr148 bool = false
-			yyq148[0] = x.ObservedGeneration != nil
-			yyq148[1] = x.LastScaleTime != nil
-			yyq148[4] = x.CurrentCPUUtilizationPercentage != nil
-			if yyr148 || yy2arr148 {
+			yysep143 := !z.EncBinary()
+			yy2arr143 := z.EncBasicHandle().StructToArray
+			var yyq143 [5]bool
+			_, _, _ = yysep143, yyq143, yy2arr143
+			const yyr143 bool = false
+			yyq143[0] = x.ObservedGeneration != nil
+			yyq143[1] = x.LastScaleTime != nil
+			yyq143[4] = x.CurrentCPUUtilizationPercentage != nil
+			if yyr143 || yy2arr143 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn148 int = 2
-				for _, b := range yyq148 {
+				var yynn143 int = 2
+				for _, b := range yyq143 {
 					if b {
-						yynn148++
+						yynn143++
 					}
 				}
-				r.EncodeMapStart(yynn148)
+				r.EncodeMapStart(yynn143)
 			}
-			if yyr148 || yy2arr148 {
-				if yyq148[0] {
+			if yyr143 || yy2arr143 {
+				if yyq143[0] {
 					if x.ObservedGeneration == nil {
 						r.EncodeNil()
 					} else {
-						yy150 := *x.ObservedGeneration
-						yym151 := z.EncBinary()
-						_ = yym151
+						yy145 := *x.ObservedGeneration
+						yym146 := z.EncBinary()
+						_ = yym146
 						if false {
 						} else {
-							r.EncodeInt(int64(yy150))
+							r.EncodeInt(int64(yy145))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq148[0] {
+				if yyq143[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("observedGeneration"))
 					if x.ObservedGeneration == nil {
 						r.EncodeNil()
 					} else {
-						yy152 := *x.ObservedGeneration
-						yym153 := z.EncBinary()
-						_ = yym153
+						yy147 := *x.ObservedGeneration
+						yym148 := z.EncBinary()
+						_ = yym148
 						if false {
 						} else {
-							r.EncodeInt(int64(yy152))
+							r.EncodeInt(int64(yy147))
 						}
 					}
 				}
 			}
-			if yyr148 || yy2arr148 {
-				if yyq148[1] {
+			if yyr143 || yy2arr143 {
+				if yyq143[1] {
 					if x.LastScaleTime == nil {
 						r.EncodeNil()
 					} else {
-						yym155 := z.EncBinary()
-						_ = yym155
+						yym150 := z.EncBinary()
+						_ = yym150
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.LastScaleTime) {
-						} else if yym155 {
+						} else if yym150 {
 							z.EncBinaryMarshal(x.LastScaleTime)
-						} else if !yym155 && z.IsJSONHandle() {
+						} else if !yym150 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.LastScaleTime)
 						} else {
 							z.EncFallback(x.LastScaleTime)
@@ -1844,18 +1800,18 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq148[1] {
+				if yyq143[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("lastScaleTime"))
 					if x.LastScaleTime == nil {
 						r.EncodeNil()
 					} else {
-						yym156 := z.EncBinary()
-						_ = yym156
+						yym151 := z.EncBinary()
+						_ = yym151
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.LastScaleTime) {
-						} else if yym156 {
+						} else if yym151 {
 							z.EncBinaryMarshal(x.LastScaleTime)
-						} else if !yym156 && z.IsJSONHandle() {
+						} else if !yym151 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.LastScaleTime)
 						} else {
 							z.EncFallback(x.LastScaleTime)
@@ -1863,71 +1819,71 @@ func (x *HorizontalPodAutoscalerStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr148 || yy2arr148 {
-				yym158 := z.EncBinary()
-				_ = yym158
+			if yyr143 || yy2arr143 {
+				yym153 := z.EncBinary()
+				_ = yym153
 				if false {
 				} else {
 					r.EncodeInt(int64(x.CurrentReplicas))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("currentReplicas"))
-				yym159 := z.EncBinary()
-				_ = yym159
+				yym154 := z.EncBinary()
+				_ = yym154
 				if false {
 				} else {
 					r.EncodeInt(int64(x.CurrentReplicas))
 				}
 			}
-			if yyr148 || yy2arr148 {
-				yym161 := z.EncBinary()
-				_ = yym161
+			if yyr143 || yy2arr143 {
+				yym156 := z.EncBinary()
+				_ = yym156
 				if false {
 				} else {
 					r.EncodeInt(int64(x.DesiredReplicas))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("desiredReplicas"))
-				yym162 := z.EncBinary()
-				_ = yym162
+				yym157 := z.EncBinary()
+				_ = yym157
 				if false {
 				} else {
 					r.EncodeInt(int64(x.DesiredReplicas))
 				}
 			}
-			if yyr148 || yy2arr148 {
-				if yyq148[4] {
+			if yyr143 || yy2arr143 {
+				if yyq143[4] {
 					if x.CurrentCPUUtilizationPercentage == nil {
 						r.EncodeNil()
 					} else {
-						yy164 := *x.CurrentCPUUtilizationPercentage
-						yym165 := z.EncBinary()
-						_ = yym165
+						yy159 := *x.CurrentCPUUtilizationPercentage
+						yym160 := z.EncBinary()
+						_ = yym160
 						if false {
 						} else {
-							r.EncodeInt(int64(yy164))
+							r.EncodeInt(int64(yy159))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq148[4] {
+				if yyq143[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("currentCPUUtilizationPercentage"))
 					if x.CurrentCPUUtilizationPercentage == nil {
 						r.EncodeNil()
 					} else {
-						yy166 := *x.CurrentCPUUtilizationPercentage
-						yym167 := z.EncBinary()
-						_ = yym167
+						yy161 := *x.CurrentCPUUtilizationPercentage
+						yym162 := z.EncBinary()
+						_ = yym162
 						if false {
 						} else {
-							r.EncodeInt(int64(yy166))
+							r.EncodeInt(int64(yy161))
 						}
 					}
 				}
 			}
-			if yysep148 {
+			if yysep143 {
 				r.EncodeEnd()
 			}
 		}
@@ -1938,24 +1894,24 @@ func (x *HorizontalPodAutoscalerStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym168 := z.DecBinary()
-	_ = yym168
+	yym163 := z.DecBinary()
+	_ = yym163
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl169 := r.ReadMapStart()
-			if yyl169 == 0 {
+			yyl164 := r.ReadMapStart()
+			if yyl164 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl169, d)
+				x.codecDecodeSelfFromMap(yyl164, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl169 := r.ReadArrayStart()
-			if yyl169 == 0 {
+			yyl164 := r.ReadArrayStart()
+			if yyl164 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl169, d)
+				x.codecDecodeSelfFromArray(yyl164, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -1967,12 +1923,12 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromMap(l int, d *codec19
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys170Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys170Slc
-	var yyhl170 bool = l >= 0
-	for yyj170 := 0; ; yyj170++ {
-		if yyhl170 {
-			if yyj170 >= l {
+	var yys165Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys165Slc
+	var yyhl165 bool = l >= 0
+	for yyj165 := 0; ; yyj165++ {
+		if yyhl165 {
+			if yyj165 >= l {
 				break
 			}
 		} else {
@@ -1980,9 +1936,9 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromMap(l int, d *codec19
 				break
 			}
 		}
-		yys170Slc = r.DecodeBytes(yys170Slc, true, true)
-		yys170 := string(yys170Slc)
-		switch yys170 {
+		yys165Slc = r.DecodeBytes(yys165Slc, true, true)
+		yys165 := string(yys165Slc)
+		switch yys165 {
 		case "observedGeneration":
 			if r.TryDecodeAsNil() {
 				if x.ObservedGeneration != nil {
@@ -1992,8 +1948,8 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromMap(l int, d *codec19
 				if x.ObservedGeneration == nil {
 					x.ObservedGeneration = new(int64)
 				}
-				yym172 := z.DecBinary()
-				_ = yym172
+				yym167 := z.DecBinary()
+				_ = yym167
 				if false {
 				} else {
 					*((*int64)(x.ObservedGeneration)) = int64(r.DecodeInt(64))
@@ -2008,13 +1964,13 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromMap(l int, d *codec19
 				if x.LastScaleTime == nil {
 					x.LastScaleTime = new(pkg1_unversioned.Time)
 				}
-				yym174 := z.DecBinary()
-				_ = yym174
+				yym169 := z.DecBinary()
+				_ = yym169
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.LastScaleTime) {
-				} else if yym174 {
+				} else if yym169 {
 					z.DecBinaryUnmarshal(x.LastScaleTime)
-				} else if !yym174 && z.IsJSONHandle() {
+				} else if !yym169 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.LastScaleTime)
 				} else {
 					z.DecFallback(x.LastScaleTime, false)
@@ -2041,18 +1997,18 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromMap(l int, d *codec19
 				if x.CurrentCPUUtilizationPercentage == nil {
 					x.CurrentCPUUtilizationPercentage = new(int)
 				}
-				yym178 := z.DecBinary()
-				_ = yym178
+				yym173 := z.DecBinary()
+				_ = yym173
 				if false {
 				} else {
 					*((*int)(x.CurrentCPUUtilizationPercentage)) = int(r.DecodeInt(codecSelferBitsize1234))
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys170)
-		} // end switch yys170
-	} // end for yyj170
-	if !yyhl170 {
+			z.DecStructFieldNotFound(-1, yys165)
+		} // end switch yys165
+	} // end for yyj165
+	if !yyhl165 {
 		r.ReadEnd()
 	}
 }
@@ -2061,16 +2017,16 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj179 int
-	var yyb179 bool
-	var yyhl179 bool = l >= 0
-	yyj179++
-	if yyhl179 {
-		yyb179 = yyj179 > l
+	var yyj174 int
+	var yyb174 bool
+	var yyhl174 bool = l >= 0
+	yyj174++
+	if yyhl174 {
+		yyb174 = yyj174 > l
 	} else {
-		yyb179 = r.CheckBreak()
+		yyb174 = r.CheckBreak()
 	}
-	if yyb179 {
+	if yyb174 {
 		r.ReadEnd()
 		return
 	}
@@ -2082,20 +2038,20 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 		if x.ObservedGeneration == nil {
 			x.ObservedGeneration = new(int64)
 		}
-		yym181 := z.DecBinary()
-		_ = yym181
+		yym176 := z.DecBinary()
+		_ = yym176
 		if false {
 		} else {
 			*((*int64)(x.ObservedGeneration)) = int64(r.DecodeInt(64))
 		}
 	}
-	yyj179++
-	if yyhl179 {
-		yyb179 = yyj179 > l
+	yyj174++
+	if yyhl174 {
+		yyb174 = yyj174 > l
 	} else {
-		yyb179 = r.CheckBreak()
+		yyb174 = r.CheckBreak()
 	}
-	if yyb179 {
+	if yyb174 {
 		r.ReadEnd()
 		return
 	}
@@ -2107,25 +2063,25 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 		if x.LastScaleTime == nil {
 			x.LastScaleTime = new(pkg1_unversioned.Time)
 		}
-		yym183 := z.DecBinary()
-		_ = yym183
+		yym178 := z.DecBinary()
+		_ = yym178
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.LastScaleTime) {
-		} else if yym183 {
+		} else if yym178 {
 			z.DecBinaryUnmarshal(x.LastScaleTime)
-		} else if !yym183 && z.IsJSONHandle() {
+		} else if !yym178 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.LastScaleTime)
 		} else {
 			z.DecFallback(x.LastScaleTime, false)
 		}
 	}
-	yyj179++
-	if yyhl179 {
-		yyb179 = yyj179 > l
+	yyj174++
+	if yyhl174 {
+		yyb174 = yyj174 > l
 	} else {
-		yyb179 = r.CheckBreak()
+		yyb174 = r.CheckBreak()
 	}
-	if yyb179 {
+	if yyb174 {
 		r.ReadEnd()
 		return
 	}
@@ -2134,13 +2090,13 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 	} else {
 		x.CurrentReplicas = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj179++
-	if yyhl179 {
-		yyb179 = yyj179 > l
+	yyj174++
+	if yyhl174 {
+		yyb174 = yyj174 > l
 	} else {
-		yyb179 = r.CheckBreak()
+		yyb174 = r.CheckBreak()
 	}
-	if yyb179 {
+	if yyb174 {
 		r.ReadEnd()
 		return
 	}
@@ -2149,13 +2105,13 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 	} else {
 		x.DesiredReplicas = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj179++
-	if yyhl179 {
-		yyb179 = yyj179 > l
+	yyj174++
+	if yyhl174 {
+		yyb174 = yyj174 > l
 	} else {
-		yyb179 = r.CheckBreak()
+		yyb174 = r.CheckBreak()
 	}
-	if yyb179 {
+	if yyb174 {
 		r.ReadEnd()
 		return
 	}
@@ -2167,24 +2123,24 @@ func (x *HorizontalPodAutoscalerStatus) codecDecodeSelfFromArray(l int, d *codec
 		if x.CurrentCPUUtilizationPercentage == nil {
 			x.CurrentCPUUtilizationPercentage = new(int)
 		}
-		yym187 := z.DecBinary()
-		_ = yym187
+		yym182 := z.DecBinary()
+		_ = yym182
 		if false {
 		} else {
 			*((*int)(x.CurrentCPUUtilizationPercentage)) = int(r.DecodeInt(codecSelferBitsize1234))
 		}
 	}
 	for {
-		yyj179++
-		if yyhl179 {
-			yyb179 = yyj179 > l
+		yyj174++
+		if yyhl174 {
+			yyb174 = yyj174 > l
 		} else {
-			yyb179 = r.CheckBreak()
+			yyb174 = r.CheckBreak()
 		}
-		if yyb179 {
+		if yyb174 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj179-1, "")
+		z.DecStructFieldNotFound(yyj174-1, "")
 	}
 	r.ReadEnd()
 }
@@ -2196,36 +2152,36 @@ func (x *HorizontalPodAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym188 := z.EncBinary()
-		_ = yym188
+		yym183 := z.EncBinary()
+		_ = yym183
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep189 := !z.EncBinary()
-			yy2arr189 := z.EncBasicHandle().StructToArray
-			var yyq189 [5]bool
-			_, _, _ = yysep189, yyq189, yy2arr189
-			const yyr189 bool = false
-			yyq189[0] = x.Kind != ""
-			yyq189[1] = x.APIVersion != ""
-			yyq189[2] = true
-			yyq189[3] = true
-			yyq189[4] = true
-			if yyr189 || yy2arr189 {
+			yysep184 := !z.EncBinary()
+			yy2arr184 := z.EncBasicHandle().StructToArray
+			var yyq184 [5]bool
+			_, _, _ = yysep184, yyq184, yy2arr184
+			const yyr184 bool = false
+			yyq184[0] = x.Kind != ""
+			yyq184[1] = x.APIVersion != ""
+			yyq184[2] = true
+			yyq184[3] = true
+			yyq184[4] = true
+			if yyr184 || yy2arr184 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn189 int = 0
-				for _, b := range yyq189 {
+				var yynn184 int = 0
+				for _, b := range yyq184 {
 					if b {
-						yynn189++
+						yynn184++
 					}
 				}
-				r.EncodeMapStart(yynn189)
+				r.EncodeMapStart(yynn184)
 			}
-			if yyr189 || yy2arr189 {
-				if yyq189[0] {
-					yym191 := z.EncBinary()
-					_ = yym191
+			if yyr184 || yy2arr184 {
+				if yyq184[0] {
+					yym186 := z.EncBinary()
+					_ = yym186
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -2234,20 +2190,20 @@ func (x *HorizontalPodAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq189[0] {
+				if yyq184[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym192 := z.EncBinary()
-					_ = yym192
+					yym187 := z.EncBinary()
+					_ = yym187
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr189 || yy2arr189 {
-				if yyq189[1] {
-					yym194 := z.EncBinary()
-					_ = yym194
+			if yyr184 || yy2arr184 {
+				if yyq184[1] {
+					yym189 := z.EncBinary()
+					_ = yym189
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -2256,59 +2212,59 @@ func (x *HorizontalPodAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq189[1] {
+				if yyq184[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym195 := z.EncBinary()
-					_ = yym195
+					yym190 := z.EncBinary()
+					_ = yym190
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr189 || yy2arr189 {
-				if yyq189[2] {
-					yy197 := &x.ObjectMeta
-					yy197.CodecEncodeSelf(e)
+			if yyr184 || yy2arr184 {
+				if yyq184[2] {
+					yy192 := &x.ObjectMeta
+					yy192.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq189[2] {
+				if yyq184[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy198 := &x.ObjectMeta
-					yy198.CodecEncodeSelf(e)
+					yy193 := &x.ObjectMeta
+					yy193.CodecEncodeSelf(e)
 				}
 			}
-			if yyr189 || yy2arr189 {
-				if yyq189[3] {
-					yy200 := &x.Spec
-					yy200.CodecEncodeSelf(e)
+			if yyr184 || yy2arr184 {
+				if yyq184[3] {
+					yy195 := &x.Spec
+					yy195.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq189[3] {
+				if yyq184[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy201 := &x.Spec
-					yy201.CodecEncodeSelf(e)
+					yy196 := &x.Spec
+					yy196.CodecEncodeSelf(e)
 				}
 			}
-			if yyr189 || yy2arr189 {
-				if yyq189[4] {
-					yy203 := &x.Status
-					yy203.CodecEncodeSelf(e)
+			if yyr184 || yy2arr184 {
+				if yyq184[4] {
+					yy198 := &x.Status
+					yy198.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq189[4] {
+				if yyq184[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy204 := &x.Status
-					yy204.CodecEncodeSelf(e)
+					yy199 := &x.Status
+					yy199.CodecEncodeSelf(e)
 				}
 			}
-			if yysep189 {
+			if yysep184 {
 				r.EncodeEnd()
 			}
 		}
@@ -2319,24 +2275,24 @@ func (x *HorizontalPodAutoscaler) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym205 := z.DecBinary()
-	_ = yym205
+	yym200 := z.DecBinary()
+	_ = yym200
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl206 := r.ReadMapStart()
-			if yyl206 == 0 {
+			yyl201 := r.ReadMapStart()
+			if yyl201 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl206, d)
+				x.codecDecodeSelfFromMap(yyl201, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl206 := r.ReadArrayStart()
-			if yyl206 == 0 {
+			yyl201 := r.ReadArrayStart()
+			if yyl201 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl206, d)
+				x.codecDecodeSelfFromArray(yyl201, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -2348,12 +2304,12 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys207Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys207Slc
-	var yyhl207 bool = l >= 0
-	for yyj207 := 0; ; yyj207++ {
-		if yyhl207 {
-			if yyj207 >= l {
+	var yys202Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys202Slc
+	var yyhl202 bool = l >= 0
+	for yyj202 := 0; ; yyj202++ {
+		if yyhl202 {
+			if yyj202 >= l {
 				break
 			}
 		} else {
@@ -2361,9 +2317,9 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				break
 			}
 		}
-		yys207Slc = r.DecodeBytes(yys207Slc, true, true)
-		yys207 := string(yys207Slc)
-		switch yys207 {
+		yys202Slc = r.DecodeBytes(yys202Slc, true, true)
+		yys202 := string(yys202Slc)
+		switch yys202 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -2380,28 +2336,28 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_v1.ObjectMeta{}
 			} else {
-				yyv210 := &x.ObjectMeta
-				yyv210.CodecDecodeSelf(d)
+				yyv205 := &x.ObjectMeta
+				yyv205.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = HorizontalPodAutoscalerSpec{}
 			} else {
-				yyv211 := &x.Spec
-				yyv211.CodecDecodeSelf(d)
+				yyv206 := &x.Spec
+				yyv206.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = HorizontalPodAutoscalerStatus{}
 			} else {
-				yyv212 := &x.Status
-				yyv212.CodecDecodeSelf(d)
+				yyv207 := &x.Status
+				yyv207.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys207)
-		} // end switch yys207
-	} // end for yyj207
-	if !yyhl207 {
+			z.DecStructFieldNotFound(-1, yys202)
+		} // end switch yys202
+	} // end for yyj202
+	if !yyhl202 {
 		r.ReadEnd()
 	}
 }
@@ -2410,16 +2366,16 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.D
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj213 int
-	var yyb213 bool
-	var yyhl213 bool = l >= 0
-	yyj213++
-	if yyhl213 {
-		yyb213 = yyj213 > l
+	var yyj208 int
+	var yyb208 bool
+	var yyhl208 bool = l >= 0
+	yyj208++
+	if yyhl208 {
+		yyb208 = yyj208 > l
 	} else {
-		yyb213 = r.CheckBreak()
+		yyb208 = r.CheckBreak()
 	}
-	if yyb213 {
+	if yyb208 {
 		r.ReadEnd()
 		return
 	}
@@ -2428,13 +2384,13 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.D
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj213++
-	if yyhl213 {
-		yyb213 = yyj213 > l
+	yyj208++
+	if yyhl208 {
+		yyb208 = yyj208 > l
 	} else {
-		yyb213 = r.CheckBreak()
+		yyb208 = r.CheckBreak()
 	}
-	if yyb213 {
+	if yyb208 {
 		r.ReadEnd()
 		return
 	}
@@ -2443,65 +2399,65 @@ func (x *HorizontalPodAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.D
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj213++
-	if yyhl213 {
-		yyb213 = yyj213 > l
+	yyj208++
+	if yyhl208 {
+		yyb208 = yyj208 > l
 	} else {
-		yyb213 = r.CheckBreak()
+		yyb208 = r.CheckBreak()
 	}
-	if yyb213 {
+	if yyb208 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_v1.ObjectMeta{}
 	} else {
-		yyv216 := &x.ObjectMeta
-		yyv216.CodecDecodeSelf(d)
+		yyv211 := &x.ObjectMeta
+		yyv211.CodecDecodeSelf(d)
 	}
-	yyj213++
-	if yyhl213 {
-		yyb213 = yyj213 > l
+	yyj208++
+	if yyhl208 {
+		yyb208 = yyj208 > l
 	} else {
-		yyb213 = r.CheckBreak()
+		yyb208 = r.CheckBreak()
 	}
-	if yyb213 {
+	if yyb208 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = HorizontalPodAutoscalerSpec{}
 	} else {
-		yyv217 := &x.Spec
-		yyv217.CodecDecodeSelf(d)
+		yyv212 := &x.Spec
+		yyv212.CodecDecodeSelf(d)
 	}
-	yyj213++
-	if yyhl213 {
-		yyb213 = yyj213 > l
+	yyj208++
+	if yyhl208 {
+		yyb208 = yyj208 > l
 	} else {
-		yyb213 = r.CheckBreak()
+		yyb208 = r.CheckBreak()
 	}
-	if yyb213 {
+	if yyb208 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = HorizontalPodAutoscalerStatus{}
 	} else {
-		yyv218 := &x.Status
-		yyv218.CodecDecodeSelf(d)
+		yyv213 := &x.Status
+		yyv213.CodecDecodeSelf(d)
 	}
 	for {
-		yyj213++
-		if yyhl213 {
-			yyb213 = yyj213 > l
+		yyj208++
+		if yyhl208 {
+			yyb208 = yyj208 > l
 		} else {
-			yyb213 = r.CheckBreak()
+			yyb208 = r.CheckBreak()
 		}
-		if yyb213 {
+		if yyb208 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj213-1, "")
+		z.DecStructFieldNotFound(yyj208-1, "")
 	}
 	r.ReadEnd()
 }
@@ -2513,34 +2469,34 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym219 := z.EncBinary()
-		_ = yym219
+		yym214 := z.EncBinary()
+		_ = yym214
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep220 := !z.EncBinary()
-			yy2arr220 := z.EncBasicHandle().StructToArray
-			var yyq220 [4]bool
-			_, _, _ = yysep220, yyq220, yy2arr220
-			const yyr220 bool = false
-			yyq220[0] = x.Kind != ""
-			yyq220[1] = x.APIVersion != ""
-			yyq220[2] = true
-			if yyr220 || yy2arr220 {
+			yysep215 := !z.EncBinary()
+			yy2arr215 := z.EncBasicHandle().StructToArray
+			var yyq215 [4]bool
+			_, _, _ = yysep215, yyq215, yy2arr215
+			const yyr215 bool = false
+			yyq215[0] = x.Kind != ""
+			yyq215[1] = x.APIVersion != ""
+			yyq215[2] = true
+			if yyr215 || yy2arr215 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn220 int = 1
-				for _, b := range yyq220 {
+				var yynn215 int = 1
+				for _, b := range yyq215 {
 					if b {
-						yynn220++
+						yynn215++
 					}
 				}
-				r.EncodeMapStart(yynn220)
+				r.EncodeMapStart(yynn215)
 			}
-			if yyr220 || yy2arr220 {
-				if yyq220[0] {
-					yym222 := z.EncBinary()
-					_ = yym222
+			if yyr215 || yy2arr215 {
+				if yyq215[0] {
+					yym217 := z.EncBinary()
+					_ = yym217
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -2549,20 +2505,20 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq220[0] {
+				if yyq215[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym223 := z.EncBinary()
-					_ = yym223
+					yym218 := z.EncBinary()
+					_ = yym218
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr220 || yy2arr220 {
-				if yyq220[1] {
-					yym225 := z.EncBinary()
-					_ = yym225
+			if yyr215 || yy2arr215 {
+				if yyq215[1] {
+					yym220 := z.EncBinary()
+					_ = yym220
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -2571,48 +2527,48 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq220[1] {
+				if yyq215[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym221 := z.EncBinary()
+					_ = yym221
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr215 || yy2arr215 {
+				if yyq215[2] {
+					yy223 := &x.ListMeta
+					yym224 := z.EncBinary()
+					_ = yym224
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy223) {
+					} else {
+						z.EncFallback(yy223)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq215[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy225 := &x.ListMeta
 					yym226 := z.EncBinary()
 					_ = yym226
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy225) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						z.EncFallback(yy225)
 					}
 				}
 			}
-			if yyr220 || yy2arr220 {
-				if yyq220[2] {
-					yy228 := &x.ListMeta
-					yym229 := z.EncBinary()
-					_ = yym229
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy228) {
-					} else {
-						z.EncFallback(yy228)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq220[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy230 := &x.ListMeta
-					yym231 := z.EncBinary()
-					_ = yym231
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy230) {
-					} else {
-						z.EncFallback(yy230)
-					}
-				}
-			}
-			if yyr220 || yy2arr220 {
+			if yyr215 || yy2arr215 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym233 := z.EncBinary()
-					_ = yym233
+					yym228 := z.EncBinary()
+					_ = yym228
 					if false {
 					} else {
 						h.encSliceHorizontalPodAutoscaler(([]HorizontalPodAutoscaler)(x.Items), e)
@@ -2623,15 +2579,15 @@ func (x *HorizontalPodAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym234 := z.EncBinary()
-					_ = yym234
+					yym229 := z.EncBinary()
+					_ = yym229
 					if false {
 					} else {
 						h.encSliceHorizontalPodAutoscaler(([]HorizontalPodAutoscaler)(x.Items), e)
 					}
 				}
 			}
-			if yysep220 {
+			if yysep215 {
 				r.EncodeEnd()
 			}
 		}
@@ -2642,24 +2598,24 @@ func (x *HorizontalPodAutoscalerList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym235 := z.DecBinary()
-	_ = yym235
+	yym230 := z.DecBinary()
+	_ = yym230
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl236 := r.ReadMapStart()
-			if yyl236 == 0 {
+			yyl231 := r.ReadMapStart()
+			if yyl231 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl236, d)
+				x.codecDecodeSelfFromMap(yyl231, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl236 := r.ReadArrayStart()
-			if yyl236 == 0 {
+			yyl231 := r.ReadArrayStart()
+			if yyl231 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl236, d)
+				x.codecDecodeSelfFromArray(yyl231, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -2671,12 +2627,12 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys237Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys237Slc
-	var yyhl237 bool = l >= 0
-	for yyj237 := 0; ; yyj237++ {
-		if yyhl237 {
-			if yyj237 >= l {
+	var yys232Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys232Slc
+	var yyhl232 bool = l >= 0
+	for yyj232 := 0; ; yyj232++ {
+		if yyhl232 {
+			if yyj232 >= l {
 				break
 			}
 		} else {
@@ -2684,9 +2640,9 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978
 				break
 			}
 		}
-		yys237Slc = r.DecodeBytes(yys237Slc, true, true)
-		yys237 := string(yys237Slc)
-		switch yys237 {
+		yys232Slc = r.DecodeBytes(yys232Slc, true, true)
+		yys232 := string(yys232Slc)
+		switch yys232 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -2703,32 +2659,32 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv240 := &x.ListMeta
-				yym241 := z.DecBinary()
-				_ = yym241
+				yyv235 := &x.ListMeta
+				yym236 := z.DecBinary()
+				_ = yym236
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv240) {
+				} else if z.HasExtensions() && z.DecExt(yyv235) {
 				} else {
-					z.DecFallback(yyv240, false)
+					z.DecFallback(yyv235, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv242 := &x.Items
-				yym243 := z.DecBinary()
-				_ = yym243
+				yyv237 := &x.Items
+				yym238 := z.DecBinary()
+				_ = yym238
 				if false {
 				} else {
-					h.decSliceHorizontalPodAutoscaler((*[]HorizontalPodAutoscaler)(yyv242), d)
+					h.decSliceHorizontalPodAutoscaler((*[]HorizontalPodAutoscaler)(yyv237), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys237)
-		} // end switch yys237
-	} // end for yyj237
-	if !yyhl237 {
+			z.DecStructFieldNotFound(-1, yys232)
+		} // end switch yys232
+	} // end for yyj232
+	if !yyhl232 {
 		r.ReadEnd()
 	}
 }
@@ -2737,16 +2693,16 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromArray(l int, d *codec19
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj244 int
-	var yyb244 bool
-	var yyhl244 bool = l >= 0
-	yyj244++
-	if yyhl244 {
-		yyb244 = yyj244 > l
+	var yyj239 int
+	var yyb239 bool
+	var yyhl239 bool = l >= 0
+	yyj239++
+	if yyhl239 {
+		yyb239 = yyj239 > l
 	} else {
-		yyb244 = r.CheckBreak()
+		yyb239 = r.CheckBreak()
 	}
-	if yyb244 {
+	if yyb239 {
 		r.ReadEnd()
 		return
 	}
@@ -2755,13 +2711,13 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromArray(l int, d *codec19
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj244++
-	if yyhl244 {
-		yyb244 = yyj244 > l
+	yyj239++
+	if yyhl239 {
+		yyb239 = yyj239 > l
 	} else {
-		yyb244 = r.CheckBreak()
+		yyb239 = r.CheckBreak()
 	}
-	if yyb244 {
+	if yyb239 {
 		r.ReadEnd()
 		return
 	}
@@ -2770,60 +2726,60 @@ func (x *HorizontalPodAutoscalerList) codecDecodeSelfFromArray(l int, d *codec19
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj244++
-	if yyhl244 {
-		yyb244 = yyj244 > l
+	yyj239++
+	if yyhl239 {
+		yyb239 = yyj239 > l
 	} else {
-		yyb244 = r.CheckBreak()
+		yyb239 = r.CheckBreak()
 	}
-	if yyb244 {
+	if yyb239 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv247 := &x.ListMeta
-		yym248 := z.DecBinary()
-		_ = yym248
+		yyv242 := &x.ListMeta
+		yym243 := z.DecBinary()
+		_ = yym243
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv247) {
+		} else if z.HasExtensions() && z.DecExt(yyv242) {
 		} else {
-			z.DecFallback(yyv247, false)
+			z.DecFallback(yyv242, false)
 		}
 	}
-	yyj244++
-	if yyhl244 {
-		yyb244 = yyj244 > l
+	yyj239++
+	if yyhl239 {
+		yyb239 = yyj239 > l
 	} else {
-		yyb244 = r.CheckBreak()
+		yyb239 = r.CheckBreak()
 	}
-	if yyb244 {
+	if yyb239 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv249 := &x.Items
-		yym250 := z.DecBinary()
-		_ = yym250
+		yyv244 := &x.Items
+		yym245 := z.DecBinary()
+		_ = yym245
 		if false {
 		} else {
-			h.decSliceHorizontalPodAutoscaler((*[]HorizontalPodAutoscaler)(yyv249), d)
+			h.decSliceHorizontalPodAutoscaler((*[]HorizontalPodAutoscaler)(yyv244), d)
 		}
 	}
 	for {
-		yyj244++
-		if yyhl244 {
-			yyb244 = yyj244 > l
+		yyj239++
+		if yyhl239 {
+			yyb239 = yyj239 > l
 		} else {
-			yyb244 = r.CheckBreak()
+			yyb239 = r.CheckBreak()
 		}
-		if yyb244 {
+		if yyb239 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj244-1, "")
+		z.DecStructFieldNotFound(yyj239-1, "")
 	}
 	r.ReadEnd()
 }
@@ -2835,36 +2791,36 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym251 := z.EncBinary()
-		_ = yym251
+		yym246 := z.EncBinary()
+		_ = yym246
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep252 := !z.EncBinary()
-			yy2arr252 := z.EncBasicHandle().StructToArray
-			var yyq252 [5]bool
-			_, _, _ = yysep252, yyq252, yy2arr252
-			const yyr252 bool = false
-			yyq252[0] = x.Kind != ""
-			yyq252[1] = x.APIVersion != ""
-			yyq252[2] = true
-			yyq252[3] = x.Description != ""
-			yyq252[4] = len(x.Versions) != 0
-			if yyr252 || yy2arr252 {
+			yysep247 := !z.EncBinary()
+			yy2arr247 := z.EncBasicHandle().StructToArray
+			var yyq247 [5]bool
+			_, _, _ = yysep247, yyq247, yy2arr247
+			const yyr247 bool = false
+			yyq247[0] = x.Kind != ""
+			yyq247[1] = x.APIVersion != ""
+			yyq247[2] = true
+			yyq247[3] = x.Description != ""
+			yyq247[4] = len(x.Versions) != 0
+			if yyr247 || yy2arr247 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn252 int = 0
-				for _, b := range yyq252 {
+				var yynn247 int = 0
+				for _, b := range yyq247 {
 					if b {
-						yynn252++
+						yynn247++
 					}
 				}
-				r.EncodeMapStart(yynn252)
+				r.EncodeMapStart(yynn247)
 			}
-			if yyr252 || yy2arr252 {
-				if yyq252[0] {
-					yym254 := z.EncBinary()
-					_ = yym254
+			if yyr247 || yy2arr247 {
+				if yyq247[0] {
+					yym249 := z.EncBinary()
+					_ = yym249
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -2873,20 +2829,20 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq252[0] {
+				if yyq247[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym255 := z.EncBinary()
-					_ = yym255
+					yym250 := z.EncBinary()
+					_ = yym250
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr252 || yy2arr252 {
-				if yyq252[1] {
-					yym257 := z.EncBinary()
-					_ = yym257
+			if yyr247 || yy2arr247 {
+				if yyq247[1] {
+					yym252 := z.EncBinary()
+					_ = yym252
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -2895,59 +2851,59 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq252[1] {
+				if yyq247[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym253 := z.EncBinary()
+					_ = yym253
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr247 || yy2arr247 {
+				if yyq247[2] {
+					yy255 := &x.ObjectMeta
+					yy255.CodecEncodeSelf(e)
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq247[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy256 := &x.ObjectMeta
+					yy256.CodecEncodeSelf(e)
+				}
+			}
+			if yyr247 || yy2arr247 {
+				if yyq247[3] {
 					yym258 := z.EncBinary()
 					_ = yym258
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
-					}
-				}
-			}
-			if yyr252 || yy2arr252 {
-				if yyq252[2] {
-					yy260 := &x.ObjectMeta
-					yy260.CodecEncodeSelf(e)
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq252[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy261 := &x.ObjectMeta
-					yy261.CodecEncodeSelf(e)
-				}
-			}
-			if yyr252 || yy2arr252 {
-				if yyq252[3] {
-					yym263 := z.EncBinary()
-					_ = yym263
-					if false {
-					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Description))
 					}
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq252[3] {
+				if yyq247[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("description"))
-					yym264 := z.EncBinary()
-					_ = yym264
+					yym259 := z.EncBinary()
+					_ = yym259
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Description))
 					}
 				}
 			}
-			if yyr252 || yy2arr252 {
-				if yyq252[4] {
+			if yyr247 || yy2arr247 {
+				if yyq247[4] {
 					if x.Versions == nil {
 						r.EncodeNil()
 					} else {
-						yym266 := z.EncBinary()
-						_ = yym266
+						yym261 := z.EncBinary()
+						_ = yym261
 						if false {
 						} else {
 							h.encSliceAPIVersion(([]APIVersion)(x.Versions), e)
@@ -2957,13 +2913,13 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq252[4] {
+				if yyq247[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("versions"))
 					if x.Versions == nil {
 						r.EncodeNil()
 					} else {
-						yym267 := z.EncBinary()
-						_ = yym267
+						yym262 := z.EncBinary()
+						_ = yym262
 						if false {
 						} else {
 							h.encSliceAPIVersion(([]APIVersion)(x.Versions), e)
@@ -2971,7 +2927,7 @@ func (x *ThirdPartyResource) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep252 {
+			if yysep247 {
 				r.EncodeEnd()
 			}
 		}
@@ -2982,24 +2938,24 @@ func (x *ThirdPartyResource) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym268 := z.DecBinary()
-	_ = yym268
+	yym263 := z.DecBinary()
+	_ = yym263
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl269 := r.ReadMapStart()
-			if yyl269 == 0 {
+			yyl264 := r.ReadMapStart()
+			if yyl264 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl269, d)
+				x.codecDecodeSelfFromMap(yyl264, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl269 := r.ReadArrayStart()
-			if yyl269 == 0 {
+			yyl264 := r.ReadArrayStart()
+			if yyl264 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl269, d)
+				x.codecDecodeSelfFromArray(yyl264, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -3011,12 +2967,12 @@ func (x *ThirdPartyResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys270Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys270Slc
-	var yyhl270 bool = l >= 0
-	for yyj270 := 0; ; yyj270++ {
-		if yyhl270 {
-			if yyj270 >= l {
+	var yys265Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys265Slc
+	var yyhl265 bool = l >= 0
+	for yyj265 := 0; ; yyj265++ {
+		if yyhl265 {
+			if yyj265 >= l {
 				break
 			}
 		} else {
@@ -3024,9 +2980,9 @@ func (x *ThirdPartyResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
-		yys270Slc = r.DecodeBytes(yys270Slc, true, true)
-		yys270 := string(yys270Slc)
-		switch yys270 {
+		yys265Slc = r.DecodeBytes(yys265Slc, true, true)
+		yys265 := string(yys265Slc)
+		switch yys265 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -3043,8 +2999,8 @@ func (x *ThirdPartyResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_v1.ObjectMeta{}
 			} else {
-				yyv273 := &x.ObjectMeta
-				yyv273.CodecDecodeSelf(d)
+				yyv268 := &x.ObjectMeta
+				yyv268.CodecDecodeSelf(d)
 			}
 		case "description":
 			if r.TryDecodeAsNil() {
@@ -3056,19 +3012,19 @@ func (x *ThirdPartyResource) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 			if r.TryDecodeAsNil() {
 				x.Versions = nil
 			} else {
-				yyv275 := &x.Versions
-				yym276 := z.DecBinary()
-				_ = yym276
+				yyv270 := &x.Versions
+				yym271 := z.DecBinary()
+				_ = yym271
 				if false {
 				} else {
-					h.decSliceAPIVersion((*[]APIVersion)(yyv275), d)
+					h.decSliceAPIVersion((*[]APIVersion)(yyv270), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys270)
-		} // end switch yys270
-	} // end for yyj270
-	if !yyhl270 {
+			z.DecStructFieldNotFound(-1, yys265)
+		} // end switch yys265
+	} // end for yyj265
+	if !yyhl265 {
 		r.ReadEnd()
 	}
 }
@@ -3077,16 +3033,16 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj277 int
-	var yyb277 bool
-	var yyhl277 bool = l >= 0
-	yyj277++
-	if yyhl277 {
-		yyb277 = yyj277 > l
+	var yyj272 int
+	var yyb272 bool
+	var yyhl272 bool = l >= 0
+	yyj272++
+	if yyhl272 {
+		yyb272 = yyj272 > l
 	} else {
-		yyb277 = r.CheckBreak()
+		yyb272 = r.CheckBreak()
 	}
-	if yyb277 {
+	if yyb272 {
 		r.ReadEnd()
 		return
 	}
@@ -3095,13 +3051,13 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj277++
-	if yyhl277 {
-		yyb277 = yyj277 > l
+	yyj272++
+	if yyhl272 {
+		yyb272 = yyj272 > l
 	} else {
-		yyb277 = r.CheckBreak()
+		yyb272 = r.CheckBreak()
 	}
-	if yyb277 {
+	if yyb272 {
 		r.ReadEnd()
 		return
 	}
@@ -3110,29 +3066,29 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj277++
-	if yyhl277 {
-		yyb277 = yyj277 > l
+	yyj272++
+	if yyhl272 {
+		yyb272 = yyj272 > l
 	} else {
-		yyb277 = r.CheckBreak()
+		yyb272 = r.CheckBreak()
 	}
-	if yyb277 {
+	if yyb272 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_v1.ObjectMeta{}
 	} else {
-		yyv280 := &x.ObjectMeta
-		yyv280.CodecDecodeSelf(d)
+		yyv275 := &x.ObjectMeta
+		yyv275.CodecDecodeSelf(d)
 	}
-	yyj277++
-	if yyhl277 {
-		yyb277 = yyj277 > l
+	yyj272++
+	if yyhl272 {
+		yyb272 = yyj272 > l
 	} else {
-		yyb277 = r.CheckBreak()
+		yyb272 = r.CheckBreak()
 	}
-	if yyb277 {
+	if yyb272 {
 		r.ReadEnd()
 		return
 	}
@@ -3141,38 +3097,38 @@ func (x *ThirdPartyResource) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.Description = string(r.DecodeString())
 	}
-	yyj277++
-	if yyhl277 {
-		yyb277 = yyj277 > l
+	yyj272++
+	if yyhl272 {
+		yyb272 = yyj272 > l
 	} else {
-		yyb277 = r.CheckBreak()
+		yyb272 = r.CheckBreak()
 	}
-	if yyb277 {
+	if yyb272 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Versions = nil
 	} else {
-		yyv282 := &x.Versions
-		yym283 := z.DecBinary()
-		_ = yym283
+		yyv277 := &x.Versions
+		yym278 := z.DecBinary()
+		_ = yym278
 		if false {
 		} else {
-			h.decSliceAPIVersion((*[]APIVersion)(yyv282), d)
+			h.decSliceAPIVersion((*[]APIVersion)(yyv277), d)
 		}
 	}
 	for {
-		yyj277++
-		if yyhl277 {
-			yyb277 = yyj277 > l
+		yyj272++
+		if yyhl272 {
+			yyb272 = yyj272 > l
 		} else {
-			yyb277 = r.CheckBreak()
+			yyb272 = r.CheckBreak()
 		}
-		if yyb277 {
+		if yyb272 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj277-1, "")
+		z.DecStructFieldNotFound(yyj272-1, "")
 	}
 	r.ReadEnd()
 }
@@ -3184,34 +3140,34 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym284 := z.EncBinary()
-		_ = yym284
+		yym279 := z.EncBinary()
+		_ = yym279
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep285 := !z.EncBinary()
-			yy2arr285 := z.EncBasicHandle().StructToArray
-			var yyq285 [4]bool
-			_, _, _ = yysep285, yyq285, yy2arr285
-			const yyr285 bool = false
-			yyq285[0] = x.Kind != ""
-			yyq285[1] = x.APIVersion != ""
-			yyq285[2] = true
-			if yyr285 || yy2arr285 {
+			yysep280 := !z.EncBinary()
+			yy2arr280 := z.EncBasicHandle().StructToArray
+			var yyq280 [4]bool
+			_, _, _ = yysep280, yyq280, yy2arr280
+			const yyr280 bool = false
+			yyq280[0] = x.Kind != ""
+			yyq280[1] = x.APIVersion != ""
+			yyq280[2] = true
+			if yyr280 || yy2arr280 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn285 int = 1
-				for _, b := range yyq285 {
+				var yynn280 int = 1
+				for _, b := range yyq280 {
 					if b {
-						yynn285++
+						yynn280++
 					}
 				}
-				r.EncodeMapStart(yynn285)
+				r.EncodeMapStart(yynn280)
 			}
-			if yyr285 || yy2arr285 {
-				if yyq285[0] {
-					yym287 := z.EncBinary()
-					_ = yym287
+			if yyr280 || yy2arr280 {
+				if yyq280[0] {
+					yym282 := z.EncBinary()
+					_ = yym282
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -3220,20 +3176,20 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq285[0] {
+				if yyq280[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym288 := z.EncBinary()
-					_ = yym288
+					yym283 := z.EncBinary()
+					_ = yym283
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr285 || yy2arr285 {
-				if yyq285[1] {
-					yym290 := z.EncBinary()
-					_ = yym290
+			if yyr280 || yy2arr280 {
+				if yyq280[1] {
+					yym285 := z.EncBinary()
+					_ = yym285
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -3242,48 +3198,48 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq285[1] {
+				if yyq280[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym286 := z.EncBinary()
+					_ = yym286
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr280 || yy2arr280 {
+				if yyq280[2] {
+					yy288 := &x.ListMeta
+					yym289 := z.EncBinary()
+					_ = yym289
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy288) {
+					} else {
+						z.EncFallback(yy288)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq280[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy290 := &x.ListMeta
 					yym291 := z.EncBinary()
 					_ = yym291
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy290) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						z.EncFallback(yy290)
 					}
 				}
 			}
-			if yyr285 || yy2arr285 {
-				if yyq285[2] {
-					yy293 := &x.ListMeta
-					yym294 := z.EncBinary()
-					_ = yym294
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy293) {
-					} else {
-						z.EncFallback(yy293)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq285[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy295 := &x.ListMeta
-					yym296 := z.EncBinary()
-					_ = yym296
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy295) {
-					} else {
-						z.EncFallback(yy295)
-					}
-				}
-			}
-			if yyr285 || yy2arr285 {
+			if yyr280 || yy2arr280 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym298 := z.EncBinary()
-					_ = yym298
+					yym293 := z.EncBinary()
+					_ = yym293
 					if false {
 					} else {
 						h.encSliceThirdPartyResource(([]ThirdPartyResource)(x.Items), e)
@@ -3294,15 +3250,15 @@ func (x *ThirdPartyResourceList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym299 := z.EncBinary()
-					_ = yym299
+					yym294 := z.EncBinary()
+					_ = yym294
 					if false {
 					} else {
 						h.encSliceThirdPartyResource(([]ThirdPartyResource)(x.Items), e)
 					}
 				}
 			}
-			if yysep285 {
+			if yysep280 {
 				r.EncodeEnd()
 			}
 		}
@@ -3313,24 +3269,24 @@ func (x *ThirdPartyResourceList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym300 := z.DecBinary()
-	_ = yym300
+	yym295 := z.DecBinary()
+	_ = yym295
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl301 := r.ReadMapStart()
-			if yyl301 == 0 {
+			yyl296 := r.ReadMapStart()
+			if yyl296 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl301, d)
+				x.codecDecodeSelfFromMap(yyl296, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl301 := r.ReadArrayStart()
-			if yyl301 == 0 {
+			yyl296 := r.ReadArrayStart()
+			if yyl296 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl301, d)
+				x.codecDecodeSelfFromArray(yyl296, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -3342,12 +3298,12 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys302Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys302Slc
-	var yyhl302 bool = l >= 0
-	for yyj302 := 0; ; yyj302++ {
-		if yyhl302 {
-			if yyj302 >= l {
+	var yys297Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys297Slc
+	var yyhl297 bool = l >= 0
+	for yyj297 := 0; ; yyj297++ {
+		if yyhl297 {
+			if yyj297 >= l {
 				break
 			}
 		} else {
@@ -3355,9 +3311,9 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				break
 			}
 		}
-		yys302Slc = r.DecodeBytes(yys302Slc, true, true)
-		yys302 := string(yys302Slc)
-		switch yys302 {
+		yys297Slc = r.DecodeBytes(yys297Slc, true, true)
+		yys297 := string(yys297Slc)
+		switch yys297 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -3374,32 +3330,32 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv305 := &x.ListMeta
-				yym306 := z.DecBinary()
-				_ = yym306
+				yyv300 := &x.ListMeta
+				yym301 := z.DecBinary()
+				_ = yym301
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv305) {
+				} else if z.HasExtensions() && z.DecExt(yyv300) {
 				} else {
-					z.DecFallback(yyv305, false)
+					z.DecFallback(yyv300, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv307 := &x.Items
-				yym308 := z.DecBinary()
-				_ = yym308
+				yyv302 := &x.Items
+				yym303 := z.DecBinary()
+				_ = yym303
 				if false {
 				} else {
-					h.decSliceThirdPartyResource((*[]ThirdPartyResource)(yyv307), d)
+					h.decSliceThirdPartyResource((*[]ThirdPartyResource)(yyv302), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys302)
-		} // end switch yys302
-	} // end for yyj302
-	if !yyhl302 {
+			z.DecStructFieldNotFound(-1, yys297)
+		} // end switch yys297
+	} // end for yyj297
+	if !yyhl297 {
 		r.ReadEnd()
 	}
 }
@@ -3408,16 +3364,16 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromArray(l int, d *codec1978.De
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj309 int
-	var yyb309 bool
-	var yyhl309 bool = l >= 0
-	yyj309++
-	if yyhl309 {
-		yyb309 = yyj309 > l
+	var yyj304 int
+	var yyb304 bool
+	var yyhl304 bool = l >= 0
+	yyj304++
+	if yyhl304 {
+		yyb304 = yyj304 > l
 	} else {
-		yyb309 = r.CheckBreak()
+		yyb304 = r.CheckBreak()
 	}
-	if yyb309 {
+	if yyb304 {
 		r.ReadEnd()
 		return
 	}
@@ -3426,13 +3382,13 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromArray(l int, d *codec1978.De
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj309++
-	if yyhl309 {
-		yyb309 = yyj309 > l
+	yyj304++
+	if yyhl304 {
+		yyb304 = yyj304 > l
 	} else {
-		yyb309 = r.CheckBreak()
+		yyb304 = r.CheckBreak()
 	}
-	if yyb309 {
+	if yyb304 {
 		r.ReadEnd()
 		return
 	}
@@ -3441,60 +3397,60 @@ func (x *ThirdPartyResourceList) codecDecodeSelfFromArray(l int, d *codec1978.De
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj309++
-	if yyhl309 {
-		yyb309 = yyj309 > l
+	yyj304++
+	if yyhl304 {
+		yyb304 = yyj304 > l
 	} else {
-		yyb309 = r.CheckBreak()
+		yyb304 = r.CheckBreak()
 	}
-	if yyb309 {
+	if yyb304 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv312 := &x.ListMeta
-		yym313 := z.DecBinary()
-		_ = yym313
+		yyv307 := &x.ListMeta
+		yym308 := z.DecBinary()
+		_ = yym308
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv312) {
+		} else if z.HasExtensions() && z.DecExt(yyv307) {
 		} else {
-			z.DecFallback(yyv312, false)
+			z.DecFallback(yyv307, false)
 		}
 	}
-	yyj309++
-	if yyhl309 {
-		yyb309 = yyj309 > l
+	yyj304++
+	if yyhl304 {
+		yyb304 = yyj304 > l
 	} else {
-		yyb309 = r.CheckBreak()
+		yyb304 = r.CheckBreak()
 	}
-	if yyb309 {
+	if yyb304 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv314 := &x.Items
-		yym315 := z.DecBinary()
-		_ = yym315
+		yyv309 := &x.Items
+		yym310 := z.DecBinary()
+		_ = yym310
 		if false {
 		} else {
-			h.decSliceThirdPartyResource((*[]ThirdPartyResource)(yyv314), d)
+			h.decSliceThirdPartyResource((*[]ThirdPartyResource)(yyv309), d)
 		}
 	}
 	for {
-		yyj309++
-		if yyhl309 {
-			yyb309 = yyj309 > l
+		yyj304++
+		if yyhl304 {
+			yyb304 = yyj304 > l
 		} else {
-			yyb309 = r.CheckBreak()
+			yyb304 = r.CheckBreak()
 		}
-		if yyb309 {
+		if yyb304 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj309-1, "")
+		z.DecStructFieldNotFound(yyj304-1, "")
 	}
 	r.ReadEnd()
 }
@@ -3506,33 +3462,33 @@ func (x *APIVersion) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym316 := z.EncBinary()
-		_ = yym316
+		yym311 := z.EncBinary()
+		_ = yym311
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep317 := !z.EncBinary()
-			yy2arr317 := z.EncBasicHandle().StructToArray
-			var yyq317 [2]bool
-			_, _, _ = yysep317, yyq317, yy2arr317
-			const yyr317 bool = false
-			yyq317[0] = x.Name != ""
-			yyq317[1] = x.APIGroup != ""
-			if yyr317 || yy2arr317 {
+			yysep312 := !z.EncBinary()
+			yy2arr312 := z.EncBasicHandle().StructToArray
+			var yyq312 [2]bool
+			_, _, _ = yysep312, yyq312, yy2arr312
+			const yyr312 bool = false
+			yyq312[0] = x.Name != ""
+			yyq312[1] = x.APIGroup != ""
+			if yyr312 || yy2arr312 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn317 int = 0
-				for _, b := range yyq317 {
+				var yynn312 int = 0
+				for _, b := range yyq312 {
 					if b {
-						yynn317++
+						yynn312++
 					}
 				}
-				r.EncodeMapStart(yynn317)
+				r.EncodeMapStart(yynn312)
 			}
-			if yyr317 || yy2arr317 {
-				if yyq317[0] {
-					yym319 := z.EncBinary()
-					_ = yym319
+			if yyr312 || yy2arr312 {
+				if yyq312[0] {
+					yym314 := z.EncBinary()
+					_ = yym314
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
@@ -3541,20 +3497,20 @@ func (x *APIVersion) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq317[0] {
+				if yyq312[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("name"))
-					yym320 := z.EncBinary()
-					_ = yym320
+					yym315 := z.EncBinary()
+					_ = yym315
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Name))
 					}
 				}
 			}
-			if yyr317 || yy2arr317 {
-				if yyq317[1] {
-					yym322 := z.EncBinary()
-					_ = yym322
+			if yyr312 || yy2arr312 {
+				if yyq312[1] {
+					yym317 := z.EncBinary()
+					_ = yym317
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIGroup))
@@ -3563,17 +3519,17 @@ func (x *APIVersion) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq317[1] {
+				if yyq312[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiGroup"))
-					yym323 := z.EncBinary()
-					_ = yym323
+					yym318 := z.EncBinary()
+					_ = yym318
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIGroup))
 					}
 				}
 			}
-			if yysep317 {
+			if yysep312 {
 				r.EncodeEnd()
 			}
 		}
@@ -3584,24 +3540,24 @@ func (x *APIVersion) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym324 := z.DecBinary()
-	_ = yym324
+	yym319 := z.DecBinary()
+	_ = yym319
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl325 := r.ReadMapStart()
-			if yyl325 == 0 {
+			yyl320 := r.ReadMapStart()
+			if yyl320 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl325, d)
+				x.codecDecodeSelfFromMap(yyl320, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl325 := r.ReadArrayStart()
-			if yyl325 == 0 {
+			yyl320 := r.ReadArrayStart()
+			if yyl320 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl325, d)
+				x.codecDecodeSelfFromArray(yyl320, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -3613,12 +3569,12 @@ func (x *APIVersion) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys326Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys326Slc
-	var yyhl326 bool = l >= 0
-	for yyj326 := 0; ; yyj326++ {
-		if yyhl326 {
-			if yyj326 >= l {
+	var yys321Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys321Slc
+	var yyhl321 bool = l >= 0
+	for yyj321 := 0; ; yyj321++ {
+		if yyhl321 {
+			if yyj321 >= l {
 				break
 			}
 		} else {
@@ -3626,9 +3582,9 @@ func (x *APIVersion) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys326Slc = r.DecodeBytes(yys326Slc, true, true)
-		yys326 := string(yys326Slc)
-		switch yys326 {
+		yys321Slc = r.DecodeBytes(yys321Slc, true, true)
+		yys321 := string(yys321Slc)
+		switch yys321 {
 		case "name":
 			if r.TryDecodeAsNil() {
 				x.Name = ""
@@ -3642,10 +3598,10 @@ func (x *APIVersion) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.APIGroup = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys326)
-		} // end switch yys326
-	} // end for yyj326
-	if !yyhl326 {
+			z.DecStructFieldNotFound(-1, yys321)
+		} // end switch yys321
+	} // end for yyj321
+	if !yyhl321 {
 		r.ReadEnd()
 	}
 }
@@ -3654,16 +3610,16 @@ func (x *APIVersion) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj329 int
-	var yyb329 bool
-	var yyhl329 bool = l >= 0
-	yyj329++
-	if yyhl329 {
-		yyb329 = yyj329 > l
+	var yyj324 int
+	var yyb324 bool
+	var yyhl324 bool = l >= 0
+	yyj324++
+	if yyhl324 {
+		yyb324 = yyj324 > l
 	} else {
-		yyb329 = r.CheckBreak()
+		yyb324 = r.CheckBreak()
 	}
-	if yyb329 {
+	if yyb324 {
 		r.ReadEnd()
 		return
 	}
@@ -3672,13 +3628,13 @@ func (x *APIVersion) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Name = string(r.DecodeString())
 	}
-	yyj329++
-	if yyhl329 {
-		yyb329 = yyj329 > l
+	yyj324++
+	if yyhl324 {
+		yyb324 = yyj324 > l
 	} else {
-		yyb329 = r.CheckBreak()
+		yyb324 = r.CheckBreak()
 	}
-	if yyb329 {
+	if yyb324 {
 		r.ReadEnd()
 		return
 	}
@@ -3688,16 +3644,16 @@ func (x *APIVersion) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.APIGroup = string(r.DecodeString())
 	}
 	for {
-		yyj329++
-		if yyhl329 {
-			yyb329 = yyj329 > l
+		yyj324++
+		if yyhl324 {
+			yyb324 = yyj324 > l
 		} else {
-			yyb329 = r.CheckBreak()
+			yyb324 = r.CheckBreak()
 		}
-		if yyb329 {
+		if yyb324 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj329-1, "")
+		z.DecStructFieldNotFound(yyj324-1, "")
 	}
 	r.ReadEnd()
 }
@@ -3709,35 +3665,35 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym332 := z.EncBinary()
-		_ = yym332
+		yym327 := z.EncBinary()
+		_ = yym327
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep333 := !z.EncBinary()
-			yy2arr333 := z.EncBasicHandle().StructToArray
-			var yyq333 [4]bool
-			_, _, _ = yysep333, yyq333, yy2arr333
-			const yyr333 bool = false
-			yyq333[0] = x.Kind != ""
-			yyq333[1] = x.APIVersion != ""
-			yyq333[2] = true
-			yyq333[3] = len(x.Data) != 0
-			if yyr333 || yy2arr333 {
+			yysep328 := !z.EncBinary()
+			yy2arr328 := z.EncBasicHandle().StructToArray
+			var yyq328 [4]bool
+			_, _, _ = yysep328, yyq328, yy2arr328
+			const yyr328 bool = false
+			yyq328[0] = x.Kind != ""
+			yyq328[1] = x.APIVersion != ""
+			yyq328[2] = true
+			yyq328[3] = len(x.Data) != 0
+			if yyr328 || yy2arr328 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn333 int = 0
-				for _, b := range yyq333 {
+				var yynn328 int = 0
+				for _, b := range yyq328 {
 					if b {
-						yynn333++
+						yynn328++
 					}
 				}
-				r.EncodeMapStart(yynn333)
+				r.EncodeMapStart(yynn328)
 			}
-			if yyr333 || yy2arr333 {
-				if yyq333[0] {
-					yym335 := z.EncBinary()
-					_ = yym335
+			if yyr328 || yy2arr328 {
+				if yyq328[0] {
+					yym330 := z.EncBinary()
+					_ = yym330
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -3746,20 +3702,20 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq333[0] {
+				if yyq328[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym336 := z.EncBinary()
-					_ = yym336
+					yym331 := z.EncBinary()
+					_ = yym331
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr333 || yy2arr333 {
-				if yyq333[1] {
-					yym338 := z.EncBinary()
-					_ = yym338
+			if yyr328 || yy2arr328 {
+				if yyq328[1] {
+					yym333 := z.EncBinary()
+					_ = yym333
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -3768,37 +3724,37 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq333[1] {
+				if yyq328[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym339 := z.EncBinary()
-					_ = yym339
+					yym334 := z.EncBinary()
+					_ = yym334
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr333 || yy2arr333 {
-				if yyq333[2] {
-					yy341 := &x.ObjectMeta
-					yy341.CodecEncodeSelf(e)
+			if yyr328 || yy2arr328 {
+				if yyq328[2] {
+					yy336 := &x.ObjectMeta
+					yy336.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq333[2] {
+				if yyq328[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy342 := &x.ObjectMeta
-					yy342.CodecEncodeSelf(e)
+					yy337 := &x.ObjectMeta
+					yy337.CodecEncodeSelf(e)
 				}
 			}
-			if yyr333 || yy2arr333 {
-				if yyq333[3] {
+			if yyr328 || yy2arr328 {
+				if yyq328[3] {
 					if x.Data == nil {
 						r.EncodeNil()
 					} else {
-						yym344 := z.EncBinary()
-						_ = yym344
+						yym339 := z.EncBinary()
+						_ = yym339
 						if false {
 						} else {
 							r.EncodeStringBytes(codecSelferC_RAW1234, []byte(x.Data))
@@ -3808,13 +3764,13 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq333[3] {
+				if yyq328[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("name"))
 					if x.Data == nil {
 						r.EncodeNil()
 					} else {
-						yym345 := z.EncBinary()
-						_ = yym345
+						yym340 := z.EncBinary()
+						_ = yym340
 						if false {
 						} else {
 							r.EncodeStringBytes(codecSelferC_RAW1234, []byte(x.Data))
@@ -3822,7 +3778,7 @@ func (x *ThirdPartyResourceData) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep333 {
+			if yysep328 {
 				r.EncodeEnd()
 			}
 		}
@@ -3833,24 +3789,24 @@ func (x *ThirdPartyResourceData) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym346 := z.DecBinary()
-	_ = yym346
+	yym341 := z.DecBinary()
+	_ = yym341
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl347 := r.ReadMapStart()
-			if yyl347 == 0 {
+			yyl342 := r.ReadMapStart()
+			if yyl342 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl347, d)
+				x.codecDecodeSelfFromMap(yyl342, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl347 := r.ReadArrayStart()
-			if yyl347 == 0 {
+			yyl342 := r.ReadArrayStart()
+			if yyl342 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl347, d)
+				x.codecDecodeSelfFromArray(yyl342, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -3862,12 +3818,12 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys348Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys348Slc
-	var yyhl348 bool = l >= 0
-	for yyj348 := 0; ; yyj348++ {
-		if yyhl348 {
-			if yyj348 >= l {
+	var yys343Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys343Slc
+	var yyhl343 bool = l >= 0
+	for yyj343 := 0; ; yyj343++ {
+		if yyhl343 {
+			if yyj343 >= l {
 				break
 			}
 		} else {
@@ -3875,9 +3831,9 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				break
 			}
 		}
-		yys348Slc = r.DecodeBytes(yys348Slc, true, true)
-		yys348 := string(yys348Slc)
-		switch yys348 {
+		yys343Slc = r.DecodeBytes(yys343Slc, true, true)
+		yys343 := string(yys343Slc)
+		switch yys343 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -3894,26 +3850,26 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_v1.ObjectMeta{}
 			} else {
-				yyv351 := &x.ObjectMeta
-				yyv351.CodecDecodeSelf(d)
+				yyv346 := &x.ObjectMeta
+				yyv346.CodecDecodeSelf(d)
 			}
 		case "name":
 			if r.TryDecodeAsNil() {
 				x.Data = nil
 			} else {
-				yyv352 := &x.Data
-				yym353 := z.DecBinary()
-				_ = yym353
+				yyv347 := &x.Data
+				yym348 := z.DecBinary()
+				_ = yym348
 				if false {
 				} else {
-					*yyv352 = r.DecodeBytes(*(*[]byte)(yyv352), false, false)
+					*yyv347 = r.DecodeBytes(*(*[]byte)(yyv347), false, false)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys348)
-		} // end switch yys348
-	} // end for yyj348
-	if !yyhl348 {
+			z.DecStructFieldNotFound(-1, yys343)
+		} // end switch yys343
+	} // end for yyj343
+	if !yyhl343 {
 		r.ReadEnd()
 	}
 }
@@ -3922,16 +3878,16 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromArray(l int, d *codec1978.De
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj354 int
-	var yyb354 bool
-	var yyhl354 bool = l >= 0
-	yyj354++
-	if yyhl354 {
-		yyb354 = yyj354 > l
+	var yyj349 int
+	var yyb349 bool
+	var yyhl349 bool = l >= 0
+	yyj349++
+	if yyhl349 {
+		yyb349 = yyj349 > l
 	} else {
-		yyb354 = r.CheckBreak()
+		yyb349 = r.CheckBreak()
 	}
-	if yyb354 {
+	if yyb349 {
 		r.ReadEnd()
 		return
 	}
@@ -3940,13 +3896,13 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromArray(l int, d *codec1978.De
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj354++
-	if yyhl354 {
-		yyb354 = yyj354 > l
+	yyj349++
+	if yyhl349 {
+		yyb349 = yyj349 > l
 	} else {
-		yyb354 = r.CheckBreak()
+		yyb349 = r.CheckBreak()
 	}
-	if yyb354 {
+	if yyb349 {
 		r.ReadEnd()
 		return
 	}
@@ -3955,54 +3911,54 @@ func (x *ThirdPartyResourceData) codecDecodeSelfFromArray(l int, d *codec1978.De
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj354++
-	if yyhl354 {
-		yyb354 = yyj354 > l
+	yyj349++
+	if yyhl349 {
+		yyb349 = yyj349 > l
 	} else {
-		yyb354 = r.CheckBreak()
+		yyb349 = r.CheckBreak()
 	}
-	if yyb354 {
+	if yyb349 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_v1.ObjectMeta{}
 	} else {
-		yyv357 := &x.ObjectMeta
-		yyv357.CodecDecodeSelf(d)
+		yyv352 := &x.ObjectMeta
+		yyv352.CodecDecodeSelf(d)
 	}
-	yyj354++
-	if yyhl354 {
-		yyb354 = yyj354 > l
+	yyj349++
+	if yyhl349 {
+		yyb349 = yyj349 > l
 	} else {
-		yyb354 = r.CheckBreak()
+		yyb349 = r.CheckBreak()
 	}
-	if yyb354 {
+	if yyb349 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Data = nil
 	} else {
-		yyv358 := &x.Data
-		yym359 := z.DecBinary()
-		_ = yym359
+		yyv353 := &x.Data
+		yym354 := z.DecBinary()
+		_ = yym354
 		if false {
 		} else {
-			*yyv358 = r.DecodeBytes(*(*[]byte)(yyv358), false, false)
+			*yyv353 = r.DecodeBytes(*(*[]byte)(yyv353), false, false)
 		}
 	}
 	for {
-		yyj354++
-		if yyhl354 {
-			yyb354 = yyj354 > l
+		yyj349++
+		if yyhl349 {
+			yyb349 = yyj349 > l
 		} else {
-			yyb354 = r.CheckBreak()
+			yyb349 = r.CheckBreak()
 		}
-		if yyb354 {
+		if yyb349 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj354-1, "")
+		z.DecStructFieldNotFound(yyj349-1, "")
 	}
 	r.ReadEnd()
 }
@@ -4014,36 +3970,36 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym360 := z.EncBinary()
-		_ = yym360
+		yym355 := z.EncBinary()
+		_ = yym355
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep361 := !z.EncBinary()
-			yy2arr361 := z.EncBasicHandle().StructToArray
-			var yyq361 [5]bool
-			_, _, _ = yysep361, yyq361, yy2arr361
-			const yyr361 bool = false
-			yyq361[0] = x.Kind != ""
-			yyq361[1] = x.APIVersion != ""
-			yyq361[2] = true
-			yyq361[3] = true
-			yyq361[4] = true
-			if yyr361 || yy2arr361 {
+			yysep356 := !z.EncBinary()
+			yy2arr356 := z.EncBasicHandle().StructToArray
+			var yyq356 [5]bool
+			_, _, _ = yysep356, yyq356, yy2arr356
+			const yyr356 bool = false
+			yyq356[0] = x.Kind != ""
+			yyq356[1] = x.APIVersion != ""
+			yyq356[2] = true
+			yyq356[3] = true
+			yyq356[4] = true
+			if yyr356 || yy2arr356 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn361 int = 0
-				for _, b := range yyq361 {
+				var yynn356 int = 0
+				for _, b := range yyq356 {
 					if b {
-						yynn361++
+						yynn356++
 					}
 				}
-				r.EncodeMapStart(yynn361)
+				r.EncodeMapStart(yynn356)
 			}
-			if yyr361 || yy2arr361 {
-				if yyq361[0] {
-					yym363 := z.EncBinary()
-					_ = yym363
+			if yyr356 || yy2arr356 {
+				if yyq356[0] {
+					yym358 := z.EncBinary()
+					_ = yym358
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -4052,20 +4008,20 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq361[0] {
+				if yyq356[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym364 := z.EncBinary()
-					_ = yym364
+					yym359 := z.EncBinary()
+					_ = yym359
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr361 || yy2arr361 {
-				if yyq361[1] {
-					yym366 := z.EncBinary()
-					_ = yym366
+			if yyr356 || yy2arr356 {
+				if yyq356[1] {
+					yym361 := z.EncBinary()
+					_ = yym361
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -4074,59 +4030,59 @@ func (x *Deployment) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq361[1] {
+				if yyq356[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym367 := z.EncBinary()
-					_ = yym367
+					yym362 := z.EncBinary()
+					_ = yym362
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr361 || yy2arr361 {
-				if yyq361[2] {
-					yy369 := &x.ObjectMeta
-					yy369.CodecEncodeSelf(e)
+			if yyr356 || yy2arr356 {
+				if yyq356[2] {
+					yy364 := &x.ObjectMeta
+					yy364.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq361[2] {
+				if yyq356[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy370 := &x.ObjectMeta
-					yy370.CodecEncodeSelf(e)
+					yy365 := &x.ObjectMeta
+					yy365.CodecEncodeSelf(e)
 				}
 			}
-			if yyr361 || yy2arr361 {
-				if yyq361[3] {
-					yy372 := &x.Spec
-					yy372.CodecEncodeSelf(e)
+			if yyr356 || yy2arr356 {
+				if yyq356[3] {
+					yy367 := &x.Spec
+					yy367.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq361[3] {
+				if yyq356[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy373 := &x.Spec
-					yy373.CodecEncodeSelf(e)
+					yy368 := &x.Spec
+					yy368.CodecEncodeSelf(e)
 				}
 			}
-			if yyr361 || yy2arr361 {
-				if yyq361[4] {
-					yy375 := &x.Status
-					yy375.CodecEncodeSelf(e)
+			if yyr356 || yy2arr356 {
+				if yyq356[4] {
+					yy370 := &x.Status
+					yy370.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq361[4] {
+				if yyq356[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy376 := &x.Status
-					yy376.CodecEncodeSelf(e)
+					yy371 := &x.Status
+					yy371.CodecEncodeSelf(e)
 				}
 			}
-			if yysep361 {
+			if yysep356 {
 				r.EncodeEnd()
 			}
 		}
@@ -4137,24 +4093,24 @@ func (x *Deployment) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym377 := z.DecBinary()
-	_ = yym377
+	yym372 := z.DecBinary()
+	_ = yym372
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl378 := r.ReadMapStart()
-			if yyl378 == 0 {
+			yyl373 := r.ReadMapStart()
+			if yyl373 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl378, d)
+				x.codecDecodeSelfFromMap(yyl373, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl378 := r.ReadArrayStart()
-			if yyl378 == 0 {
+			yyl373 := r.ReadArrayStart()
+			if yyl373 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl378, d)
+				x.codecDecodeSelfFromArray(yyl373, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4166,12 +4122,12 @@ func (x *Deployment) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys379Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys379Slc
-	var yyhl379 bool = l >= 0
-	for yyj379 := 0; ; yyj379++ {
-		if yyhl379 {
-			if yyj379 >= l {
+	var yys374Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys374Slc
+	var yyhl374 bool = l >= 0
+	for yyj374 := 0; ; yyj374++ {
+		if yyhl374 {
+			if yyj374 >= l {
 				break
 			}
 		} else {
@@ -4179,9 +4135,9 @@ func (x *Deployment) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys379Slc = r.DecodeBytes(yys379Slc, true, true)
-		yys379 := string(yys379Slc)
-		switch yys379 {
+		yys374Slc = r.DecodeBytes(yys374Slc, true, true)
+		yys374 := string(yys374Slc)
+		switch yys374 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -4198,28 +4154,28 @@ func (x *Deployment) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_v1.ObjectMeta{}
 			} else {
-				yyv382 := &x.ObjectMeta
-				yyv382.CodecDecodeSelf(d)
+				yyv377 := &x.ObjectMeta
+				yyv377.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = DeploymentSpec{}
 			} else {
-				yyv383 := &x.Spec
-				yyv383.CodecDecodeSelf(d)
+				yyv378 := &x.Spec
+				yyv378.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = DeploymentStatus{}
 			} else {
-				yyv384 := &x.Status
-				yyv384.CodecDecodeSelf(d)
+				yyv379 := &x.Status
+				yyv379.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys379)
-		} // end switch yys379
-	} // end for yyj379
-	if !yyhl379 {
+			z.DecStructFieldNotFound(-1, yys374)
+		} // end switch yys374
+	} // end for yyj374
+	if !yyhl374 {
 		r.ReadEnd()
 	}
 }
@@ -4228,16 +4184,16 @@ func (x *Deployment) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj385 int
-	var yyb385 bool
-	var yyhl385 bool = l >= 0
-	yyj385++
-	if yyhl385 {
-		yyb385 = yyj385 > l
+	var yyj380 int
+	var yyb380 bool
+	var yyhl380 bool = l >= 0
+	yyj380++
+	if yyhl380 {
+		yyb380 = yyj380 > l
 	} else {
-		yyb385 = r.CheckBreak()
+		yyb380 = r.CheckBreak()
 	}
-	if yyb385 {
+	if yyb380 {
 		r.ReadEnd()
 		return
 	}
@@ -4246,13 +4202,13 @@ func (x *Deployment) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj385++
-	if yyhl385 {
-		yyb385 = yyj385 > l
+	yyj380++
+	if yyhl380 {
+		yyb380 = yyj380 > l
 	} else {
-		yyb385 = r.CheckBreak()
+		yyb380 = r.CheckBreak()
 	}
-	if yyb385 {
+	if yyb380 {
 		r.ReadEnd()
 		return
 	}
@@ -4261,65 +4217,65 @@ func (x *Deployment) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj385++
-	if yyhl385 {
-		yyb385 = yyj385 > l
+	yyj380++
+	if yyhl380 {
+		yyb380 = yyj380 > l
 	} else {
-		yyb385 = r.CheckBreak()
+		yyb380 = r.CheckBreak()
 	}
-	if yyb385 {
+	if yyb380 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_v1.ObjectMeta{}
 	} else {
-		yyv388 := &x.ObjectMeta
-		yyv388.CodecDecodeSelf(d)
+		yyv383 := &x.ObjectMeta
+		yyv383.CodecDecodeSelf(d)
 	}
-	yyj385++
-	if yyhl385 {
-		yyb385 = yyj385 > l
+	yyj380++
+	if yyhl380 {
+		yyb380 = yyj380 > l
 	} else {
-		yyb385 = r.CheckBreak()
+		yyb380 = r.CheckBreak()
 	}
-	if yyb385 {
+	if yyb380 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = DeploymentSpec{}
 	} else {
-		yyv389 := &x.Spec
-		yyv389.CodecDecodeSelf(d)
+		yyv384 := &x.Spec
+		yyv384.CodecDecodeSelf(d)
 	}
-	yyj385++
-	if yyhl385 {
-		yyb385 = yyj385 > l
+	yyj380++
+	if yyhl380 {
+		yyb380 = yyj380 > l
 	} else {
-		yyb385 = r.CheckBreak()
+		yyb380 = r.CheckBreak()
 	}
-	if yyb385 {
+	if yyb380 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = DeploymentStatus{}
 	} else {
-		yyv390 := &x.Status
-		yyv390.CodecDecodeSelf(d)
+		yyv385 := &x.Status
+		yyv385.CodecDecodeSelf(d)
 	}
 	for {
-		yyj385++
-		if yyhl385 {
-			yyb385 = yyj385 > l
+		yyj380++
+		if yyhl380 {
+			yyb380 = yyj380 > l
 		} else {
-			yyb385 = r.CheckBreak()
+			yyb380 = r.CheckBreak()
 		}
-		if yyb385 {
+		if yyb380 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj385-1, "")
+		z.DecStructFieldNotFound(yyj380-1, "")
 	}
 	r.ReadEnd()
 }
@@ -4331,70 +4287,70 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym391 := z.EncBinary()
-		_ = yym391
+		yym386 := z.EncBinary()
+		_ = yym386
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep392 := !z.EncBinary()
-			yy2arr392 := z.EncBasicHandle().StructToArray
-			var yyq392 [5]bool
-			_, _, _ = yysep392, yyq392, yy2arr392
-			const yyr392 bool = false
-			yyq392[0] = x.Replicas != nil
-			yyq392[1] = len(x.Selector) != 0
-			yyq392[3] = true
-			yyq392[4] = x.UniqueLabelKey != nil
-			if yyr392 || yy2arr392 {
+			yysep387 := !z.EncBinary()
+			yy2arr387 := z.EncBasicHandle().StructToArray
+			var yyq387 [5]bool
+			_, _, _ = yysep387, yyq387, yy2arr387
+			const yyr387 bool = false
+			yyq387[0] = x.Replicas != nil
+			yyq387[1] = len(x.Selector) != 0
+			yyq387[3] = true
+			yyq387[4] = x.UniqueLabelKey != nil
+			if yyr387 || yy2arr387 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn392 int = 1
-				for _, b := range yyq392 {
+				var yynn387 int = 1
+				for _, b := range yyq387 {
 					if b {
-						yynn392++
+						yynn387++
 					}
 				}
-				r.EncodeMapStart(yynn392)
+				r.EncodeMapStart(yynn387)
 			}
-			if yyr392 || yy2arr392 {
-				if yyq392[0] {
+			if yyr387 || yy2arr387 {
+				if yyq387[0] {
 					if x.Replicas == nil {
 						r.EncodeNil()
 					} else {
-						yy394 := *x.Replicas
-						yym395 := z.EncBinary()
-						_ = yym395
+						yy389 := *x.Replicas
+						yym390 := z.EncBinary()
+						_ = yym390
 						if false {
 						} else {
-							r.EncodeInt(int64(yy394))
+							r.EncodeInt(int64(yy389))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq392[0] {
+				if yyq387[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("replicas"))
 					if x.Replicas == nil {
 						r.EncodeNil()
 					} else {
-						yy396 := *x.Replicas
-						yym397 := z.EncBinary()
-						_ = yym397
+						yy391 := *x.Replicas
+						yym392 := z.EncBinary()
+						_ = yym392
 						if false {
 						} else {
-							r.EncodeInt(int64(yy396))
+							r.EncodeInt(int64(yy391))
 						}
 					}
 				}
 			}
-			if yyr392 || yy2arr392 {
-				if yyq392[1] {
+			if yyr387 || yy2arr387 {
+				if yyq387[1] {
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
-						yym399 := z.EncBinary()
-						_ = yym399
+						yym394 := z.EncBinary()
+						_ = yym394
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.Selector, false, e)
@@ -4404,13 +4360,13 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq392[1] {
+				if yyq387[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
-						yym400 := z.EncBinary()
-						_ = yym400
+						yym395 := z.EncBinary()
+						_ = yym395
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.Selector, false, e)
@@ -4418,61 +4374,61 @@ func (x *DeploymentSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr392 || yy2arr392 {
-				yy402 := &x.Template
-				yy402.CodecEncodeSelf(e)
+			if yyr387 || yy2arr387 {
+				yy397 := &x.Template
+				yy397.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("template"))
-				yy403 := &x.Template
-				yy403.CodecEncodeSelf(e)
+				yy398 := &x.Template
+				yy398.CodecEncodeSelf(e)
 			}
-			if yyr392 || yy2arr392 {
-				if yyq392[3] {
-					yy405 := &x.Strategy
-					yy405.CodecEncodeSelf(e)
+			if yyr387 || yy2arr387 {
+				if yyq387[3] {
+					yy400 := &x.Strategy
+					yy400.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq392[3] {
+				if yyq387[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("strategy"))
-					yy406 := &x.Strategy
-					yy406.CodecEncodeSelf(e)
+					yy401 := &x.Strategy
+					yy401.CodecEncodeSelf(e)
 				}
 			}
-			if yyr392 || yy2arr392 {
-				if yyq392[4] {
+			if yyr387 || yy2arr387 {
+				if yyq387[4] {
 					if x.UniqueLabelKey == nil {
 						r.EncodeNil()
 					} else {
-						yy408 := *x.UniqueLabelKey
-						yym409 := z.EncBinary()
-						_ = yym409
+						yy403 := *x.UniqueLabelKey
+						yym404 := z.EncBinary()
+						_ = yym404
 						if false {
 						} else {
-							r.EncodeString(codecSelferC_UTF81234, string(yy408))
+							r.EncodeString(codecSelferC_UTF81234, string(yy403))
 						}
 					}
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq392[4] {
+				if yyq387[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("uniqueLabelKey"))
 					if x.UniqueLabelKey == nil {
 						r.EncodeNil()
 					} else {
-						yy410 := *x.UniqueLabelKey
-						yym411 := z.EncBinary()
-						_ = yym411
+						yy405 := *x.UniqueLabelKey
+						yym406 := z.EncBinary()
+						_ = yym406
 						if false {
 						} else {
-							r.EncodeString(codecSelferC_UTF81234, string(yy410))
+							r.EncodeString(codecSelferC_UTF81234, string(yy405))
 						}
 					}
 				}
 			}
-			if yysep392 {
+			if yysep387 {
 				r.EncodeEnd()
 			}
 		}
@@ -4483,24 +4439,24 @@ func (x *DeploymentSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym412 := z.DecBinary()
-	_ = yym412
+	yym407 := z.DecBinary()
+	_ = yym407
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl413 := r.ReadMapStart()
-			if yyl413 == 0 {
+			yyl408 := r.ReadMapStart()
+			if yyl408 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl413, d)
+				x.codecDecodeSelfFromMap(yyl408, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl413 := r.ReadArrayStart()
-			if yyl413 == 0 {
+			yyl408 := r.ReadArrayStart()
+			if yyl408 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl413, d)
+				x.codecDecodeSelfFromArray(yyl408, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4512,12 +4468,12 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys414Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys414Slc
-	var yyhl414 bool = l >= 0
-	for yyj414 := 0; ; yyj414++ {
-		if yyhl414 {
-			if yyj414 >= l {
+	var yys409Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys409Slc
+	var yyhl409 bool = l >= 0
+	for yyj409 := 0; ; yyj409++ {
+		if yyhl409 {
+			if yyj409 >= l {
 				break
 			}
 		} else {
@@ -4525,9 +4481,9 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys414Slc = r.DecodeBytes(yys414Slc, true, true)
-		yys414 := string(yys414Slc)
-		switch yys414 {
+		yys409Slc = r.DecodeBytes(yys409Slc, true, true)
+		yys409 := string(yys409Slc)
+		switch yys409 {
 		case "replicas":
 			if r.TryDecodeAsNil() {
 				if x.Replicas != nil {
@@ -4537,8 +4493,8 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.Replicas == nil {
 					x.Replicas = new(int)
 				}
-				yym416 := z.DecBinary()
-				_ = yym416
+				yym411 := z.DecBinary()
+				_ = yym411
 				if false {
 				} else {
 					*((*int)(x.Replicas)) = int(r.DecodeInt(codecSelferBitsize1234))
@@ -4548,27 +4504,27 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Selector = nil
 			} else {
-				yyv417 := &x.Selector
-				yym418 := z.DecBinary()
-				_ = yym418
+				yyv412 := &x.Selector
+				yym413 := z.DecBinary()
+				_ = yym413
 				if false {
 				} else {
-					z.F.DecMapStringStringX(yyv417, false, d)
+					z.F.DecMapStringStringX(yyv412, false, d)
 				}
 			}
 		case "template":
 			if r.TryDecodeAsNil() {
 				x.Template = pkg2_v1.PodTemplateSpec{}
 			} else {
-				yyv419 := &x.Template
-				yyv419.CodecDecodeSelf(d)
+				yyv414 := &x.Template
+				yyv414.CodecDecodeSelf(d)
 			}
 		case "strategy":
 			if r.TryDecodeAsNil() {
 				x.Strategy = DeploymentStrategy{}
 			} else {
-				yyv420 := &x.Strategy
-				yyv420.CodecDecodeSelf(d)
+				yyv415 := &x.Strategy
+				yyv415.CodecDecodeSelf(d)
 			}
 		case "uniqueLabelKey":
 			if r.TryDecodeAsNil() {
@@ -4579,18 +4535,18 @@ func (x *DeploymentSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.UniqueLabelKey == nil {
 					x.UniqueLabelKey = new(string)
 				}
-				yym422 := z.DecBinary()
-				_ = yym422
+				yym417 := z.DecBinary()
+				_ = yym417
 				if false {
 				} else {
 					*((*string)(x.UniqueLabelKey)) = r.DecodeString()
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys414)
-		} // end switch yys414
-	} // end for yyj414
-	if !yyhl414 {
+			z.DecStructFieldNotFound(-1, yys409)
+		} // end switch yys409
+	} // end for yyj409
+	if !yyhl409 {
 		r.ReadEnd()
 	}
 }
@@ -4599,16 +4555,16 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj423 int
-	var yyb423 bool
-	var yyhl423 bool = l >= 0
-	yyj423++
-	if yyhl423 {
-		yyb423 = yyj423 > l
+	var yyj418 int
+	var yyb418 bool
+	var yyhl418 bool = l >= 0
+	yyj418++
+	if yyhl418 {
+		yyb418 = yyj418 > l
 	} else {
-		yyb423 = r.CheckBreak()
+		yyb418 = r.CheckBreak()
 	}
-	if yyb423 {
+	if yyb418 {
 		r.ReadEnd()
 		return
 	}
@@ -4620,73 +4576,73 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.Replicas == nil {
 			x.Replicas = new(int)
 		}
-		yym425 := z.DecBinary()
-		_ = yym425
+		yym420 := z.DecBinary()
+		_ = yym420
 		if false {
 		} else {
 			*((*int)(x.Replicas)) = int(r.DecodeInt(codecSelferBitsize1234))
 		}
 	}
-	yyj423++
-	if yyhl423 {
-		yyb423 = yyj423 > l
+	yyj418++
+	if yyhl418 {
+		yyb418 = yyj418 > l
 	} else {
-		yyb423 = r.CheckBreak()
+		yyb418 = r.CheckBreak()
 	}
-	if yyb423 {
+	if yyb418 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Selector = nil
 	} else {
-		yyv426 := &x.Selector
-		yym427 := z.DecBinary()
-		_ = yym427
+		yyv421 := &x.Selector
+		yym422 := z.DecBinary()
+		_ = yym422
 		if false {
 		} else {
-			z.F.DecMapStringStringX(yyv426, false, d)
+			z.F.DecMapStringStringX(yyv421, false, d)
 		}
 	}
-	yyj423++
-	if yyhl423 {
-		yyb423 = yyj423 > l
+	yyj418++
+	if yyhl418 {
+		yyb418 = yyj418 > l
 	} else {
-		yyb423 = r.CheckBreak()
+		yyb418 = r.CheckBreak()
 	}
-	if yyb423 {
+	if yyb418 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Template = pkg2_v1.PodTemplateSpec{}
 	} else {
-		yyv428 := &x.Template
-		yyv428.CodecDecodeSelf(d)
+		yyv423 := &x.Template
+		yyv423.CodecDecodeSelf(d)
 	}
-	yyj423++
-	if yyhl423 {
-		yyb423 = yyj423 > l
+	yyj418++
+	if yyhl418 {
+		yyb418 = yyj418 > l
 	} else {
-		yyb423 = r.CheckBreak()
+		yyb418 = r.CheckBreak()
 	}
-	if yyb423 {
+	if yyb418 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Strategy = DeploymentStrategy{}
 	} else {
-		yyv429 := &x.Strategy
-		yyv429.CodecDecodeSelf(d)
+		yyv424 := &x.Strategy
+		yyv424.CodecDecodeSelf(d)
 	}
-	yyj423++
-	if yyhl423 {
-		yyb423 = yyj423 > l
+	yyj418++
+	if yyhl418 {
+		yyb418 = yyj418 > l
 	} else {
-		yyb423 = r.CheckBreak()
+		yyb418 = r.CheckBreak()
 	}
-	if yyb423 {
+	if yyb418 {
 		r.ReadEnd()
 		return
 	}
@@ -4698,24 +4654,24 @@ func (x *DeploymentSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.UniqueLabelKey == nil {
 			x.UniqueLabelKey = new(string)
 		}
-		yym431 := z.DecBinary()
-		_ = yym431
+		yym426 := z.DecBinary()
+		_ = yym426
 		if false {
 		} else {
 			*((*string)(x.UniqueLabelKey)) = r.DecodeString()
 		}
 	}
 	for {
-		yyj423++
-		if yyhl423 {
-			yyb423 = yyj423 > l
+		yyj418++
+		if yyhl418 {
+			yyb418 = yyj418 > l
 		} else {
-			yyb423 = r.CheckBreak()
+			yyb418 = r.CheckBreak()
 		}
-		if yyb423 {
+		if yyb418 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj423-1, "")
+		z.DecStructFieldNotFound(yyj418-1, "")
 	}
 	r.ReadEnd()
 }
@@ -4727,43 +4683,43 @@ func (x *DeploymentStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym432 := z.EncBinary()
-		_ = yym432
+		yym427 := z.EncBinary()
+		_ = yym427
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep433 := !z.EncBinary()
-			yy2arr433 := z.EncBasicHandle().StructToArray
-			var yyq433 [2]bool
-			_, _, _ = yysep433, yyq433, yy2arr433
-			const yyr433 bool = false
-			yyq433[0] = x.Type != ""
-			yyq433[1] = x.RollingUpdate != nil
-			if yyr433 || yy2arr433 {
+			yysep428 := !z.EncBinary()
+			yy2arr428 := z.EncBasicHandle().StructToArray
+			var yyq428 [2]bool
+			_, _, _ = yysep428, yyq428, yy2arr428
+			const yyr428 bool = false
+			yyq428[0] = x.Type != ""
+			yyq428[1] = x.RollingUpdate != nil
+			if yyr428 || yy2arr428 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn433 int = 0
-				for _, b := range yyq433 {
+				var yynn428 int = 0
+				for _, b := range yyq428 {
 					if b {
-						yynn433++
+						yynn428++
 					}
 				}
-				r.EncodeMapStart(yynn433)
+				r.EncodeMapStart(yynn428)
 			}
-			if yyr433 || yy2arr433 {
-				if yyq433[0] {
+			if yyr428 || yy2arr428 {
+				if yyq428[0] {
 					x.Type.CodecEncodeSelf(e)
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq433[0] {
+				if yyq428[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("type"))
 					x.Type.CodecEncodeSelf(e)
 				}
 			}
-			if yyr433 || yy2arr433 {
-				if yyq433[1] {
+			if yyr428 || yy2arr428 {
+				if yyq428[1] {
 					if x.RollingUpdate == nil {
 						r.EncodeNil()
 					} else {
@@ -4773,7 +4729,7 @@ func (x *DeploymentStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq433[1] {
+				if yyq428[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("rollingUpdate"))
 					if x.RollingUpdate == nil {
 						r.EncodeNil()
@@ -4782,7 +4738,7 @@ func (x *DeploymentStrategy) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep433 {
+			if yysep428 {
 				r.EncodeEnd()
 			}
 		}
@@ -4793,24 +4749,24 @@ func (x *DeploymentStrategy) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym436 := z.DecBinary()
-	_ = yym436
+	yym431 := z.DecBinary()
+	_ = yym431
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl437 := r.ReadMapStart()
-			if yyl437 == 0 {
+			yyl432 := r.ReadMapStart()
+			if yyl432 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl437, d)
+				x.codecDecodeSelfFromMap(yyl432, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl437 := r.ReadArrayStart()
-			if yyl437 == 0 {
+			yyl432 := r.ReadArrayStart()
+			if yyl432 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl437, d)
+				x.codecDecodeSelfFromArray(yyl432, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -4822,12 +4778,12 @@ func (x *DeploymentStrategy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys438Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys438Slc
-	var yyhl438 bool = l >= 0
-	for yyj438 := 0; ; yyj438++ {
-		if yyhl438 {
-			if yyj438 >= l {
+	var yys433Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys433Slc
+	var yyhl433 bool = l >= 0
+	for yyj433 := 0; ; yyj433++ {
+		if yyhl433 {
+			if yyj433 >= l {
 				break
 			}
 		} else {
@@ -4835,9 +4791,9 @@ func (x *DeploymentStrategy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				break
 			}
 		}
-		yys438Slc = r.DecodeBytes(yys438Slc, true, true)
-		yys438 := string(yys438Slc)
-		switch yys438 {
+		yys433Slc = r.DecodeBytes(yys433Slc, true, true)
+		yys433 := string(yys433Slc)
+		switch yys433 {
 		case "type":
 			if r.TryDecodeAsNil() {
 				x.Type = ""
@@ -4856,10 +4812,10 @@ func (x *DeploymentStrategy) codecDecodeSelfFromMap(l int, d *codec1978.Decoder)
 				x.RollingUpdate.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys438)
-		} // end switch yys438
-	} // end for yyj438
-	if !yyhl438 {
+			z.DecStructFieldNotFound(-1, yys433)
+		} // end switch yys433
+	} // end for yyj433
+	if !yyhl433 {
 		r.ReadEnd()
 	}
 }
@@ -4868,16 +4824,16 @@ func (x *DeploymentStrategy) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj441 int
-	var yyb441 bool
-	var yyhl441 bool = l >= 0
-	yyj441++
-	if yyhl441 {
-		yyb441 = yyj441 > l
+	var yyj436 int
+	var yyb436 bool
+	var yyhl436 bool = l >= 0
+	yyj436++
+	if yyhl436 {
+		yyb436 = yyj436 > l
 	} else {
-		yyb441 = r.CheckBreak()
+		yyb436 = r.CheckBreak()
 	}
-	if yyb441 {
+	if yyb436 {
 		r.ReadEnd()
 		return
 	}
@@ -4886,13 +4842,13 @@ func (x *DeploymentStrategy) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 	} else {
 		x.Type = DeploymentStrategyType(r.DecodeString())
 	}
-	yyj441++
-	if yyhl441 {
-		yyb441 = yyj441 > l
+	yyj436++
+	if yyhl436 {
+		yyb436 = yyj436 > l
 	} else {
-		yyb441 = r.CheckBreak()
+		yyb436 = r.CheckBreak()
 	}
-	if yyb441 {
+	if yyb436 {
 		r.ReadEnd()
 		return
 	}
@@ -4907,16 +4863,16 @@ func (x *DeploymentStrategy) codecDecodeSelfFromArray(l int, d *codec1978.Decode
 		x.RollingUpdate.CodecDecodeSelf(d)
 	}
 	for {
-		yyj441++
-		if yyhl441 {
-			yyb441 = yyj441 > l
+		yyj436++
+		if yyhl436 {
+			yyb436 = yyj436 > l
 		} else {
-			yyb441 = r.CheckBreak()
+			yyb436 = r.CheckBreak()
 		}
-		if yyb441 {
+		if yyb436 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj441-1, "")
+		z.DecStructFieldNotFound(yyj436-1, "")
 	}
 	r.ReadEnd()
 }
@@ -4925,8 +4881,8 @@ func (x DeploymentStrategyType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym444 := z.EncBinary()
-	_ = yym444
+	yym439 := z.EncBinary()
+	_ = yym439
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -4938,8 +4894,8 @@ func (x *DeploymentStrategyType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym445 := z.DecBinary()
-	_ = yym445
+	yym440 := z.DecBinary()
+	_ = yym440
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -4954,40 +4910,40 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym446 := z.EncBinary()
-		_ = yym446
+		yym441 := z.EncBinary()
+		_ = yym441
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep447 := !z.EncBinary()
-			yy2arr447 := z.EncBasicHandle().StructToArray
-			var yyq447 [3]bool
-			_, _, _ = yysep447, yyq447, yy2arr447
-			const yyr447 bool = false
-			yyq447[0] = x.MaxUnavailable != nil
-			yyq447[1] = x.MaxSurge != nil
-			yyq447[2] = x.MinReadySeconds != 0
-			if yyr447 || yy2arr447 {
+			yysep442 := !z.EncBinary()
+			yy2arr442 := z.EncBasicHandle().StructToArray
+			var yyq442 [3]bool
+			_, _, _ = yysep442, yyq442, yy2arr442
+			const yyr442 bool = false
+			yyq442[0] = x.MaxUnavailable != nil
+			yyq442[1] = x.MaxSurge != nil
+			yyq442[2] = x.MinReadySeconds != 0
+			if yyr442 || yy2arr442 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn447 int = 0
-				for _, b := range yyq447 {
+				var yynn442 int = 0
+				for _, b := range yyq442 {
 					if b {
-						yynn447++
+						yynn442++
 					}
 				}
-				r.EncodeMapStart(yynn447)
+				r.EncodeMapStart(yynn442)
 			}
-			if yyr447 || yy2arr447 {
-				if yyq447[0] {
+			if yyr442 || yy2arr442 {
+				if yyq442[0] {
 					if x.MaxUnavailable == nil {
 						r.EncodeNil()
 					} else {
-						yym449 := z.EncBinary()
-						_ = yym449
+						yym444 := z.EncBinary()
+						_ = yym444
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.MaxUnavailable) {
-						} else if !yym449 && z.IsJSONHandle() {
+						} else if !yym444 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.MaxUnavailable)
 						} else {
 							z.EncFallback(x.MaxUnavailable)
@@ -4997,16 +4953,16 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq447[0] {
+				if yyq442[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("maxUnavailable"))
 					if x.MaxUnavailable == nil {
 						r.EncodeNil()
 					} else {
-						yym450 := z.EncBinary()
-						_ = yym450
+						yym445 := z.EncBinary()
+						_ = yym445
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.MaxUnavailable) {
-						} else if !yym450 && z.IsJSONHandle() {
+						} else if !yym445 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.MaxUnavailable)
 						} else {
 							z.EncFallback(x.MaxUnavailable)
@@ -5014,16 +4970,16 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr447 || yy2arr447 {
-				if yyq447[1] {
+			if yyr442 || yy2arr442 {
+				if yyq442[1] {
 					if x.MaxSurge == nil {
 						r.EncodeNil()
 					} else {
-						yym452 := z.EncBinary()
-						_ = yym452
+						yym447 := z.EncBinary()
+						_ = yym447
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.MaxSurge) {
-						} else if !yym452 && z.IsJSONHandle() {
+						} else if !yym447 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.MaxSurge)
 						} else {
 							z.EncFallback(x.MaxSurge)
@@ -5033,16 +4989,16 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq447[1] {
+				if yyq442[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("maxSurge"))
 					if x.MaxSurge == nil {
 						r.EncodeNil()
 					} else {
-						yym453 := z.EncBinary()
-						_ = yym453
+						yym448 := z.EncBinary()
+						_ = yym448
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.MaxSurge) {
-						} else if !yym453 && z.IsJSONHandle() {
+						} else if !yym448 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.MaxSurge)
 						} else {
 							z.EncFallback(x.MaxSurge)
@@ -5050,10 +5006,10 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr447 || yy2arr447 {
-				if yyq447[2] {
-					yym455 := z.EncBinary()
-					_ = yym455
+			if yyr442 || yy2arr442 {
+				if yyq442[2] {
+					yym450 := z.EncBinary()
+					_ = yym450
 					if false {
 					} else {
 						r.EncodeInt(int64(x.MinReadySeconds))
@@ -5062,17 +5018,17 @@ func (x *RollingUpdateDeployment) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq447[2] {
+				if yyq442[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("minReadySeconds"))
-					yym456 := z.EncBinary()
-					_ = yym456
+					yym451 := z.EncBinary()
+					_ = yym451
 					if false {
 					} else {
 						r.EncodeInt(int64(x.MinReadySeconds))
 					}
 				}
 			}
-			if yysep447 {
+			if yysep442 {
 				r.EncodeEnd()
 			}
 		}
@@ -5083,24 +5039,24 @@ func (x *RollingUpdateDeployment) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym457 := z.DecBinary()
-	_ = yym457
+	yym452 := z.DecBinary()
+	_ = yym452
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl458 := r.ReadMapStart()
-			if yyl458 == 0 {
+			yyl453 := r.ReadMapStart()
+			if yyl453 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl458, d)
+				x.codecDecodeSelfFromMap(yyl453, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl458 := r.ReadArrayStart()
-			if yyl458 == 0 {
+			yyl453 := r.ReadArrayStart()
+			if yyl453 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl458, d)
+				x.codecDecodeSelfFromArray(yyl453, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -5112,12 +5068,12 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys459Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys459Slc
-	var yyhl459 bool = l >= 0
-	for yyj459 := 0; ; yyj459++ {
-		if yyhl459 {
-			if yyj459 >= l {
+	var yys454Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys454Slc
+	var yyhl454 bool = l >= 0
+	for yyj454 := 0; ; yyj454++ {
+		if yyhl454 {
+			if yyj454 >= l {
 				break
 			}
 		} else {
@@ -5125,9 +5081,9 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				break
 			}
 		}
-		yys459Slc = r.DecodeBytes(yys459Slc, true, true)
-		yys459 := string(yys459Slc)
-		switch yys459 {
+		yys454Slc = r.DecodeBytes(yys454Slc, true, true)
+		yys454 := string(yys454Slc)
+		switch yys454 {
 		case "maxUnavailable":
 			if r.TryDecodeAsNil() {
 				if x.MaxUnavailable != nil {
@@ -5137,11 +5093,11 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				if x.MaxUnavailable == nil {
 					x.MaxUnavailable = new(pkg6_util.IntOrString)
 				}
-				yym461 := z.DecBinary()
-				_ = yym461
+				yym456 := z.DecBinary()
+				_ = yym456
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.MaxUnavailable) {
-				} else if !yym461 && z.IsJSONHandle() {
+				} else if !yym456 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.MaxUnavailable)
 				} else {
 					z.DecFallback(x.MaxUnavailable, false)
@@ -5156,11 +5112,11 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				if x.MaxSurge == nil {
 					x.MaxSurge = new(pkg6_util.IntOrString)
 				}
-				yym463 := z.DecBinary()
-				_ = yym463
+				yym458 := z.DecBinary()
+				_ = yym458
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.MaxSurge) {
-				} else if !yym463 && z.IsJSONHandle() {
+				} else if !yym458 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.MaxSurge)
 				} else {
 					z.DecFallback(x.MaxSurge, false)
@@ -5173,10 +5129,10 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromMap(l int, d *codec1978.Dec
 				x.MinReadySeconds = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys459)
-		} // end switch yys459
-	} // end for yyj459
-	if !yyhl459 {
+			z.DecStructFieldNotFound(-1, yys454)
+		} // end switch yys454
+	} // end for yyj454
+	if !yyhl454 {
 		r.ReadEnd()
 	}
 }
@@ -5185,16 +5141,16 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromArray(l int, d *codec1978.D
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj465 int
-	var yyb465 bool
-	var yyhl465 bool = l >= 0
-	yyj465++
-	if yyhl465 {
-		yyb465 = yyj465 > l
+	var yyj460 int
+	var yyb460 bool
+	var yyhl460 bool = l >= 0
+	yyj460++
+	if yyhl460 {
+		yyb460 = yyj460 > l
 	} else {
-		yyb465 = r.CheckBreak()
+		yyb460 = r.CheckBreak()
 	}
-	if yyb465 {
+	if yyb460 {
 		r.ReadEnd()
 		return
 	}
@@ -5206,23 +5162,23 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromArray(l int, d *codec1978.D
 		if x.MaxUnavailable == nil {
 			x.MaxUnavailable = new(pkg6_util.IntOrString)
 		}
-		yym467 := z.DecBinary()
-		_ = yym467
+		yym462 := z.DecBinary()
+		_ = yym462
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.MaxUnavailable) {
-		} else if !yym467 && z.IsJSONHandle() {
+		} else if !yym462 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.MaxUnavailable)
 		} else {
 			z.DecFallback(x.MaxUnavailable, false)
 		}
 	}
-	yyj465++
-	if yyhl465 {
-		yyb465 = yyj465 > l
+	yyj460++
+	if yyhl460 {
+		yyb460 = yyj460 > l
 	} else {
-		yyb465 = r.CheckBreak()
+		yyb460 = r.CheckBreak()
 	}
-	if yyb465 {
+	if yyb460 {
 		r.ReadEnd()
 		return
 	}
@@ -5234,23 +5190,23 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromArray(l int, d *codec1978.D
 		if x.MaxSurge == nil {
 			x.MaxSurge = new(pkg6_util.IntOrString)
 		}
-		yym469 := z.DecBinary()
-		_ = yym469
+		yym464 := z.DecBinary()
+		_ = yym464
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.MaxSurge) {
-		} else if !yym469 && z.IsJSONHandle() {
+		} else if !yym464 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.MaxSurge)
 		} else {
 			z.DecFallback(x.MaxSurge, false)
 		}
 	}
-	yyj465++
-	if yyhl465 {
-		yyb465 = yyj465 > l
+	yyj460++
+	if yyhl460 {
+		yyb460 = yyj460 > l
 	} else {
-		yyb465 = r.CheckBreak()
+		yyb460 = r.CheckBreak()
 	}
-	if yyb465 {
+	if yyb460 {
 		r.ReadEnd()
 		return
 	}
@@ -5260,16 +5216,16 @@ func (x *RollingUpdateDeployment) codecDecodeSelfFromArray(l int, d *codec1978.D
 		x.MinReadySeconds = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj465++
-		if yyhl465 {
-			yyb465 = yyj465 > l
+		yyj460++
+		if yyhl460 {
+			yyb460 = yyj460 > l
 		} else {
-			yyb465 = r.CheckBreak()
+			yyb460 = r.CheckBreak()
 		}
-		if yyb465 {
+		if yyb460 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj465-1, "")
+		z.DecStructFieldNotFound(yyj460-1, "")
 	}
 	r.ReadEnd()
 }
@@ -5281,33 +5237,33 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym471 := z.EncBinary()
-		_ = yym471
+		yym466 := z.EncBinary()
+		_ = yym466
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep472 := !z.EncBinary()
-			yy2arr472 := z.EncBasicHandle().StructToArray
-			var yyq472 [2]bool
-			_, _, _ = yysep472, yyq472, yy2arr472
-			const yyr472 bool = false
-			yyq472[0] = x.Replicas != 0
-			yyq472[1] = x.UpdatedReplicas != 0
-			if yyr472 || yy2arr472 {
+			yysep467 := !z.EncBinary()
+			yy2arr467 := z.EncBasicHandle().StructToArray
+			var yyq467 [2]bool
+			_, _, _ = yysep467, yyq467, yy2arr467
+			const yyr467 bool = false
+			yyq467[0] = x.Replicas != 0
+			yyq467[1] = x.UpdatedReplicas != 0
+			if yyr467 || yy2arr467 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn472 int = 0
-				for _, b := range yyq472 {
+				var yynn467 int = 0
+				for _, b := range yyq467 {
 					if b {
-						yynn472++
+						yynn467++
 					}
 				}
-				r.EncodeMapStart(yynn472)
+				r.EncodeMapStart(yynn467)
 			}
-			if yyr472 || yy2arr472 {
-				if yyq472[0] {
-					yym474 := z.EncBinary()
-					_ = yym474
+			if yyr467 || yy2arr467 {
+				if yyq467[0] {
+					yym469 := z.EncBinary()
+					_ = yym469
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Replicas))
@@ -5316,20 +5272,20 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq472[0] {
+				if yyq467[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("replicas"))
-					yym475 := z.EncBinary()
-					_ = yym475
+					yym470 := z.EncBinary()
+					_ = yym470
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Replicas))
 					}
 				}
 			}
-			if yyr472 || yy2arr472 {
-				if yyq472[1] {
-					yym477 := z.EncBinary()
-					_ = yym477
+			if yyr467 || yy2arr467 {
+				if yyq467[1] {
+					yym472 := z.EncBinary()
+					_ = yym472
 					if false {
 					} else {
 						r.EncodeInt(int64(x.UpdatedReplicas))
@@ -5338,17 +5294,17 @@ func (x *DeploymentStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq472[1] {
+				if yyq467[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("updatedReplicas"))
-					yym478 := z.EncBinary()
-					_ = yym478
+					yym473 := z.EncBinary()
+					_ = yym473
 					if false {
 					} else {
 						r.EncodeInt(int64(x.UpdatedReplicas))
 					}
 				}
 			}
-			if yysep472 {
+			if yysep467 {
 				r.EncodeEnd()
 			}
 		}
@@ -5359,24 +5315,24 @@ func (x *DeploymentStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym479 := z.DecBinary()
-	_ = yym479
+	yym474 := z.DecBinary()
+	_ = yym474
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl480 := r.ReadMapStart()
-			if yyl480 == 0 {
+			yyl475 := r.ReadMapStart()
+			if yyl475 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl480, d)
+				x.codecDecodeSelfFromMap(yyl475, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl480 := r.ReadArrayStart()
-			if yyl480 == 0 {
+			yyl475 := r.ReadArrayStart()
+			if yyl475 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl480, d)
+				x.codecDecodeSelfFromArray(yyl475, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -5388,12 +5344,12 @@ func (x *DeploymentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys481Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys481Slc
-	var yyhl481 bool = l >= 0
-	for yyj481 := 0; ; yyj481++ {
-		if yyhl481 {
-			if yyj481 >= l {
+	var yys476Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys476Slc
+	var yyhl476 bool = l >= 0
+	for yyj476 := 0; ; yyj476++ {
+		if yyhl476 {
+			if yyj476 >= l {
 				break
 			}
 		} else {
@@ -5401,9 +5357,9 @@ func (x *DeploymentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys481Slc = r.DecodeBytes(yys481Slc, true, true)
-		yys481 := string(yys481Slc)
-		switch yys481 {
+		yys476Slc = r.DecodeBytes(yys476Slc, true, true)
+		yys476 := string(yys476Slc)
+		switch yys476 {
 		case "replicas":
 			if r.TryDecodeAsNil() {
 				x.Replicas = 0
@@ -5417,10 +5373,10 @@ func (x *DeploymentStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.UpdatedReplicas = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys481)
-		} // end switch yys481
-	} // end for yyj481
-	if !yyhl481 {
+			z.DecStructFieldNotFound(-1, yys476)
+		} // end switch yys476
+	} // end for yyj476
+	if !yyhl476 {
 		r.ReadEnd()
 	}
 }
@@ -5429,16 +5385,16 @@ func (x *DeploymentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj484 int
-	var yyb484 bool
-	var yyhl484 bool = l >= 0
-	yyj484++
-	if yyhl484 {
-		yyb484 = yyj484 > l
+	var yyj479 int
+	var yyb479 bool
+	var yyhl479 bool = l >= 0
+	yyj479++
+	if yyhl479 {
+		yyb479 = yyj479 > l
 	} else {
-		yyb484 = r.CheckBreak()
+		yyb479 = r.CheckBreak()
 	}
-	if yyb484 {
+	if yyb479 {
 		r.ReadEnd()
 		return
 	}
@@ -5447,13 +5403,13 @@ func (x *DeploymentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	} else {
 		x.Replicas = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj484++
-	if yyhl484 {
-		yyb484 = yyj484 > l
+	yyj479++
+	if yyhl479 {
+		yyb479 = yyj479 > l
 	} else {
-		yyb484 = r.CheckBreak()
+		yyb479 = r.CheckBreak()
 	}
-	if yyb484 {
+	if yyb479 {
 		r.ReadEnd()
 		return
 	}
@@ -5463,16 +5419,16 @@ func (x *DeploymentStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		x.UpdatedReplicas = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj484++
-		if yyhl484 {
-			yyb484 = yyj484 > l
+		yyj479++
+		if yyhl479 {
+			yyb479 = yyj479 > l
 		} else {
-			yyb484 = r.CheckBreak()
+			yyb479 = r.CheckBreak()
 		}
-		if yyb484 {
+		if yyb479 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj484-1, "")
+		z.DecStructFieldNotFound(yyj479-1, "")
 	}
 	r.ReadEnd()
 }
@@ -5484,34 +5440,34 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym487 := z.EncBinary()
-		_ = yym487
+		yym482 := z.EncBinary()
+		_ = yym482
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep488 := !z.EncBinary()
-			yy2arr488 := z.EncBasicHandle().StructToArray
-			var yyq488 [4]bool
-			_, _, _ = yysep488, yyq488, yy2arr488
-			const yyr488 bool = false
-			yyq488[0] = x.Kind != ""
-			yyq488[1] = x.APIVersion != ""
-			yyq488[2] = true
-			if yyr488 || yy2arr488 {
+			yysep483 := !z.EncBinary()
+			yy2arr483 := z.EncBasicHandle().StructToArray
+			var yyq483 [4]bool
+			_, _, _ = yysep483, yyq483, yy2arr483
+			const yyr483 bool = false
+			yyq483[0] = x.Kind != ""
+			yyq483[1] = x.APIVersion != ""
+			yyq483[2] = true
+			if yyr483 || yy2arr483 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn488 int = 1
-				for _, b := range yyq488 {
+				var yynn483 int = 1
+				for _, b := range yyq483 {
 					if b {
-						yynn488++
+						yynn483++
 					}
 				}
-				r.EncodeMapStart(yynn488)
+				r.EncodeMapStart(yynn483)
 			}
-			if yyr488 || yy2arr488 {
-				if yyq488[0] {
-					yym490 := z.EncBinary()
-					_ = yym490
+			if yyr483 || yy2arr483 {
+				if yyq483[0] {
+					yym485 := z.EncBinary()
+					_ = yym485
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -5520,20 +5476,20 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq488[0] {
+				if yyq483[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym491 := z.EncBinary()
-					_ = yym491
+					yym486 := z.EncBinary()
+					_ = yym486
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr488 || yy2arr488 {
-				if yyq488[1] {
-					yym493 := z.EncBinary()
-					_ = yym493
+			if yyr483 || yy2arr483 {
+				if yyq483[1] {
+					yym488 := z.EncBinary()
+					_ = yym488
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -5542,48 +5498,48 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq488[1] {
+				if yyq483[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym489 := z.EncBinary()
+					_ = yym489
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr483 || yy2arr483 {
+				if yyq483[2] {
+					yy491 := &x.ListMeta
+					yym492 := z.EncBinary()
+					_ = yym492
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy491) {
+					} else {
+						z.EncFallback(yy491)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq483[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy493 := &x.ListMeta
 					yym494 := z.EncBinary()
 					_ = yym494
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy493) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						z.EncFallback(yy493)
 					}
 				}
 			}
-			if yyr488 || yy2arr488 {
-				if yyq488[2] {
-					yy496 := &x.ListMeta
-					yym497 := z.EncBinary()
-					_ = yym497
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy496) {
-					} else {
-						z.EncFallback(yy496)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq488[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy498 := &x.ListMeta
-					yym499 := z.EncBinary()
-					_ = yym499
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy498) {
-					} else {
-						z.EncFallback(yy498)
-					}
-				}
-			}
-			if yyr488 || yy2arr488 {
+			if yyr483 || yy2arr483 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym501 := z.EncBinary()
-					_ = yym501
+					yym496 := z.EncBinary()
+					_ = yym496
 					if false {
 					} else {
 						h.encSliceDeployment(([]Deployment)(x.Items), e)
@@ -5594,15 +5550,15 @@ func (x *DeploymentList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym502 := z.EncBinary()
-					_ = yym502
+					yym497 := z.EncBinary()
+					_ = yym497
 					if false {
 					} else {
 						h.encSliceDeployment(([]Deployment)(x.Items), e)
 					}
 				}
 			}
-			if yysep488 {
+			if yysep483 {
 				r.EncodeEnd()
 			}
 		}
@@ -5613,24 +5569,24 @@ func (x *DeploymentList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym503 := z.DecBinary()
-	_ = yym503
+	yym498 := z.DecBinary()
+	_ = yym498
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl504 := r.ReadMapStart()
-			if yyl504 == 0 {
+			yyl499 := r.ReadMapStart()
+			if yyl499 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl504, d)
+				x.codecDecodeSelfFromMap(yyl499, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl504 := r.ReadArrayStart()
-			if yyl504 == 0 {
+			yyl499 := r.ReadArrayStart()
+			if yyl499 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl504, d)
+				x.codecDecodeSelfFromArray(yyl499, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -5642,12 +5598,12 @@ func (x *DeploymentList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys505Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys505Slc
-	var yyhl505 bool = l >= 0
-	for yyj505 := 0; ; yyj505++ {
-		if yyhl505 {
-			if yyj505 >= l {
+	var yys500Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys500Slc
+	var yyhl500 bool = l >= 0
+	for yyj500 := 0; ; yyj500++ {
+		if yyhl500 {
+			if yyj500 >= l {
 				break
 			}
 		} else {
@@ -5655,9 +5611,9 @@ func (x *DeploymentList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys505Slc = r.DecodeBytes(yys505Slc, true, true)
-		yys505 := string(yys505Slc)
-		switch yys505 {
+		yys500Slc = r.DecodeBytes(yys500Slc, true, true)
+		yys500 := string(yys500Slc)
+		switch yys500 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -5674,32 +5630,32 @@ func (x *DeploymentList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv508 := &x.ListMeta
-				yym509 := z.DecBinary()
-				_ = yym509
+				yyv503 := &x.ListMeta
+				yym504 := z.DecBinary()
+				_ = yym504
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv508) {
+				} else if z.HasExtensions() && z.DecExt(yyv503) {
 				} else {
-					z.DecFallback(yyv508, false)
+					z.DecFallback(yyv503, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv510 := &x.Items
-				yym511 := z.DecBinary()
-				_ = yym511
+				yyv505 := &x.Items
+				yym506 := z.DecBinary()
+				_ = yym506
 				if false {
 				} else {
-					h.decSliceDeployment((*[]Deployment)(yyv510), d)
+					h.decSliceDeployment((*[]Deployment)(yyv505), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys505)
-		} // end switch yys505
-	} // end for yyj505
-	if !yyhl505 {
+			z.DecStructFieldNotFound(-1, yys500)
+		} // end switch yys500
+	} // end for yyj500
+	if !yyhl500 {
 		r.ReadEnd()
 	}
 }
@@ -5708,16 +5664,16 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj512 int
-	var yyb512 bool
-	var yyhl512 bool = l >= 0
-	yyj512++
-	if yyhl512 {
-		yyb512 = yyj512 > l
+	var yyj507 int
+	var yyb507 bool
+	var yyhl507 bool = l >= 0
+	yyj507++
+	if yyhl507 {
+		yyb507 = yyj507 > l
 	} else {
-		yyb512 = r.CheckBreak()
+		yyb507 = r.CheckBreak()
 	}
-	if yyb512 {
+	if yyb507 {
 		r.ReadEnd()
 		return
 	}
@@ -5726,13 +5682,13 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj512++
-	if yyhl512 {
-		yyb512 = yyj512 > l
+	yyj507++
+	if yyhl507 {
+		yyb507 = yyj507 > l
 	} else {
-		yyb512 = r.CheckBreak()
+		yyb507 = r.CheckBreak()
 	}
-	if yyb512 {
+	if yyb507 {
 		r.ReadEnd()
 		return
 	}
@@ -5741,60 +5697,60 @@ func (x *DeploymentList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj512++
-	if yyhl512 {
-		yyb512 = yyj512 > l
+	yyj507++
+	if yyhl507 {
+		yyb507 = yyj507 > l
 	} else {
-		yyb512 = r.CheckBreak()
+		yyb507 = r.CheckBreak()
 	}
-	if yyb512 {
+	if yyb507 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv515 := &x.ListMeta
-		yym516 := z.DecBinary()
-		_ = yym516
+		yyv510 := &x.ListMeta
+		yym511 := z.DecBinary()
+		_ = yym511
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv515) {
+		} else if z.HasExtensions() && z.DecExt(yyv510) {
 		} else {
-			z.DecFallback(yyv515, false)
+			z.DecFallback(yyv510, false)
 		}
 	}
-	yyj512++
-	if yyhl512 {
-		yyb512 = yyj512 > l
+	yyj507++
+	if yyhl507 {
+		yyb507 = yyj507 > l
 	} else {
-		yyb512 = r.CheckBreak()
+		yyb507 = r.CheckBreak()
 	}
-	if yyb512 {
+	if yyb507 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv517 := &x.Items
-		yym518 := z.DecBinary()
-		_ = yym518
+		yyv512 := &x.Items
+		yym513 := z.DecBinary()
+		_ = yym513
 		if false {
 		} else {
-			h.decSliceDeployment((*[]Deployment)(yyv517), d)
+			h.decSliceDeployment((*[]Deployment)(yyv512), d)
 		}
 	}
 	for {
-		yyj512++
-		if yyhl512 {
-			yyb512 = yyj512 > l
+		yyj507++
+		if yyhl507 {
+			yyb507 = yyj507 > l
 		} else {
-			yyb512 = r.CheckBreak()
+			yyb507 = r.CheckBreak()
 		}
-		if yyb512 {
+		if yyb507 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj512-1, "")
+		z.DecStructFieldNotFound(yyj507-1, "")
 	}
 	r.ReadEnd()
 }
@@ -5806,36 +5762,36 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym519 := z.EncBinary()
-		_ = yym519
+		yym514 := z.EncBinary()
+		_ = yym514
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep520 := !z.EncBinary()
-			yy2arr520 := z.EncBasicHandle().StructToArray
-			var yyq520 [2]bool
-			_, _, _ = yysep520, yyq520, yy2arr520
-			const yyr520 bool = false
-			yyq520[0] = len(x.Selector) != 0
-			yyq520[1] = x.Template != nil
-			if yyr520 || yy2arr520 {
+			yysep515 := !z.EncBinary()
+			yy2arr515 := z.EncBasicHandle().StructToArray
+			var yyq515 [2]bool
+			_, _, _ = yysep515, yyq515, yy2arr515
+			const yyr515 bool = false
+			yyq515[0] = len(x.Selector) != 0
+			yyq515[1] = x.Template != nil
+			if yyr515 || yy2arr515 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn520 int = 0
-				for _, b := range yyq520 {
+				var yynn515 int = 0
+				for _, b := range yyq515 {
 					if b {
-						yynn520++
+						yynn515++
 					}
 				}
-				r.EncodeMapStart(yynn520)
+				r.EncodeMapStart(yynn515)
 			}
-			if yyr520 || yy2arr520 {
-				if yyq520[0] {
+			if yyr515 || yy2arr515 {
+				if yyq515[0] {
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
-						yym522 := z.EncBinary()
-						_ = yym522
+						yym517 := z.EncBinary()
+						_ = yym517
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.Selector, false, e)
@@ -5845,13 +5801,13 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq520[0] {
+				if yyq515[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
-						yym523 := z.EncBinary()
-						_ = yym523
+						yym518 := z.EncBinary()
+						_ = yym518
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.Selector, false, e)
@@ -5859,8 +5815,8 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr520 || yy2arr520 {
-				if yyq520[1] {
+			if yyr515 || yy2arr515 {
+				if yyq515[1] {
 					if x.Template == nil {
 						r.EncodeNil()
 					} else {
@@ -5870,7 +5826,7 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq520[1] {
+				if yyq515[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("template"))
 					if x.Template == nil {
 						r.EncodeNil()
@@ -5879,7 +5835,7 @@ func (x *DaemonSetSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep520 {
+			if yysep515 {
 				r.EncodeEnd()
 			}
 		}
@@ -5890,24 +5846,24 @@ func (x *DaemonSetSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym525 := z.DecBinary()
-	_ = yym525
+	yym520 := z.DecBinary()
+	_ = yym520
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl526 := r.ReadMapStart()
-			if yyl526 == 0 {
+			yyl521 := r.ReadMapStart()
+			if yyl521 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl526, d)
+				x.codecDecodeSelfFromMap(yyl521, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl526 := r.ReadArrayStart()
-			if yyl526 == 0 {
+			yyl521 := r.ReadArrayStart()
+			if yyl521 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl526, d)
+				x.codecDecodeSelfFromArray(yyl521, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -5919,12 +5875,12 @@ func (x *DaemonSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys527Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys527Slc
-	var yyhl527 bool = l >= 0
-	for yyj527 := 0; ; yyj527++ {
-		if yyhl527 {
-			if yyj527 >= l {
+	var yys522Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys522Slc
+	var yyhl522 bool = l >= 0
+	for yyj522 := 0; ; yyj522++ {
+		if yyhl522 {
+			if yyj522 >= l {
 				break
 			}
 		} else {
@@ -5932,19 +5888,19 @@ func (x *DaemonSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys527Slc = r.DecodeBytes(yys527Slc, true, true)
-		yys527 := string(yys527Slc)
-		switch yys527 {
+		yys522Slc = r.DecodeBytes(yys522Slc, true, true)
+		yys522 := string(yys522Slc)
+		switch yys522 {
 		case "selector":
 			if r.TryDecodeAsNil() {
 				x.Selector = nil
 			} else {
-				yyv528 := &x.Selector
-				yym529 := z.DecBinary()
-				_ = yym529
+				yyv523 := &x.Selector
+				yym524 := z.DecBinary()
+				_ = yym524
 				if false {
 				} else {
-					z.F.DecMapStringStringX(yyv528, false, d)
+					z.F.DecMapStringStringX(yyv523, false, d)
 				}
 			}
 		case "template":
@@ -5959,10 +5915,10 @@ func (x *DaemonSetSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Template.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys527)
-		} // end switch yys527
-	} // end for yyj527
-	if !yyhl527 {
+			z.DecStructFieldNotFound(-1, yys522)
+		} // end switch yys522
+	} // end for yyj522
+	if !yyhl522 {
 		r.ReadEnd()
 	}
 }
@@ -5971,37 +5927,37 @@ func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj531 int
-	var yyb531 bool
-	var yyhl531 bool = l >= 0
-	yyj531++
-	if yyhl531 {
-		yyb531 = yyj531 > l
+	var yyj526 int
+	var yyb526 bool
+	var yyhl526 bool = l >= 0
+	yyj526++
+	if yyhl526 {
+		yyb526 = yyj526 > l
 	} else {
-		yyb531 = r.CheckBreak()
+		yyb526 = r.CheckBreak()
 	}
-	if yyb531 {
+	if yyb526 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Selector = nil
 	} else {
-		yyv532 := &x.Selector
-		yym533 := z.DecBinary()
-		_ = yym533
+		yyv527 := &x.Selector
+		yym528 := z.DecBinary()
+		_ = yym528
 		if false {
 		} else {
-			z.F.DecMapStringStringX(yyv532, false, d)
+			z.F.DecMapStringStringX(yyv527, false, d)
 		}
 	}
-	yyj531++
-	if yyhl531 {
-		yyb531 = yyj531 > l
+	yyj526++
+	if yyhl526 {
+		yyb526 = yyj526 > l
 	} else {
-		yyb531 = r.CheckBreak()
+		yyb526 = r.CheckBreak()
 	}
-	if yyb531 {
+	if yyb526 {
 		r.ReadEnd()
 		return
 	}
@@ -6016,16 +5972,16 @@ func (x *DaemonSetSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Template.CodecDecodeSelf(d)
 	}
 	for {
-		yyj531++
-		if yyhl531 {
-			yyb531 = yyj531 > l
+		yyj526++
+		if yyhl526 {
+			yyb526 = yyj526 > l
 		} else {
-			yyb531 = r.CheckBreak()
+			yyb526 = r.CheckBreak()
 		}
-		if yyb531 {
+		if yyb526 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj531-1, "")
+		z.DecStructFieldNotFound(yyj526-1, "")
 	}
 	r.ReadEnd()
 }
@@ -6037,76 +5993,76 @@ func (x *DaemonSetStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym535 := z.EncBinary()
-		_ = yym535
+		yym530 := z.EncBinary()
+		_ = yym530
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep536 := !z.EncBinary()
-			yy2arr536 := z.EncBasicHandle().StructToArray
-			var yyq536 [3]bool
-			_, _, _ = yysep536, yyq536, yy2arr536
-			const yyr536 bool = false
-			if yyr536 || yy2arr536 {
+			yysep531 := !z.EncBinary()
+			yy2arr531 := z.EncBasicHandle().StructToArray
+			var yyq531 [3]bool
+			_, _, _ = yysep531, yyq531, yy2arr531
+			const yyr531 bool = false
+			if yyr531 || yy2arr531 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn536 int = 3
-				for _, b := range yyq536 {
+				var yynn531 int = 3
+				for _, b := range yyq531 {
 					if b {
-						yynn536++
+						yynn531++
 					}
 				}
-				r.EncodeMapStart(yynn536)
+				r.EncodeMapStart(yynn531)
 			}
-			if yyr536 || yy2arr536 {
-				yym538 := z.EncBinary()
-				_ = yym538
+			if yyr531 || yy2arr531 {
+				yym533 := z.EncBinary()
+				_ = yym533
 				if false {
 				} else {
 					r.EncodeInt(int64(x.CurrentNumberScheduled))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("currentNumberScheduled"))
-				yym539 := z.EncBinary()
-				_ = yym539
+				yym534 := z.EncBinary()
+				_ = yym534
 				if false {
 				} else {
 					r.EncodeInt(int64(x.CurrentNumberScheduled))
 				}
 			}
-			if yyr536 || yy2arr536 {
-				yym541 := z.EncBinary()
-				_ = yym541
+			if yyr531 || yy2arr531 {
+				yym536 := z.EncBinary()
+				_ = yym536
 				if false {
 				} else {
 					r.EncodeInt(int64(x.NumberMisscheduled))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("numberMisscheduled"))
-				yym542 := z.EncBinary()
-				_ = yym542
+				yym537 := z.EncBinary()
+				_ = yym537
 				if false {
 				} else {
 					r.EncodeInt(int64(x.NumberMisscheduled))
 				}
 			}
-			if yyr536 || yy2arr536 {
-				yym544 := z.EncBinary()
-				_ = yym544
+			if yyr531 || yy2arr531 {
+				yym539 := z.EncBinary()
+				_ = yym539
 				if false {
 				} else {
 					r.EncodeInt(int64(x.DesiredNumberScheduled))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("desiredNumberScheduled"))
-				yym545 := z.EncBinary()
-				_ = yym545
+				yym540 := z.EncBinary()
+				_ = yym540
 				if false {
 				} else {
 					r.EncodeInt(int64(x.DesiredNumberScheduled))
 				}
 			}
-			if yysep536 {
+			if yysep531 {
 				r.EncodeEnd()
 			}
 		}
@@ -6117,24 +6073,24 @@ func (x *DaemonSetStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym546 := z.DecBinary()
-	_ = yym546
+	yym541 := z.DecBinary()
+	_ = yym541
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl547 := r.ReadMapStart()
-			if yyl547 == 0 {
+			yyl542 := r.ReadMapStart()
+			if yyl542 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl547, d)
+				x.codecDecodeSelfFromMap(yyl542, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl547 := r.ReadArrayStart()
-			if yyl547 == 0 {
+			yyl542 := r.ReadArrayStart()
+			if yyl542 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl547, d)
+				x.codecDecodeSelfFromArray(yyl542, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -6146,12 +6102,12 @@ func (x *DaemonSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys548Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys548Slc
-	var yyhl548 bool = l >= 0
-	for yyj548 := 0; ; yyj548++ {
-		if yyhl548 {
-			if yyj548 >= l {
+	var yys543Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys543Slc
+	var yyhl543 bool = l >= 0
+	for yyj543 := 0; ; yyj543++ {
+		if yyhl543 {
+			if yyj543 >= l {
 				break
 			}
 		} else {
@@ -6159,9 +6115,9 @@ func (x *DaemonSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys548Slc = r.DecodeBytes(yys548Slc, true, true)
-		yys548 := string(yys548Slc)
-		switch yys548 {
+		yys543Slc = r.DecodeBytes(yys543Slc, true, true)
+		yys543 := string(yys543Slc)
+		switch yys543 {
 		case "currentNumberScheduled":
 			if r.TryDecodeAsNil() {
 				x.CurrentNumberScheduled = 0
@@ -6181,10 +6137,10 @@ func (x *DaemonSetStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.DesiredNumberScheduled = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys548)
-		} // end switch yys548
-	} // end for yyj548
-	if !yyhl548 {
+			z.DecStructFieldNotFound(-1, yys543)
+		} // end switch yys543
+	} // end for yyj543
+	if !yyhl543 {
 		r.ReadEnd()
 	}
 }
@@ -6193,16 +6149,16 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj552 int
-	var yyb552 bool
-	var yyhl552 bool = l >= 0
-	yyj552++
-	if yyhl552 {
-		yyb552 = yyj552 > l
+	var yyj547 int
+	var yyb547 bool
+	var yyhl547 bool = l >= 0
+	yyj547++
+	if yyhl547 {
+		yyb547 = yyj547 > l
 	} else {
-		yyb552 = r.CheckBreak()
+		yyb547 = r.CheckBreak()
 	}
-	if yyb552 {
+	if yyb547 {
 		r.ReadEnd()
 		return
 	}
@@ -6211,13 +6167,13 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.CurrentNumberScheduled = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj552++
-	if yyhl552 {
-		yyb552 = yyj552 > l
+	yyj547++
+	if yyhl547 {
+		yyb547 = yyj547 > l
 	} else {
-		yyb552 = r.CheckBreak()
+		yyb547 = r.CheckBreak()
 	}
-	if yyb552 {
+	if yyb547 {
 		r.ReadEnd()
 		return
 	}
@@ -6226,13 +6182,13 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.NumberMisscheduled = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj552++
-	if yyhl552 {
-		yyb552 = yyj552 > l
+	yyj547++
+	if yyhl547 {
+		yyb547 = yyj547 > l
 	} else {
-		yyb552 = r.CheckBreak()
+		yyb547 = r.CheckBreak()
 	}
-	if yyb552 {
+	if yyb547 {
 		r.ReadEnd()
 		return
 	}
@@ -6242,16 +6198,16 @@ func (x *DaemonSetStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.DesiredNumberScheduled = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj552++
-		if yyhl552 {
-			yyb552 = yyj552 > l
+		yyj547++
+		if yyhl547 {
+			yyb547 = yyj547 > l
 		} else {
-			yyb552 = r.CheckBreak()
+			yyb547 = r.CheckBreak()
 		}
-		if yyb552 {
+		if yyb547 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj552-1, "")
+		z.DecStructFieldNotFound(yyj547-1, "")
 	}
 	r.ReadEnd()
 }
@@ -6263,36 +6219,36 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym556 := z.EncBinary()
-		_ = yym556
+		yym551 := z.EncBinary()
+		_ = yym551
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep557 := !z.EncBinary()
-			yy2arr557 := z.EncBasicHandle().StructToArray
-			var yyq557 [5]bool
-			_, _, _ = yysep557, yyq557, yy2arr557
-			const yyr557 bool = false
-			yyq557[0] = x.Kind != ""
-			yyq557[1] = x.APIVersion != ""
-			yyq557[2] = true
-			yyq557[3] = true
-			yyq557[4] = true
-			if yyr557 || yy2arr557 {
+			yysep552 := !z.EncBinary()
+			yy2arr552 := z.EncBasicHandle().StructToArray
+			var yyq552 [5]bool
+			_, _, _ = yysep552, yyq552, yy2arr552
+			const yyr552 bool = false
+			yyq552[0] = x.Kind != ""
+			yyq552[1] = x.APIVersion != ""
+			yyq552[2] = true
+			yyq552[3] = true
+			yyq552[4] = true
+			if yyr552 || yy2arr552 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn557 int = 0
-				for _, b := range yyq557 {
+				var yynn552 int = 0
+				for _, b := range yyq552 {
 					if b {
-						yynn557++
+						yynn552++
 					}
 				}
-				r.EncodeMapStart(yynn557)
+				r.EncodeMapStart(yynn552)
 			}
-			if yyr557 || yy2arr557 {
-				if yyq557[0] {
-					yym559 := z.EncBinary()
-					_ = yym559
+			if yyr552 || yy2arr552 {
+				if yyq552[0] {
+					yym554 := z.EncBinary()
+					_ = yym554
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -6301,20 +6257,20 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq557[0] {
+				if yyq552[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym560 := z.EncBinary()
-					_ = yym560
+					yym555 := z.EncBinary()
+					_ = yym555
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr557 || yy2arr557 {
-				if yyq557[1] {
-					yym562 := z.EncBinary()
-					_ = yym562
+			if yyr552 || yy2arr552 {
+				if yyq552[1] {
+					yym557 := z.EncBinary()
+					_ = yym557
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -6323,59 +6279,59 @@ func (x *DaemonSet) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq557[1] {
+				if yyq552[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym563 := z.EncBinary()
-					_ = yym563
+					yym558 := z.EncBinary()
+					_ = yym558
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr557 || yy2arr557 {
-				if yyq557[2] {
-					yy565 := &x.ObjectMeta
-					yy565.CodecEncodeSelf(e)
+			if yyr552 || yy2arr552 {
+				if yyq552[2] {
+					yy560 := &x.ObjectMeta
+					yy560.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq557[2] {
+				if yyq552[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy566 := &x.ObjectMeta
-					yy566.CodecEncodeSelf(e)
+					yy561 := &x.ObjectMeta
+					yy561.CodecEncodeSelf(e)
 				}
 			}
-			if yyr557 || yy2arr557 {
-				if yyq557[3] {
-					yy568 := &x.Spec
-					yy568.CodecEncodeSelf(e)
+			if yyr552 || yy2arr552 {
+				if yyq552[3] {
+					yy563 := &x.Spec
+					yy563.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq557[3] {
+				if yyq552[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy569 := &x.Spec
-					yy569.CodecEncodeSelf(e)
+					yy564 := &x.Spec
+					yy564.CodecEncodeSelf(e)
 				}
 			}
-			if yyr557 || yy2arr557 {
-				if yyq557[4] {
-					yy571 := &x.Status
-					yy571.CodecEncodeSelf(e)
+			if yyr552 || yy2arr552 {
+				if yyq552[4] {
+					yy566 := &x.Status
+					yy566.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq557[4] {
+				if yyq552[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy572 := &x.Status
-					yy572.CodecEncodeSelf(e)
+					yy567 := &x.Status
+					yy567.CodecEncodeSelf(e)
 				}
 			}
-			if yysep557 {
+			if yysep552 {
 				r.EncodeEnd()
 			}
 		}
@@ -6386,24 +6342,24 @@ func (x *DaemonSet) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym573 := z.DecBinary()
-	_ = yym573
+	yym568 := z.DecBinary()
+	_ = yym568
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl574 := r.ReadMapStart()
-			if yyl574 == 0 {
+			yyl569 := r.ReadMapStart()
+			if yyl569 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl574, d)
+				x.codecDecodeSelfFromMap(yyl569, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl574 := r.ReadArrayStart()
-			if yyl574 == 0 {
+			yyl569 := r.ReadArrayStart()
+			if yyl569 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl574, d)
+				x.codecDecodeSelfFromArray(yyl569, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -6415,12 +6371,12 @@ func (x *DaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys575Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys575Slc
-	var yyhl575 bool = l >= 0
-	for yyj575 := 0; ; yyj575++ {
-		if yyhl575 {
-			if yyj575 >= l {
+	var yys570Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys570Slc
+	var yyhl570 bool = l >= 0
+	for yyj570 := 0; ; yyj570++ {
+		if yyhl570 {
+			if yyj570 >= l {
 				break
 			}
 		} else {
@@ -6428,9 +6384,9 @@ func (x *DaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys575Slc = r.DecodeBytes(yys575Slc, true, true)
-		yys575 := string(yys575Slc)
-		switch yys575 {
+		yys570Slc = r.DecodeBytes(yys570Slc, true, true)
+		yys570 := string(yys570Slc)
+		switch yys570 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -6447,28 +6403,28 @@ func (x *DaemonSet) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_v1.ObjectMeta{}
 			} else {
-				yyv578 := &x.ObjectMeta
-				yyv578.CodecDecodeSelf(d)
+				yyv573 := &x.ObjectMeta
+				yyv573.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = DaemonSetSpec{}
 			} else {
-				yyv579 := &x.Spec
-				yyv579.CodecDecodeSelf(d)
+				yyv574 := &x.Spec
+				yyv574.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = DaemonSetStatus{}
 			} else {
-				yyv580 := &x.Status
-				yyv580.CodecDecodeSelf(d)
+				yyv575 := &x.Status
+				yyv575.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys575)
-		} // end switch yys575
-	} // end for yyj575
-	if !yyhl575 {
+			z.DecStructFieldNotFound(-1, yys570)
+		} // end switch yys570
+	} // end for yyj570
+	if !yyhl570 {
 		r.ReadEnd()
 	}
 }
@@ -6477,16 +6433,16 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj581 int
-	var yyb581 bool
-	var yyhl581 bool = l >= 0
-	yyj581++
-	if yyhl581 {
-		yyb581 = yyj581 > l
+	var yyj576 int
+	var yyb576 bool
+	var yyhl576 bool = l >= 0
+	yyj576++
+	if yyhl576 {
+		yyb576 = yyj576 > l
 	} else {
-		yyb581 = r.CheckBreak()
+		yyb576 = r.CheckBreak()
 	}
-	if yyb581 {
+	if yyb576 {
 		r.ReadEnd()
 		return
 	}
@@ -6495,13 +6451,13 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj581++
-	if yyhl581 {
-		yyb581 = yyj581 > l
+	yyj576++
+	if yyhl576 {
+		yyb576 = yyj576 > l
 	} else {
-		yyb581 = r.CheckBreak()
+		yyb576 = r.CheckBreak()
 	}
-	if yyb581 {
+	if yyb576 {
 		r.ReadEnd()
 		return
 	}
@@ -6510,65 +6466,65 @@ func (x *DaemonSet) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj581++
-	if yyhl581 {
-		yyb581 = yyj581 > l
+	yyj576++
+	if yyhl576 {
+		yyb576 = yyj576 > l
 	} else {
-		yyb581 = r.CheckBreak()
+		yyb576 = r.CheckBreak()
 	}
-	if yyb581 {
+	if yyb576 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_v1.ObjectMeta{}
 	} else {
-		yyv584 := &x.ObjectMeta
-		yyv584.CodecDecodeSelf(d)
+		yyv579 := &x.ObjectMeta
+		yyv579.CodecDecodeSelf(d)
 	}
-	yyj581++
-	if yyhl581 {
-		yyb581 = yyj581 > l
+	yyj576++
+	if yyhl576 {
+		yyb576 = yyj576 > l
 	} else {
-		yyb581 = r.CheckBreak()
+		yyb576 = r.CheckBreak()
 	}
-	if yyb581 {
+	if yyb576 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = DaemonSetSpec{}
 	} else {
-		yyv585 := &x.Spec
-		yyv585.CodecDecodeSelf(d)
+		yyv580 := &x.Spec
+		yyv580.CodecDecodeSelf(d)
 	}
-	yyj581++
-	if yyhl581 {
-		yyb581 = yyj581 > l
+	yyj576++
+	if yyhl576 {
+		yyb576 = yyj576 > l
 	} else {
-		yyb581 = r.CheckBreak()
+		yyb576 = r.CheckBreak()
 	}
-	if yyb581 {
+	if yyb576 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = DaemonSetStatus{}
 	} else {
-		yyv586 := &x.Status
-		yyv586.CodecDecodeSelf(d)
+		yyv581 := &x.Status
+		yyv581.CodecDecodeSelf(d)
 	}
 	for {
-		yyj581++
-		if yyhl581 {
-			yyb581 = yyj581 > l
+		yyj576++
+		if yyhl576 {
+			yyb576 = yyj576 > l
 		} else {
-			yyb581 = r.CheckBreak()
+			yyb576 = r.CheckBreak()
 		}
-		if yyb581 {
+		if yyb576 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj581-1, "")
+		z.DecStructFieldNotFound(yyj576-1, "")
 	}
 	r.ReadEnd()
 }
@@ -6580,34 +6536,34 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym587 := z.EncBinary()
-		_ = yym587
+		yym582 := z.EncBinary()
+		_ = yym582
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep588 := !z.EncBinary()
-			yy2arr588 := z.EncBasicHandle().StructToArray
-			var yyq588 [4]bool
-			_, _, _ = yysep588, yyq588, yy2arr588
-			const yyr588 bool = false
-			yyq588[0] = x.Kind != ""
-			yyq588[1] = x.APIVersion != ""
-			yyq588[2] = true
-			if yyr588 || yy2arr588 {
+			yysep583 := !z.EncBinary()
+			yy2arr583 := z.EncBasicHandle().StructToArray
+			var yyq583 [4]bool
+			_, _, _ = yysep583, yyq583, yy2arr583
+			const yyr583 bool = false
+			yyq583[0] = x.Kind != ""
+			yyq583[1] = x.APIVersion != ""
+			yyq583[2] = true
+			if yyr583 || yy2arr583 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn588 int = 1
-				for _, b := range yyq588 {
+				var yynn583 int = 1
+				for _, b := range yyq583 {
 					if b {
-						yynn588++
+						yynn583++
 					}
 				}
-				r.EncodeMapStart(yynn588)
+				r.EncodeMapStart(yynn583)
 			}
-			if yyr588 || yy2arr588 {
-				if yyq588[0] {
-					yym590 := z.EncBinary()
-					_ = yym590
+			if yyr583 || yy2arr583 {
+				if yyq583[0] {
+					yym585 := z.EncBinary()
+					_ = yym585
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -6616,20 +6572,20 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq588[0] {
+				if yyq583[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym591 := z.EncBinary()
-					_ = yym591
+					yym586 := z.EncBinary()
+					_ = yym586
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr588 || yy2arr588 {
-				if yyq588[1] {
-					yym593 := z.EncBinary()
-					_ = yym593
+			if yyr583 || yy2arr583 {
+				if yyq583[1] {
+					yym588 := z.EncBinary()
+					_ = yym588
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -6638,48 +6594,48 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq588[1] {
+				if yyq583[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym589 := z.EncBinary()
+					_ = yym589
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr583 || yy2arr583 {
+				if yyq583[2] {
+					yy591 := &x.ListMeta
+					yym592 := z.EncBinary()
+					_ = yym592
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy591) {
+					} else {
+						z.EncFallback(yy591)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq583[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy593 := &x.ListMeta
 					yym594 := z.EncBinary()
 					_ = yym594
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy593) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						z.EncFallback(yy593)
 					}
 				}
 			}
-			if yyr588 || yy2arr588 {
-				if yyq588[2] {
-					yy596 := &x.ListMeta
-					yym597 := z.EncBinary()
-					_ = yym597
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy596) {
-					} else {
-						z.EncFallback(yy596)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq588[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy598 := &x.ListMeta
-					yym599 := z.EncBinary()
-					_ = yym599
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy598) {
-					} else {
-						z.EncFallback(yy598)
-					}
-				}
-			}
-			if yyr588 || yy2arr588 {
+			if yyr583 || yy2arr583 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym601 := z.EncBinary()
-					_ = yym601
+					yym596 := z.EncBinary()
+					_ = yym596
 					if false {
 					} else {
 						h.encSliceDaemonSet(([]DaemonSet)(x.Items), e)
@@ -6690,15 +6646,15 @@ func (x *DaemonSetList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym602 := z.EncBinary()
-					_ = yym602
+					yym597 := z.EncBinary()
+					_ = yym597
 					if false {
 					} else {
 						h.encSliceDaemonSet(([]DaemonSet)(x.Items), e)
 					}
 				}
 			}
-			if yysep588 {
+			if yysep583 {
 				r.EncodeEnd()
 			}
 		}
@@ -6709,24 +6665,24 @@ func (x *DaemonSetList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym603 := z.DecBinary()
-	_ = yym603
+	yym598 := z.DecBinary()
+	_ = yym598
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl604 := r.ReadMapStart()
-			if yyl604 == 0 {
+			yyl599 := r.ReadMapStart()
+			if yyl599 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl604, d)
+				x.codecDecodeSelfFromMap(yyl599, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl604 := r.ReadArrayStart()
-			if yyl604 == 0 {
+			yyl599 := r.ReadArrayStart()
+			if yyl599 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl604, d)
+				x.codecDecodeSelfFromArray(yyl599, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -6738,12 +6694,12 @@ func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys605Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys605Slc
-	var yyhl605 bool = l >= 0
-	for yyj605 := 0; ; yyj605++ {
-		if yyhl605 {
-			if yyj605 >= l {
+	var yys600Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys600Slc
+	var yyhl600 bool = l >= 0
+	for yyj600 := 0; ; yyj600++ {
+		if yyhl600 {
+			if yyj600 >= l {
 				break
 			}
 		} else {
@@ -6751,9 +6707,9 @@ func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys605Slc = r.DecodeBytes(yys605Slc, true, true)
-		yys605 := string(yys605Slc)
-		switch yys605 {
+		yys600Slc = r.DecodeBytes(yys600Slc, true, true)
+		yys600 := string(yys600Slc)
+		switch yys600 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -6770,32 +6726,32 @@ func (x *DaemonSetList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv608 := &x.ListMeta
-				yym609 := z.DecBinary()
-				_ = yym609
+				yyv603 := &x.ListMeta
+				yym604 := z.DecBinary()
+				_ = yym604
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv608) {
+				} else if z.HasExtensions() && z.DecExt(yyv603) {
 				} else {
-					z.DecFallback(yyv608, false)
+					z.DecFallback(yyv603, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv610 := &x.Items
-				yym611 := z.DecBinary()
-				_ = yym611
+				yyv605 := &x.Items
+				yym606 := z.DecBinary()
+				_ = yym606
 				if false {
 				} else {
-					h.decSliceDaemonSet((*[]DaemonSet)(yyv610), d)
+					h.decSliceDaemonSet((*[]DaemonSet)(yyv605), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys605)
-		} // end switch yys605
-	} // end for yyj605
-	if !yyhl605 {
+			z.DecStructFieldNotFound(-1, yys600)
+		} // end switch yys600
+	} // end for yyj600
+	if !yyhl600 {
 		r.ReadEnd()
 	}
 }
@@ -6804,16 +6760,16 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj612 int
-	var yyb612 bool
-	var yyhl612 bool = l >= 0
-	yyj612++
-	if yyhl612 {
-		yyb612 = yyj612 > l
+	var yyj607 int
+	var yyb607 bool
+	var yyhl607 bool = l >= 0
+	yyj607++
+	if yyhl607 {
+		yyb607 = yyj607 > l
 	} else {
-		yyb612 = r.CheckBreak()
+		yyb607 = r.CheckBreak()
 	}
-	if yyb612 {
+	if yyb607 {
 		r.ReadEnd()
 		return
 	}
@@ -6822,13 +6778,13 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj612++
-	if yyhl612 {
-		yyb612 = yyj612 > l
+	yyj607++
+	if yyhl607 {
+		yyb607 = yyj607 > l
 	} else {
-		yyb612 = r.CheckBreak()
+		yyb607 = r.CheckBreak()
 	}
-	if yyb612 {
+	if yyb607 {
 		r.ReadEnd()
 		return
 	}
@@ -6837,60 +6793,60 @@ func (x *DaemonSetList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj612++
-	if yyhl612 {
-		yyb612 = yyj612 > l
+	yyj607++
+	if yyhl607 {
+		yyb607 = yyj607 > l
 	} else {
-		yyb612 = r.CheckBreak()
+		yyb607 = r.CheckBreak()
 	}
-	if yyb612 {
+	if yyb607 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv615 := &x.ListMeta
-		yym616 := z.DecBinary()
-		_ = yym616
+		yyv610 := &x.ListMeta
+		yym611 := z.DecBinary()
+		_ = yym611
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv615) {
+		} else if z.HasExtensions() && z.DecExt(yyv610) {
 		} else {
-			z.DecFallback(yyv615, false)
+			z.DecFallback(yyv610, false)
 		}
 	}
-	yyj612++
-	if yyhl612 {
-		yyb612 = yyj612 > l
+	yyj607++
+	if yyhl607 {
+		yyb607 = yyj607 > l
 	} else {
-		yyb612 = r.CheckBreak()
+		yyb607 = r.CheckBreak()
 	}
-	if yyb612 {
+	if yyb607 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv617 := &x.Items
-		yym618 := z.DecBinary()
-		_ = yym618
+		yyv612 := &x.Items
+		yym613 := z.DecBinary()
+		_ = yym613
 		if false {
 		} else {
-			h.decSliceDaemonSet((*[]DaemonSet)(yyv617), d)
+			h.decSliceDaemonSet((*[]DaemonSet)(yyv612), d)
 		}
 	}
 	for {
-		yyj612++
-		if yyhl612 {
-			yyb612 = yyj612 > l
+		yyj607++
+		if yyhl607 {
+			yyb607 = yyj607 > l
 		} else {
-			yyb612 = r.CheckBreak()
+			yyb607 = r.CheckBreak()
 		}
-		if yyb612 {
+		if yyb607 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj612-1, "")
+		z.DecStructFieldNotFound(yyj607-1, "")
 	}
 	r.ReadEnd()
 }
@@ -6902,34 +6858,34 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym619 := z.EncBinary()
-		_ = yym619
+		yym614 := z.EncBinary()
+		_ = yym614
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep620 := !z.EncBinary()
-			yy2arr620 := z.EncBasicHandle().StructToArray
-			var yyq620 [4]bool
-			_, _, _ = yysep620, yyq620, yy2arr620
-			const yyr620 bool = false
-			yyq620[0] = x.Kind != ""
-			yyq620[1] = x.APIVersion != ""
-			yyq620[2] = true
-			if yyr620 || yy2arr620 {
+			yysep615 := !z.EncBinary()
+			yy2arr615 := z.EncBasicHandle().StructToArray
+			var yyq615 [4]bool
+			_, _, _ = yysep615, yyq615, yy2arr615
+			const yyr615 bool = false
+			yyq615[0] = x.Kind != ""
+			yyq615[1] = x.APIVersion != ""
+			yyq615[2] = true
+			if yyr615 || yy2arr615 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn620 int = 1
-				for _, b := range yyq620 {
+				var yynn615 int = 1
+				for _, b := range yyq615 {
 					if b {
-						yynn620++
+						yynn615++
 					}
 				}
-				r.EncodeMapStart(yynn620)
+				r.EncodeMapStart(yynn615)
 			}
-			if yyr620 || yy2arr620 {
-				if yyq620[0] {
-					yym622 := z.EncBinary()
-					_ = yym622
+			if yyr615 || yy2arr615 {
+				if yyq615[0] {
+					yym617 := z.EncBinary()
+					_ = yym617
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -6938,20 +6894,20 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq620[0] {
+				if yyq615[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym623 := z.EncBinary()
-					_ = yym623
+					yym618 := z.EncBinary()
+					_ = yym618
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr620 || yy2arr620 {
-				if yyq620[1] {
-					yym625 := z.EncBinary()
-					_ = yym625
+			if yyr615 || yy2arr615 {
+				if yyq615[1] {
+					yym620 := z.EncBinary()
+					_ = yym620
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -6960,48 +6916,48 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq620[1] {
+				if yyq615[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym621 := z.EncBinary()
+					_ = yym621
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr615 || yy2arr615 {
+				if yyq615[2] {
+					yy623 := &x.ListMeta
+					yym624 := z.EncBinary()
+					_ = yym624
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy623) {
+					} else {
+						z.EncFallback(yy623)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq615[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy625 := &x.ListMeta
 					yym626 := z.EncBinary()
 					_ = yym626
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy625) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						z.EncFallback(yy625)
 					}
 				}
 			}
-			if yyr620 || yy2arr620 {
-				if yyq620[2] {
-					yy628 := &x.ListMeta
-					yym629 := z.EncBinary()
-					_ = yym629
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy628) {
-					} else {
-						z.EncFallback(yy628)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq620[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy630 := &x.ListMeta
-					yym631 := z.EncBinary()
-					_ = yym631
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy630) {
-					} else {
-						z.EncFallback(yy630)
-					}
-				}
-			}
-			if yyr620 || yy2arr620 {
+			if yyr615 || yy2arr615 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym633 := z.EncBinary()
-					_ = yym633
+					yym628 := z.EncBinary()
+					_ = yym628
 					if false {
 					} else {
 						h.encSliceThirdPartyResourceData(([]ThirdPartyResourceData)(x.Items), e)
@@ -7012,15 +6968,15 @@ func (x *ThirdPartyResourceDataList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym634 := z.EncBinary()
-					_ = yym634
+					yym629 := z.EncBinary()
+					_ = yym629
 					if false {
 					} else {
 						h.encSliceThirdPartyResourceData(([]ThirdPartyResourceData)(x.Items), e)
 					}
 				}
 			}
-			if yysep620 {
+			if yysep615 {
 				r.EncodeEnd()
 			}
 		}
@@ -7031,24 +6987,24 @@ func (x *ThirdPartyResourceDataList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym635 := z.DecBinary()
-	_ = yym635
+	yym630 := z.DecBinary()
+	_ = yym630
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl636 := r.ReadMapStart()
-			if yyl636 == 0 {
+			yyl631 := r.ReadMapStart()
+			if yyl631 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl636, d)
+				x.codecDecodeSelfFromMap(yyl631, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl636 := r.ReadArrayStart()
-			if yyl636 == 0 {
+			yyl631 := r.ReadArrayStart()
+			if yyl631 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl636, d)
+				x.codecDecodeSelfFromArray(yyl631, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -7060,12 +7016,12 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys637Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys637Slc
-	var yyhl637 bool = l >= 0
-	for yyj637 := 0; ; yyj637++ {
-		if yyhl637 {
-			if yyj637 >= l {
+	var yys632Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys632Slc
+	var yyhl632 bool = l >= 0
+	for yyj632 := 0; ; yyj632++ {
+		if yyhl632 {
+			if yyj632 >= l {
 				break
 			}
 		} else {
@@ -7073,9 +7029,9 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.
 				break
 			}
 		}
-		yys637Slc = r.DecodeBytes(yys637Slc, true, true)
-		yys637 := string(yys637Slc)
-		switch yys637 {
+		yys632Slc = r.DecodeBytes(yys632Slc, true, true)
+		yys632 := string(yys632Slc)
+		switch yys632 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -7092,32 +7048,32 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromMap(l int, d *codec1978.
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv640 := &x.ListMeta
-				yym641 := z.DecBinary()
-				_ = yym641
+				yyv635 := &x.ListMeta
+				yym636 := z.DecBinary()
+				_ = yym636
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv640) {
+				} else if z.HasExtensions() && z.DecExt(yyv635) {
 				} else {
-					z.DecFallback(yyv640, false)
+					z.DecFallback(yyv635, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv642 := &x.Items
-				yym643 := z.DecBinary()
-				_ = yym643
+				yyv637 := &x.Items
+				yym638 := z.DecBinary()
+				_ = yym638
 				if false {
 				} else {
-					h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv642), d)
+					h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv637), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys637)
-		} // end switch yys637
-	} // end for yyj637
-	if !yyhl637 {
+			z.DecStructFieldNotFound(-1, yys632)
+		} // end switch yys632
+	} // end for yyj632
+	if !yyhl632 {
 		r.ReadEnd()
 	}
 }
@@ -7126,16 +7082,16 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj644 int
-	var yyb644 bool
-	var yyhl644 bool = l >= 0
-	yyj644++
-	if yyhl644 {
-		yyb644 = yyj644 > l
+	var yyj639 int
+	var yyb639 bool
+	var yyhl639 bool = l >= 0
+	yyj639++
+	if yyhl639 {
+		yyb639 = yyj639 > l
 	} else {
-		yyb644 = r.CheckBreak()
+		yyb639 = r.CheckBreak()
 	}
-	if yyb644 {
+	if yyb639 {
 		r.ReadEnd()
 		return
 	}
@@ -7144,13 +7100,13 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj644++
-	if yyhl644 {
-		yyb644 = yyj644 > l
+	yyj639++
+	if yyhl639 {
+		yyb639 = yyj639 > l
 	} else {
-		yyb644 = r.CheckBreak()
+		yyb639 = r.CheckBreak()
 	}
-	if yyb644 {
+	if yyb639 {
 		r.ReadEnd()
 		return
 	}
@@ -7159,60 +7115,60 @@ func (x *ThirdPartyResourceDataList) codecDecodeSelfFromArray(l int, d *codec197
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj644++
-	if yyhl644 {
-		yyb644 = yyj644 > l
+	yyj639++
+	if yyhl639 {
+		yyb639 = yyj639 > l
 	} else {
-		yyb644 = r.CheckBreak()
+		yyb639 = r.CheckBreak()
 	}
-	if yyb644 {
+	if yyb639 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv647 := &x.ListMeta
-		yym648 := z.DecBinary()
-		_ = yym648
+		yyv642 := &x.ListMeta
+		yym643 := z.DecBinary()
+		_ = yym643
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv647) {
+		} else if z.HasExtensions() && z.DecExt(yyv642) {
 		} else {
-			z.DecFallback(yyv647, false)
+			z.DecFallback(yyv642, false)
 		}
 	}
-	yyj644++
-	if yyhl644 {
-		yyb644 = yyj644 > l
+	yyj639++
+	if yyhl639 {
+		yyb639 = yyj639 > l
 	} else {
-		yyb644 = r.CheckBreak()
+		yyb639 = r.CheckBreak()
 	}
-	if yyb644 {
+	if yyb639 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv649 := &x.Items
-		yym650 := z.DecBinary()
-		_ = yym650
+		yyv644 := &x.Items
+		yym645 := z.DecBinary()
+		_ = yym645
 		if false {
 		} else {
-			h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv649), d)
+			h.decSliceThirdPartyResourceData((*[]ThirdPartyResourceData)(yyv644), d)
 		}
 	}
 	for {
-		yyj644++
-		if yyhl644 {
-			yyb644 = yyj644 > l
+		yyj639++
+		if yyhl639 {
+			yyb639 = yyj639 > l
 		} else {
-			yyb644 = r.CheckBreak()
+			yyb639 = r.CheckBreak()
 		}
-		if yyb644 {
+		if yyb639 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj644-1, "")
+		z.DecStructFieldNotFound(yyj639-1, "")
 	}
 	r.ReadEnd()
 }
@@ -7224,36 +7180,36 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym651 := z.EncBinary()
-		_ = yym651
+		yym646 := z.EncBinary()
+		_ = yym646
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep652 := !z.EncBinary()
-			yy2arr652 := z.EncBasicHandle().StructToArray
-			var yyq652 [5]bool
-			_, _, _ = yysep652, yyq652, yy2arr652
-			const yyr652 bool = false
-			yyq652[0] = x.Kind != ""
-			yyq652[1] = x.APIVersion != ""
-			yyq652[2] = true
-			yyq652[3] = true
-			yyq652[4] = true
-			if yyr652 || yy2arr652 {
+			yysep647 := !z.EncBinary()
+			yy2arr647 := z.EncBasicHandle().StructToArray
+			var yyq647 [5]bool
+			_, _, _ = yysep647, yyq647, yy2arr647
+			const yyr647 bool = false
+			yyq647[0] = x.Kind != ""
+			yyq647[1] = x.APIVersion != ""
+			yyq647[2] = true
+			yyq647[3] = true
+			yyq647[4] = true
+			if yyr647 || yy2arr647 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn652 int = 0
-				for _, b := range yyq652 {
+				var yynn647 int = 0
+				for _, b := range yyq647 {
 					if b {
-						yynn652++
+						yynn647++
 					}
 				}
-				r.EncodeMapStart(yynn652)
+				r.EncodeMapStart(yynn647)
 			}
-			if yyr652 || yy2arr652 {
-				if yyq652[0] {
-					yym654 := z.EncBinary()
-					_ = yym654
+			if yyr647 || yy2arr647 {
+				if yyq647[0] {
+					yym649 := z.EncBinary()
+					_ = yym649
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -7262,20 +7218,20 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq652[0] {
+				if yyq647[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym655 := z.EncBinary()
-					_ = yym655
+					yym650 := z.EncBinary()
+					_ = yym650
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr652 || yy2arr652 {
-				if yyq652[1] {
-					yym657 := z.EncBinary()
-					_ = yym657
+			if yyr647 || yy2arr647 {
+				if yyq647[1] {
+					yym652 := z.EncBinary()
+					_ = yym652
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -7284,59 +7240,59 @@ func (x *Job) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq652[1] {
+				if yyq647[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym658 := z.EncBinary()
-					_ = yym658
+					yym653 := z.EncBinary()
+					_ = yym653
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr652 || yy2arr652 {
-				if yyq652[2] {
-					yy660 := &x.ObjectMeta
-					yy660.CodecEncodeSelf(e)
+			if yyr647 || yy2arr647 {
+				if yyq647[2] {
+					yy655 := &x.ObjectMeta
+					yy655.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq652[2] {
+				if yyq647[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy661 := &x.ObjectMeta
-					yy661.CodecEncodeSelf(e)
+					yy656 := &x.ObjectMeta
+					yy656.CodecEncodeSelf(e)
 				}
 			}
-			if yyr652 || yy2arr652 {
-				if yyq652[3] {
-					yy663 := &x.Spec
-					yy663.CodecEncodeSelf(e)
+			if yyr647 || yy2arr647 {
+				if yyq647[3] {
+					yy658 := &x.Spec
+					yy658.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq652[3] {
+				if yyq647[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy664 := &x.Spec
-					yy664.CodecEncodeSelf(e)
+					yy659 := &x.Spec
+					yy659.CodecEncodeSelf(e)
 				}
 			}
-			if yyr652 || yy2arr652 {
-				if yyq652[4] {
-					yy666 := &x.Status
-					yy666.CodecEncodeSelf(e)
+			if yyr647 || yy2arr647 {
+				if yyq647[4] {
+					yy661 := &x.Status
+					yy661.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq652[4] {
+				if yyq647[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy667 := &x.Status
-					yy667.CodecEncodeSelf(e)
+					yy662 := &x.Status
+					yy662.CodecEncodeSelf(e)
 				}
 			}
-			if yysep652 {
+			if yysep647 {
 				r.EncodeEnd()
 			}
 		}
@@ -7347,24 +7303,24 @@ func (x *Job) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym668 := z.DecBinary()
-	_ = yym668
+	yym663 := z.DecBinary()
+	_ = yym663
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl669 := r.ReadMapStart()
-			if yyl669 == 0 {
+			yyl664 := r.ReadMapStart()
+			if yyl664 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl669, d)
+				x.codecDecodeSelfFromMap(yyl664, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl669 := r.ReadArrayStart()
-			if yyl669 == 0 {
+			yyl664 := r.ReadArrayStart()
+			if yyl664 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl669, d)
+				x.codecDecodeSelfFromArray(yyl664, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -7376,12 +7332,12 @@ func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys670Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys670Slc
-	var yyhl670 bool = l >= 0
-	for yyj670 := 0; ; yyj670++ {
-		if yyhl670 {
-			if yyj670 >= l {
+	var yys665Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys665Slc
+	var yyhl665 bool = l >= 0
+	for yyj665 := 0; ; yyj665++ {
+		if yyhl665 {
+			if yyj665 >= l {
 				break
 			}
 		} else {
@@ -7389,9 +7345,9 @@ func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys670Slc = r.DecodeBytes(yys670Slc, true, true)
-		yys670 := string(yys670Slc)
-		switch yys670 {
+		yys665Slc = r.DecodeBytes(yys665Slc, true, true)
+		yys665 := string(yys665Slc)
+		switch yys665 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -7408,28 +7364,28 @@ func (x *Job) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_v1.ObjectMeta{}
 			} else {
-				yyv673 := &x.ObjectMeta
-				yyv673.CodecDecodeSelf(d)
+				yyv668 := &x.ObjectMeta
+				yyv668.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = JobSpec{}
 			} else {
-				yyv674 := &x.Spec
-				yyv674.CodecDecodeSelf(d)
+				yyv669 := &x.Spec
+				yyv669.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = JobStatus{}
 			} else {
-				yyv675 := &x.Status
-				yyv675.CodecDecodeSelf(d)
+				yyv670 := &x.Status
+				yyv670.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys670)
-		} // end switch yys670
-	} // end for yyj670
-	if !yyhl670 {
+			z.DecStructFieldNotFound(-1, yys665)
+		} // end switch yys665
+	} // end for yyj665
+	if !yyhl665 {
 		r.ReadEnd()
 	}
 }
@@ -7438,16 +7394,16 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj676 int
-	var yyb676 bool
-	var yyhl676 bool = l >= 0
-	yyj676++
-	if yyhl676 {
-		yyb676 = yyj676 > l
+	var yyj671 int
+	var yyb671 bool
+	var yyhl671 bool = l >= 0
+	yyj671++
+	if yyhl671 {
+		yyb671 = yyj671 > l
 	} else {
-		yyb676 = r.CheckBreak()
+		yyb671 = r.CheckBreak()
 	}
-	if yyb676 {
+	if yyb671 {
 		r.ReadEnd()
 		return
 	}
@@ -7456,13 +7412,13 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj676++
-	if yyhl676 {
-		yyb676 = yyj676 > l
+	yyj671++
+	if yyhl671 {
+		yyb671 = yyj671 > l
 	} else {
-		yyb676 = r.CheckBreak()
+		yyb671 = r.CheckBreak()
 	}
-	if yyb676 {
+	if yyb671 {
 		r.ReadEnd()
 		return
 	}
@@ -7471,65 +7427,65 @@ func (x *Job) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj676++
-	if yyhl676 {
-		yyb676 = yyj676 > l
+	yyj671++
+	if yyhl671 {
+		yyb671 = yyj671 > l
 	} else {
-		yyb676 = r.CheckBreak()
+		yyb671 = r.CheckBreak()
 	}
-	if yyb676 {
+	if yyb671 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_v1.ObjectMeta{}
 	} else {
-		yyv679 := &x.ObjectMeta
-		yyv679.CodecDecodeSelf(d)
+		yyv674 := &x.ObjectMeta
+		yyv674.CodecDecodeSelf(d)
 	}
-	yyj676++
-	if yyhl676 {
-		yyb676 = yyj676 > l
+	yyj671++
+	if yyhl671 {
+		yyb671 = yyj671 > l
 	} else {
-		yyb676 = r.CheckBreak()
+		yyb671 = r.CheckBreak()
 	}
-	if yyb676 {
+	if yyb671 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = JobSpec{}
 	} else {
-		yyv680 := &x.Spec
-		yyv680.CodecDecodeSelf(d)
+		yyv675 := &x.Spec
+		yyv675.CodecDecodeSelf(d)
 	}
-	yyj676++
-	if yyhl676 {
-		yyb676 = yyj676 > l
+	yyj671++
+	if yyhl671 {
+		yyb671 = yyj671 > l
 	} else {
-		yyb676 = r.CheckBreak()
+		yyb671 = r.CheckBreak()
 	}
-	if yyb676 {
+	if yyb671 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = JobStatus{}
 	} else {
-		yyv681 := &x.Status
-		yyv681.CodecDecodeSelf(d)
+		yyv676 := &x.Status
+		yyv676.CodecDecodeSelf(d)
 	}
 	for {
-		yyj676++
-		if yyhl676 {
-			yyb676 = yyj676 > l
+		yyj671++
+		if yyhl671 {
+			yyb671 = yyj671 > l
 		} else {
-			yyb676 = r.CheckBreak()
+			yyb671 = r.CheckBreak()
 		}
-		if yyb676 {
+		if yyb671 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj676-1, "")
+		z.DecStructFieldNotFound(yyj671-1, "")
 	}
 	r.ReadEnd()
 }
@@ -7541,34 +7497,34 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym682 := z.EncBinary()
-		_ = yym682
+		yym677 := z.EncBinary()
+		_ = yym677
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep683 := !z.EncBinary()
-			yy2arr683 := z.EncBasicHandle().StructToArray
-			var yyq683 [4]bool
-			_, _, _ = yysep683, yyq683, yy2arr683
-			const yyr683 bool = false
-			yyq683[0] = x.Kind != ""
-			yyq683[1] = x.APIVersion != ""
-			yyq683[2] = true
-			if yyr683 || yy2arr683 {
+			yysep678 := !z.EncBinary()
+			yy2arr678 := z.EncBasicHandle().StructToArray
+			var yyq678 [4]bool
+			_, _, _ = yysep678, yyq678, yy2arr678
+			const yyr678 bool = false
+			yyq678[0] = x.Kind != ""
+			yyq678[1] = x.APIVersion != ""
+			yyq678[2] = true
+			if yyr678 || yy2arr678 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn683 int = 1
-				for _, b := range yyq683 {
+				var yynn678 int = 1
+				for _, b := range yyq678 {
 					if b {
-						yynn683++
+						yynn678++
 					}
 				}
-				r.EncodeMapStart(yynn683)
+				r.EncodeMapStart(yynn678)
 			}
-			if yyr683 || yy2arr683 {
-				if yyq683[0] {
-					yym685 := z.EncBinary()
-					_ = yym685
+			if yyr678 || yy2arr678 {
+				if yyq678[0] {
+					yym680 := z.EncBinary()
+					_ = yym680
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -7577,20 +7533,20 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq683[0] {
+				if yyq678[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym686 := z.EncBinary()
-					_ = yym686
+					yym681 := z.EncBinary()
+					_ = yym681
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr683 || yy2arr683 {
-				if yyq683[1] {
-					yym688 := z.EncBinary()
-					_ = yym688
+			if yyr678 || yy2arr678 {
+				if yyq678[1] {
+					yym683 := z.EncBinary()
+					_ = yym683
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -7599,48 +7555,48 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq683[1] {
+				if yyq678[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym684 := z.EncBinary()
+					_ = yym684
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr678 || yy2arr678 {
+				if yyq678[2] {
+					yy686 := &x.ListMeta
+					yym687 := z.EncBinary()
+					_ = yym687
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy686) {
+					} else {
+						z.EncFallback(yy686)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq678[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy688 := &x.ListMeta
 					yym689 := z.EncBinary()
 					_ = yym689
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy688) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						z.EncFallback(yy688)
 					}
 				}
 			}
-			if yyr683 || yy2arr683 {
-				if yyq683[2] {
-					yy691 := &x.ListMeta
-					yym692 := z.EncBinary()
-					_ = yym692
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy691) {
-					} else {
-						z.EncFallback(yy691)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq683[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy693 := &x.ListMeta
-					yym694 := z.EncBinary()
-					_ = yym694
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy693) {
-					} else {
-						z.EncFallback(yy693)
-					}
-				}
-			}
-			if yyr683 || yy2arr683 {
+			if yyr678 || yy2arr678 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym696 := z.EncBinary()
-					_ = yym696
+					yym691 := z.EncBinary()
+					_ = yym691
 					if false {
 					} else {
 						h.encSliceJob(([]Job)(x.Items), e)
@@ -7651,15 +7607,15 @@ func (x *JobList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym697 := z.EncBinary()
-					_ = yym697
+					yym692 := z.EncBinary()
+					_ = yym692
 					if false {
 					} else {
 						h.encSliceJob(([]Job)(x.Items), e)
 					}
 				}
 			}
-			if yysep683 {
+			if yysep678 {
 				r.EncodeEnd()
 			}
 		}
@@ -7670,24 +7626,24 @@ func (x *JobList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym698 := z.DecBinary()
-	_ = yym698
+	yym693 := z.DecBinary()
+	_ = yym693
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl699 := r.ReadMapStart()
-			if yyl699 == 0 {
+			yyl694 := r.ReadMapStart()
+			if yyl694 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl699, d)
+				x.codecDecodeSelfFromMap(yyl694, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl699 := r.ReadArrayStart()
-			if yyl699 == 0 {
+			yyl694 := r.ReadArrayStart()
+			if yyl694 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl699, d)
+				x.codecDecodeSelfFromArray(yyl694, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -7699,12 +7655,12 @@ func (x *JobList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys700Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys700Slc
-	var yyhl700 bool = l >= 0
-	for yyj700 := 0; ; yyj700++ {
-		if yyhl700 {
-			if yyj700 >= l {
+	var yys695Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys695Slc
+	var yyhl695 bool = l >= 0
+	for yyj695 := 0; ; yyj695++ {
+		if yyhl695 {
+			if yyj695 >= l {
 				break
 			}
 		} else {
@@ -7712,9 +7668,9 @@ func (x *JobList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys700Slc = r.DecodeBytes(yys700Slc, true, true)
-		yys700 := string(yys700Slc)
-		switch yys700 {
+		yys695Slc = r.DecodeBytes(yys695Slc, true, true)
+		yys695 := string(yys695Slc)
+		switch yys695 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -7731,32 +7687,32 @@ func (x *JobList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv703 := &x.ListMeta
-				yym704 := z.DecBinary()
-				_ = yym704
+				yyv698 := &x.ListMeta
+				yym699 := z.DecBinary()
+				_ = yym699
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv703) {
+				} else if z.HasExtensions() && z.DecExt(yyv698) {
 				} else {
-					z.DecFallback(yyv703, false)
+					z.DecFallback(yyv698, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv705 := &x.Items
-				yym706 := z.DecBinary()
-				_ = yym706
+				yyv700 := &x.Items
+				yym701 := z.DecBinary()
+				_ = yym701
 				if false {
 				} else {
-					h.decSliceJob((*[]Job)(yyv705), d)
+					h.decSliceJob((*[]Job)(yyv700), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys700)
-		} // end switch yys700
-	} // end for yyj700
-	if !yyhl700 {
+			z.DecStructFieldNotFound(-1, yys695)
+		} // end switch yys695
+	} // end for yyj695
+	if !yyhl695 {
 		r.ReadEnd()
 	}
 }
@@ -7765,16 +7721,16 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj707 int
-	var yyb707 bool
-	var yyhl707 bool = l >= 0
-	yyj707++
-	if yyhl707 {
-		yyb707 = yyj707 > l
+	var yyj702 int
+	var yyb702 bool
+	var yyhl702 bool = l >= 0
+	yyj702++
+	if yyhl702 {
+		yyb702 = yyj702 > l
 	} else {
-		yyb707 = r.CheckBreak()
+		yyb702 = r.CheckBreak()
 	}
-	if yyb707 {
+	if yyb702 {
 		r.ReadEnd()
 		return
 	}
@@ -7783,13 +7739,13 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj707++
-	if yyhl707 {
-		yyb707 = yyj707 > l
+	yyj702++
+	if yyhl702 {
+		yyb702 = yyj702 > l
 	} else {
-		yyb707 = r.CheckBreak()
+		yyb702 = r.CheckBreak()
 	}
-	if yyb707 {
+	if yyb702 {
 		r.ReadEnd()
 		return
 	}
@@ -7798,60 +7754,60 @@ func (x *JobList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj707++
-	if yyhl707 {
-		yyb707 = yyj707 > l
+	yyj702++
+	if yyhl702 {
+		yyb702 = yyj702 > l
 	} else {
-		yyb707 = r.CheckBreak()
+		yyb702 = r.CheckBreak()
 	}
-	if yyb707 {
+	if yyb702 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv710 := &x.ListMeta
-		yym711 := z.DecBinary()
-		_ = yym711
+		yyv705 := &x.ListMeta
+		yym706 := z.DecBinary()
+		_ = yym706
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv710) {
+		} else if z.HasExtensions() && z.DecExt(yyv705) {
 		} else {
-			z.DecFallback(yyv710, false)
+			z.DecFallback(yyv705, false)
 		}
 	}
-	yyj707++
-	if yyhl707 {
-		yyb707 = yyj707 > l
+	yyj702++
+	if yyhl702 {
+		yyb702 = yyj702 > l
 	} else {
-		yyb707 = r.CheckBreak()
+		yyb702 = r.CheckBreak()
 	}
-	if yyb707 {
+	if yyb702 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv712 := &x.Items
-		yym713 := z.DecBinary()
-		_ = yym713
+		yyv707 := &x.Items
+		yym708 := z.DecBinary()
+		_ = yym708
 		if false {
 		} else {
-			h.decSliceJob((*[]Job)(yyv712), d)
+			h.decSliceJob((*[]Job)(yyv707), d)
 		}
 	}
 	for {
-		yyj707++
-		if yyhl707 {
-			yyb707 = yyj707 > l
+		yyj702++
+		if yyhl702 {
+			yyb702 = yyj702 > l
 		} else {
-			yyb707 = r.CheckBreak()
+			yyb702 = r.CheckBreak()
 		}
-		if yyb707 {
+		if yyb702 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj707-1, "")
+		z.DecStructFieldNotFound(yyj702-1, "")
 	}
 	r.ReadEnd()
 }
@@ -7863,36 +7819,68 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym714 := z.EncBinary()
-		_ = yym714
+		yym709 := z.EncBinary()
+		_ = yym709
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep715 := !z.EncBinary()
-			yy2arr715 := z.EncBasicHandle().StructToArray
-			var yyq715 [4]bool
-			_, _, _ = yysep715, yyq715, yy2arr715
-			const yyr715 bool = false
-			yyq715[0] = x.Parallelism != nil
-			yyq715[1] = x.Completions != nil
-			yyq715[2] = x.Selector != nil
-			if yyr715 || yy2arr715 {
+			yysep710 := !z.EncBinary()
+			yy2arr710 := z.EncBasicHandle().StructToArray
+			var yyq710 [4]bool
+			_, _, _ = yysep710, yyq710, yy2arr710
+			const yyr710 bool = false
+			yyq710[0] = x.Parallelism != nil
+			yyq710[1] = x.Completions != nil
+			yyq710[2] = x.Selector != nil
+			if yyr710 || yy2arr710 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn715 int = 1
-				for _, b := range yyq715 {
+				var yynn710 int = 1
+				for _, b := range yyq710 {
 					if b {
-						yynn715++
+						yynn710++
 					}
 				}
-				r.EncodeMapStart(yynn715)
+				r.EncodeMapStart(yynn710)
 			}
-			if yyr715 || yy2arr715 {
-				if yyq715[0] {
+			if yyr710 || yy2arr710 {
+				if yyq710[0] {
 					if x.Parallelism == nil {
 						r.EncodeNil()
 					} else {
-						yy717 := *x.Parallelism
+						yy712 := *x.Parallelism
+						yym713 := z.EncBinary()
+						_ = yym713
+						if false {
+						} else {
+							r.EncodeInt(int64(yy712))
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq710[0] {
+					r.EncodeString(codecSelferC_UTF81234, string("parallelism"))
+					if x.Parallelism == nil {
+						r.EncodeNil()
+					} else {
+						yy714 := *x.Parallelism
+						yym715 := z.EncBinary()
+						_ = yym715
+						if false {
+						} else {
+							r.EncodeInt(int64(yy714))
+						}
+					}
+				}
+			}
+			if yyr710 || yy2arr710 {
+				if yyq710[1] {
+					if x.Completions == nil {
+						r.EncodeNil()
+					} else {
+						yy717 := *x.Completions
 						yym718 := z.EncBinary()
 						_ = yym718
 						if false {
@@ -7904,12 +7892,12 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq715[0] {
-					r.EncodeString(codecSelferC_UTF81234, string("parallelism"))
-					if x.Parallelism == nil {
+				if yyq710[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("completions"))
+					if x.Completions == nil {
 						r.EncodeNil()
 					} else {
-						yy719 := *x.Parallelism
+						yy719 := *x.Completions
 						yym720 := z.EncBinary()
 						_ = yym720
 						if false {
@@ -7919,40 +7907,8 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr715 || yy2arr715 {
-				if yyq715[1] {
-					if x.Completions == nil {
-						r.EncodeNil()
-					} else {
-						yy722 := *x.Completions
-						yym723 := z.EncBinary()
-						_ = yym723
-						if false {
-						} else {
-							r.EncodeInt(int64(yy722))
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq715[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("completions"))
-					if x.Completions == nil {
-						r.EncodeNil()
-					} else {
-						yy724 := *x.Completions
-						yym725 := z.EncBinary()
-						_ = yym725
-						if false {
-						} else {
-							r.EncodeInt(int64(yy724))
-						}
-					}
-				}
-			}
-			if yyr715 || yy2arr715 {
-				if yyq715[2] {
+			if yyr710 || yy2arr710 {
+				if yyq710[2] {
 					if x.Selector == nil {
 						r.EncodeNil()
 					} else {
@@ -7962,7 +7918,7 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq715[2] {
+				if yyq710[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("selector"))
 					if x.Selector == nil {
 						r.EncodeNil()
@@ -7971,15 +7927,15 @@ func (x *JobSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr715 || yy2arr715 {
-				yy728 := &x.Template
-				yy728.CodecEncodeSelf(e)
+			if yyr710 || yy2arr710 {
+				yy723 := &x.Template
+				yy723.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("template"))
-				yy729 := &x.Template
-				yy729.CodecEncodeSelf(e)
+				yy724 := &x.Template
+				yy724.CodecEncodeSelf(e)
 			}
-			if yysep715 {
+			if yysep710 {
 				r.EncodeEnd()
 			}
 		}
@@ -7990,24 +7946,24 @@ func (x *JobSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym730 := z.DecBinary()
-	_ = yym730
+	yym725 := z.DecBinary()
+	_ = yym725
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl731 := r.ReadMapStart()
-			if yyl731 == 0 {
+			yyl726 := r.ReadMapStart()
+			if yyl726 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl731, d)
+				x.codecDecodeSelfFromMap(yyl726, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl731 := r.ReadArrayStart()
-			if yyl731 == 0 {
+			yyl726 := r.ReadArrayStart()
+			if yyl726 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl731, d)
+				x.codecDecodeSelfFromArray(yyl726, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -8019,12 +7975,12 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys732Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys732Slc
-	var yyhl732 bool = l >= 0
-	for yyj732 := 0; ; yyj732++ {
-		if yyhl732 {
-			if yyj732 >= l {
+	var yys727Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys727Slc
+	var yyhl727 bool = l >= 0
+	for yyj727 := 0; ; yyj727++ {
+		if yyhl727 {
+			if yyj727 >= l {
 				break
 			}
 		} else {
@@ -8032,9 +7988,9 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys732Slc = r.DecodeBytes(yys732Slc, true, true)
-		yys732 := string(yys732Slc)
-		switch yys732 {
+		yys727Slc = r.DecodeBytes(yys727Slc, true, true)
+		yys727 := string(yys727Slc)
+		switch yys727 {
 		case "parallelism":
 			if r.TryDecodeAsNil() {
 				if x.Parallelism != nil {
@@ -8044,8 +8000,8 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.Parallelism == nil {
 					x.Parallelism = new(int)
 				}
-				yym734 := z.DecBinary()
-				_ = yym734
+				yym729 := z.DecBinary()
+				_ = yym729
 				if false {
 				} else {
 					*((*int)(x.Parallelism)) = int(r.DecodeInt(codecSelferBitsize1234))
@@ -8060,8 +8016,8 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.Completions == nil {
 					x.Completions = new(int)
 				}
-				yym736 := z.DecBinary()
-				_ = yym736
+				yym731 := z.DecBinary()
+				_ = yym731
 				if false {
 				} else {
 					*((*int)(x.Completions)) = int(r.DecodeInt(codecSelferBitsize1234))
@@ -8082,14 +8038,14 @@ func (x *JobSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Template = pkg2_v1.PodTemplateSpec{}
 			} else {
-				yyv738 := &x.Template
-				yyv738.CodecDecodeSelf(d)
+				yyv733 := &x.Template
+				yyv733.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys732)
-		} // end switch yys732
-	} // end for yyj732
-	if !yyhl732 {
+			z.DecStructFieldNotFound(-1, yys727)
+		} // end switch yys727
+	} // end for yyj727
+	if !yyhl727 {
 		r.ReadEnd()
 	}
 }
@@ -8098,16 +8054,16 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj739 int
-	var yyb739 bool
-	var yyhl739 bool = l >= 0
-	yyj739++
-	if yyhl739 {
-		yyb739 = yyj739 > l
+	var yyj734 int
+	var yyb734 bool
+	var yyhl734 bool = l >= 0
+	yyj734++
+	if yyhl734 {
+		yyb734 = yyj734 > l
 	} else {
-		yyb739 = r.CheckBreak()
+		yyb734 = r.CheckBreak()
 	}
-	if yyb739 {
+	if yyb734 {
 		r.ReadEnd()
 		return
 	}
@@ -8119,20 +8075,20 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.Parallelism == nil {
 			x.Parallelism = new(int)
 		}
-		yym741 := z.DecBinary()
-		_ = yym741
+		yym736 := z.DecBinary()
+		_ = yym736
 		if false {
 		} else {
 			*((*int)(x.Parallelism)) = int(r.DecodeInt(codecSelferBitsize1234))
 		}
 	}
-	yyj739++
-	if yyhl739 {
-		yyb739 = yyj739 > l
+	yyj734++
+	if yyhl734 {
+		yyb734 = yyj734 > l
 	} else {
-		yyb739 = r.CheckBreak()
+		yyb734 = r.CheckBreak()
 	}
-	if yyb739 {
+	if yyb734 {
 		r.ReadEnd()
 		return
 	}
@@ -8144,20 +8100,20 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.Completions == nil {
 			x.Completions = new(int)
 		}
-		yym743 := z.DecBinary()
-		_ = yym743
+		yym738 := z.DecBinary()
+		_ = yym738
 		if false {
 		} else {
 			*((*int)(x.Completions)) = int(r.DecodeInt(codecSelferBitsize1234))
 		}
 	}
-	yyj739++
-	if yyhl739 {
-		yyb739 = yyj739 > l
+	yyj734++
+	if yyhl734 {
+		yyb734 = yyj734 > l
 	} else {
-		yyb739 = r.CheckBreak()
+		yyb734 = r.CheckBreak()
 	}
-	if yyb739 {
+	if yyb734 {
 		r.ReadEnd()
 		return
 	}
@@ -8171,33 +8127,33 @@ func (x *JobSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.Selector.CodecDecodeSelf(d)
 	}
-	yyj739++
-	if yyhl739 {
-		yyb739 = yyj739 > l
+	yyj734++
+	if yyhl734 {
+		yyb734 = yyj734 > l
 	} else {
-		yyb739 = r.CheckBreak()
+		yyb734 = r.CheckBreak()
 	}
-	if yyb739 {
+	if yyb734 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Template = pkg2_v1.PodTemplateSpec{}
 	} else {
-		yyv745 := &x.Template
-		yyv745.CodecDecodeSelf(d)
+		yyv740 := &x.Template
+		yyv740.CodecDecodeSelf(d)
 	}
 	for {
-		yyj739++
-		if yyhl739 {
-			yyb739 = yyj739 > l
+		yyj734++
+		if yyhl734 {
+			yyb734 = yyj734 > l
 		} else {
-			yyb739 = r.CheckBreak()
+			yyb734 = r.CheckBreak()
 		}
-		if yyb739 {
+		if yyb734 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj739-1, "")
+		z.DecStructFieldNotFound(yyj734-1, "")
 	}
 	r.ReadEnd()
 }
@@ -8209,40 +8165,40 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym746 := z.EncBinary()
-		_ = yym746
+		yym741 := z.EncBinary()
+		_ = yym741
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep747 := !z.EncBinary()
-			yy2arr747 := z.EncBasicHandle().StructToArray
-			var yyq747 [6]bool
-			_, _, _ = yysep747, yyq747, yy2arr747
-			const yyr747 bool = false
-			yyq747[0] = len(x.Conditions) != 0
-			yyq747[1] = x.StartTime != nil
-			yyq747[2] = x.CompletionTime != nil
-			yyq747[3] = x.Active != 0
-			yyq747[4] = x.Succeeded != 0
-			yyq747[5] = x.Failed != 0
-			if yyr747 || yy2arr747 {
+			yysep742 := !z.EncBinary()
+			yy2arr742 := z.EncBasicHandle().StructToArray
+			var yyq742 [6]bool
+			_, _, _ = yysep742, yyq742, yy2arr742
+			const yyr742 bool = false
+			yyq742[0] = len(x.Conditions) != 0
+			yyq742[1] = x.StartTime != nil
+			yyq742[2] = x.CompletionTime != nil
+			yyq742[3] = x.Active != 0
+			yyq742[4] = x.Succeeded != 0
+			yyq742[5] = x.Failed != 0
+			if yyr742 || yy2arr742 {
 				r.EncodeArrayStart(6)
 			} else {
-				var yynn747 int = 0
-				for _, b := range yyq747 {
+				var yynn742 int = 0
+				for _, b := range yyq742 {
 					if b {
-						yynn747++
+						yynn742++
 					}
 				}
-				r.EncodeMapStart(yynn747)
+				r.EncodeMapStart(yynn742)
 			}
-			if yyr747 || yy2arr747 {
-				if yyq747[0] {
+			if yyr742 || yy2arr742 {
+				if yyq742[0] {
 					if x.Conditions == nil {
 						r.EncodeNil()
 					} else {
-						yym749 := z.EncBinary()
-						_ = yym749
+						yym744 := z.EncBinary()
+						_ = yym744
 						if false {
 						} else {
 							h.encSliceJobCondition(([]JobCondition)(x.Conditions), e)
@@ -8252,72 +8208,72 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq747[0] {
+				if yyq742[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("conditions"))
 					if x.Conditions == nil {
+						r.EncodeNil()
+					} else {
+						yym745 := z.EncBinary()
+						_ = yym745
+						if false {
+						} else {
+							h.encSliceJobCondition(([]JobCondition)(x.Conditions), e)
+						}
+					}
+				}
+			}
+			if yyr742 || yy2arr742 {
+				if yyq742[1] {
+					if x.StartTime == nil {
+						r.EncodeNil()
+					} else {
+						yym747 := z.EncBinary()
+						_ = yym747
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.StartTime) {
+						} else if yym747 {
+							z.EncBinaryMarshal(x.StartTime)
+						} else if !yym747 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.StartTime)
+						} else {
+							z.EncFallback(x.StartTime)
+						}
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq742[1] {
+					r.EncodeString(codecSelferC_UTF81234, string("startTime"))
+					if x.StartTime == nil {
+						r.EncodeNil()
+					} else {
+						yym748 := z.EncBinary()
+						_ = yym748
+						if false {
+						} else if z.HasExtensions() && z.EncExt(x.StartTime) {
+						} else if yym748 {
+							z.EncBinaryMarshal(x.StartTime)
+						} else if !yym748 && z.IsJSONHandle() {
+							z.EncJSONMarshal(x.StartTime)
+						} else {
+							z.EncFallback(x.StartTime)
+						}
+					}
+				}
+			}
+			if yyr742 || yy2arr742 {
+				if yyq742[2] {
+					if x.CompletionTime == nil {
 						r.EncodeNil()
 					} else {
 						yym750 := z.EncBinary()
 						_ = yym750
 						if false {
-						} else {
-							h.encSliceJobCondition(([]JobCondition)(x.Conditions), e)
-						}
-					}
-				}
-			}
-			if yyr747 || yy2arr747 {
-				if yyq747[1] {
-					if x.StartTime == nil {
-						r.EncodeNil()
-					} else {
-						yym752 := z.EncBinary()
-						_ = yym752
-						if false {
-						} else if z.HasExtensions() && z.EncExt(x.StartTime) {
-						} else if yym752 {
-							z.EncBinaryMarshal(x.StartTime)
-						} else if !yym752 && z.IsJSONHandle() {
-							z.EncJSONMarshal(x.StartTime)
-						} else {
-							z.EncFallback(x.StartTime)
-						}
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq747[1] {
-					r.EncodeString(codecSelferC_UTF81234, string("startTime"))
-					if x.StartTime == nil {
-						r.EncodeNil()
-					} else {
-						yym753 := z.EncBinary()
-						_ = yym753
-						if false {
-						} else if z.HasExtensions() && z.EncExt(x.StartTime) {
-						} else if yym753 {
-							z.EncBinaryMarshal(x.StartTime)
-						} else if !yym753 && z.IsJSONHandle() {
-							z.EncJSONMarshal(x.StartTime)
-						} else {
-							z.EncFallback(x.StartTime)
-						}
-					}
-				}
-			}
-			if yyr747 || yy2arr747 {
-				if yyq747[2] {
-					if x.CompletionTime == nil {
-						r.EncodeNil()
-					} else {
-						yym755 := z.EncBinary()
-						_ = yym755
-						if false {
 						} else if z.HasExtensions() && z.EncExt(x.CompletionTime) {
-						} else if yym755 {
+						} else if yym750 {
 							z.EncBinaryMarshal(x.CompletionTime)
-						} else if !yym755 && z.IsJSONHandle() {
+						} else if !yym750 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.CompletionTime)
 						} else {
 							z.EncFallback(x.CompletionTime)
@@ -8327,18 +8283,18 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq747[2] {
+				if yyq742[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("completionTime"))
 					if x.CompletionTime == nil {
 						r.EncodeNil()
 					} else {
-						yym756 := z.EncBinary()
-						_ = yym756
+						yym751 := z.EncBinary()
+						_ = yym751
 						if false {
 						} else if z.HasExtensions() && z.EncExt(x.CompletionTime) {
-						} else if yym756 {
+						} else if yym751 {
 							z.EncBinaryMarshal(x.CompletionTime)
-						} else if !yym756 && z.IsJSONHandle() {
+						} else if !yym751 && z.IsJSONHandle() {
 							z.EncJSONMarshal(x.CompletionTime)
 						} else {
 							z.EncFallback(x.CompletionTime)
@@ -8346,10 +8302,10 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr747 || yy2arr747 {
-				if yyq747[3] {
-					yym758 := z.EncBinary()
-					_ = yym758
+			if yyr742 || yy2arr742 {
+				if yyq742[3] {
+					yym753 := z.EncBinary()
+					_ = yym753
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Active))
@@ -8358,61 +8314,61 @@ func (x *JobStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq747[3] {
+				if yyq742[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("active"))
+					yym754 := z.EncBinary()
+					_ = yym754
+					if false {
+					} else {
+						r.EncodeInt(int64(x.Active))
+					}
+				}
+			}
+			if yyr742 || yy2arr742 {
+				if yyq742[4] {
+					yym756 := z.EncBinary()
+					_ = yym756
+					if false {
+					} else {
+						r.EncodeInt(int64(x.Succeeded))
+					}
+				} else {
+					r.EncodeInt(0)
+				}
+			} else {
+				if yyq742[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("succeeded"))
+					yym757 := z.EncBinary()
+					_ = yym757
+					if false {
+					} else {
+						r.EncodeInt(int64(x.Succeeded))
+					}
+				}
+			}
+			if yyr742 || yy2arr742 {
+				if yyq742[5] {
 					yym759 := z.EncBinary()
 					_ = yym759
 					if false {
 					} else {
-						r.EncodeInt(int64(x.Active))
-					}
-				}
-			}
-			if yyr747 || yy2arr747 {
-				if yyq747[4] {
-					yym761 := z.EncBinary()
-					_ = yym761
-					if false {
-					} else {
-						r.EncodeInt(int64(x.Succeeded))
-					}
-				} else {
-					r.EncodeInt(0)
-				}
-			} else {
-				if yyq747[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("succeeded"))
-					yym762 := z.EncBinary()
-					_ = yym762
-					if false {
-					} else {
-						r.EncodeInt(int64(x.Succeeded))
-					}
-				}
-			}
-			if yyr747 || yy2arr747 {
-				if yyq747[5] {
-					yym764 := z.EncBinary()
-					_ = yym764
-					if false {
-					} else {
 						r.EncodeInt(int64(x.Failed))
 					}
 				} else {
 					r.EncodeInt(0)
 				}
 			} else {
-				if yyq747[5] {
+				if yyq742[5] {
 					r.EncodeString(codecSelferC_UTF81234, string("failed"))
-					yym765 := z.EncBinary()
-					_ = yym765
+					yym760 := z.EncBinary()
+					_ = yym760
 					if false {
 					} else {
 						r.EncodeInt(int64(x.Failed))
 					}
 				}
 			}
-			if yysep747 {
+			if yysep742 {
 				r.EncodeEnd()
 			}
 		}
@@ -8423,24 +8379,24 @@ func (x *JobStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym766 := z.DecBinary()
-	_ = yym766
+	yym761 := z.DecBinary()
+	_ = yym761
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl767 := r.ReadMapStart()
-			if yyl767 == 0 {
+			yyl762 := r.ReadMapStart()
+			if yyl762 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl767, d)
+				x.codecDecodeSelfFromMap(yyl762, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl767 := r.ReadArrayStart()
-			if yyl767 == 0 {
+			yyl762 := r.ReadArrayStart()
+			if yyl762 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl767, d)
+				x.codecDecodeSelfFromArray(yyl762, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -8452,12 +8408,12 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys768Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys768Slc
-	var yyhl768 bool = l >= 0
-	for yyj768 := 0; ; yyj768++ {
-		if yyhl768 {
-			if yyj768 >= l {
+	var yys763Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys763Slc
+	var yyhl763 bool = l >= 0
+	for yyj763 := 0; ; yyj763++ {
+		if yyhl763 {
+			if yyj763 >= l {
 				break
 			}
 		} else {
@@ -8465,19 +8421,19 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys768Slc = r.DecodeBytes(yys768Slc, true, true)
-		yys768 := string(yys768Slc)
-		switch yys768 {
+		yys763Slc = r.DecodeBytes(yys763Slc, true, true)
+		yys763 := string(yys763Slc)
+		switch yys763 {
 		case "conditions":
 			if r.TryDecodeAsNil() {
 				x.Conditions = nil
 			} else {
-				yyv769 := &x.Conditions
-				yym770 := z.DecBinary()
-				_ = yym770
+				yyv764 := &x.Conditions
+				yym765 := z.DecBinary()
+				_ = yym765
 				if false {
 				} else {
-					h.decSliceJobCondition((*[]JobCondition)(yyv769), d)
+					h.decSliceJobCondition((*[]JobCondition)(yyv764), d)
 				}
 			}
 		case "startTime":
@@ -8489,13 +8445,13 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.StartTime == nil {
 					x.StartTime = new(pkg1_unversioned.Time)
 				}
-				yym772 := z.DecBinary()
-				_ = yym772
+				yym767 := z.DecBinary()
+				_ = yym767
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.StartTime) {
-				} else if yym772 {
+				} else if yym767 {
 					z.DecBinaryUnmarshal(x.StartTime)
-				} else if !yym772 && z.IsJSONHandle() {
+				} else if !yym767 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.StartTime)
 				} else {
 					z.DecFallback(x.StartTime, false)
@@ -8510,13 +8466,13 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				if x.CompletionTime == nil {
 					x.CompletionTime = new(pkg1_unversioned.Time)
 				}
-				yym774 := z.DecBinary()
-				_ = yym774
+				yym769 := z.DecBinary()
+				_ = yym769
 				if false {
 				} else if z.HasExtensions() && z.DecExt(x.CompletionTime) {
-				} else if yym774 {
+				} else if yym769 {
 					z.DecBinaryUnmarshal(x.CompletionTime)
-				} else if !yym774 && z.IsJSONHandle() {
+				} else if !yym769 && z.IsJSONHandle() {
 					z.DecJSONUnmarshal(x.CompletionTime)
 				} else {
 					z.DecFallback(x.CompletionTime, false)
@@ -8541,10 +8497,10 @@ func (x *JobStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Failed = int(r.DecodeInt(codecSelferBitsize1234))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys768)
-		} // end switch yys768
-	} // end for yyj768
-	if !yyhl768 {
+			z.DecStructFieldNotFound(-1, yys763)
+		} // end switch yys763
+	} // end for yyj763
+	if !yyhl763 {
 		r.ReadEnd()
 	}
 }
@@ -8553,37 +8509,37 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj778 int
-	var yyb778 bool
-	var yyhl778 bool = l >= 0
-	yyj778++
-	if yyhl778 {
-		yyb778 = yyj778 > l
+	var yyj773 int
+	var yyb773 bool
+	var yyhl773 bool = l >= 0
+	yyj773++
+	if yyhl773 {
+		yyb773 = yyj773 > l
 	} else {
-		yyb778 = r.CheckBreak()
+		yyb773 = r.CheckBreak()
 	}
-	if yyb778 {
+	if yyb773 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Conditions = nil
 	} else {
-		yyv779 := &x.Conditions
-		yym780 := z.DecBinary()
-		_ = yym780
+		yyv774 := &x.Conditions
+		yym775 := z.DecBinary()
+		_ = yym775
 		if false {
 		} else {
-			h.decSliceJobCondition((*[]JobCondition)(yyv779), d)
+			h.decSliceJobCondition((*[]JobCondition)(yyv774), d)
 		}
 	}
-	yyj778++
-	if yyhl778 {
-		yyb778 = yyj778 > l
+	yyj773++
+	if yyhl773 {
+		yyb773 = yyj773 > l
 	} else {
-		yyb778 = r.CheckBreak()
+		yyb773 = r.CheckBreak()
 	}
-	if yyb778 {
+	if yyb773 {
 		r.ReadEnd()
 		return
 	}
@@ -8595,25 +8551,25 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.StartTime == nil {
 			x.StartTime = new(pkg1_unversioned.Time)
 		}
-		yym782 := z.DecBinary()
-		_ = yym782
+		yym777 := z.DecBinary()
+		_ = yym777
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.StartTime) {
-		} else if yym782 {
+		} else if yym777 {
 			z.DecBinaryUnmarshal(x.StartTime)
-		} else if !yym782 && z.IsJSONHandle() {
+		} else if !yym777 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.StartTime)
 		} else {
 			z.DecFallback(x.StartTime, false)
 		}
 	}
-	yyj778++
-	if yyhl778 {
-		yyb778 = yyj778 > l
+	yyj773++
+	if yyhl773 {
+		yyb773 = yyj773 > l
 	} else {
-		yyb778 = r.CheckBreak()
+		yyb773 = r.CheckBreak()
 	}
-	if yyb778 {
+	if yyb773 {
 		r.ReadEnd()
 		return
 	}
@@ -8625,25 +8581,25 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if x.CompletionTime == nil {
 			x.CompletionTime = new(pkg1_unversioned.Time)
 		}
-		yym784 := z.DecBinary()
-		_ = yym784
+		yym779 := z.DecBinary()
+		_ = yym779
 		if false {
 		} else if z.HasExtensions() && z.DecExt(x.CompletionTime) {
-		} else if yym784 {
+		} else if yym779 {
 			z.DecBinaryUnmarshal(x.CompletionTime)
-		} else if !yym784 && z.IsJSONHandle() {
+		} else if !yym779 && z.IsJSONHandle() {
 			z.DecJSONUnmarshal(x.CompletionTime)
 		} else {
 			z.DecFallback(x.CompletionTime, false)
 		}
 	}
-	yyj778++
-	if yyhl778 {
-		yyb778 = yyj778 > l
+	yyj773++
+	if yyhl773 {
+		yyb773 = yyj773 > l
 	} else {
-		yyb778 = r.CheckBreak()
+		yyb773 = r.CheckBreak()
 	}
-	if yyb778 {
+	if yyb773 {
 		r.ReadEnd()
 		return
 	}
@@ -8652,13 +8608,13 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Active = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj778++
-	if yyhl778 {
-		yyb778 = yyj778 > l
+	yyj773++
+	if yyhl773 {
+		yyb773 = yyj773 > l
 	} else {
-		yyb778 = r.CheckBreak()
+		yyb773 = r.CheckBreak()
 	}
-	if yyb778 {
+	if yyb773 {
 		r.ReadEnd()
 		return
 	}
@@ -8667,13 +8623,13 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Succeeded = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj778++
-	if yyhl778 {
-		yyb778 = yyj778 > l
+	yyj773++
+	if yyhl773 {
+		yyb773 = yyj773 > l
 	} else {
-		yyb778 = r.CheckBreak()
+		yyb773 = r.CheckBreak()
 	}
-	if yyb778 {
+	if yyb773 {
 		r.ReadEnd()
 		return
 	}
@@ -8683,16 +8639,16 @@ func (x *JobStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Failed = int(r.DecodeInt(codecSelferBitsize1234))
 	}
 	for {
-		yyj778++
-		if yyhl778 {
-			yyb778 = yyj778 > l
+		yyj773++
+		if yyhl773 {
+			yyb773 = yyj773 > l
 		} else {
-			yyb778 = r.CheckBreak()
+			yyb773 = r.CheckBreak()
 		}
-		if yyb778 {
+		if yyb773 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj778-1, "")
+		z.DecStructFieldNotFound(yyj773-1, "")
 	}
 	r.ReadEnd()
 }
@@ -8701,8 +8657,8 @@ func (x JobConditionType) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym788 := z.EncBinary()
-	_ = yym788
+	yym783 := z.EncBinary()
+	_ = yym783
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -8714,8 +8670,8 @@ func (x *JobConditionType) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym789 := z.DecBinary()
-	_ = yym789
+	yym784 := z.DecBinary()
+	_ = yym784
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -8730,40 +8686,40 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym790 := z.EncBinary()
-		_ = yym790
+		yym785 := z.EncBinary()
+		_ = yym785
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep791 := !z.EncBinary()
-			yy2arr791 := z.EncBasicHandle().StructToArray
-			var yyq791 [6]bool
-			_, _, _ = yysep791, yyq791, yy2arr791
-			const yyr791 bool = false
-			yyq791[2] = true
-			yyq791[3] = true
-			yyq791[4] = x.Reason != ""
-			yyq791[5] = x.Message != ""
-			if yyr791 || yy2arr791 {
+			yysep786 := !z.EncBinary()
+			yy2arr786 := z.EncBasicHandle().StructToArray
+			var yyq786 [6]bool
+			_, _, _ = yysep786, yyq786, yy2arr786
+			const yyr786 bool = false
+			yyq786[2] = true
+			yyq786[3] = true
+			yyq786[4] = x.Reason != ""
+			yyq786[5] = x.Message != ""
+			if yyr786 || yy2arr786 {
 				r.EncodeArrayStart(6)
 			} else {
-				var yynn791 int = 2
-				for _, b := range yyq791 {
+				var yynn786 int = 2
+				for _, b := range yyq786 {
 					if b {
-						yynn791++
+						yynn786++
 					}
 				}
-				r.EncodeMapStart(yynn791)
+				r.EncodeMapStart(yynn786)
 			}
-			if yyr791 || yy2arr791 {
+			if yyr786 || yy2arr786 {
 				x.Type.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("type"))
 				x.Type.CodecEncodeSelf(e)
 			}
-			if yyr791 || yy2arr791 {
-				yym794 := z.EncBinary()
-				_ = yym794
+			if yyr786 || yy2arr786 {
+				yym789 := z.EncBinary()
+				_ = yym789
 				if false {
 				} else if z.HasExtensions() && z.EncExt(x.Status) {
 				} else {
@@ -8771,17 +8727,51 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("status"))
-				yym795 := z.EncBinary()
-				_ = yym795
+				yym790 := z.EncBinary()
+				_ = yym790
 				if false {
 				} else if z.HasExtensions() && z.EncExt(x.Status) {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Status))
 				}
 			}
-			if yyr791 || yy2arr791 {
-				if yyq791[2] {
-					yy797 := &x.LastProbeTime
+			if yyr786 || yy2arr786 {
+				if yyq786[2] {
+					yy792 := &x.LastProbeTime
+					yym793 := z.EncBinary()
+					_ = yym793
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy792) {
+					} else if yym793 {
+						z.EncBinaryMarshal(yy792)
+					} else if !yym793 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy792)
+					} else {
+						z.EncFallback(yy792)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq786[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("lastProbeTime"))
+					yy794 := &x.LastProbeTime
+					yym795 := z.EncBinary()
+					_ = yym795
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy794) {
+					} else if yym795 {
+						z.EncBinaryMarshal(yy794)
+					} else if !yym795 && z.IsJSONHandle() {
+						z.EncJSONMarshal(yy794)
+					} else {
+						z.EncFallback(yy794)
+					}
+				}
+			}
+			if yyr786 || yy2arr786 {
+				if yyq786[3] {
+					yy797 := &x.LastTransitionTime
 					yym798 := z.EncBinary()
 					_ = yym798
 					if false {
@@ -8797,9 +8787,9 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq791[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("lastProbeTime"))
-					yy799 := &x.LastProbeTime
+				if yyq786[3] {
+					r.EncodeString(codecSelferC_UTF81234, string("lastTransitionTime"))
+					yy799 := &x.LastTransitionTime
 					yym800 := z.EncBinary()
 					_ = yym800
 					if false {
@@ -8813,67 +8803,33 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr791 || yy2arr791 {
-				if yyq791[3] {
-					yy802 := &x.LastTransitionTime
+			if yyr786 || yy2arr786 {
+				if yyq786[4] {
+					yym802 := z.EncBinary()
+					_ = yym802
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
+					}
+				} else {
+					r.EncodeString(codecSelferC_UTF81234, "")
+				}
+			} else {
+				if yyq786[4] {
+					r.EncodeString(codecSelferC_UTF81234, string("reason"))
 					yym803 := z.EncBinary()
 					_ = yym803
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy802) {
-					} else if yym803 {
-						z.EncBinaryMarshal(yy802)
-					} else if !yym803 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy802)
 					} else {
-						z.EncFallback(yy802)
+						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
 					}
-				} else {
-					r.EncodeNil()
 				}
-			} else {
-				if yyq791[3] {
-					r.EncodeString(codecSelferC_UTF81234, string("lastTransitionTime"))
-					yy804 := &x.LastTransitionTime
+			}
+			if yyr786 || yy2arr786 {
+				if yyq786[5] {
 					yym805 := z.EncBinary()
 					_ = yym805
 					if false {
-					} else if z.HasExtensions() && z.EncExt(yy804) {
-					} else if yym805 {
-						z.EncBinaryMarshal(yy804)
-					} else if !yym805 && z.IsJSONHandle() {
-						z.EncJSONMarshal(yy804)
-					} else {
-						z.EncFallback(yy804)
-					}
-				}
-			}
-			if yyr791 || yy2arr791 {
-				if yyq791[4] {
-					yym807 := z.EncBinary()
-					_ = yym807
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
-					}
-				} else {
-					r.EncodeString(codecSelferC_UTF81234, "")
-				}
-			} else {
-				if yyq791[4] {
-					r.EncodeString(codecSelferC_UTF81234, string("reason"))
-					yym808 := z.EncBinary()
-					_ = yym808
-					if false {
-					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.Reason))
-					}
-				}
-			}
-			if yyr791 || yy2arr791 {
-				if yyq791[5] {
-					yym810 := z.EncBinary()
-					_ = yym810
-					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
 					}
@@ -8881,17 +8837,17 @@ func (x *JobCondition) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq791[5] {
+				if yyq786[5] {
 					r.EncodeString(codecSelferC_UTF81234, string("message"))
-					yym811 := z.EncBinary()
-					_ = yym811
+					yym806 := z.EncBinary()
+					_ = yym806
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Message))
 					}
 				}
 			}
-			if yysep791 {
+			if yysep786 {
 				r.EncodeEnd()
 			}
 		}
@@ -8902,24 +8858,24 @@ func (x *JobCondition) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym812 := z.DecBinary()
-	_ = yym812
+	yym807 := z.DecBinary()
+	_ = yym807
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl813 := r.ReadMapStart()
-			if yyl813 == 0 {
+			yyl808 := r.ReadMapStart()
+			if yyl808 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl813, d)
+				x.codecDecodeSelfFromMap(yyl808, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl813 := r.ReadArrayStart()
-			if yyl813 == 0 {
+			yyl808 := r.ReadArrayStart()
+			if yyl808 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl813, d)
+				x.codecDecodeSelfFromArray(yyl808, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -8931,12 +8887,12 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys814Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys814Slc
-	var yyhl814 bool = l >= 0
-	for yyj814 := 0; ; yyj814++ {
-		if yyhl814 {
-			if yyj814 >= l {
+	var yys809Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys809Slc
+	var yyhl809 bool = l >= 0
+	for yyj809 := 0; ; yyj809++ {
+		if yyhl809 {
+			if yyj809 >= l {
 				break
 			}
 		} else {
@@ -8944,9 +8900,9 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys814Slc = r.DecodeBytes(yys814Slc, true, true)
-		yys814 := string(yys814Slc)
-		switch yys814 {
+		yys809Slc = r.DecodeBytes(yys809Slc, true, true)
+		yys809 := string(yys809Slc)
+		switch yys809 {
 		case "type":
 			if r.TryDecodeAsNil() {
 				x.Type = ""
@@ -8963,34 +8919,34 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.LastProbeTime = pkg1_unversioned.Time{}
 			} else {
-				yyv817 := &x.LastProbeTime
-				yym818 := z.DecBinary()
-				_ = yym818
+				yyv812 := &x.LastProbeTime
+				yym813 := z.DecBinary()
+				_ = yym813
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv817) {
-				} else if yym818 {
-					z.DecBinaryUnmarshal(yyv817)
-				} else if !yym818 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv817)
+				} else if z.HasExtensions() && z.DecExt(yyv812) {
+				} else if yym813 {
+					z.DecBinaryUnmarshal(yyv812)
+				} else if !yym813 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv812)
 				} else {
-					z.DecFallback(yyv817, false)
+					z.DecFallback(yyv812, false)
 				}
 			}
 		case "lastTransitionTime":
 			if r.TryDecodeAsNil() {
 				x.LastTransitionTime = pkg1_unversioned.Time{}
 			} else {
-				yyv819 := &x.LastTransitionTime
-				yym820 := z.DecBinary()
-				_ = yym820
+				yyv814 := &x.LastTransitionTime
+				yym815 := z.DecBinary()
+				_ = yym815
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv819) {
-				} else if yym820 {
-					z.DecBinaryUnmarshal(yyv819)
-				} else if !yym820 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv819)
+				} else if z.HasExtensions() && z.DecExt(yyv814) {
+				} else if yym815 {
+					z.DecBinaryUnmarshal(yyv814)
+				} else if !yym815 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv814)
 				} else {
-					z.DecFallback(yyv819, false)
+					z.DecFallback(yyv814, false)
 				}
 			}
 		case "reason":
@@ -9006,10 +8962,10 @@ func (x *JobCondition) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Message = string(r.DecodeString())
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys814)
-		} // end switch yys814
-	} // end for yyj814
-	if !yyhl814 {
+			z.DecStructFieldNotFound(-1, yys809)
+		} // end switch yys809
+	} // end for yyj809
+	if !yyhl809 {
 		r.ReadEnd()
 	}
 }
@@ -9018,16 +8974,16 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj823 int
-	var yyb823 bool
-	var yyhl823 bool = l >= 0
-	yyj823++
-	if yyhl823 {
-		yyb823 = yyj823 > l
+	var yyj818 int
+	var yyb818 bool
+	var yyhl818 bool = l >= 0
+	yyj818++
+	if yyhl818 {
+		yyb818 = yyj818 > l
 	} else {
-		yyb823 = r.CheckBreak()
+		yyb818 = r.CheckBreak()
 	}
-	if yyb823 {
+	if yyb818 {
 		r.ReadEnd()
 		return
 	}
@@ -9036,13 +8992,13 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Type = JobConditionType(r.DecodeString())
 	}
-	yyj823++
-	if yyhl823 {
-		yyb823 = yyj823 > l
+	yyj818++
+	if yyhl818 {
+		yyb818 = yyj818 > l
 	} else {
-		yyb823 = r.CheckBreak()
+		yyb818 = r.CheckBreak()
 	}
-	if yyb823 {
+	if yyb818 {
 		r.ReadEnd()
 		return
 	}
@@ -9051,65 +9007,65 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Status = pkg2_v1.ConditionStatus(r.DecodeString())
 	}
-	yyj823++
-	if yyhl823 {
-		yyb823 = yyj823 > l
+	yyj818++
+	if yyhl818 {
+		yyb818 = yyj818 > l
 	} else {
-		yyb823 = r.CheckBreak()
+		yyb818 = r.CheckBreak()
 	}
-	if yyb823 {
+	if yyb818 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.LastProbeTime = pkg1_unversioned.Time{}
 	} else {
-		yyv826 := &x.LastProbeTime
-		yym827 := z.DecBinary()
-		_ = yym827
+		yyv821 := &x.LastProbeTime
+		yym822 := z.DecBinary()
+		_ = yym822
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv826) {
-		} else if yym827 {
-			z.DecBinaryUnmarshal(yyv826)
-		} else if !yym827 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv826)
+		} else if z.HasExtensions() && z.DecExt(yyv821) {
+		} else if yym822 {
+			z.DecBinaryUnmarshal(yyv821)
+		} else if !yym822 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv821)
 		} else {
-			z.DecFallback(yyv826, false)
+			z.DecFallback(yyv821, false)
 		}
 	}
-	yyj823++
-	if yyhl823 {
-		yyb823 = yyj823 > l
+	yyj818++
+	if yyhl818 {
+		yyb818 = yyj818 > l
 	} else {
-		yyb823 = r.CheckBreak()
+		yyb818 = r.CheckBreak()
 	}
-	if yyb823 {
+	if yyb818 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.LastTransitionTime = pkg1_unversioned.Time{}
 	} else {
-		yyv828 := &x.LastTransitionTime
-		yym829 := z.DecBinary()
-		_ = yym829
+		yyv823 := &x.LastTransitionTime
+		yym824 := z.DecBinary()
+		_ = yym824
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv828) {
-		} else if yym829 {
-			z.DecBinaryUnmarshal(yyv828)
-		} else if !yym829 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv828)
+		} else if z.HasExtensions() && z.DecExt(yyv823) {
+		} else if yym824 {
+			z.DecBinaryUnmarshal(yyv823)
+		} else if !yym824 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv823)
 		} else {
-			z.DecFallback(yyv828, false)
+			z.DecFallback(yyv823, false)
 		}
 	}
-	yyj823++
-	if yyhl823 {
-		yyb823 = yyj823 > l
+	yyj818++
+	if yyhl818 {
+		yyb818 = yyj818 > l
 	} else {
-		yyb823 = r.CheckBreak()
+		yyb818 = r.CheckBreak()
 	}
-	if yyb823 {
+	if yyb818 {
 		r.ReadEnd()
 		return
 	}
@@ -9118,13 +9074,13 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Reason = string(r.DecodeString())
 	}
-	yyj823++
-	if yyhl823 {
-		yyb823 = yyj823 > l
+	yyj818++
+	if yyhl818 {
+		yyb818 = yyj818 > l
 	} else {
-		yyb823 = r.CheckBreak()
+		yyb818 = r.CheckBreak()
 	}
-	if yyb823 {
+	if yyb818 {
 		r.ReadEnd()
 		return
 	}
@@ -9134,16 +9090,16 @@ func (x *JobCondition) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.Message = string(r.DecodeString())
 	}
 	for {
-		yyj823++
-		if yyhl823 {
-			yyb823 = yyj823 > l
+		yyj818++
+		if yyhl818 {
+			yyb818 = yyj818 > l
 		} else {
-			yyb823 = r.CheckBreak()
+			yyb818 = r.CheckBreak()
 		}
-		if yyb823 {
+		if yyb818 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj823-1, "")
+		z.DecStructFieldNotFound(yyj818-1, "")
 	}
 	r.ReadEnd()
 }
@@ -9155,36 +9111,36 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym832 := z.EncBinary()
-		_ = yym832
+		yym827 := z.EncBinary()
+		_ = yym827
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep833 := !z.EncBinary()
-			yy2arr833 := z.EncBasicHandle().StructToArray
-			var yyq833 [5]bool
-			_, _, _ = yysep833, yyq833, yy2arr833
-			const yyr833 bool = false
-			yyq833[0] = x.Kind != ""
-			yyq833[1] = x.APIVersion != ""
-			yyq833[2] = true
-			yyq833[3] = true
-			yyq833[4] = true
-			if yyr833 || yy2arr833 {
+			yysep828 := !z.EncBinary()
+			yy2arr828 := z.EncBasicHandle().StructToArray
+			var yyq828 [5]bool
+			_, _, _ = yysep828, yyq828, yy2arr828
+			const yyr828 bool = false
+			yyq828[0] = x.Kind != ""
+			yyq828[1] = x.APIVersion != ""
+			yyq828[2] = true
+			yyq828[3] = true
+			yyq828[4] = true
+			if yyr828 || yy2arr828 {
 				r.EncodeArrayStart(5)
 			} else {
-				var yynn833 int = 0
-				for _, b := range yyq833 {
+				var yynn828 int = 0
+				for _, b := range yyq828 {
 					if b {
-						yynn833++
+						yynn828++
 					}
 				}
-				r.EncodeMapStart(yynn833)
+				r.EncodeMapStart(yynn828)
 			}
-			if yyr833 || yy2arr833 {
-				if yyq833[0] {
-					yym835 := z.EncBinary()
-					_ = yym835
+			if yyr828 || yy2arr828 {
+				if yyq828[0] {
+					yym830 := z.EncBinary()
+					_ = yym830
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -9193,20 +9149,20 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq833[0] {
+				if yyq828[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym836 := z.EncBinary()
-					_ = yym836
+					yym831 := z.EncBinary()
+					_ = yym831
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr833 || yy2arr833 {
-				if yyq833[1] {
-					yym838 := z.EncBinary()
-					_ = yym838
+			if yyr828 || yy2arr828 {
+				if yyq828[1] {
+					yym833 := z.EncBinary()
+					_ = yym833
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -9215,59 +9171,59 @@ func (x *Ingress) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq833[1] {
+				if yyq828[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym839 := z.EncBinary()
-					_ = yym839
+					yym834 := z.EncBinary()
+					_ = yym834
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr833 || yy2arr833 {
-				if yyq833[2] {
-					yy841 := &x.ObjectMeta
-					yy841.CodecEncodeSelf(e)
+			if yyr828 || yy2arr828 {
+				if yyq828[2] {
+					yy836 := &x.ObjectMeta
+					yy836.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq833[2] {
+				if yyq828[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy842 := &x.ObjectMeta
-					yy842.CodecEncodeSelf(e)
+					yy837 := &x.ObjectMeta
+					yy837.CodecEncodeSelf(e)
 				}
 			}
-			if yyr833 || yy2arr833 {
-				if yyq833[3] {
-					yy844 := &x.Spec
-					yy844.CodecEncodeSelf(e)
+			if yyr828 || yy2arr828 {
+				if yyq828[3] {
+					yy839 := &x.Spec
+					yy839.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq833[3] {
+				if yyq828[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy845 := &x.Spec
-					yy845.CodecEncodeSelf(e)
+					yy840 := &x.Spec
+					yy840.CodecEncodeSelf(e)
 				}
 			}
-			if yyr833 || yy2arr833 {
-				if yyq833[4] {
-					yy847 := &x.Status
-					yy847.CodecEncodeSelf(e)
+			if yyr828 || yy2arr828 {
+				if yyq828[4] {
+					yy842 := &x.Status
+					yy842.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq833[4] {
+				if yyq828[4] {
 					r.EncodeString(codecSelferC_UTF81234, string("status"))
-					yy848 := &x.Status
-					yy848.CodecEncodeSelf(e)
+					yy843 := &x.Status
+					yy843.CodecEncodeSelf(e)
 				}
 			}
-			if yysep833 {
+			if yysep828 {
 				r.EncodeEnd()
 			}
 		}
@@ -9278,24 +9234,24 @@ func (x *Ingress) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym849 := z.DecBinary()
-	_ = yym849
+	yym844 := z.DecBinary()
+	_ = yym844
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl850 := r.ReadMapStart()
-			if yyl850 == 0 {
+			yyl845 := r.ReadMapStart()
+			if yyl845 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl850, d)
+				x.codecDecodeSelfFromMap(yyl845, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl850 := r.ReadArrayStart()
-			if yyl850 == 0 {
+			yyl845 := r.ReadArrayStart()
+			if yyl845 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl850, d)
+				x.codecDecodeSelfFromArray(yyl845, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -9307,12 +9263,12 @@ func (x *Ingress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys851Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys851Slc
-	var yyhl851 bool = l >= 0
-	for yyj851 := 0; ; yyj851++ {
-		if yyhl851 {
-			if yyj851 >= l {
+	var yys846Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys846Slc
+	var yyhl846 bool = l >= 0
+	for yyj846 := 0; ; yyj846++ {
+		if yyhl846 {
+			if yyj846 >= l {
 				break
 			}
 		} else {
@@ -9320,9 +9276,9 @@ func (x *Ingress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys851Slc = r.DecodeBytes(yys851Slc, true, true)
-		yys851 := string(yys851Slc)
-		switch yys851 {
+		yys846Slc = r.DecodeBytes(yys846Slc, true, true)
+		yys846 := string(yys846Slc)
+		switch yys846 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -9339,28 +9295,28 @@ func (x *Ingress) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_v1.ObjectMeta{}
 			} else {
-				yyv854 := &x.ObjectMeta
-				yyv854.CodecDecodeSelf(d)
+				yyv849 := &x.ObjectMeta
+				yyv849.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = IngressSpec{}
 			} else {
-				yyv855 := &x.Spec
-				yyv855.CodecDecodeSelf(d)
+				yyv850 := &x.Spec
+				yyv850.CodecDecodeSelf(d)
 			}
 		case "status":
 			if r.TryDecodeAsNil() {
 				x.Status = IngressStatus{}
 			} else {
-				yyv856 := &x.Status
-				yyv856.CodecDecodeSelf(d)
+				yyv851 := &x.Status
+				yyv851.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys851)
-		} // end switch yys851
-	} // end for yyj851
-	if !yyhl851 {
+			z.DecStructFieldNotFound(-1, yys846)
+		} // end switch yys846
+	} // end for yyj846
+	if !yyhl846 {
 		r.ReadEnd()
 	}
 }
@@ -9369,16 +9325,16 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj857 int
-	var yyb857 bool
-	var yyhl857 bool = l >= 0
-	yyj857++
-	if yyhl857 {
-		yyb857 = yyj857 > l
+	var yyj852 int
+	var yyb852 bool
+	var yyhl852 bool = l >= 0
+	yyj852++
+	if yyhl852 {
+		yyb852 = yyj852 > l
 	} else {
-		yyb857 = r.CheckBreak()
+		yyb852 = r.CheckBreak()
 	}
-	if yyb857 {
+	if yyb852 {
 		r.ReadEnd()
 		return
 	}
@@ -9387,13 +9343,13 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj857++
-	if yyhl857 {
-		yyb857 = yyj857 > l
+	yyj852++
+	if yyhl852 {
+		yyb852 = yyj852 > l
 	} else {
-		yyb857 = r.CheckBreak()
+		yyb852 = r.CheckBreak()
 	}
-	if yyb857 {
+	if yyb852 {
 		r.ReadEnd()
 		return
 	}
@@ -9402,65 +9358,65 @@ func (x *Ingress) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj857++
-	if yyhl857 {
-		yyb857 = yyj857 > l
+	yyj852++
+	if yyhl852 {
+		yyb852 = yyj852 > l
 	} else {
-		yyb857 = r.CheckBreak()
+		yyb852 = r.CheckBreak()
 	}
-	if yyb857 {
+	if yyb852 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_v1.ObjectMeta{}
 	} else {
-		yyv860 := &x.ObjectMeta
-		yyv860.CodecDecodeSelf(d)
+		yyv855 := &x.ObjectMeta
+		yyv855.CodecDecodeSelf(d)
 	}
-	yyj857++
-	if yyhl857 {
-		yyb857 = yyj857 > l
+	yyj852++
+	if yyhl852 {
+		yyb852 = yyj852 > l
 	} else {
-		yyb857 = r.CheckBreak()
+		yyb852 = r.CheckBreak()
 	}
-	if yyb857 {
+	if yyb852 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = IngressSpec{}
 	} else {
-		yyv861 := &x.Spec
-		yyv861.CodecDecodeSelf(d)
+		yyv856 := &x.Spec
+		yyv856.CodecDecodeSelf(d)
 	}
-	yyj857++
-	if yyhl857 {
-		yyb857 = yyj857 > l
+	yyj852++
+	if yyhl852 {
+		yyb852 = yyj852 > l
 	} else {
-		yyb857 = r.CheckBreak()
+		yyb852 = r.CheckBreak()
 	}
-	if yyb857 {
+	if yyb852 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Status = IngressStatus{}
 	} else {
-		yyv862 := &x.Status
-		yyv862.CodecDecodeSelf(d)
+		yyv857 := &x.Status
+		yyv857.CodecDecodeSelf(d)
 	}
 	for {
-		yyj857++
-		if yyhl857 {
-			yyb857 = yyj857 > l
+		yyj852++
+		if yyhl852 {
+			yyb852 = yyj852 > l
 		} else {
-			yyb857 = r.CheckBreak()
+			yyb852 = r.CheckBreak()
 		}
-		if yyb857 {
+		if yyb852 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj857-1, "")
+		z.DecStructFieldNotFound(yyj852-1, "")
 	}
 	r.ReadEnd()
 }
@@ -9472,34 +9428,34 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym863 := z.EncBinary()
-		_ = yym863
+		yym858 := z.EncBinary()
+		_ = yym858
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep864 := !z.EncBinary()
-			yy2arr864 := z.EncBasicHandle().StructToArray
-			var yyq864 [4]bool
-			_, _, _ = yysep864, yyq864, yy2arr864
-			const yyr864 bool = false
-			yyq864[0] = x.Kind != ""
-			yyq864[1] = x.APIVersion != ""
-			yyq864[2] = true
-			if yyr864 || yy2arr864 {
+			yysep859 := !z.EncBinary()
+			yy2arr859 := z.EncBasicHandle().StructToArray
+			var yyq859 [4]bool
+			_, _, _ = yysep859, yyq859, yy2arr859
+			const yyr859 bool = false
+			yyq859[0] = x.Kind != ""
+			yyq859[1] = x.APIVersion != ""
+			yyq859[2] = true
+			if yyr859 || yy2arr859 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn864 int = 1
-				for _, b := range yyq864 {
+				var yynn859 int = 1
+				for _, b := range yyq859 {
 					if b {
-						yynn864++
+						yynn859++
 					}
 				}
-				r.EncodeMapStart(yynn864)
+				r.EncodeMapStart(yynn859)
 			}
-			if yyr864 || yy2arr864 {
-				if yyq864[0] {
-					yym866 := z.EncBinary()
-					_ = yym866
+			if yyr859 || yy2arr859 {
+				if yyq859[0] {
+					yym861 := z.EncBinary()
+					_ = yym861
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -9508,20 +9464,20 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq864[0] {
+				if yyq859[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym867 := z.EncBinary()
-					_ = yym867
+					yym862 := z.EncBinary()
+					_ = yym862
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr864 || yy2arr864 {
-				if yyq864[1] {
-					yym869 := z.EncBinary()
-					_ = yym869
+			if yyr859 || yy2arr859 {
+				if yyq859[1] {
+					yym864 := z.EncBinary()
+					_ = yym864
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -9530,48 +9486,48 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq864[1] {
+				if yyq859[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym865 := z.EncBinary()
+					_ = yym865
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr859 || yy2arr859 {
+				if yyq859[2] {
+					yy867 := &x.ListMeta
+					yym868 := z.EncBinary()
+					_ = yym868
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy867) {
+					} else {
+						z.EncFallback(yy867)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq859[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy869 := &x.ListMeta
 					yym870 := z.EncBinary()
 					_ = yym870
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy869) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						z.EncFallback(yy869)
 					}
 				}
 			}
-			if yyr864 || yy2arr864 {
-				if yyq864[2] {
-					yy872 := &x.ListMeta
-					yym873 := z.EncBinary()
-					_ = yym873
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy872) {
-					} else {
-						z.EncFallback(yy872)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq864[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy874 := &x.ListMeta
-					yym875 := z.EncBinary()
-					_ = yym875
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy874) {
-					} else {
-						z.EncFallback(yy874)
-					}
-				}
-			}
-			if yyr864 || yy2arr864 {
+			if yyr859 || yy2arr859 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym877 := z.EncBinary()
-					_ = yym877
+					yym872 := z.EncBinary()
+					_ = yym872
 					if false {
 					} else {
 						h.encSliceIngress(([]Ingress)(x.Items), e)
@@ -9582,15 +9538,15 @@ func (x *IngressList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym878 := z.EncBinary()
-					_ = yym878
+					yym873 := z.EncBinary()
+					_ = yym873
 					if false {
 					} else {
 						h.encSliceIngress(([]Ingress)(x.Items), e)
 					}
 				}
 			}
-			if yysep864 {
+			if yysep859 {
 				r.EncodeEnd()
 			}
 		}
@@ -9601,24 +9557,24 @@ func (x *IngressList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym879 := z.DecBinary()
-	_ = yym879
+	yym874 := z.DecBinary()
+	_ = yym874
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl880 := r.ReadMapStart()
-			if yyl880 == 0 {
+			yyl875 := r.ReadMapStart()
+			if yyl875 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl880, d)
+				x.codecDecodeSelfFromMap(yyl875, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl880 := r.ReadArrayStart()
-			if yyl880 == 0 {
+			yyl875 := r.ReadArrayStart()
+			if yyl875 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl880, d)
+				x.codecDecodeSelfFromArray(yyl875, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -9630,12 +9586,12 @@ func (x *IngressList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys881Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys881Slc
-	var yyhl881 bool = l >= 0
-	for yyj881 := 0; ; yyj881++ {
-		if yyhl881 {
-			if yyj881 >= l {
+	var yys876Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys876Slc
+	var yyhl876 bool = l >= 0
+	for yyj876 := 0; ; yyj876++ {
+		if yyhl876 {
+			if yyj876 >= l {
 				break
 			}
 		} else {
@@ -9643,9 +9599,9 @@ func (x *IngressList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys881Slc = r.DecodeBytes(yys881Slc, true, true)
-		yys881 := string(yys881Slc)
-		switch yys881 {
+		yys876Slc = r.DecodeBytes(yys876Slc, true, true)
+		yys876 := string(yys876Slc)
+		switch yys876 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -9662,32 +9618,32 @@ func (x *IngressList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv884 := &x.ListMeta
-				yym885 := z.DecBinary()
-				_ = yym885
+				yyv879 := &x.ListMeta
+				yym880 := z.DecBinary()
+				_ = yym880
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv884) {
+				} else if z.HasExtensions() && z.DecExt(yyv879) {
 				} else {
-					z.DecFallback(yyv884, false)
+					z.DecFallback(yyv879, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv886 := &x.Items
-				yym887 := z.DecBinary()
-				_ = yym887
+				yyv881 := &x.Items
+				yym882 := z.DecBinary()
+				_ = yym882
 				if false {
 				} else {
-					h.decSliceIngress((*[]Ingress)(yyv886), d)
+					h.decSliceIngress((*[]Ingress)(yyv881), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys881)
-		} // end switch yys881
-	} // end for yyj881
-	if !yyhl881 {
+			z.DecStructFieldNotFound(-1, yys876)
+		} // end switch yys876
+	} // end for yyj876
+	if !yyhl876 {
 		r.ReadEnd()
 	}
 }
@@ -9696,16 +9652,16 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj888 int
-	var yyb888 bool
-	var yyhl888 bool = l >= 0
-	yyj888++
-	if yyhl888 {
-		yyb888 = yyj888 > l
+	var yyj883 int
+	var yyb883 bool
+	var yyhl883 bool = l >= 0
+	yyj883++
+	if yyhl883 {
+		yyb883 = yyj883 > l
 	} else {
-		yyb888 = r.CheckBreak()
+		yyb883 = r.CheckBreak()
 	}
-	if yyb888 {
+	if yyb883 {
 		r.ReadEnd()
 		return
 	}
@@ -9714,13 +9670,13 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj888++
-	if yyhl888 {
-		yyb888 = yyj888 > l
+	yyj883++
+	if yyhl883 {
+		yyb883 = yyj883 > l
 	} else {
-		yyb888 = r.CheckBreak()
+		yyb883 = r.CheckBreak()
 	}
-	if yyb888 {
+	if yyb883 {
 		r.ReadEnd()
 		return
 	}
@@ -9729,60 +9685,60 @@ func (x *IngressList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj888++
-	if yyhl888 {
-		yyb888 = yyj888 > l
+	yyj883++
+	if yyhl883 {
+		yyb883 = yyj883 > l
 	} else {
-		yyb888 = r.CheckBreak()
+		yyb883 = r.CheckBreak()
 	}
-	if yyb888 {
+	if yyb883 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv891 := &x.ListMeta
-		yym892 := z.DecBinary()
-		_ = yym892
+		yyv886 := &x.ListMeta
+		yym887 := z.DecBinary()
+		_ = yym887
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv891) {
+		} else if z.HasExtensions() && z.DecExt(yyv886) {
 		} else {
-			z.DecFallback(yyv891, false)
+			z.DecFallback(yyv886, false)
 		}
 	}
-	yyj888++
-	if yyhl888 {
-		yyb888 = yyj888 > l
+	yyj883++
+	if yyhl883 {
+		yyb883 = yyj883 > l
 	} else {
-		yyb888 = r.CheckBreak()
+		yyb883 = r.CheckBreak()
 	}
-	if yyb888 {
+	if yyb883 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv893 := &x.Items
-		yym894 := z.DecBinary()
-		_ = yym894
+		yyv888 := &x.Items
+		yym889 := z.DecBinary()
+		_ = yym889
 		if false {
 		} else {
-			h.decSliceIngress((*[]Ingress)(yyv893), d)
+			h.decSliceIngress((*[]Ingress)(yyv888), d)
 		}
 	}
 	for {
-		yyj888++
-		if yyhl888 {
-			yyb888 = yyj888 > l
+		yyj883++
+		if yyhl883 {
+			yyb883 = yyj883 > l
 		} else {
-			yyb888 = r.CheckBreak()
+			yyb883 = r.CheckBreak()
 		}
-		if yyb888 {
+		if yyb883 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj888-1, "")
+		z.DecStructFieldNotFound(yyj883-1, "")
 	}
 	r.ReadEnd()
 }
@@ -9794,31 +9750,31 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym895 := z.EncBinary()
-		_ = yym895
+		yym890 := z.EncBinary()
+		_ = yym890
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep896 := !z.EncBinary()
-			yy2arr896 := z.EncBasicHandle().StructToArray
-			var yyq896 [2]bool
-			_, _, _ = yysep896, yyq896, yy2arr896
-			const yyr896 bool = false
-			yyq896[0] = x.Backend != nil
-			yyq896[1] = len(x.Rules) != 0
-			if yyr896 || yy2arr896 {
+			yysep891 := !z.EncBinary()
+			yy2arr891 := z.EncBasicHandle().StructToArray
+			var yyq891 [2]bool
+			_, _, _ = yysep891, yyq891, yy2arr891
+			const yyr891 bool = false
+			yyq891[0] = x.Backend != nil
+			yyq891[1] = len(x.Rules) != 0
+			if yyr891 || yy2arr891 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn896 int = 0
-				for _, b := range yyq896 {
+				var yynn891 int = 0
+				for _, b := range yyq891 {
 					if b {
-						yynn896++
+						yynn891++
 					}
 				}
-				r.EncodeMapStart(yynn896)
+				r.EncodeMapStart(yynn891)
 			}
-			if yyr896 || yy2arr896 {
-				if yyq896[0] {
+			if yyr891 || yy2arr891 {
+				if yyq891[0] {
 					if x.Backend == nil {
 						r.EncodeNil()
 					} else {
@@ -9828,7 +9784,7 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq896[0] {
+				if yyq891[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("backend"))
 					if x.Backend == nil {
 						r.EncodeNil()
@@ -9837,13 +9793,13 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr896 || yy2arr896 {
-				if yyq896[1] {
+			if yyr891 || yy2arr891 {
+				if yyq891[1] {
 					if x.Rules == nil {
 						r.EncodeNil()
 					} else {
-						yym899 := z.EncBinary()
-						_ = yym899
+						yym894 := z.EncBinary()
+						_ = yym894
 						if false {
 						} else {
 							h.encSliceIngressRule(([]IngressRule)(x.Rules), e)
@@ -9853,13 +9809,13 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq896[1] {
+				if yyq891[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("rules"))
 					if x.Rules == nil {
 						r.EncodeNil()
 					} else {
-						yym900 := z.EncBinary()
-						_ = yym900
+						yym895 := z.EncBinary()
+						_ = yym895
 						if false {
 						} else {
 							h.encSliceIngressRule(([]IngressRule)(x.Rules), e)
@@ -9867,7 +9823,7 @@ func (x *IngressSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep896 {
+			if yysep891 {
 				r.EncodeEnd()
 			}
 		}
@@ -9878,24 +9834,24 @@ func (x *IngressSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym901 := z.DecBinary()
-	_ = yym901
+	yym896 := z.DecBinary()
+	_ = yym896
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl902 := r.ReadMapStart()
-			if yyl902 == 0 {
+			yyl897 := r.ReadMapStart()
+			if yyl897 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl902, d)
+				x.codecDecodeSelfFromMap(yyl897, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl902 := r.ReadArrayStart()
-			if yyl902 == 0 {
+			yyl897 := r.ReadArrayStart()
+			if yyl897 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl902, d)
+				x.codecDecodeSelfFromArray(yyl897, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -9907,12 +9863,12 @@ func (x *IngressSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys903Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys903Slc
-	var yyhl903 bool = l >= 0
-	for yyj903 := 0; ; yyj903++ {
-		if yyhl903 {
-			if yyj903 >= l {
+	var yys898Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys898Slc
+	var yyhl898 bool = l >= 0
+	for yyj898 := 0; ; yyj898++ {
+		if yyhl898 {
+			if yyj898 >= l {
 				break
 			}
 		} else {
@@ -9920,9 +9876,9 @@ func (x *IngressSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys903Slc = r.DecodeBytes(yys903Slc, true, true)
-		yys903 := string(yys903Slc)
-		switch yys903 {
+		yys898Slc = r.DecodeBytes(yys898Slc, true, true)
+		yys898 := string(yys898Slc)
+		switch yys898 {
 		case "backend":
 			if r.TryDecodeAsNil() {
 				if x.Backend != nil {
@@ -9938,19 +9894,19 @@ func (x *IngressSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Rules = nil
 			} else {
-				yyv905 := &x.Rules
-				yym906 := z.DecBinary()
-				_ = yym906
+				yyv900 := &x.Rules
+				yym901 := z.DecBinary()
+				_ = yym901
 				if false {
 				} else {
-					h.decSliceIngressRule((*[]IngressRule)(yyv905), d)
+					h.decSliceIngressRule((*[]IngressRule)(yyv900), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys903)
-		} // end switch yys903
-	} // end for yyj903
-	if !yyhl903 {
+			z.DecStructFieldNotFound(-1, yys898)
+		} // end switch yys898
+	} // end for yyj898
+	if !yyhl898 {
 		r.ReadEnd()
 	}
 }
@@ -9959,16 +9915,16 @@ func (x *IngressSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj907 int
-	var yyb907 bool
-	var yyhl907 bool = l >= 0
-	yyj907++
-	if yyhl907 {
-		yyb907 = yyj907 > l
+	var yyj902 int
+	var yyb902 bool
+	var yyhl902 bool = l >= 0
+	yyj902++
+	if yyhl902 {
+		yyb902 = yyj902 > l
 	} else {
-		yyb907 = r.CheckBreak()
+		yyb902 = r.CheckBreak()
 	}
-	if yyb907 {
+	if yyb902 {
 		r.ReadEnd()
 		return
 	}
@@ -9982,38 +9938,38 @@ func (x *IngressSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		}
 		x.Backend.CodecDecodeSelf(d)
 	}
-	yyj907++
-	if yyhl907 {
-		yyb907 = yyj907 > l
+	yyj902++
+	if yyhl902 {
+		yyb902 = yyj902 > l
 	} else {
-		yyb907 = r.CheckBreak()
+		yyb902 = r.CheckBreak()
 	}
-	if yyb907 {
+	if yyb902 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Rules = nil
 	} else {
-		yyv909 := &x.Rules
-		yym910 := z.DecBinary()
-		_ = yym910
+		yyv904 := &x.Rules
+		yym905 := z.DecBinary()
+		_ = yym905
 		if false {
 		} else {
-			h.decSliceIngressRule((*[]IngressRule)(yyv909), d)
+			h.decSliceIngressRule((*[]IngressRule)(yyv904), d)
 		}
 	}
 	for {
-		yyj907++
-		if yyhl907 {
-			yyb907 = yyj907 > l
+		yyj902++
+		if yyhl902 {
+			yyb902 = yyj902 > l
 		} else {
-			yyb907 = r.CheckBreak()
+			yyb902 = r.CheckBreak()
 		}
-		if yyb907 {
+		if yyb902 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj907-1, "")
+		z.DecStructFieldNotFound(yyj902-1, "")
 	}
 	r.ReadEnd()
 }
@@ -10025,43 +9981,43 @@ func (x *IngressStatus) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym911 := z.EncBinary()
-		_ = yym911
+		yym906 := z.EncBinary()
+		_ = yym906
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep912 := !z.EncBinary()
-			yy2arr912 := z.EncBasicHandle().StructToArray
-			var yyq912 [1]bool
-			_, _, _ = yysep912, yyq912, yy2arr912
-			const yyr912 bool = false
-			yyq912[0] = true
-			if yyr912 || yy2arr912 {
+			yysep907 := !z.EncBinary()
+			yy2arr907 := z.EncBasicHandle().StructToArray
+			var yyq907 [1]bool
+			_, _, _ = yysep907, yyq907, yy2arr907
+			const yyr907 bool = false
+			yyq907[0] = true
+			if yyr907 || yy2arr907 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn912 int = 0
-				for _, b := range yyq912 {
+				var yynn907 int = 0
+				for _, b := range yyq907 {
 					if b {
-						yynn912++
+						yynn907++
 					}
 				}
-				r.EncodeMapStart(yynn912)
+				r.EncodeMapStart(yynn907)
 			}
-			if yyr912 || yy2arr912 {
-				if yyq912[0] {
-					yy914 := &x.LoadBalancer
-					yy914.CodecEncodeSelf(e)
+			if yyr907 || yy2arr907 {
+				if yyq907[0] {
+					yy909 := &x.LoadBalancer
+					yy909.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq912[0] {
+				if yyq907[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("loadBalancer"))
-					yy915 := &x.LoadBalancer
-					yy915.CodecEncodeSelf(e)
+					yy910 := &x.LoadBalancer
+					yy910.CodecEncodeSelf(e)
 				}
 			}
-			if yysep912 {
+			if yysep907 {
 				r.EncodeEnd()
 			}
 		}
@@ -10072,24 +10028,24 @@ func (x *IngressStatus) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym916 := z.DecBinary()
-	_ = yym916
+	yym911 := z.DecBinary()
+	_ = yym911
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl917 := r.ReadMapStart()
-			if yyl917 == 0 {
+			yyl912 := r.ReadMapStart()
+			if yyl912 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl917, d)
+				x.codecDecodeSelfFromMap(yyl912, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl917 := r.ReadArrayStart()
-			if yyl917 == 0 {
+			yyl912 := r.ReadArrayStart()
+			if yyl912 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl917, d)
+				x.codecDecodeSelfFromArray(yyl912, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10101,12 +10057,12 @@ func (x *IngressStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys918Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys918Slc
-	var yyhl918 bool = l >= 0
-	for yyj918 := 0; ; yyj918++ {
-		if yyhl918 {
-			if yyj918 >= l {
+	var yys913Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys913Slc
+	var yyhl913 bool = l >= 0
+	for yyj913 := 0; ; yyj913++ {
+		if yyhl913 {
+			if yyj913 >= l {
 				break
 			}
 		} else {
@@ -10114,21 +10070,21 @@ func (x *IngressStatus) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys918Slc = r.DecodeBytes(yys918Slc, true, true)
-		yys918 := string(yys918Slc)
-		switch yys918 {
+		yys913Slc = r.DecodeBytes(yys913Slc, true, true)
+		yys913 := string(yys913Slc)
+		switch yys913 {
 		case "loadBalancer":
 			if r.TryDecodeAsNil() {
 				x.LoadBalancer = pkg2_v1.LoadBalancerStatus{}
 			} else {
-				yyv919 := &x.LoadBalancer
-				yyv919.CodecDecodeSelf(d)
+				yyv914 := &x.LoadBalancer
+				yyv914.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys918)
-		} // end switch yys918
-	} // end for yyj918
-	if !yyhl918 {
+			z.DecStructFieldNotFound(-1, yys913)
+		} // end switch yys913
+	} // end for yyj913
+	if !yyhl913 {
 		r.ReadEnd()
 	}
 }
@@ -10137,36 +10093,36 @@ func (x *IngressStatus) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj920 int
-	var yyb920 bool
-	var yyhl920 bool = l >= 0
-	yyj920++
-	if yyhl920 {
-		yyb920 = yyj920 > l
+	var yyj915 int
+	var yyb915 bool
+	var yyhl915 bool = l >= 0
+	yyj915++
+	if yyhl915 {
+		yyb915 = yyj915 > l
 	} else {
-		yyb920 = r.CheckBreak()
+		yyb915 = r.CheckBreak()
 	}
-	if yyb920 {
+	if yyb915 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.LoadBalancer = pkg2_v1.LoadBalancerStatus{}
 	} else {
-		yyv921 := &x.LoadBalancer
-		yyv921.CodecDecodeSelf(d)
+		yyv916 := &x.LoadBalancer
+		yyv916.CodecDecodeSelf(d)
 	}
 	for {
-		yyj920++
-		if yyhl920 {
-			yyb920 = yyj920 > l
+		yyj915++
+		if yyhl915 {
+			yyb915 = yyj915 > l
 		} else {
-			yyb920 = r.CheckBreak()
+			yyb915 = r.CheckBreak()
 		}
-		if yyb920 {
+		if yyb915 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj920-1, "")
+		z.DecStructFieldNotFound(yyj915-1, "")
 	}
 	r.ReadEnd()
 }
@@ -10178,33 +10134,33 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym922 := z.EncBinary()
-		_ = yym922
+		yym917 := z.EncBinary()
+		_ = yym917
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep923 := !z.EncBinary()
-			yy2arr923 := z.EncBasicHandle().StructToArray
-			var yyq923 [2]bool
-			_, _, _ = yysep923, yyq923, yy2arr923
-			const yyr923 bool = false
-			yyq923[0] = x.Host != ""
-			yyq923[1] = x.IngressRuleValue.HTTP != nil && x.HTTP != nil
-			if yyr923 || yy2arr923 {
+			yysep918 := !z.EncBinary()
+			yy2arr918 := z.EncBasicHandle().StructToArray
+			var yyq918 [2]bool
+			_, _, _ = yysep918, yyq918, yy2arr918
+			const yyr918 bool = false
+			yyq918[0] = x.Host != ""
+			yyq918[1] = x.IngressRuleValue.HTTP != nil && x.HTTP != nil
+			if yyr918 || yy2arr918 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn923 int = 0
-				for _, b := range yyq923 {
+				var yynn918 int = 0
+				for _, b := range yyq918 {
 					if b {
-						yynn923++
+						yynn918++
 					}
 				}
-				r.EncodeMapStart(yynn923)
+				r.EncodeMapStart(yynn918)
 			}
-			if yyr923 || yy2arr923 {
-				if yyq923[0] {
-					yym925 := z.EncBinary()
-					_ = yym925
+			if yyr918 || yy2arr918 {
+				if yyq918[0] {
+					yym920 := z.EncBinary()
+					_ = yym920
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Host))
@@ -10213,27 +10169,27 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq923[0] {
+				if yyq918[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("host"))
-					yym926 := z.EncBinary()
-					_ = yym926
+					yym921 := z.EncBinary()
+					_ = yym921
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Host))
 					}
 				}
 			}
-			var yyn927 bool
+			var yyn922 bool
 			if x.IngressRuleValue.HTTP == nil {
-				yyn927 = true
-				goto LABEL927
+				yyn922 = true
+				goto LABEL922
 			}
-		LABEL927:
-			if yyr923 || yy2arr923 {
-				if yyn927 {
+		LABEL922:
+			if yyr918 || yy2arr918 {
+				if yyn922 {
 					r.EncodeNil()
 				} else {
-					if yyq923[1] {
+					if yyq918[1] {
 						if x.HTTP == nil {
 							r.EncodeNil()
 						} else {
@@ -10244,9 +10200,9 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
-				if yyq923[1] {
+				if yyq918[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("http"))
-					if yyn927 {
+					if yyn922 {
 						r.EncodeNil()
 					} else {
 						if x.HTTP == nil {
@@ -10257,7 +10213,7 @@ func (x *IngressRule) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep923 {
+			if yysep918 {
 				r.EncodeEnd()
 			}
 		}
@@ -10268,24 +10224,24 @@ func (x *IngressRule) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym928 := z.DecBinary()
-	_ = yym928
+	yym923 := z.DecBinary()
+	_ = yym923
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl929 := r.ReadMapStart()
-			if yyl929 == 0 {
+			yyl924 := r.ReadMapStart()
+			if yyl924 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl929, d)
+				x.codecDecodeSelfFromMap(yyl924, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl929 := r.ReadArrayStart()
-			if yyl929 == 0 {
+			yyl924 := r.ReadArrayStart()
+			if yyl924 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl929, d)
+				x.codecDecodeSelfFromArray(yyl924, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10297,12 +10253,12 @@ func (x *IngressRule) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys930Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys930Slc
-	var yyhl930 bool = l >= 0
-	for yyj930 := 0; ; yyj930++ {
-		if yyhl930 {
-			if yyj930 >= l {
+	var yys925Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys925Slc
+	var yyhl925 bool = l >= 0
+	for yyj925 := 0; ; yyj925++ {
+		if yyhl925 {
+			if yyj925 >= l {
 				break
 			}
 		} else {
@@ -10310,9 +10266,9 @@ func (x *IngressRule) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys930Slc = r.DecodeBytes(yys930Slc, true, true)
-		yys930 := string(yys930Slc)
-		switch yys930 {
+		yys925Slc = r.DecodeBytes(yys925Slc, true, true)
+		yys925 := string(yys925Slc)
+		switch yys925 {
 		case "host":
 			if r.TryDecodeAsNil() {
 				x.Host = ""
@@ -10334,10 +10290,10 @@ func (x *IngressRule) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.HTTP.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys930)
-		} // end switch yys930
-	} // end for yyj930
-	if !yyhl930 {
+			z.DecStructFieldNotFound(-1, yys925)
+		} // end switch yys925
+	} // end for yyj925
+	if !yyhl925 {
 		r.ReadEnd()
 	}
 }
@@ -10346,16 +10302,16 @@ func (x *IngressRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj933 int
-	var yyb933 bool
-	var yyhl933 bool = l >= 0
-	yyj933++
-	if yyhl933 {
-		yyb933 = yyj933 > l
+	var yyj928 int
+	var yyb928 bool
+	var yyhl928 bool = l >= 0
+	yyj928++
+	if yyhl928 {
+		yyb928 = yyj928 > l
 	} else {
-		yyb933 = r.CheckBreak()
+		yyb928 = r.CheckBreak()
 	}
-	if yyb933 {
+	if yyb928 {
 		r.ReadEnd()
 		return
 	}
@@ -10364,13 +10320,13 @@ func (x *IngressRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.Host = string(r.DecodeString())
 	}
-	yyj933++
-	if yyhl933 {
-		yyb933 = yyj933 > l
+	yyj928++
+	if yyhl928 {
+		yyb928 = yyj928 > l
 	} else {
-		yyb933 = r.CheckBreak()
+		yyb928 = r.CheckBreak()
 	}
-	if yyb933 {
+	if yyb928 {
 		r.ReadEnd()
 		return
 	}
@@ -10385,16 +10341,16 @@ func (x *IngressRule) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		x.HTTP.CodecDecodeSelf(d)
 	}
 	for {
-		yyj933++
-		if yyhl933 {
-			yyb933 = yyj933 > l
+		yyj928++
+		if yyhl928 {
+			yyb928 = yyj928 > l
 		} else {
-			yyb933 = r.CheckBreak()
+			yyb928 = r.CheckBreak()
 		}
-		if yyb933 {
+		if yyb928 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj933-1, "")
+		z.DecStructFieldNotFound(yyj928-1, "")
 	}
 	r.ReadEnd()
 }
@@ -10406,30 +10362,30 @@ func (x *IngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym936 := z.EncBinary()
-		_ = yym936
+		yym931 := z.EncBinary()
+		_ = yym931
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep937 := !z.EncBinary()
-			yy2arr937 := z.EncBasicHandle().StructToArray
-			var yyq937 [1]bool
-			_, _, _ = yysep937, yyq937, yy2arr937
-			const yyr937 bool = false
-			yyq937[0] = x.HTTP != nil
-			if yyr937 || yy2arr937 {
+			yysep932 := !z.EncBinary()
+			yy2arr932 := z.EncBasicHandle().StructToArray
+			var yyq932 [1]bool
+			_, _, _ = yysep932, yyq932, yy2arr932
+			const yyr932 bool = false
+			yyq932[0] = x.HTTP != nil
+			if yyr932 || yy2arr932 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn937 int = 0
-				for _, b := range yyq937 {
+				var yynn932 int = 0
+				for _, b := range yyq932 {
 					if b {
-						yynn937++
+						yynn932++
 					}
 				}
-				r.EncodeMapStart(yynn937)
+				r.EncodeMapStart(yynn932)
 			}
-			if yyr937 || yy2arr937 {
-				if yyq937[0] {
+			if yyr932 || yy2arr932 {
+				if yyq932[0] {
 					if x.HTTP == nil {
 						r.EncodeNil()
 					} else {
@@ -10439,7 +10395,7 @@ func (x *IngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq937[0] {
+				if yyq932[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("http"))
 					if x.HTTP == nil {
 						r.EncodeNil()
@@ -10448,7 +10404,7 @@ func (x *IngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep937 {
+			if yysep932 {
 				r.EncodeEnd()
 			}
 		}
@@ -10459,24 +10415,24 @@ func (x *IngressRuleValue) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym939 := z.DecBinary()
-	_ = yym939
+	yym934 := z.DecBinary()
+	_ = yym934
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl940 := r.ReadMapStart()
-			if yyl940 == 0 {
+			yyl935 := r.ReadMapStart()
+			if yyl935 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl940, d)
+				x.codecDecodeSelfFromMap(yyl935, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl940 := r.ReadArrayStart()
-			if yyl940 == 0 {
+			yyl935 := r.ReadArrayStart()
+			if yyl935 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl940, d)
+				x.codecDecodeSelfFromArray(yyl935, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10488,12 +10444,12 @@ func (x *IngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys941Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys941Slc
-	var yyhl941 bool = l >= 0
-	for yyj941 := 0; ; yyj941++ {
-		if yyhl941 {
-			if yyj941 >= l {
+	var yys936Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys936Slc
+	var yyhl936 bool = l >= 0
+	for yyj936 := 0; ; yyj936++ {
+		if yyhl936 {
+			if yyj936 >= l {
 				break
 			}
 		} else {
@@ -10501,9 +10457,9 @@ func (x *IngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys941Slc = r.DecodeBytes(yys941Slc, true, true)
-		yys941 := string(yys941Slc)
-		switch yys941 {
+		yys936Slc = r.DecodeBytes(yys936Slc, true, true)
+		yys936 := string(yys936Slc)
+		switch yys936 {
 		case "http":
 			if r.TryDecodeAsNil() {
 				if x.HTTP != nil {
@@ -10516,10 +10472,10 @@ func (x *IngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.HTTP.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys941)
-		} // end switch yys941
-	} // end for yyj941
-	if !yyhl941 {
+			z.DecStructFieldNotFound(-1, yys936)
+		} // end switch yys936
+	} // end for yyj936
+	if !yyhl936 {
 		r.ReadEnd()
 	}
 }
@@ -10528,16 +10484,16 @@ func (x *IngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj943 int
-	var yyb943 bool
-	var yyhl943 bool = l >= 0
-	yyj943++
-	if yyhl943 {
-		yyb943 = yyj943 > l
+	var yyj938 int
+	var yyb938 bool
+	var yyhl938 bool = l >= 0
+	yyj938++
+	if yyhl938 {
+		yyb938 = yyj938 > l
 	} else {
-		yyb943 = r.CheckBreak()
+		yyb938 = r.CheckBreak()
 	}
-	if yyb943 {
+	if yyb938 {
 		r.ReadEnd()
 		return
 	}
@@ -10552,16 +10508,16 @@ func (x *IngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Decoder)
 		x.HTTP.CodecDecodeSelf(d)
 	}
 	for {
-		yyj943++
-		if yyhl943 {
-			yyb943 = yyj943 > l
+		yyj938++
+		if yyhl938 {
+			yyb938 = yyj938 > l
 		} else {
-			yyb943 = r.CheckBreak()
+			yyb938 = r.CheckBreak()
 		}
-		if yyb943 {
+		if yyb938 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj943-1, "")
+		z.DecStructFieldNotFound(yyj938-1, "")
 	}
 	r.ReadEnd()
 }
@@ -10573,33 +10529,33 @@ func (x *HTTPIngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym945 := z.EncBinary()
-		_ = yym945
+		yym940 := z.EncBinary()
+		_ = yym940
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep946 := !z.EncBinary()
-			yy2arr946 := z.EncBasicHandle().StructToArray
-			var yyq946 [1]bool
-			_, _, _ = yysep946, yyq946, yy2arr946
-			const yyr946 bool = false
-			if yyr946 || yy2arr946 {
+			yysep941 := !z.EncBinary()
+			yy2arr941 := z.EncBasicHandle().StructToArray
+			var yyq941 [1]bool
+			_, _, _ = yysep941, yyq941, yy2arr941
+			const yyr941 bool = false
+			if yyr941 || yy2arr941 {
 				r.EncodeArrayStart(1)
 			} else {
-				var yynn946 int = 1
-				for _, b := range yyq946 {
+				var yynn941 int = 1
+				for _, b := range yyq941 {
 					if b {
-						yynn946++
+						yynn941++
 					}
 				}
-				r.EncodeMapStart(yynn946)
+				r.EncodeMapStart(yynn941)
 			}
-			if yyr946 || yy2arr946 {
+			if yyr941 || yy2arr941 {
 				if x.Paths == nil {
 					r.EncodeNil()
 				} else {
-					yym948 := z.EncBinary()
-					_ = yym948
+					yym943 := z.EncBinary()
+					_ = yym943
 					if false {
 					} else {
 						h.encSliceHTTPIngressPath(([]HTTPIngressPath)(x.Paths), e)
@@ -10610,15 +10566,15 @@ func (x *HTTPIngressRuleValue) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Paths == nil {
 					r.EncodeNil()
 				} else {
-					yym949 := z.EncBinary()
-					_ = yym949
+					yym944 := z.EncBinary()
+					_ = yym944
 					if false {
 					} else {
 						h.encSliceHTTPIngressPath(([]HTTPIngressPath)(x.Paths), e)
 					}
 				}
 			}
-			if yysep946 {
+			if yysep941 {
 				r.EncodeEnd()
 			}
 		}
@@ -10629,24 +10585,24 @@ func (x *HTTPIngressRuleValue) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym950 := z.DecBinary()
-	_ = yym950
+	yym945 := z.DecBinary()
+	_ = yym945
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl951 := r.ReadMapStart()
-			if yyl951 == 0 {
+			yyl946 := r.ReadMapStart()
+			if yyl946 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl951, d)
+				x.codecDecodeSelfFromMap(yyl946, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl951 := r.ReadArrayStart()
-			if yyl951 == 0 {
+			yyl946 := r.ReadArrayStart()
+			if yyl946 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl951, d)
+				x.codecDecodeSelfFromArray(yyl946, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10658,12 +10614,12 @@ func (x *HTTPIngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys952Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys952Slc
-	var yyhl952 bool = l >= 0
-	for yyj952 := 0; ; yyj952++ {
-		if yyhl952 {
-			if yyj952 >= l {
+	var yys947Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys947Slc
+	var yyhl947 bool = l >= 0
+	for yyj947 := 0; ; yyj947++ {
+		if yyhl947 {
+			if yyj947 >= l {
 				break
 			}
 		} else {
@@ -10671,26 +10627,26 @@ func (x *HTTPIngressRuleValue) codecDecodeSelfFromMap(l int, d *codec1978.Decode
 				break
 			}
 		}
-		yys952Slc = r.DecodeBytes(yys952Slc, true, true)
-		yys952 := string(yys952Slc)
-		switch yys952 {
+		yys947Slc = r.DecodeBytes(yys947Slc, true, true)
+		yys947 := string(yys947Slc)
+		switch yys947 {
 		case "paths":
 			if r.TryDecodeAsNil() {
 				x.Paths = nil
 			} else {
-				yyv953 := &x.Paths
-				yym954 := z.DecBinary()
-				_ = yym954
+				yyv948 := &x.Paths
+				yym949 := z.DecBinary()
+				_ = yym949
 				if false {
 				} else {
-					h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv953), d)
+					h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv948), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys952)
-		} // end switch yys952
-	} // end for yyj952
-	if !yyhl952 {
+			z.DecStructFieldNotFound(-1, yys947)
+		} // end switch yys947
+	} // end for yyj947
+	if !yyhl947 {
 		r.ReadEnd()
 	}
 }
@@ -10699,41 +10655,41 @@ func (x *HTTPIngressRuleValue) codecDecodeSelfFromArray(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj955 int
-	var yyb955 bool
-	var yyhl955 bool = l >= 0
-	yyj955++
-	if yyhl955 {
-		yyb955 = yyj955 > l
+	var yyj950 int
+	var yyb950 bool
+	var yyhl950 bool = l >= 0
+	yyj950++
+	if yyhl950 {
+		yyb950 = yyj950 > l
 	} else {
-		yyb955 = r.CheckBreak()
+		yyb950 = r.CheckBreak()
 	}
-	if yyb955 {
+	if yyb950 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Paths = nil
 	} else {
-		yyv956 := &x.Paths
-		yym957 := z.DecBinary()
-		_ = yym957
+		yyv951 := &x.Paths
+		yym952 := z.DecBinary()
+		_ = yym952
 		if false {
 		} else {
-			h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv956), d)
+			h.decSliceHTTPIngressPath((*[]HTTPIngressPath)(yyv951), d)
 		}
 	}
 	for {
-		yyj955++
-		if yyhl955 {
-			yyb955 = yyj955 > l
+		yyj950++
+		if yyhl950 {
+			yyb950 = yyj950 > l
 		} else {
-			yyb955 = r.CheckBreak()
+			yyb950 = r.CheckBreak()
 		}
-		if yyb955 {
+		if yyb950 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj955-1, "")
+		z.DecStructFieldNotFound(yyj950-1, "")
 	}
 	r.ReadEnd()
 }
@@ -10745,32 +10701,32 @@ func (x *HTTPIngressPath) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym958 := z.EncBinary()
-		_ = yym958
+		yym953 := z.EncBinary()
+		_ = yym953
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep959 := !z.EncBinary()
-			yy2arr959 := z.EncBasicHandle().StructToArray
-			var yyq959 [2]bool
-			_, _, _ = yysep959, yyq959, yy2arr959
-			const yyr959 bool = false
-			yyq959[0] = x.Path != ""
-			if yyr959 || yy2arr959 {
+			yysep954 := !z.EncBinary()
+			yy2arr954 := z.EncBasicHandle().StructToArray
+			var yyq954 [2]bool
+			_, _, _ = yysep954, yyq954, yy2arr954
+			const yyr954 bool = false
+			yyq954[0] = x.Path != ""
+			if yyr954 || yy2arr954 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn959 int = 1
-				for _, b := range yyq959 {
+				var yynn954 int = 1
+				for _, b := range yyq954 {
 					if b {
-						yynn959++
+						yynn954++
 					}
 				}
-				r.EncodeMapStart(yynn959)
+				r.EncodeMapStart(yynn954)
 			}
-			if yyr959 || yy2arr959 {
-				if yyq959[0] {
-					yym961 := z.EncBinary()
-					_ = yym961
+			if yyr954 || yy2arr954 {
+				if yyq954[0] {
+					yym956 := z.EncBinary()
+					_ = yym956
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Path))
@@ -10779,25 +10735,25 @@ func (x *HTTPIngressPath) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq959[0] {
+				if yyq954[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("path"))
-					yym962 := z.EncBinary()
-					_ = yym962
+					yym957 := z.EncBinary()
+					_ = yym957
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Path))
 					}
 				}
 			}
-			if yyr959 || yy2arr959 {
-				yy964 := &x.Backend
-				yy964.CodecEncodeSelf(e)
+			if yyr954 || yy2arr954 {
+				yy959 := &x.Backend
+				yy959.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("backend"))
-				yy965 := &x.Backend
-				yy965.CodecEncodeSelf(e)
+				yy960 := &x.Backend
+				yy960.CodecEncodeSelf(e)
 			}
-			if yysep959 {
+			if yysep954 {
 				r.EncodeEnd()
 			}
 		}
@@ -10808,24 +10764,24 @@ func (x *HTTPIngressPath) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym966 := z.DecBinary()
-	_ = yym966
+	yym961 := z.DecBinary()
+	_ = yym961
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl967 := r.ReadMapStart()
-			if yyl967 == 0 {
+			yyl962 := r.ReadMapStart()
+			if yyl962 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl967, d)
+				x.codecDecodeSelfFromMap(yyl962, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl967 := r.ReadArrayStart()
-			if yyl967 == 0 {
+			yyl962 := r.ReadArrayStart()
+			if yyl962 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl967, d)
+				x.codecDecodeSelfFromArray(yyl962, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -10837,12 +10793,12 @@ func (x *HTTPIngressPath) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys968Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys968Slc
-	var yyhl968 bool = l >= 0
-	for yyj968 := 0; ; yyj968++ {
-		if yyhl968 {
-			if yyj968 >= l {
+	var yys963Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys963Slc
+	var yyhl963 bool = l >= 0
+	for yyj963 := 0; ; yyj963++ {
+		if yyhl963 {
+			if yyj963 >= l {
 				break
 			}
 		} else {
@@ -10850,9 +10806,9 @@ func (x *HTTPIngressPath) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys968Slc = r.DecodeBytes(yys968Slc, true, true)
-		yys968 := string(yys968Slc)
-		switch yys968 {
+		yys963Slc = r.DecodeBytes(yys963Slc, true, true)
+		yys963 := string(yys963Slc)
+		switch yys963 {
 		case "path":
 			if r.TryDecodeAsNil() {
 				x.Path = ""
@@ -10863,14 +10819,14 @@ func (x *HTTPIngressPath) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.Backend = IngressBackend{}
 			} else {
-				yyv970 := &x.Backend
-				yyv970.CodecDecodeSelf(d)
+				yyv965 := &x.Backend
+				yyv965.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys968)
-		} // end switch yys968
-	} // end for yyj968
-	if !yyhl968 {
+			z.DecStructFieldNotFound(-1, yys963)
+		} // end switch yys963
+	} // end for yyj963
+	if !yyhl963 {
 		r.ReadEnd()
 	}
 }
@@ -10879,16 +10835,16 @@ func (x *HTTPIngressPath) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj971 int
-	var yyb971 bool
-	var yyhl971 bool = l >= 0
-	yyj971++
-	if yyhl971 {
-		yyb971 = yyj971 > l
+	var yyj966 int
+	var yyb966 bool
+	var yyhl966 bool = l >= 0
+	yyj966++
+	if yyhl966 {
+		yyb966 = yyj966 > l
 	} else {
-		yyb971 = r.CheckBreak()
+		yyb966 = r.CheckBreak()
 	}
-	if yyb971 {
+	if yyb966 {
 		r.ReadEnd()
 		return
 	}
@@ -10897,33 +10853,33 @@ func (x *HTTPIngressPath) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Path = string(r.DecodeString())
 	}
-	yyj971++
-	if yyhl971 {
-		yyb971 = yyj971 > l
+	yyj966++
+	if yyhl966 {
+		yyb966 = yyj966 > l
 	} else {
-		yyb971 = r.CheckBreak()
+		yyb966 = r.CheckBreak()
 	}
-	if yyb971 {
+	if yyb966 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Backend = IngressBackend{}
 	} else {
-		yyv973 := &x.Backend
-		yyv973.CodecDecodeSelf(d)
+		yyv968 := &x.Backend
+		yyv968.CodecDecodeSelf(d)
 	}
 	for {
-		yyj971++
-		if yyhl971 {
-			yyb971 = yyj971 > l
+		yyj966++
+		if yyhl966 {
+			yyb966 = yyj966 > l
 		} else {
-			yyb971 = r.CheckBreak()
+			yyb966 = r.CheckBreak()
 		}
-		if yyb971 {
+		if yyb966 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj971-1, "")
+		z.DecStructFieldNotFound(yyj966-1, "")
 	}
 	r.ReadEnd()
 }
@@ -10935,68 +10891,68 @@ func (x *IngressBackend) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym974 := z.EncBinary()
-		_ = yym974
+		yym969 := z.EncBinary()
+		_ = yym969
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep975 := !z.EncBinary()
-			yy2arr975 := z.EncBasicHandle().StructToArray
-			var yyq975 [2]bool
-			_, _, _ = yysep975, yyq975, yy2arr975
-			const yyr975 bool = false
-			if yyr975 || yy2arr975 {
+			yysep970 := !z.EncBinary()
+			yy2arr970 := z.EncBasicHandle().StructToArray
+			var yyq970 [2]bool
+			_, _, _ = yysep970, yyq970, yy2arr970
+			const yyr970 bool = false
+			if yyr970 || yy2arr970 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn975 int = 2
-				for _, b := range yyq975 {
+				var yynn970 int = 2
+				for _, b := range yyq970 {
 					if b {
-						yynn975++
+						yynn970++
 					}
 				}
-				r.EncodeMapStart(yynn975)
+				r.EncodeMapStart(yynn970)
 			}
-			if yyr975 || yy2arr975 {
-				yym977 := z.EncBinary()
-				_ = yym977
+			if yyr970 || yy2arr970 {
+				yym972 := z.EncBinary()
+				_ = yym972
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ServiceName))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("serviceName"))
-				yym978 := z.EncBinary()
-				_ = yym978
+				yym973 := z.EncBinary()
+				_ = yym973
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.ServiceName))
 				}
 			}
-			if yyr975 || yy2arr975 {
-				yy980 := &x.ServicePort
-				yym981 := z.EncBinary()
-				_ = yym981
+			if yyr970 || yy2arr970 {
+				yy975 := &x.ServicePort
+				yym976 := z.EncBinary()
+				_ = yym976
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy980) {
-				} else if !yym981 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy980)
+				} else if z.HasExtensions() && z.EncExt(yy975) {
+				} else if !yym976 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy975)
 				} else {
-					z.EncFallback(yy980)
+					z.EncFallback(yy975)
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("servicePort"))
-				yy982 := &x.ServicePort
-				yym983 := z.EncBinary()
-				_ = yym983
+				yy977 := &x.ServicePort
+				yym978 := z.EncBinary()
+				_ = yym978
 				if false {
-				} else if z.HasExtensions() && z.EncExt(yy982) {
-				} else if !yym983 && z.IsJSONHandle() {
-					z.EncJSONMarshal(yy982)
+				} else if z.HasExtensions() && z.EncExt(yy977) {
+				} else if !yym978 && z.IsJSONHandle() {
+					z.EncJSONMarshal(yy977)
 				} else {
-					z.EncFallback(yy982)
+					z.EncFallback(yy977)
 				}
 			}
-			if yysep975 {
+			if yysep970 {
 				r.EncodeEnd()
 			}
 		}
@@ -11007,24 +10963,24 @@ func (x *IngressBackend) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym984 := z.DecBinary()
-	_ = yym984
+	yym979 := z.DecBinary()
+	_ = yym979
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl985 := r.ReadMapStart()
-			if yyl985 == 0 {
+			yyl980 := r.ReadMapStart()
+			if yyl980 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl985, d)
+				x.codecDecodeSelfFromMap(yyl980, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl985 := r.ReadArrayStart()
-			if yyl985 == 0 {
+			yyl980 := r.ReadArrayStart()
+			if yyl980 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl985, d)
+				x.codecDecodeSelfFromArray(yyl980, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -11036,12 +10992,12 @@ func (x *IngressBackend) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys986Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys986Slc
-	var yyhl986 bool = l >= 0
-	for yyj986 := 0; ; yyj986++ {
-		if yyhl986 {
-			if yyj986 >= l {
+	var yys981Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys981Slc
+	var yyhl981 bool = l >= 0
+	for yyj981 := 0; ; yyj981++ {
+		if yyhl981 {
+			if yyj981 >= l {
 				break
 			}
 		} else {
@@ -11049,9 +11005,9 @@ func (x *IngressBackend) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys986Slc = r.DecodeBytes(yys986Slc, true, true)
-		yys986 := string(yys986Slc)
-		switch yys986 {
+		yys981Slc = r.DecodeBytes(yys981Slc, true, true)
+		yys981 := string(yys981Slc)
+		switch yys981 {
 		case "serviceName":
 			if r.TryDecodeAsNil() {
 				x.ServiceName = ""
@@ -11062,22 +11018,22 @@ func (x *IngressBackend) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			if r.TryDecodeAsNil() {
 				x.ServicePort = pkg6_util.IntOrString{}
 			} else {
-				yyv988 := &x.ServicePort
-				yym989 := z.DecBinary()
-				_ = yym989
+				yyv983 := &x.ServicePort
+				yym984 := z.DecBinary()
+				_ = yym984
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv988) {
-				} else if !yym989 && z.IsJSONHandle() {
-					z.DecJSONUnmarshal(yyv988)
+				} else if z.HasExtensions() && z.DecExt(yyv983) {
+				} else if !yym984 && z.IsJSONHandle() {
+					z.DecJSONUnmarshal(yyv983)
 				} else {
-					z.DecFallback(yyv988, false)
+					z.DecFallback(yyv983, false)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys986)
-		} // end switch yys986
-	} // end for yyj986
-	if !yyhl986 {
+			z.DecStructFieldNotFound(-1, yys981)
+		} // end switch yys981
+	} // end for yyj981
+	if !yyhl981 {
 		r.ReadEnd()
 	}
 }
@@ -11086,16 +11042,16 @@ func (x *IngressBackend) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj990 int
-	var yyb990 bool
-	var yyhl990 bool = l >= 0
-	yyj990++
-	if yyhl990 {
-		yyb990 = yyj990 > l
+	var yyj985 int
+	var yyb985 bool
+	var yyhl985 bool = l >= 0
+	yyj985++
+	if yyhl985 {
+		yyb985 = yyj985 > l
 	} else {
-		yyb990 = r.CheckBreak()
+		yyb985 = r.CheckBreak()
 	}
-	if yyb990 {
+	if yyb985 {
 		r.ReadEnd()
 		return
 	}
@@ -11104,41 +11060,41 @@ func (x *IngressBackend) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	} else {
 		x.ServiceName = string(r.DecodeString())
 	}
-	yyj990++
-	if yyhl990 {
-		yyb990 = yyj990 > l
+	yyj985++
+	if yyhl985 {
+		yyb985 = yyj985 > l
 	} else {
-		yyb990 = r.CheckBreak()
+		yyb985 = r.CheckBreak()
 	}
-	if yyb990 {
+	if yyb985 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ServicePort = pkg6_util.IntOrString{}
 	} else {
-		yyv992 := &x.ServicePort
-		yym993 := z.DecBinary()
-		_ = yym993
+		yyv987 := &x.ServicePort
+		yym988 := z.DecBinary()
+		_ = yym988
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv992) {
-		} else if !yym993 && z.IsJSONHandle() {
-			z.DecJSONUnmarshal(yyv992)
+		} else if z.HasExtensions() && z.DecExt(yyv987) {
+		} else if !yym988 && z.IsJSONHandle() {
+			z.DecJSONUnmarshal(yyv987)
 		} else {
-			z.DecFallback(yyv992, false)
+			z.DecFallback(yyv987, false)
 		}
 	}
 	for {
-		yyj990++
-		if yyhl990 {
-			yyb990 = yyj990 > l
+		yyj985++
+		if yyhl985 {
+			yyb985 = yyj985 > l
 		} else {
-			yyb990 = r.CheckBreak()
+			yyb985 = r.CheckBreak()
 		}
-		if yyb990 {
+		if yyb985 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj990-1, "")
+		z.DecStructFieldNotFound(yyj985-1, "")
 	}
 	r.ReadEnd()
 }
@@ -11147,8 +11103,8 @@ func (x NodeResource) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym994 := z.EncBinary()
-	_ = yym994
+	yym989 := z.EncBinary()
+	_ = yym989
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -11160,8 +11116,8 @@ func (x *NodeResource) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym995 := z.DecBinary()
-	_ = yym995
+	yym990 := z.DecBinary()
+	_ = yym990
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -11176,50 +11132,50 @@ func (x *NodeUtilization) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym996 := z.EncBinary()
-		_ = yym996
+		yym991 := z.EncBinary()
+		_ = yym991
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep997 := !z.EncBinary()
-			yy2arr997 := z.EncBasicHandle().StructToArray
-			var yyq997 [2]bool
-			_, _, _ = yysep997, yyq997, yy2arr997
-			const yyr997 bool = false
-			if yyr997 || yy2arr997 {
+			yysep992 := !z.EncBinary()
+			yy2arr992 := z.EncBasicHandle().StructToArray
+			var yyq992 [2]bool
+			_, _, _ = yysep992, yyq992, yy2arr992
+			const yyr992 bool = false
+			if yyr992 || yy2arr992 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn997 int = 2
-				for _, b := range yyq997 {
+				var yynn992 int = 2
+				for _, b := range yyq992 {
 					if b {
-						yynn997++
+						yynn992++
 					}
 				}
-				r.EncodeMapStart(yynn997)
+				r.EncodeMapStart(yynn992)
 			}
-			if yyr997 || yy2arr997 {
+			if yyr992 || yy2arr992 {
 				x.Resource.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("resource"))
 				x.Resource.CodecEncodeSelf(e)
 			}
-			if yyr997 || yy2arr997 {
-				yym1000 := z.EncBinary()
-				_ = yym1000
+			if yyr992 || yy2arr992 {
+				yym995 := z.EncBinary()
+				_ = yym995
 				if false {
 				} else {
 					r.EncodeFloat64(float64(x.Value))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("value"))
-				yym1001 := z.EncBinary()
-				_ = yym1001
+				yym996 := z.EncBinary()
+				_ = yym996
 				if false {
 				} else {
 					r.EncodeFloat64(float64(x.Value))
 				}
 			}
-			if yysep997 {
+			if yysep992 {
 				r.EncodeEnd()
 			}
 		}
@@ -11230,24 +11186,24 @@ func (x *NodeUtilization) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1002 := z.DecBinary()
-	_ = yym1002
+	yym997 := z.DecBinary()
+	_ = yym997
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1003 := r.ReadMapStart()
-			if yyl1003 == 0 {
+			yyl998 := r.ReadMapStart()
+			if yyl998 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1003, d)
+				x.codecDecodeSelfFromMap(yyl998, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1003 := r.ReadArrayStart()
-			if yyl1003 == 0 {
+			yyl998 := r.ReadArrayStart()
+			if yyl998 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1003, d)
+				x.codecDecodeSelfFromArray(yyl998, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -11259,12 +11215,12 @@ func (x *NodeUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1004Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1004Slc
-	var yyhl1004 bool = l >= 0
-	for yyj1004 := 0; ; yyj1004++ {
-		if yyhl1004 {
-			if yyj1004 >= l {
+	var yys999Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys999Slc
+	var yyhl999 bool = l >= 0
+	for yyj999 := 0; ; yyj999++ {
+		if yyhl999 {
+			if yyj999 >= l {
 				break
 			}
 		} else {
@@ -11272,9 +11228,9 @@ func (x *NodeUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys1004Slc = r.DecodeBytes(yys1004Slc, true, true)
-		yys1004 := string(yys1004Slc)
-		switch yys1004 {
+		yys999Slc = r.DecodeBytes(yys999Slc, true, true)
+		yys999 := string(yys999Slc)
+		switch yys999 {
 		case "resource":
 			if r.TryDecodeAsNil() {
 				x.Resource = ""
@@ -11288,10 +11244,10 @@ func (x *NodeUtilization) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				x.Value = float64(r.DecodeFloat(false))
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1004)
-		} // end switch yys1004
-	} // end for yyj1004
-	if !yyhl1004 {
+			z.DecStructFieldNotFound(-1, yys999)
+		} // end switch yys999
+	} // end for yyj999
+	if !yyhl999 {
 		r.ReadEnd()
 	}
 }
@@ -11300,16 +11256,16 @@ func (x *NodeUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1007 int
-	var yyb1007 bool
-	var yyhl1007 bool = l >= 0
-	yyj1007++
-	if yyhl1007 {
-		yyb1007 = yyj1007 > l
+	var yyj1002 int
+	var yyb1002 bool
+	var yyhl1002 bool = l >= 0
+	yyj1002++
+	if yyhl1002 {
+		yyb1002 = yyj1002 > l
 	} else {
-		yyb1007 = r.CheckBreak()
+		yyb1002 = r.CheckBreak()
 	}
-	if yyb1007 {
+	if yyb1002 {
 		r.ReadEnd()
 		return
 	}
@@ -11318,13 +11274,13 @@ func (x *NodeUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 	} else {
 		x.Resource = NodeResource(r.DecodeString())
 	}
-	yyj1007++
-	if yyhl1007 {
-		yyb1007 = yyj1007 > l
+	yyj1002++
+	if yyhl1002 {
+		yyb1002 = yyj1002 > l
 	} else {
-		yyb1007 = r.CheckBreak()
+		yyb1002 = r.CheckBreak()
 	}
-	if yyb1007 {
+	if yyb1002 {
 		r.ReadEnd()
 		return
 	}
@@ -11334,16 +11290,16 @@ func (x *NodeUtilization) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		x.Value = float64(r.DecodeFloat(false))
 	}
 	for {
-		yyj1007++
-		if yyhl1007 {
-			yyb1007 = yyj1007 > l
+		yyj1002++
+		if yyhl1002 {
+			yyb1002 = yyj1002 > l
 		} else {
-			yyb1007 = r.CheckBreak()
+			yyb1002 = r.CheckBreak()
 		}
-		if yyb1007 {
+		if yyb1002 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1007-1, "")
+		z.DecStructFieldNotFound(yyj1002-1, "")
 	}
 	r.ReadEnd()
 }
@@ -11355,65 +11311,65 @@ func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1010 := z.EncBinary()
-		_ = yym1010
+		yym1005 := z.EncBinary()
+		_ = yym1005
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1011 := !z.EncBinary()
-			yy2arr1011 := z.EncBasicHandle().StructToArray
-			var yyq1011 [3]bool
-			_, _, _ = yysep1011, yyq1011, yy2arr1011
-			const yyr1011 bool = false
-			if yyr1011 || yy2arr1011 {
+			yysep1006 := !z.EncBinary()
+			yy2arr1006 := z.EncBasicHandle().StructToArray
+			var yyq1006 [3]bool
+			_, _, _ = yysep1006, yyq1006, yy2arr1006
+			const yyr1006 bool = false
+			if yyr1006 || yy2arr1006 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn1011 int = 3
-				for _, b := range yyq1011 {
+				var yynn1006 int = 3
+				for _, b := range yyq1006 {
 					if b {
-						yynn1011++
+						yynn1006++
 					}
 				}
-				r.EncodeMapStart(yynn1011)
+				r.EncodeMapStart(yynn1006)
 			}
-			if yyr1011 || yy2arr1011 {
-				yym1013 := z.EncBinary()
-				_ = yym1013
+			if yyr1006 || yy2arr1006 {
+				yym1008 := z.EncBinary()
+				_ = yym1008
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MinNodes))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("minNodes"))
-				yym1014 := z.EncBinary()
-				_ = yym1014
+				yym1009 := z.EncBinary()
+				_ = yym1009
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MinNodes))
 				}
 			}
-			if yyr1011 || yy2arr1011 {
-				yym1016 := z.EncBinary()
-				_ = yym1016
+			if yyr1006 || yy2arr1006 {
+				yym1011 := z.EncBinary()
+				_ = yym1011
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MaxNodes))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("maxNodes"))
-				yym1017 := z.EncBinary()
-				_ = yym1017
+				yym1012 := z.EncBinary()
+				_ = yym1012
 				if false {
 				} else {
 					r.EncodeInt(int64(x.MaxNodes))
 				}
 			}
-			if yyr1011 || yy2arr1011 {
+			if yyr1006 || yy2arr1006 {
 				if x.TargetUtilization == nil {
 					r.EncodeNil()
 				} else {
-					yym1019 := z.EncBinary()
-					_ = yym1019
+					yym1014 := z.EncBinary()
+					_ = yym1014
 					if false {
 					} else {
 						h.encSliceNodeUtilization(([]NodeUtilization)(x.TargetUtilization), e)
@@ -11424,15 +11380,15 @@ func (x *ClusterAutoscalerSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.TargetUtilization == nil {
 					r.EncodeNil()
 				} else {
-					yym1020 := z.EncBinary()
-					_ = yym1020
+					yym1015 := z.EncBinary()
+					_ = yym1015
 					if false {
 					} else {
 						h.encSliceNodeUtilization(([]NodeUtilization)(x.TargetUtilization), e)
 					}
 				}
 			}
-			if yysep1011 {
+			if yysep1006 {
 				r.EncodeEnd()
 			}
 		}
@@ -11443,24 +11399,24 @@ func (x *ClusterAutoscalerSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1021 := z.DecBinary()
-	_ = yym1021
+	yym1016 := z.DecBinary()
+	_ = yym1016
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1022 := r.ReadMapStart()
-			if yyl1022 == 0 {
+			yyl1017 := r.ReadMapStart()
+			if yyl1017 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1022, d)
+				x.codecDecodeSelfFromMap(yyl1017, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1022 := r.ReadArrayStart()
-			if yyl1022 == 0 {
+			yyl1017 := r.ReadArrayStart()
+			if yyl1017 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1022, d)
+				x.codecDecodeSelfFromArray(yyl1017, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -11472,12 +11428,12 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1023Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1023Slc
-	var yyhl1023 bool = l >= 0
-	for yyj1023 := 0; ; yyj1023++ {
-		if yyhl1023 {
-			if yyj1023 >= l {
+	var yys1018Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1018Slc
+	var yyhl1018 bool = l >= 0
+	for yyj1018 := 0; ; yyj1018++ {
+		if yyhl1018 {
+			if yyj1018 >= l {
 				break
 			}
 		} else {
@@ -11485,9 +11441,9 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				break
 			}
 		}
-		yys1023Slc = r.DecodeBytes(yys1023Slc, true, true)
-		yys1023 := string(yys1023Slc)
-		switch yys1023 {
+		yys1018Slc = r.DecodeBytes(yys1018Slc, true, true)
+		yys1018 := string(yys1018Slc)
+		switch yys1018 {
 		case "minNodes":
 			if r.TryDecodeAsNil() {
 				x.MinNodes = 0
@@ -11504,19 +11460,19 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			if r.TryDecodeAsNil() {
 				x.TargetUtilization = nil
 			} else {
-				yyv1026 := &x.TargetUtilization
-				yym1027 := z.DecBinary()
-				_ = yym1027
+				yyv1021 := &x.TargetUtilization
+				yym1022 := z.DecBinary()
+				_ = yym1022
 				if false {
 				} else {
-					h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1026), d)
+					h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1021), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1023)
-		} // end switch yys1023
-	} // end for yyj1023
-	if !yyhl1023 {
+			z.DecStructFieldNotFound(-1, yys1018)
+		} // end switch yys1018
+	} // end for yyj1018
+	if !yyhl1018 {
 		r.ReadEnd()
 	}
 }
@@ -11525,16 +11481,16 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1028 int
-	var yyb1028 bool
-	var yyhl1028 bool = l >= 0
-	yyj1028++
-	if yyhl1028 {
-		yyb1028 = yyj1028 > l
+	var yyj1023 int
+	var yyb1023 bool
+	var yyhl1023 bool = l >= 0
+	yyj1023++
+	if yyhl1023 {
+		yyb1023 = yyj1023 > l
 	} else {
-		yyb1028 = r.CheckBreak()
+		yyb1023 = r.CheckBreak()
 	}
-	if yyb1028 {
+	if yyb1023 {
 		r.ReadEnd()
 		return
 	}
@@ -11543,13 +11499,13 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.MinNodes = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj1028++
-	if yyhl1028 {
-		yyb1028 = yyj1028 > l
+	yyj1023++
+	if yyhl1023 {
+		yyb1023 = yyj1023 > l
 	} else {
-		yyb1028 = r.CheckBreak()
+		yyb1023 = r.CheckBreak()
 	}
-	if yyb1028 {
+	if yyb1023 {
 		r.ReadEnd()
 		return
 	}
@@ -11558,38 +11514,38 @@ func (x *ClusterAutoscalerSpec) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.MaxNodes = int(r.DecodeInt(codecSelferBitsize1234))
 	}
-	yyj1028++
-	if yyhl1028 {
-		yyb1028 = yyj1028 > l
+	yyj1023++
+	if yyhl1023 {
+		yyb1023 = yyj1023 > l
 	} else {
-		yyb1028 = r.CheckBreak()
+		yyb1023 = r.CheckBreak()
 	}
-	if yyb1028 {
+	if yyb1023 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.TargetUtilization = nil
 	} else {
-		yyv1031 := &x.TargetUtilization
-		yym1032 := z.DecBinary()
-		_ = yym1032
+		yyv1026 := &x.TargetUtilization
+		yym1027 := z.DecBinary()
+		_ = yym1027
 		if false {
 		} else {
-			h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1031), d)
+			h.decSliceNodeUtilization((*[]NodeUtilization)(yyv1026), d)
 		}
 	}
 	for {
-		yyj1028++
-		if yyhl1028 {
-			yyb1028 = yyj1028 > l
+		yyj1023++
+		if yyhl1023 {
+			yyb1023 = yyj1023 > l
 		} else {
-			yyb1028 = r.CheckBreak()
+			yyb1023 = r.CheckBreak()
 		}
-		if yyb1028 {
+		if yyb1023 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1028-1, "")
+		z.DecStructFieldNotFound(yyj1023-1, "")
 	}
 	r.ReadEnd()
 }
@@ -11601,35 +11557,35 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1033 := z.EncBinary()
-		_ = yym1033
+		yym1028 := z.EncBinary()
+		_ = yym1028
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1034 := !z.EncBinary()
-			yy2arr1034 := z.EncBasicHandle().StructToArray
-			var yyq1034 [4]bool
-			_, _, _ = yysep1034, yyq1034, yy2arr1034
-			const yyr1034 bool = false
-			yyq1034[0] = x.Kind != ""
-			yyq1034[1] = x.APIVersion != ""
-			yyq1034[2] = true
-			yyq1034[3] = true
-			if yyr1034 || yy2arr1034 {
+			yysep1029 := !z.EncBinary()
+			yy2arr1029 := z.EncBasicHandle().StructToArray
+			var yyq1029 [4]bool
+			_, _, _ = yysep1029, yyq1029, yy2arr1029
+			const yyr1029 bool = false
+			yyq1029[0] = x.Kind != ""
+			yyq1029[1] = x.APIVersion != ""
+			yyq1029[2] = true
+			yyq1029[3] = true
+			if yyr1029 || yy2arr1029 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1034 int = 0
-				for _, b := range yyq1034 {
+				var yynn1029 int = 0
+				for _, b := range yyq1029 {
 					if b {
-						yynn1034++
+						yynn1029++
 					}
 				}
-				r.EncodeMapStart(yynn1034)
+				r.EncodeMapStart(yynn1029)
 			}
-			if yyr1034 || yy2arr1034 {
-				if yyq1034[0] {
-					yym1036 := z.EncBinary()
-					_ = yym1036
+			if yyr1029 || yy2arr1029 {
+				if yyq1029[0] {
+					yym1031 := z.EncBinary()
+					_ = yym1031
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -11638,20 +11594,20 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1034[0] {
+				if yyq1029[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym1037 := z.EncBinary()
-					_ = yym1037
+					yym1032 := z.EncBinary()
+					_ = yym1032
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1034 || yy2arr1034 {
-				if yyq1034[1] {
-					yym1039 := z.EncBinary()
-					_ = yym1039
+			if yyr1029 || yy2arr1029 {
+				if yyq1029[1] {
+					yym1034 := z.EncBinary()
+					_ = yym1034
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -11660,45 +11616,45 @@ func (x *ClusterAutoscaler) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1034[1] {
+				if yyq1029[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
-					yym1040 := z.EncBinary()
-					_ = yym1040
+					yym1035 := z.EncBinary()
+					_ = yym1035
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
 					}
 				}
 			}
-			if yyr1034 || yy2arr1034 {
-				if yyq1034[2] {
-					yy1042 := &x.ObjectMeta
-					yy1042.CodecEncodeSelf(e)
+			if yyr1029 || yy2arr1029 {
+				if yyq1029[2] {
+					yy1037 := &x.ObjectMeta
+					yy1037.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1034[2] {
+				if yyq1029[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy1043 := &x.ObjectMeta
-					yy1043.CodecEncodeSelf(e)
+					yy1038 := &x.ObjectMeta
+					yy1038.CodecEncodeSelf(e)
 				}
 			}
-			if yyr1034 || yy2arr1034 {
-				if yyq1034[3] {
-					yy1045 := &x.Spec
-					yy1045.CodecEncodeSelf(e)
+			if yyr1029 || yy2arr1029 {
+				if yyq1029[3] {
+					yy1040 := &x.Spec
+					yy1040.CodecEncodeSelf(e)
 				} else {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1034[3] {
+				if yyq1029[3] {
 					r.EncodeString(codecSelferC_UTF81234, string("spec"))
-					yy1046 := &x.Spec
-					yy1046.CodecEncodeSelf(e)
+					yy1041 := &x.Spec
+					yy1041.CodecEncodeSelf(e)
 				}
 			}
-			if yysep1034 {
+			if yysep1029 {
 				r.EncodeEnd()
 			}
 		}
@@ -11709,24 +11665,24 @@ func (x *ClusterAutoscaler) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1047 := z.DecBinary()
-	_ = yym1047
+	yym1042 := z.DecBinary()
+	_ = yym1042
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1048 := r.ReadMapStart()
-			if yyl1048 == 0 {
+			yyl1043 := r.ReadMapStart()
+			if yyl1043 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1048, d)
+				x.codecDecodeSelfFromMap(yyl1043, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1048 := r.ReadArrayStart()
-			if yyl1048 == 0 {
+			yyl1043 := r.ReadArrayStart()
+			if yyl1043 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1048, d)
+				x.codecDecodeSelfFromArray(yyl1043, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -11738,12 +11694,12 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1049Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1049Slc
-	var yyhl1049 bool = l >= 0
-	for yyj1049 := 0; ; yyj1049++ {
-		if yyhl1049 {
-			if yyj1049 >= l {
+	var yys1044Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1044Slc
+	var yyhl1044 bool = l >= 0
+	for yyj1044 := 0; ; yyj1044++ {
+		if yyhl1044 {
+			if yyj1044 >= l {
 				break
 			}
 		} else {
@@ -11751,9 +11707,9 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 				break
 			}
 		}
-		yys1049Slc = r.DecodeBytes(yys1049Slc, true, true)
-		yys1049 := string(yys1049Slc)
-		switch yys1049 {
+		yys1044Slc = r.DecodeBytes(yys1044Slc, true, true)
+		yys1044 := string(yys1044Slc)
+		switch yys1044 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -11770,21 +11726,21 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) 
 			if r.TryDecodeAsNil() {
 				x.ObjectMeta = pkg2_v1.ObjectMeta{}
 			} else {
-				yyv1052 := &x.ObjectMeta
-				yyv1052.CodecDecodeSelf(d)
+				yyv1047 := &x.ObjectMeta
+				yyv1047.CodecDecodeSelf(d)
 			}
 		case "spec":
 			if r.TryDecodeAsNil() {
 				x.Spec = ClusterAutoscalerSpec{}
 			} else {
-				yyv1053 := &x.Spec
-				yyv1053.CodecDecodeSelf(d)
+				yyv1048 := &x.Spec
+				yyv1048.CodecDecodeSelf(d)
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1049)
-		} // end switch yys1049
-	} // end for yyj1049
-	if !yyhl1049 {
+			z.DecStructFieldNotFound(-1, yys1044)
+		} // end switch yys1044
+	} // end for yyj1044
+	if !yyhl1044 {
 		r.ReadEnd()
 	}
 }
@@ -11793,16 +11749,16 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1054 int
-	var yyb1054 bool
-	var yyhl1054 bool = l >= 0
-	yyj1054++
-	if yyhl1054 {
-		yyb1054 = yyj1054 > l
+	var yyj1049 int
+	var yyb1049 bool
+	var yyhl1049 bool = l >= 0
+	yyj1049++
+	if yyhl1049 {
+		yyb1049 = yyj1049 > l
 	} else {
-		yyb1054 = r.CheckBreak()
+		yyb1049 = r.CheckBreak()
 	}
-	if yyb1054 {
+	if yyb1049 {
 		r.ReadEnd()
 		return
 	}
@@ -11811,13 +11767,13 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1054++
-	if yyhl1054 {
-		yyb1054 = yyj1054 > l
+	yyj1049++
+	if yyhl1049 {
+		yyb1049 = yyj1049 > l
 	} else {
-		yyb1054 = r.CheckBreak()
+		yyb1049 = r.CheckBreak()
 	}
-	if yyb1054 {
+	if yyb1049 {
 		r.ReadEnd()
 		return
 	}
@@ -11826,49 +11782,49 @@ func (x *ClusterAutoscaler) codecDecodeSelfFromArray(l int, d *codec1978.Decoder
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj1054++
-	if yyhl1054 {
-		yyb1054 = yyj1054 > l
+	yyj1049++
+	if yyhl1049 {
+		yyb1049 = yyj1049 > l
 	} else {
-		yyb1054 = r.CheckBreak()
+		yyb1049 = r.CheckBreak()
 	}
-	if yyb1054 {
+	if yyb1049 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg2_v1.ObjectMeta{}
 	} else {
-		yyv1057 := &x.ObjectMeta
-		yyv1057.CodecDecodeSelf(d)
+		yyv1052 := &x.ObjectMeta
+		yyv1052.CodecDecodeSelf(d)
 	}
-	yyj1054++
-	if yyhl1054 {
-		yyb1054 = yyj1054 > l
+	yyj1049++
+	if yyhl1049 {
+		yyb1049 = yyj1049 > l
 	} else {
-		yyb1054 = r.CheckBreak()
+		yyb1049 = r.CheckBreak()
 	}
-	if yyb1054 {
+	if yyb1049 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Spec = ClusterAutoscalerSpec{}
 	} else {
-		yyv1058 := &x.Spec
-		yyv1058.CodecDecodeSelf(d)
+		yyv1053 := &x.Spec
+		yyv1053.CodecDecodeSelf(d)
 	}
 	for {
-		yyj1054++
-		if yyhl1054 {
-			yyb1054 = yyj1054 > l
+		yyj1049++
+		if yyhl1049 {
+			yyb1049 = yyj1049 > l
 		} else {
-			yyb1054 = r.CheckBreak()
+			yyb1049 = r.CheckBreak()
 		}
-		if yyb1054 {
+		if yyb1049 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1054-1, "")
+		z.DecStructFieldNotFound(yyj1049-1, "")
 	}
 	r.ReadEnd()
 }
@@ -11880,34 +11836,34 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1059 := z.EncBinary()
-		_ = yym1059
+		yym1054 := z.EncBinary()
+		_ = yym1054
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1060 := !z.EncBinary()
-			yy2arr1060 := z.EncBasicHandle().StructToArray
-			var yyq1060 [4]bool
-			_, _, _ = yysep1060, yyq1060, yy2arr1060
-			const yyr1060 bool = false
-			yyq1060[0] = x.Kind != ""
-			yyq1060[1] = x.APIVersion != ""
-			yyq1060[2] = true
-			if yyr1060 || yy2arr1060 {
+			yysep1055 := !z.EncBinary()
+			yy2arr1055 := z.EncBasicHandle().StructToArray
+			var yyq1055 [4]bool
+			_, _, _ = yysep1055, yyq1055, yy2arr1055
+			const yyr1055 bool = false
+			yyq1055[0] = x.Kind != ""
+			yyq1055[1] = x.APIVersion != ""
+			yyq1055[2] = true
+			if yyr1055 || yy2arr1055 {
 				r.EncodeArrayStart(4)
 			} else {
-				var yynn1060 int = 1
-				for _, b := range yyq1060 {
+				var yynn1055 int = 1
+				for _, b := range yyq1055 {
 					if b {
-						yynn1060++
+						yynn1055++
 					}
 				}
-				r.EncodeMapStart(yynn1060)
+				r.EncodeMapStart(yynn1055)
 			}
-			if yyr1060 || yy2arr1060 {
-				if yyq1060[0] {
-					yym1062 := z.EncBinary()
-					_ = yym1062
+			if yyr1055 || yy2arr1055 {
+				if yyq1055[0] {
+					yym1057 := z.EncBinary()
+					_ = yym1057
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
@@ -11916,20 +11872,20 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1060[0] {
+				if yyq1055[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("kind"))
-					yym1063 := z.EncBinary()
-					_ = yym1063
+					yym1058 := z.EncBinary()
+					_ = yym1058
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.Kind))
 					}
 				}
 			}
-			if yyr1060 || yy2arr1060 {
-				if yyq1060[1] {
-					yym1065 := z.EncBinary()
-					_ = yym1065
+			if yyr1055 || yy2arr1055 {
+				if yyq1055[1] {
+					yym1060 := z.EncBinary()
+					_ = yym1060
 					if false {
 					} else {
 						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
@@ -11938,48 +11894,48 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeString(codecSelferC_UTF81234, "")
 				}
 			} else {
-				if yyq1060[1] {
+				if yyq1055[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("apiVersion"))
+					yym1061 := z.EncBinary()
+					_ = yym1061
+					if false {
+					} else {
+						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+					}
+				}
+			}
+			if yyr1055 || yy2arr1055 {
+				if yyq1055[2] {
+					yy1063 := &x.ListMeta
+					yym1064 := z.EncBinary()
+					_ = yym1064
+					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1063) {
+					} else {
+						z.EncFallback(yy1063)
+					}
+				} else {
+					r.EncodeNil()
+				}
+			} else {
+				if yyq1055[2] {
+					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
+					yy1065 := &x.ListMeta
 					yym1066 := z.EncBinary()
 					_ = yym1066
 					if false {
+					} else if z.HasExtensions() && z.EncExt(yy1065) {
 					} else {
-						r.EncodeString(codecSelferC_UTF81234, string(x.APIVersion))
+						z.EncFallback(yy1065)
 					}
 				}
 			}
-			if yyr1060 || yy2arr1060 {
-				if yyq1060[2] {
-					yy1068 := &x.ListMeta
-					yym1069 := z.EncBinary()
-					_ = yym1069
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1068) {
-					} else {
-						z.EncFallback(yy1068)
-					}
-				} else {
-					r.EncodeNil()
-				}
-			} else {
-				if yyq1060[2] {
-					r.EncodeString(codecSelferC_UTF81234, string("metadata"))
-					yy1070 := &x.ListMeta
-					yym1071 := z.EncBinary()
-					_ = yym1071
-					if false {
-					} else if z.HasExtensions() && z.EncExt(yy1070) {
-					} else {
-						z.EncFallback(yy1070)
-					}
-				}
-			}
-			if yyr1060 || yy2arr1060 {
+			if yyr1055 || yy2arr1055 {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1073 := z.EncBinary()
-					_ = yym1073
+					yym1068 := z.EncBinary()
+					_ = yym1068
 					if false {
 					} else {
 						h.encSliceClusterAutoscaler(([]ClusterAutoscaler)(x.Items), e)
@@ -11990,15 +11946,15 @@ func (x *ClusterAutoscalerList) CodecEncodeSelf(e *codec1978.Encoder) {
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
-					yym1074 := z.EncBinary()
-					_ = yym1074
+					yym1069 := z.EncBinary()
+					_ = yym1069
 					if false {
 					} else {
 						h.encSliceClusterAutoscaler(([]ClusterAutoscaler)(x.Items), e)
 					}
 				}
 			}
-			if yysep1060 {
+			if yysep1055 {
 				r.EncodeEnd()
 			}
 		}
@@ -12009,24 +11965,24 @@ func (x *ClusterAutoscalerList) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1075 := z.DecBinary()
-	_ = yym1075
+	yym1070 := z.DecBinary()
+	_ = yym1070
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1076 := r.ReadMapStart()
-			if yyl1076 == 0 {
+			yyl1071 := r.ReadMapStart()
+			if yyl1071 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1076, d)
+				x.codecDecodeSelfFromMap(yyl1071, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1076 := r.ReadArrayStart()
-			if yyl1076 == 0 {
+			yyl1071 := r.ReadArrayStart()
+			if yyl1071 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1076, d)
+				x.codecDecodeSelfFromArray(yyl1071, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -12038,12 +11994,12 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1077Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1077Slc
-	var yyhl1077 bool = l >= 0
-	for yyj1077 := 0; ; yyj1077++ {
-		if yyhl1077 {
-			if yyj1077 >= l {
+	var yys1072Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1072Slc
+	var yyhl1072 bool = l >= 0
+	for yyj1072 := 0; ; yyj1072++ {
+		if yyhl1072 {
+			if yyj1072 >= l {
 				break
 			}
 		} else {
@@ -12051,9 +12007,9 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 				break
 			}
 		}
-		yys1077Slc = r.DecodeBytes(yys1077Slc, true, true)
-		yys1077 := string(yys1077Slc)
-		switch yys1077 {
+		yys1072Slc = r.DecodeBytes(yys1072Slc, true, true)
+		yys1072 := string(yys1072Slc)
+		switch yys1072 {
 		case "kind":
 			if r.TryDecodeAsNil() {
 				x.Kind = ""
@@ -12070,32 +12026,32 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromMap(l int, d *codec1978.Decod
 			if r.TryDecodeAsNil() {
 				x.ListMeta = pkg1_unversioned.ListMeta{}
 			} else {
-				yyv1080 := &x.ListMeta
-				yym1081 := z.DecBinary()
-				_ = yym1081
+				yyv1075 := &x.ListMeta
+				yym1076 := z.DecBinary()
+				_ = yym1076
 				if false {
-				} else if z.HasExtensions() && z.DecExt(yyv1080) {
+				} else if z.HasExtensions() && z.DecExt(yyv1075) {
 				} else {
-					z.DecFallback(yyv1080, false)
+					z.DecFallback(yyv1075, false)
 				}
 			}
 		case "items":
 			if r.TryDecodeAsNil() {
 				x.Items = nil
 			} else {
-				yyv1082 := &x.Items
-				yym1083 := z.DecBinary()
-				_ = yym1083
+				yyv1077 := &x.Items
+				yym1078 := z.DecBinary()
+				_ = yym1078
 				if false {
 				} else {
-					h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1082), d)
+					h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1077), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1077)
-		} // end switch yys1077
-	} // end for yyj1077
-	if !yyhl1077 {
+			z.DecStructFieldNotFound(-1, yys1072)
+		} // end switch yys1072
+	} // end for yyj1072
+	if !yyhl1072 {
 		r.ReadEnd()
 	}
 }
@@ -12104,16 +12060,16 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1084 int
-	var yyb1084 bool
-	var yyhl1084 bool = l >= 0
-	yyj1084++
-	if yyhl1084 {
-		yyb1084 = yyj1084 > l
+	var yyj1079 int
+	var yyb1079 bool
+	var yyhl1079 bool = l >= 0
+	yyj1079++
+	if yyhl1079 {
+		yyb1079 = yyj1079 > l
 	} else {
-		yyb1084 = r.CheckBreak()
+		yyb1079 = r.CheckBreak()
 	}
-	if yyb1084 {
+	if yyb1079 {
 		r.ReadEnd()
 		return
 	}
@@ -12122,13 +12078,13 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.Kind = string(r.DecodeString())
 	}
-	yyj1084++
-	if yyhl1084 {
-		yyb1084 = yyj1084 > l
+	yyj1079++
+	if yyhl1079 {
+		yyb1079 = yyj1079 > l
 	} else {
-		yyb1084 = r.CheckBreak()
+		yyb1079 = r.CheckBreak()
 	}
-	if yyb1084 {
+	if yyb1079 {
 		r.ReadEnd()
 		return
 	}
@@ -12137,60 +12093,60 @@ func (x *ClusterAutoscalerList) codecDecodeSelfFromArray(l int, d *codec1978.Dec
 	} else {
 		x.APIVersion = string(r.DecodeString())
 	}
-	yyj1084++
-	if yyhl1084 {
-		yyb1084 = yyj1084 > l
+	yyj1079++
+	if yyhl1079 {
+		yyb1079 = yyj1079 > l
 	} else {
-		yyb1084 = r.CheckBreak()
+		yyb1079 = r.CheckBreak()
 	}
-	if yyb1084 {
+	if yyb1079 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg1_unversioned.ListMeta{}
 	} else {
-		yyv1087 := &x.ListMeta
-		yym1088 := z.DecBinary()
-		_ = yym1088
+		yyv1082 := &x.ListMeta
+		yym1083 := z.DecBinary()
+		_ = yym1083
 		if false {
-		} else if z.HasExtensions() && z.DecExt(yyv1087) {
+		} else if z.HasExtensions() && z.DecExt(yyv1082) {
 		} else {
-			z.DecFallback(yyv1087, false)
+			z.DecFallback(yyv1082, false)
 		}
 	}
-	yyj1084++
-	if yyhl1084 {
-		yyb1084 = yyj1084 > l
+	yyj1079++
+	if yyhl1079 {
+		yyb1079 = yyj1079 > l
 	} else {
-		yyb1084 = r.CheckBreak()
+		yyb1079 = r.CheckBreak()
 	}
-	if yyb1084 {
+	if yyb1079 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
-		yyv1089 := &x.Items
-		yym1090 := z.DecBinary()
-		_ = yym1090
+		yyv1084 := &x.Items
+		yym1085 := z.DecBinary()
+		_ = yym1085
 		if false {
 		} else {
-			h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1089), d)
+			h.decSliceClusterAutoscaler((*[]ClusterAutoscaler)(yyv1084), d)
 		}
 	}
 	for {
-		yyj1084++
-		if yyhl1084 {
-			yyb1084 = yyj1084 > l
+		yyj1079++
+		if yyhl1079 {
+			yyb1079 = yyj1079 > l
 		} else {
-			yyb1084 = r.CheckBreak()
+			yyb1079 = r.CheckBreak()
 		}
-		if yyb1084 {
+		if yyb1079 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1084-1, "")
+		z.DecStructFieldNotFound(yyj1079-1, "")
 	}
 	r.ReadEnd()
 }
@@ -12202,36 +12158,36 @@ func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1091 := z.EncBinary()
-		_ = yym1091
+		yym1086 := z.EncBinary()
+		_ = yym1086
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1092 := !z.EncBinary()
-			yy2arr1092 := z.EncBasicHandle().StructToArray
-			var yyq1092 [2]bool
-			_, _, _ = yysep1092, yyq1092, yy2arr1092
-			const yyr1092 bool = false
-			yyq1092[0] = len(x.MatchLabels) != 0
-			yyq1092[1] = len(x.MatchExpressions) != 0
-			if yyr1092 || yy2arr1092 {
+			yysep1087 := !z.EncBinary()
+			yy2arr1087 := z.EncBasicHandle().StructToArray
+			var yyq1087 [2]bool
+			_, _, _ = yysep1087, yyq1087, yy2arr1087
+			const yyr1087 bool = false
+			yyq1087[0] = len(x.MatchLabels) != 0
+			yyq1087[1] = len(x.MatchExpressions) != 0
+			if yyr1087 || yy2arr1087 {
 				r.EncodeArrayStart(2)
 			} else {
-				var yynn1092 int = 0
-				for _, b := range yyq1092 {
+				var yynn1087 int = 0
+				for _, b := range yyq1087 {
 					if b {
-						yynn1092++
+						yynn1087++
 					}
 				}
-				r.EncodeMapStart(yynn1092)
+				r.EncodeMapStart(yynn1087)
 			}
-			if yyr1092 || yy2arr1092 {
-				if yyq1092[0] {
+			if yyr1087 || yy2arr1087 {
+				if yyq1087[0] {
 					if x.MatchLabels == nil {
 						r.EncodeNil()
 					} else {
-						yym1094 := z.EncBinary()
-						_ = yym1094
+						yym1089 := z.EncBinary()
+						_ = yym1089
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.MatchLabels, false, e)
@@ -12241,13 +12197,13 @@ func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1092[0] {
+				if yyq1087[0] {
 					r.EncodeString(codecSelferC_UTF81234, string("matchLabels"))
 					if x.MatchLabels == nil {
 						r.EncodeNil()
 					} else {
-						yym1095 := z.EncBinary()
-						_ = yym1095
+						yym1090 := z.EncBinary()
+						_ = yym1090
 						if false {
 						} else {
 							z.F.EncMapStringStringV(x.MatchLabels, false, e)
@@ -12255,13 +12211,13 @@ func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yyr1092 || yy2arr1092 {
-				if yyq1092[1] {
+			if yyr1087 || yy2arr1087 {
+				if yyq1087[1] {
 					if x.MatchExpressions == nil {
 						r.EncodeNil()
 					} else {
-						yym1097 := z.EncBinary()
-						_ = yym1097
+						yym1092 := z.EncBinary()
+						_ = yym1092
 						if false {
 						} else {
 							h.encSlicePodSelectorRequirement(([]PodSelectorRequirement)(x.MatchExpressions), e)
@@ -12271,13 +12227,13 @@ func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1092[1] {
+				if yyq1087[1] {
 					r.EncodeString(codecSelferC_UTF81234, string("matchExpressions"))
 					if x.MatchExpressions == nil {
 						r.EncodeNil()
 					} else {
-						yym1098 := z.EncBinary()
-						_ = yym1098
+						yym1093 := z.EncBinary()
+						_ = yym1093
 						if false {
 						} else {
 							h.encSlicePodSelectorRequirement(([]PodSelectorRequirement)(x.MatchExpressions), e)
@@ -12285,7 +12241,7 @@ func (x *PodSelector) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1092 {
+			if yysep1087 {
 				r.EncodeEnd()
 			}
 		}
@@ -12296,24 +12252,24 @@ func (x *PodSelector) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1099 := z.DecBinary()
-	_ = yym1099
+	yym1094 := z.DecBinary()
+	_ = yym1094
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1100 := r.ReadMapStart()
-			if yyl1100 == 0 {
+			yyl1095 := r.ReadMapStart()
+			if yyl1095 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1100, d)
+				x.codecDecodeSelfFromMap(yyl1095, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1100 := r.ReadArrayStart()
-			if yyl1100 == 0 {
+			yyl1095 := r.ReadArrayStart()
+			if yyl1095 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1100, d)
+				x.codecDecodeSelfFromArray(yyl1095, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -12325,12 +12281,12 @@ func (x *PodSelector) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1101Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1101Slc
-	var yyhl1101 bool = l >= 0
-	for yyj1101 := 0; ; yyj1101++ {
-		if yyhl1101 {
-			if yyj1101 >= l {
+	var yys1096Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1096Slc
+	var yyhl1096 bool = l >= 0
+	for yyj1096 := 0; ; yyj1096++ {
+		if yyhl1096 {
+			if yyj1096 >= l {
 				break
 			}
 		} else {
@@ -12338,38 +12294,38 @@ func (x *PodSelector) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		yys1101Slc = r.DecodeBytes(yys1101Slc, true, true)
-		yys1101 := string(yys1101Slc)
-		switch yys1101 {
+		yys1096Slc = r.DecodeBytes(yys1096Slc, true, true)
+		yys1096 := string(yys1096Slc)
+		switch yys1096 {
 		case "matchLabels":
 			if r.TryDecodeAsNil() {
 				x.MatchLabels = nil
 			} else {
-				yyv1102 := &x.MatchLabels
-				yym1103 := z.DecBinary()
-				_ = yym1103
+				yyv1097 := &x.MatchLabels
+				yym1098 := z.DecBinary()
+				_ = yym1098
 				if false {
 				} else {
-					z.F.DecMapStringStringX(yyv1102, false, d)
+					z.F.DecMapStringStringX(yyv1097, false, d)
 				}
 			}
 		case "matchExpressions":
 			if r.TryDecodeAsNil() {
 				x.MatchExpressions = nil
 			} else {
-				yyv1104 := &x.MatchExpressions
-				yym1105 := z.DecBinary()
-				_ = yym1105
+				yyv1099 := &x.MatchExpressions
+				yym1100 := z.DecBinary()
+				_ = yym1100
 				if false {
 				} else {
-					h.decSlicePodSelectorRequirement((*[]PodSelectorRequirement)(yyv1104), d)
+					h.decSlicePodSelectorRequirement((*[]PodSelectorRequirement)(yyv1099), d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1101)
-		} // end switch yys1101
-	} // end for yyj1101
-	if !yyhl1101 {
+			z.DecStructFieldNotFound(-1, yys1096)
+		} // end switch yys1096
+	} // end for yyj1096
+	if !yyhl1096 {
 		r.ReadEnd()
 	}
 }
@@ -12378,62 +12334,62 @@ func (x *PodSelector) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1106 int
-	var yyb1106 bool
-	var yyhl1106 bool = l >= 0
-	yyj1106++
-	if yyhl1106 {
-		yyb1106 = yyj1106 > l
+	var yyj1101 int
+	var yyb1101 bool
+	var yyhl1101 bool = l >= 0
+	yyj1101++
+	if yyhl1101 {
+		yyb1101 = yyj1101 > l
 	} else {
-		yyb1106 = r.CheckBreak()
+		yyb1101 = r.CheckBreak()
 	}
-	if yyb1106 {
+	if yyb1101 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.MatchLabels = nil
 	} else {
-		yyv1107 := &x.MatchLabels
-		yym1108 := z.DecBinary()
-		_ = yym1108
+		yyv1102 := &x.MatchLabels
+		yym1103 := z.DecBinary()
+		_ = yym1103
 		if false {
 		} else {
-			z.F.DecMapStringStringX(yyv1107, false, d)
+			z.F.DecMapStringStringX(yyv1102, false, d)
 		}
 	}
-	yyj1106++
-	if yyhl1106 {
-		yyb1106 = yyj1106 > l
+	yyj1101++
+	if yyhl1101 {
+		yyb1101 = yyj1101 > l
 	} else {
-		yyb1106 = r.CheckBreak()
+		yyb1101 = r.CheckBreak()
 	}
-	if yyb1106 {
+	if yyb1101 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.MatchExpressions = nil
 	} else {
-		yyv1109 := &x.MatchExpressions
-		yym1110 := z.DecBinary()
-		_ = yym1110
+		yyv1104 := &x.MatchExpressions
+		yym1105 := z.DecBinary()
+		_ = yym1105
 		if false {
 		} else {
-			h.decSlicePodSelectorRequirement((*[]PodSelectorRequirement)(yyv1109), d)
+			h.decSlicePodSelectorRequirement((*[]PodSelectorRequirement)(yyv1104), d)
 		}
 	}
 	for {
-		yyj1106++
-		if yyhl1106 {
-			yyb1106 = yyj1106 > l
+		yyj1101++
+		if yyhl1101 {
+			yyb1101 = yyj1101 > l
 		} else {
-			yyb1106 = r.CheckBreak()
+			yyb1101 = r.CheckBreak()
 		}
-		if yyb1106 {
+		if yyb1101 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1106-1, "")
+		z.DecStructFieldNotFound(yyj1101-1, "")
 	}
 	r.ReadEnd()
 }
@@ -12445,57 +12401,57 @@ func (x *PodSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
 	if x == nil {
 		r.EncodeNil()
 	} else {
-		yym1111 := z.EncBinary()
-		_ = yym1111
+		yym1106 := z.EncBinary()
+		_ = yym1106
 		if false {
 		} else if z.HasExtensions() && z.EncExt(x) {
 		} else {
-			yysep1112 := !z.EncBinary()
-			yy2arr1112 := z.EncBasicHandle().StructToArray
-			var yyq1112 [3]bool
-			_, _, _ = yysep1112, yyq1112, yy2arr1112
-			const yyr1112 bool = false
-			yyq1112[2] = len(x.Values) != 0
-			if yyr1112 || yy2arr1112 {
+			yysep1107 := !z.EncBinary()
+			yy2arr1107 := z.EncBasicHandle().StructToArray
+			var yyq1107 [3]bool
+			_, _, _ = yysep1107, yyq1107, yy2arr1107
+			const yyr1107 bool = false
+			yyq1107[2] = len(x.Values) != 0
+			if yyr1107 || yy2arr1107 {
 				r.EncodeArrayStart(3)
 			} else {
-				var yynn1112 int = 2
-				for _, b := range yyq1112 {
+				var yynn1107 int = 2
+				for _, b := range yyq1107 {
 					if b {
-						yynn1112++
+						yynn1107++
 					}
 				}
-				r.EncodeMapStart(yynn1112)
+				r.EncodeMapStart(yynn1107)
 			}
-			if yyr1112 || yy2arr1112 {
-				yym1114 := z.EncBinary()
-				_ = yym1114
+			if yyr1107 || yy2arr1107 {
+				yym1109 := z.EncBinary()
+				_ = yym1109
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
 				}
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("key"))
-				yym1115 := z.EncBinary()
-				_ = yym1115
+				yym1110 := z.EncBinary()
+				_ = yym1110
 				if false {
 				} else {
 					r.EncodeString(codecSelferC_UTF81234, string(x.Key))
 				}
 			}
-			if yyr1112 || yy2arr1112 {
+			if yyr1107 || yy2arr1107 {
 				x.Operator.CodecEncodeSelf(e)
 			} else {
 				r.EncodeString(codecSelferC_UTF81234, string("operator"))
 				x.Operator.CodecEncodeSelf(e)
 			}
-			if yyr1112 || yy2arr1112 {
-				if yyq1112[2] {
+			if yyr1107 || yy2arr1107 {
+				if yyq1107[2] {
 					if x.Values == nil {
 						r.EncodeNil()
 					} else {
-						yym1118 := z.EncBinary()
-						_ = yym1118
+						yym1113 := z.EncBinary()
+						_ = yym1113
 						if false {
 						} else {
 							z.F.EncSliceStringV(x.Values, false, e)
@@ -12505,13 +12461,13 @@ func (x *PodSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeNil()
 				}
 			} else {
-				if yyq1112[2] {
+				if yyq1107[2] {
 					r.EncodeString(codecSelferC_UTF81234, string("values"))
 					if x.Values == nil {
 						r.EncodeNil()
 					} else {
-						yym1119 := z.EncBinary()
-						_ = yym1119
+						yym1114 := z.EncBinary()
+						_ = yym1114
 						if false {
 						} else {
 							z.F.EncSliceStringV(x.Values, false, e)
@@ -12519,7 +12475,7 @@ func (x *PodSelectorRequirement) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			}
-			if yysep1112 {
+			if yysep1107 {
 				r.EncodeEnd()
 			}
 		}
@@ -12530,24 +12486,24 @@ func (x *PodSelectorRequirement) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1120 := z.DecBinary()
-	_ = yym1120
+	yym1115 := z.DecBinary()
+	_ = yym1115
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		if r.IsContainerType(codecSelferValueTypeMap1234) {
-			yyl1121 := r.ReadMapStart()
-			if yyl1121 == 0 {
+			yyl1116 := r.ReadMapStart()
+			if yyl1116 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromMap(yyl1121, d)
+				x.codecDecodeSelfFromMap(yyl1116, d)
 			}
 		} else if r.IsContainerType(codecSelferValueTypeArray1234) {
-			yyl1121 := r.ReadArrayStart()
-			if yyl1121 == 0 {
+			yyl1116 := r.ReadArrayStart()
+			if yyl1116 == 0 {
 				r.ReadEnd()
 			} else {
-				x.codecDecodeSelfFromArray(yyl1121, d)
+				x.codecDecodeSelfFromArray(yyl1116, d)
 			}
 		} else {
 			panic(codecSelferOnlyMapOrArrayEncodeToStructErr1234)
@@ -12559,12 +12515,12 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yys1122Slc = z.DecScratchBuffer() // default slice to decode into
-	_ = yys1122Slc
-	var yyhl1122 bool = l >= 0
-	for yyj1122 := 0; ; yyj1122++ {
-		if yyhl1122 {
-			if yyj1122 >= l {
+	var yys1117Slc = z.DecScratchBuffer() // default slice to decode into
+	_ = yys1117Slc
+	var yyhl1117 bool = l >= 0
+	for yyj1117 := 0; ; yyj1117++ {
+		if yyhl1117 {
+			if yyj1117 >= l {
 				break
 			}
 		} else {
@@ -12572,9 +12528,9 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 				break
 			}
 		}
-		yys1122Slc = r.DecodeBytes(yys1122Slc, true, true)
-		yys1122 := string(yys1122Slc)
-		switch yys1122 {
+		yys1117Slc = r.DecodeBytes(yys1117Slc, true, true)
+		yys1117 := string(yys1117Slc)
+		switch yys1117 {
 		case "key":
 			if r.TryDecodeAsNil() {
 				x.Key = ""
@@ -12591,19 +12547,19 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromMap(l int, d *codec1978.Deco
 			if r.TryDecodeAsNil() {
 				x.Values = nil
 			} else {
-				yyv1125 := &x.Values
-				yym1126 := z.DecBinary()
-				_ = yym1126
+				yyv1120 := &x.Values
+				yym1121 := z.DecBinary()
+				_ = yym1121
 				if false {
 				} else {
-					z.F.DecSliceStringX(yyv1125, false, d)
+					z.F.DecSliceStringX(yyv1120, false, d)
 				}
 			}
 		default:
-			z.DecStructFieldNotFound(-1, yys1122)
-		} // end switch yys1122
-	} // end for yyj1122
-	if !yyhl1122 {
+			z.DecStructFieldNotFound(-1, yys1117)
+		} // end switch yys1117
+	} // end for yyj1117
+	if !yyhl1117 {
 		r.ReadEnd()
 	}
 }
@@ -12612,16 +12568,16 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromArray(l int, d *codec1978.De
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj1127 int
-	var yyb1127 bool
-	var yyhl1127 bool = l >= 0
-	yyj1127++
-	if yyhl1127 {
-		yyb1127 = yyj1127 > l
+	var yyj1122 int
+	var yyb1122 bool
+	var yyhl1122 bool = l >= 0
+	yyj1122++
+	if yyhl1122 {
+		yyb1122 = yyj1122 > l
 	} else {
-		yyb1127 = r.CheckBreak()
+		yyb1122 = r.CheckBreak()
 	}
-	if yyb1127 {
+	if yyb1122 {
 		r.ReadEnd()
 		return
 	}
@@ -12630,13 +12586,13 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromArray(l int, d *codec1978.De
 	} else {
 		x.Key = string(r.DecodeString())
 	}
-	yyj1127++
-	if yyhl1127 {
-		yyb1127 = yyj1127 > l
+	yyj1122++
+	if yyhl1122 {
+		yyb1122 = yyj1122 > l
 	} else {
-		yyb1127 = r.CheckBreak()
+		yyb1122 = r.CheckBreak()
 	}
-	if yyb1127 {
+	if yyb1122 {
 		r.ReadEnd()
 		return
 	}
@@ -12645,38 +12601,38 @@ func (x *PodSelectorRequirement) codecDecodeSelfFromArray(l int, d *codec1978.De
 	} else {
 		x.Operator = PodSelectorOperator(r.DecodeString())
 	}
-	yyj1127++
-	if yyhl1127 {
-		yyb1127 = yyj1127 > l
+	yyj1122++
+	if yyhl1122 {
+		yyb1122 = yyj1122 > l
 	} else {
-		yyb1127 = r.CheckBreak()
+		yyb1122 = r.CheckBreak()
 	}
-	if yyb1127 {
+	if yyb1122 {
 		r.ReadEnd()
 		return
 	}
 	if r.TryDecodeAsNil() {
 		x.Values = nil
 	} else {
-		yyv1130 := &x.Values
-		yym1131 := z.DecBinary()
-		_ = yym1131
+		yyv1125 := &x.Values
+		yym1126 := z.DecBinary()
+		_ = yym1126
 		if false {
 		} else {
-			z.F.DecSliceStringX(yyv1130, false, d)
+			z.F.DecSliceStringX(yyv1125, false, d)
 		}
 	}
 	for {
-		yyj1127++
-		if yyhl1127 {
-			yyb1127 = yyj1127 > l
+		yyj1122++
+		if yyhl1122 {
+			yyb1122 = yyj1122 > l
 		} else {
-			yyb1127 = r.CheckBreak()
+			yyb1122 = r.CheckBreak()
 		}
-		if yyb1127 {
+		if yyb1122 {
 			break
 		}
-		z.DecStructFieldNotFound(yyj1127-1, "")
+		z.DecStructFieldNotFound(yyj1122-1, "")
 	}
 	r.ReadEnd()
 }
@@ -12685,8 +12641,8 @@ func (x PodSelectorOperator) CodecEncodeSelf(e *codec1978.Encoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
-	yym1132 := z.EncBinary()
-	_ = yym1132
+	yym1127 := z.EncBinary()
+	_ = yym1127
 	if false {
 	} else if z.HasExtensions() && z.EncExt(x) {
 	} else {
@@ -12698,8 +12654,8 @@ func (x *PodSelectorOperator) CodecDecodeSelf(d *codec1978.Decoder) {
 	var h codecSelfer1234
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	yym1133 := z.DecBinary()
-	_ = yym1133
+	yym1128 := z.DecBinary()
+	_ = yym1128
 	if false {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
@@ -12712,9 +12668,9 @@ func (x codecSelfer1234) encSliceHorizontalPodAutoscaler(v []HorizontalPodAutosc
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1134 := range v {
-		yy1135 := &yyv1134
-		yy1135.CodecEncodeSelf(e)
+	for _, yyv1129 := range v {
+		yy1130 := &yyv1129
+		yy1130.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -12724,75 +12680,75 @@ func (x codecSelfer1234) decSliceHorizontalPodAutoscaler(v *[]HorizontalPodAutos
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1136 := *v
-	yyh1136, yyl1136 := z.DecSliceHelperStart()
+	yyv1131 := *v
+	yyh1131, yyl1131 := z.DecSliceHelperStart()
 
-	var yyrr1136, yyrl1136 int
-	var yyc1136, yyrt1136 bool
-	_, _, _ = yyc1136, yyrt1136, yyrl1136
-	yyrr1136 = yyl1136
+	var yyrr1131, yyrl1131 int
+	var yyc1131, yyrt1131 bool
+	_, _, _ = yyc1131, yyrt1131, yyrl1131
+	yyrr1131 = yyl1131
 
-	if yyv1136 == nil {
-		if yyrl1136, yyrt1136 = z.DecInferLen(yyl1136, z.DecBasicHandle().MaxInitLen, 336); yyrt1136 {
-			yyrr1136 = yyrl1136
+	if yyv1131 == nil {
+		if yyrl1131, yyrt1131 = z.DecInferLen(yyl1131, z.DecBasicHandle().MaxInitLen, 320); yyrt1131 {
+			yyrr1131 = yyrl1131
 		}
-		yyv1136 = make([]HorizontalPodAutoscaler, yyrl1136)
-		yyc1136 = true
+		yyv1131 = make([]HorizontalPodAutoscaler, yyrl1131)
+		yyc1131 = true
 	}
 
-	if yyl1136 == 0 {
-		if len(yyv1136) != 0 {
-			yyv1136 = yyv1136[:0]
-			yyc1136 = true
+	if yyl1131 == 0 {
+		if len(yyv1131) != 0 {
+			yyv1131 = yyv1131[:0]
+			yyc1131 = true
 		}
-	} else if yyl1136 > 0 {
+	} else if yyl1131 > 0 {
 
-		if yyl1136 > cap(yyv1136) {
-			yyrl1136, yyrt1136 = z.DecInferLen(yyl1136, z.DecBasicHandle().MaxInitLen, 336)
-			yyv1136 = make([]HorizontalPodAutoscaler, yyrl1136)
-			yyc1136 = true
+		if yyl1131 > cap(yyv1131) {
+			yyrl1131, yyrt1131 = z.DecInferLen(yyl1131, z.DecBasicHandle().MaxInitLen, 320)
+			yyv1131 = make([]HorizontalPodAutoscaler, yyrl1131)
+			yyc1131 = true
 
-			yyrr1136 = len(yyv1136)
-		} else if yyl1136 != len(yyv1136) {
-			yyv1136 = yyv1136[:yyl1136]
-			yyc1136 = true
+			yyrr1131 = len(yyv1131)
+		} else if yyl1131 != len(yyv1131) {
+			yyv1131 = yyv1131[:yyl1131]
+			yyc1131 = true
 		}
-		yyj1136 := 0
-		for ; yyj1136 < yyrr1136; yyj1136++ {
+		yyj1131 := 0
+		for ; yyj1131 < yyrr1131; yyj1131++ {
 			if r.TryDecodeAsNil() {
-				yyv1136[yyj1136] = HorizontalPodAutoscaler{}
+				yyv1131[yyj1131] = HorizontalPodAutoscaler{}
 			} else {
-				yyv1137 := &yyv1136[yyj1136]
-				yyv1137.CodecDecodeSelf(d)
+				yyv1132 := &yyv1131[yyj1131]
+				yyv1132.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1136 {
-			for ; yyj1136 < yyl1136; yyj1136++ {
-				yyv1136 = append(yyv1136, HorizontalPodAutoscaler{})
+		if yyrt1131 {
+			for ; yyj1131 < yyl1131; yyj1131++ {
+				yyv1131 = append(yyv1131, HorizontalPodAutoscaler{})
 				if r.TryDecodeAsNil() {
-					yyv1136[yyj1136] = HorizontalPodAutoscaler{}
+					yyv1131[yyj1131] = HorizontalPodAutoscaler{}
 				} else {
-					yyv1138 := &yyv1136[yyj1136]
-					yyv1138.CodecDecodeSelf(d)
+					yyv1133 := &yyv1131[yyj1131]
+					yyv1133.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1136 := 0; !r.CheckBreak(); yyj1136++ {
-			if yyj1136 >= len(yyv1136) {
-				yyv1136 = append(yyv1136, HorizontalPodAutoscaler{}) // var yyz1136 HorizontalPodAutoscaler
-				yyc1136 = true
+		for yyj1131 := 0; !r.CheckBreak(); yyj1131++ {
+			if yyj1131 >= len(yyv1131) {
+				yyv1131 = append(yyv1131, HorizontalPodAutoscaler{}) // var yyz1131 HorizontalPodAutoscaler
+				yyc1131 = true
 			}
 
-			if yyj1136 < len(yyv1136) {
+			if yyj1131 < len(yyv1131) {
 				if r.TryDecodeAsNil() {
-					yyv1136[yyj1136] = HorizontalPodAutoscaler{}
+					yyv1131[yyj1131] = HorizontalPodAutoscaler{}
 				} else {
-					yyv1139 := &yyv1136[yyj1136]
-					yyv1139.CodecDecodeSelf(d)
+					yyv1134 := &yyv1131[yyj1131]
+					yyv1134.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -12800,10 +12756,10 @@ func (x codecSelfer1234) decSliceHorizontalPodAutoscaler(v *[]HorizontalPodAutos
 			}
 
 		}
-		yyh1136.End()
+		yyh1131.End()
 	}
-	if yyc1136 {
-		*v = yyv1136
+	if yyc1131 {
+		*v = yyv1131
 	}
 
 }
@@ -12813,9 +12769,9 @@ func (x codecSelfer1234) encSliceAPIVersion(v []APIVersion, e *codec1978.Encoder
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1140 := range v {
-		yy1141 := &yyv1140
-		yy1141.CodecEncodeSelf(e)
+	for _, yyv1135 := range v {
+		yy1136 := &yyv1135
+		yy1136.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -12825,75 +12781,75 @@ func (x codecSelfer1234) decSliceAPIVersion(v *[]APIVersion, d *codec1978.Decode
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1142 := *v
-	yyh1142, yyl1142 := z.DecSliceHelperStart()
+	yyv1137 := *v
+	yyh1137, yyl1137 := z.DecSliceHelperStart()
 
-	var yyrr1142, yyrl1142 int
-	var yyc1142, yyrt1142 bool
-	_, _, _ = yyc1142, yyrt1142, yyrl1142
-	yyrr1142 = yyl1142
+	var yyrr1137, yyrl1137 int
+	var yyc1137, yyrt1137 bool
+	_, _, _ = yyc1137, yyrt1137, yyrl1137
+	yyrr1137 = yyl1137
 
-	if yyv1142 == nil {
-		if yyrl1142, yyrt1142 = z.DecInferLen(yyl1142, z.DecBasicHandle().MaxInitLen, 32); yyrt1142 {
-			yyrr1142 = yyrl1142
+	if yyv1137 == nil {
+		if yyrl1137, yyrt1137 = z.DecInferLen(yyl1137, z.DecBasicHandle().MaxInitLen, 32); yyrt1137 {
+			yyrr1137 = yyrl1137
 		}
-		yyv1142 = make([]APIVersion, yyrl1142)
-		yyc1142 = true
+		yyv1137 = make([]APIVersion, yyrl1137)
+		yyc1137 = true
 	}
 
-	if yyl1142 == 0 {
-		if len(yyv1142) != 0 {
-			yyv1142 = yyv1142[:0]
-			yyc1142 = true
+	if yyl1137 == 0 {
+		if len(yyv1137) != 0 {
+			yyv1137 = yyv1137[:0]
+			yyc1137 = true
 		}
-	} else if yyl1142 > 0 {
+	} else if yyl1137 > 0 {
 
-		if yyl1142 > cap(yyv1142) {
-			yyrl1142, yyrt1142 = z.DecInferLen(yyl1142, z.DecBasicHandle().MaxInitLen, 32)
-			yyv1142 = make([]APIVersion, yyrl1142)
-			yyc1142 = true
+		if yyl1137 > cap(yyv1137) {
+			yyrl1137, yyrt1137 = z.DecInferLen(yyl1137, z.DecBasicHandle().MaxInitLen, 32)
+			yyv1137 = make([]APIVersion, yyrl1137)
+			yyc1137 = true
 
-			yyrr1142 = len(yyv1142)
-		} else if yyl1142 != len(yyv1142) {
-			yyv1142 = yyv1142[:yyl1142]
-			yyc1142 = true
+			yyrr1137 = len(yyv1137)
+		} else if yyl1137 != len(yyv1137) {
+			yyv1137 = yyv1137[:yyl1137]
+			yyc1137 = true
 		}
-		yyj1142 := 0
-		for ; yyj1142 < yyrr1142; yyj1142++ {
+		yyj1137 := 0
+		for ; yyj1137 < yyrr1137; yyj1137++ {
 			if r.TryDecodeAsNil() {
-				yyv1142[yyj1142] = APIVersion{}
+				yyv1137[yyj1137] = APIVersion{}
 			} else {
-				yyv1143 := &yyv1142[yyj1142]
-				yyv1143.CodecDecodeSelf(d)
+				yyv1138 := &yyv1137[yyj1137]
+				yyv1138.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1142 {
-			for ; yyj1142 < yyl1142; yyj1142++ {
-				yyv1142 = append(yyv1142, APIVersion{})
+		if yyrt1137 {
+			for ; yyj1137 < yyl1137; yyj1137++ {
+				yyv1137 = append(yyv1137, APIVersion{})
 				if r.TryDecodeAsNil() {
-					yyv1142[yyj1142] = APIVersion{}
+					yyv1137[yyj1137] = APIVersion{}
 				} else {
-					yyv1144 := &yyv1142[yyj1142]
-					yyv1144.CodecDecodeSelf(d)
+					yyv1139 := &yyv1137[yyj1137]
+					yyv1139.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1142 := 0; !r.CheckBreak(); yyj1142++ {
-			if yyj1142 >= len(yyv1142) {
-				yyv1142 = append(yyv1142, APIVersion{}) // var yyz1142 APIVersion
-				yyc1142 = true
+		for yyj1137 := 0; !r.CheckBreak(); yyj1137++ {
+			if yyj1137 >= len(yyv1137) {
+				yyv1137 = append(yyv1137, APIVersion{}) // var yyz1137 APIVersion
+				yyc1137 = true
 			}
 
-			if yyj1142 < len(yyv1142) {
+			if yyj1137 < len(yyv1137) {
 				if r.TryDecodeAsNil() {
-					yyv1142[yyj1142] = APIVersion{}
+					yyv1137[yyj1137] = APIVersion{}
 				} else {
-					yyv1145 := &yyv1142[yyj1142]
-					yyv1145.CodecDecodeSelf(d)
+					yyv1140 := &yyv1137[yyj1137]
+					yyv1140.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -12901,10 +12857,10 @@ func (x codecSelfer1234) decSliceAPIVersion(v *[]APIVersion, d *codec1978.Decode
 			}
 
 		}
-		yyh1142.End()
+		yyh1137.End()
 	}
-	if yyc1142 {
-		*v = yyv1142
+	if yyc1137 {
+		*v = yyv1137
 	}
 
 }
@@ -12914,9 +12870,9 @@ func (x codecSelfer1234) encSliceThirdPartyResource(v []ThirdPartyResource, e *c
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1146 := range v {
-		yy1147 := &yyv1146
-		yy1147.CodecEncodeSelf(e)
+	for _, yyv1141 := range v {
+		yy1142 := &yyv1141
+		yy1142.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -12926,75 +12882,75 @@ func (x codecSelfer1234) decSliceThirdPartyResource(v *[]ThirdPartyResource, d *
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1148 := *v
-	yyh1148, yyl1148 := z.DecSliceHelperStart()
+	yyv1143 := *v
+	yyh1143, yyl1143 := z.DecSliceHelperStart()
 
-	var yyrr1148, yyrl1148 int
-	var yyc1148, yyrt1148 bool
-	_, _, _ = yyc1148, yyrt1148, yyrl1148
-	yyrr1148 = yyl1148
+	var yyrr1143, yyrl1143 int
+	var yyc1143, yyrt1143 bool
+	_, _, _ = yyc1143, yyrt1143, yyrl1143
+	yyrr1143 = yyl1143
 
-	if yyv1148 == nil {
-		if yyrl1148, yyrt1148 = z.DecInferLen(yyl1148, z.DecBasicHandle().MaxInitLen, 232); yyrt1148 {
-			yyrr1148 = yyrl1148
+	if yyv1143 == nil {
+		if yyrl1143, yyrt1143 = z.DecInferLen(yyl1143, z.DecBasicHandle().MaxInitLen, 232); yyrt1143 {
+			yyrr1143 = yyrl1143
 		}
-		yyv1148 = make([]ThirdPartyResource, yyrl1148)
-		yyc1148 = true
+		yyv1143 = make([]ThirdPartyResource, yyrl1143)
+		yyc1143 = true
 	}
 
-	if yyl1148 == 0 {
-		if len(yyv1148) != 0 {
-			yyv1148 = yyv1148[:0]
-			yyc1148 = true
+	if yyl1143 == 0 {
+		if len(yyv1143) != 0 {
+			yyv1143 = yyv1143[:0]
+			yyc1143 = true
 		}
-	} else if yyl1148 > 0 {
+	} else if yyl1143 > 0 {
 
-		if yyl1148 > cap(yyv1148) {
-			yyrl1148, yyrt1148 = z.DecInferLen(yyl1148, z.DecBasicHandle().MaxInitLen, 232)
-			yyv1148 = make([]ThirdPartyResource, yyrl1148)
-			yyc1148 = true
+		if yyl1143 > cap(yyv1143) {
+			yyrl1143, yyrt1143 = z.DecInferLen(yyl1143, z.DecBasicHandle().MaxInitLen, 232)
+			yyv1143 = make([]ThirdPartyResource, yyrl1143)
+			yyc1143 = true
 
-			yyrr1148 = len(yyv1148)
-		} else if yyl1148 != len(yyv1148) {
-			yyv1148 = yyv1148[:yyl1148]
-			yyc1148 = true
+			yyrr1143 = len(yyv1143)
+		} else if yyl1143 != len(yyv1143) {
+			yyv1143 = yyv1143[:yyl1143]
+			yyc1143 = true
 		}
-		yyj1148 := 0
-		for ; yyj1148 < yyrr1148; yyj1148++ {
+		yyj1143 := 0
+		for ; yyj1143 < yyrr1143; yyj1143++ {
 			if r.TryDecodeAsNil() {
-				yyv1148[yyj1148] = ThirdPartyResource{}
+				yyv1143[yyj1143] = ThirdPartyResource{}
 			} else {
-				yyv1149 := &yyv1148[yyj1148]
-				yyv1149.CodecDecodeSelf(d)
+				yyv1144 := &yyv1143[yyj1143]
+				yyv1144.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1148 {
-			for ; yyj1148 < yyl1148; yyj1148++ {
-				yyv1148 = append(yyv1148, ThirdPartyResource{})
+		if yyrt1143 {
+			for ; yyj1143 < yyl1143; yyj1143++ {
+				yyv1143 = append(yyv1143, ThirdPartyResource{})
 				if r.TryDecodeAsNil() {
-					yyv1148[yyj1148] = ThirdPartyResource{}
+					yyv1143[yyj1143] = ThirdPartyResource{}
 				} else {
-					yyv1150 := &yyv1148[yyj1148]
-					yyv1150.CodecDecodeSelf(d)
+					yyv1145 := &yyv1143[yyj1143]
+					yyv1145.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1148 := 0; !r.CheckBreak(); yyj1148++ {
-			if yyj1148 >= len(yyv1148) {
-				yyv1148 = append(yyv1148, ThirdPartyResource{}) // var yyz1148 ThirdPartyResource
-				yyc1148 = true
+		for yyj1143 := 0; !r.CheckBreak(); yyj1143++ {
+			if yyj1143 >= len(yyv1143) {
+				yyv1143 = append(yyv1143, ThirdPartyResource{}) // var yyz1143 ThirdPartyResource
+				yyc1143 = true
 			}
 
-			if yyj1148 < len(yyv1148) {
+			if yyj1143 < len(yyv1143) {
 				if r.TryDecodeAsNil() {
-					yyv1148[yyj1148] = ThirdPartyResource{}
+					yyv1143[yyj1143] = ThirdPartyResource{}
 				} else {
-					yyv1151 := &yyv1148[yyj1148]
-					yyv1151.CodecDecodeSelf(d)
+					yyv1146 := &yyv1143[yyj1143]
+					yyv1146.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13002,10 +12958,10 @@ func (x codecSelfer1234) decSliceThirdPartyResource(v *[]ThirdPartyResource, d *
 			}
 
 		}
-		yyh1148.End()
+		yyh1143.End()
 	}
-	if yyc1148 {
-		*v = yyv1148
+	if yyc1143 {
+		*v = yyv1143
 	}
 
 }
@@ -13015,9 +12971,9 @@ func (x codecSelfer1234) encSliceDeployment(v []Deployment, e *codec1978.Encoder
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1152 := range v {
-		yy1153 := &yyv1152
-		yy1153.CodecEncodeSelf(e)
+	for _, yyv1147 := range v {
+		yy1148 := &yyv1147
+		yy1148.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13027,75 +12983,75 @@ func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decode
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1154 := *v
-	yyh1154, yyl1154 := z.DecSliceHelperStart()
+	yyv1149 := *v
+	yyh1149, yyl1149 := z.DecSliceHelperStart()
 
-	var yyrr1154, yyrl1154 int
-	var yyc1154, yyrt1154 bool
-	_, _, _ = yyc1154, yyrt1154, yyrl1154
-	yyrr1154 = yyl1154
+	var yyrr1149, yyrl1149 int
+	var yyc1149, yyrt1149 bool
+	_, _, _ = yyc1149, yyrt1149, yyrl1149
+	yyrr1149 = yyl1149
 
-	if yyv1154 == nil {
-		if yyrl1154, yyrt1154 = z.DecInferLen(yyl1154, z.DecBasicHandle().MaxInitLen, 608); yyrt1154 {
-			yyrr1154 = yyrl1154
+	if yyv1149 == nil {
+		if yyrl1149, yyrt1149 = z.DecInferLen(yyl1149, z.DecBasicHandle().MaxInitLen, 608); yyrt1149 {
+			yyrr1149 = yyrl1149
 		}
-		yyv1154 = make([]Deployment, yyrl1154)
-		yyc1154 = true
+		yyv1149 = make([]Deployment, yyrl1149)
+		yyc1149 = true
 	}
 
-	if yyl1154 == 0 {
-		if len(yyv1154) != 0 {
-			yyv1154 = yyv1154[:0]
-			yyc1154 = true
+	if yyl1149 == 0 {
+		if len(yyv1149) != 0 {
+			yyv1149 = yyv1149[:0]
+			yyc1149 = true
 		}
-	} else if yyl1154 > 0 {
+	} else if yyl1149 > 0 {
 
-		if yyl1154 > cap(yyv1154) {
-			yyrl1154, yyrt1154 = z.DecInferLen(yyl1154, z.DecBasicHandle().MaxInitLen, 608)
-			yyv1154 = make([]Deployment, yyrl1154)
-			yyc1154 = true
+		if yyl1149 > cap(yyv1149) {
+			yyrl1149, yyrt1149 = z.DecInferLen(yyl1149, z.DecBasicHandle().MaxInitLen, 608)
+			yyv1149 = make([]Deployment, yyrl1149)
+			yyc1149 = true
 
-			yyrr1154 = len(yyv1154)
-		} else if yyl1154 != len(yyv1154) {
-			yyv1154 = yyv1154[:yyl1154]
-			yyc1154 = true
+			yyrr1149 = len(yyv1149)
+		} else if yyl1149 != len(yyv1149) {
+			yyv1149 = yyv1149[:yyl1149]
+			yyc1149 = true
 		}
-		yyj1154 := 0
-		for ; yyj1154 < yyrr1154; yyj1154++ {
+		yyj1149 := 0
+		for ; yyj1149 < yyrr1149; yyj1149++ {
 			if r.TryDecodeAsNil() {
-				yyv1154[yyj1154] = Deployment{}
+				yyv1149[yyj1149] = Deployment{}
 			} else {
-				yyv1155 := &yyv1154[yyj1154]
-				yyv1155.CodecDecodeSelf(d)
+				yyv1150 := &yyv1149[yyj1149]
+				yyv1150.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1154 {
-			for ; yyj1154 < yyl1154; yyj1154++ {
-				yyv1154 = append(yyv1154, Deployment{})
+		if yyrt1149 {
+			for ; yyj1149 < yyl1149; yyj1149++ {
+				yyv1149 = append(yyv1149, Deployment{})
 				if r.TryDecodeAsNil() {
-					yyv1154[yyj1154] = Deployment{}
+					yyv1149[yyj1149] = Deployment{}
 				} else {
-					yyv1156 := &yyv1154[yyj1154]
-					yyv1156.CodecDecodeSelf(d)
+					yyv1151 := &yyv1149[yyj1149]
+					yyv1151.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1154 := 0; !r.CheckBreak(); yyj1154++ {
-			if yyj1154 >= len(yyv1154) {
-				yyv1154 = append(yyv1154, Deployment{}) // var yyz1154 Deployment
-				yyc1154 = true
+		for yyj1149 := 0; !r.CheckBreak(); yyj1149++ {
+			if yyj1149 >= len(yyv1149) {
+				yyv1149 = append(yyv1149, Deployment{}) // var yyz1149 Deployment
+				yyc1149 = true
 			}
 
-			if yyj1154 < len(yyv1154) {
+			if yyj1149 < len(yyv1149) {
 				if r.TryDecodeAsNil() {
-					yyv1154[yyj1154] = Deployment{}
+					yyv1149[yyj1149] = Deployment{}
 				} else {
-					yyv1157 := &yyv1154[yyj1154]
-					yyv1157.CodecDecodeSelf(d)
+					yyv1152 := &yyv1149[yyj1149]
+					yyv1152.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13103,10 +13059,10 @@ func (x codecSelfer1234) decSliceDeployment(v *[]Deployment, d *codec1978.Decode
 			}
 
 		}
-		yyh1154.End()
+		yyh1149.End()
 	}
-	if yyc1154 {
-		*v = yyv1154
+	if yyc1149 {
+		*v = yyv1149
 	}
 
 }
@@ -13116,9 +13072,9 @@ func (x codecSelfer1234) encSliceDaemonSet(v []DaemonSet, e *codec1978.Encoder) 
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1158 := range v {
-		yy1159 := &yyv1158
-		yy1159.CodecEncodeSelf(e)
+	for _, yyv1153 := range v {
+		yy1154 := &yyv1153
+		yy1154.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13128,75 +13084,75 @@ func (x codecSelfer1234) decSliceDaemonSet(v *[]DaemonSet, d *codec1978.Decoder)
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1160 := *v
-	yyh1160, yyl1160 := z.DecSliceHelperStart()
+	yyv1155 := *v
+	yyh1155, yyl1155 := z.DecSliceHelperStart()
 
-	var yyrr1160, yyrl1160 int
-	var yyc1160, yyrt1160 bool
-	_, _, _ = yyc1160, yyrt1160, yyrl1160
-	yyrr1160 = yyl1160
+	var yyrr1155, yyrl1155 int
+	var yyc1155, yyrt1155 bool
+	_, _, _ = yyc1155, yyrt1155, yyrl1155
+	yyrr1155 = yyl1155
 
-	if yyv1160 == nil {
-		if yyrl1160, yyrt1160 = z.DecInferLen(yyl1160, z.DecBasicHandle().MaxInitLen, 232); yyrt1160 {
-			yyrr1160 = yyrl1160
+	if yyv1155 == nil {
+		if yyrl1155, yyrt1155 = z.DecInferLen(yyl1155, z.DecBasicHandle().MaxInitLen, 232); yyrt1155 {
+			yyrr1155 = yyrl1155
 		}
-		yyv1160 = make([]DaemonSet, yyrl1160)
-		yyc1160 = true
+		yyv1155 = make([]DaemonSet, yyrl1155)
+		yyc1155 = true
 	}
 
-	if yyl1160 == 0 {
-		if len(yyv1160) != 0 {
-			yyv1160 = yyv1160[:0]
-			yyc1160 = true
+	if yyl1155 == 0 {
+		if len(yyv1155) != 0 {
+			yyv1155 = yyv1155[:0]
+			yyc1155 = true
 		}
-	} else if yyl1160 > 0 {
+	} else if yyl1155 > 0 {
 
-		if yyl1160 > cap(yyv1160) {
-			yyrl1160, yyrt1160 = z.DecInferLen(yyl1160, z.DecBasicHandle().MaxInitLen, 232)
-			yyv1160 = make([]DaemonSet, yyrl1160)
-			yyc1160 = true
+		if yyl1155 > cap(yyv1155) {
+			yyrl1155, yyrt1155 = z.DecInferLen(yyl1155, z.DecBasicHandle().MaxInitLen, 232)
+			yyv1155 = make([]DaemonSet, yyrl1155)
+			yyc1155 = true
 
-			yyrr1160 = len(yyv1160)
-		} else if yyl1160 != len(yyv1160) {
-			yyv1160 = yyv1160[:yyl1160]
-			yyc1160 = true
+			yyrr1155 = len(yyv1155)
+		} else if yyl1155 != len(yyv1155) {
+			yyv1155 = yyv1155[:yyl1155]
+			yyc1155 = true
 		}
-		yyj1160 := 0
-		for ; yyj1160 < yyrr1160; yyj1160++ {
+		yyj1155 := 0
+		for ; yyj1155 < yyrr1155; yyj1155++ {
 			if r.TryDecodeAsNil() {
-				yyv1160[yyj1160] = DaemonSet{}
+				yyv1155[yyj1155] = DaemonSet{}
 			} else {
-				yyv1161 := &yyv1160[yyj1160]
-				yyv1161.CodecDecodeSelf(d)
+				yyv1156 := &yyv1155[yyj1155]
+				yyv1156.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1160 {
-			for ; yyj1160 < yyl1160; yyj1160++ {
-				yyv1160 = append(yyv1160, DaemonSet{})
+		if yyrt1155 {
+			for ; yyj1155 < yyl1155; yyj1155++ {
+				yyv1155 = append(yyv1155, DaemonSet{})
 				if r.TryDecodeAsNil() {
-					yyv1160[yyj1160] = DaemonSet{}
+					yyv1155[yyj1155] = DaemonSet{}
 				} else {
-					yyv1162 := &yyv1160[yyj1160]
-					yyv1162.CodecDecodeSelf(d)
+					yyv1157 := &yyv1155[yyj1155]
+					yyv1157.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1160 := 0; !r.CheckBreak(); yyj1160++ {
-			if yyj1160 >= len(yyv1160) {
-				yyv1160 = append(yyv1160, DaemonSet{}) // var yyz1160 DaemonSet
-				yyc1160 = true
+		for yyj1155 := 0; !r.CheckBreak(); yyj1155++ {
+			if yyj1155 >= len(yyv1155) {
+				yyv1155 = append(yyv1155, DaemonSet{}) // var yyz1155 DaemonSet
+				yyc1155 = true
 			}
 
-			if yyj1160 < len(yyv1160) {
+			if yyj1155 < len(yyv1155) {
 				if r.TryDecodeAsNil() {
-					yyv1160[yyj1160] = DaemonSet{}
+					yyv1155[yyj1155] = DaemonSet{}
 				} else {
-					yyv1163 := &yyv1160[yyj1160]
-					yyv1163.CodecDecodeSelf(d)
+					yyv1158 := &yyv1155[yyj1155]
+					yyv1158.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13204,10 +13160,10 @@ func (x codecSelfer1234) decSliceDaemonSet(v *[]DaemonSet, d *codec1978.Decoder)
 			}
 
 		}
-		yyh1160.End()
+		yyh1155.End()
 	}
-	if yyc1160 {
-		*v = yyv1160
+	if yyc1155 {
+		*v = yyv1155
 	}
 
 }
@@ -13217,9 +13173,9 @@ func (x codecSelfer1234) encSliceThirdPartyResourceData(v []ThirdPartyResourceDa
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1164 := range v {
-		yy1165 := &yyv1164
-		yy1165.CodecEncodeSelf(e)
+	for _, yyv1159 := range v {
+		yy1160 := &yyv1159
+		yy1160.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13229,75 +13185,75 @@ func (x codecSelfer1234) decSliceThirdPartyResourceData(v *[]ThirdPartyResourceD
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1166 := *v
-	yyh1166, yyl1166 := z.DecSliceHelperStart()
+	yyv1161 := *v
+	yyh1161, yyl1161 := z.DecSliceHelperStart()
 
-	var yyrr1166, yyrl1166 int
-	var yyc1166, yyrt1166 bool
-	_, _, _ = yyc1166, yyrt1166, yyrl1166
-	yyrr1166 = yyl1166
+	var yyrr1161, yyrl1161 int
+	var yyc1161, yyrt1161 bool
+	_, _, _ = yyc1161, yyrt1161, yyrl1161
+	yyrr1161 = yyl1161
 
-	if yyv1166 == nil {
-		if yyrl1166, yyrt1166 = z.DecInferLen(yyl1166, z.DecBasicHandle().MaxInitLen, 216); yyrt1166 {
-			yyrr1166 = yyrl1166
+	if yyv1161 == nil {
+		if yyrl1161, yyrt1161 = z.DecInferLen(yyl1161, z.DecBasicHandle().MaxInitLen, 216); yyrt1161 {
+			yyrr1161 = yyrl1161
 		}
-		yyv1166 = make([]ThirdPartyResourceData, yyrl1166)
-		yyc1166 = true
+		yyv1161 = make([]ThirdPartyResourceData, yyrl1161)
+		yyc1161 = true
 	}
 
-	if yyl1166 == 0 {
-		if len(yyv1166) != 0 {
-			yyv1166 = yyv1166[:0]
-			yyc1166 = true
+	if yyl1161 == 0 {
+		if len(yyv1161) != 0 {
+			yyv1161 = yyv1161[:0]
+			yyc1161 = true
 		}
-	} else if yyl1166 > 0 {
+	} else if yyl1161 > 0 {
 
-		if yyl1166 > cap(yyv1166) {
-			yyrl1166, yyrt1166 = z.DecInferLen(yyl1166, z.DecBasicHandle().MaxInitLen, 216)
-			yyv1166 = make([]ThirdPartyResourceData, yyrl1166)
-			yyc1166 = true
+		if yyl1161 > cap(yyv1161) {
+			yyrl1161, yyrt1161 = z.DecInferLen(yyl1161, z.DecBasicHandle().MaxInitLen, 216)
+			yyv1161 = make([]ThirdPartyResourceData, yyrl1161)
+			yyc1161 = true
 
-			yyrr1166 = len(yyv1166)
-		} else if yyl1166 != len(yyv1166) {
-			yyv1166 = yyv1166[:yyl1166]
-			yyc1166 = true
+			yyrr1161 = len(yyv1161)
+		} else if yyl1161 != len(yyv1161) {
+			yyv1161 = yyv1161[:yyl1161]
+			yyc1161 = true
 		}
-		yyj1166 := 0
-		for ; yyj1166 < yyrr1166; yyj1166++ {
+		yyj1161 := 0
+		for ; yyj1161 < yyrr1161; yyj1161++ {
 			if r.TryDecodeAsNil() {
-				yyv1166[yyj1166] = ThirdPartyResourceData{}
+				yyv1161[yyj1161] = ThirdPartyResourceData{}
 			} else {
-				yyv1167 := &yyv1166[yyj1166]
-				yyv1167.CodecDecodeSelf(d)
+				yyv1162 := &yyv1161[yyj1161]
+				yyv1162.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1166 {
-			for ; yyj1166 < yyl1166; yyj1166++ {
-				yyv1166 = append(yyv1166, ThirdPartyResourceData{})
+		if yyrt1161 {
+			for ; yyj1161 < yyl1161; yyj1161++ {
+				yyv1161 = append(yyv1161, ThirdPartyResourceData{})
 				if r.TryDecodeAsNil() {
-					yyv1166[yyj1166] = ThirdPartyResourceData{}
+					yyv1161[yyj1161] = ThirdPartyResourceData{}
 				} else {
-					yyv1168 := &yyv1166[yyj1166]
-					yyv1168.CodecDecodeSelf(d)
+					yyv1163 := &yyv1161[yyj1161]
+					yyv1163.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1166 := 0; !r.CheckBreak(); yyj1166++ {
-			if yyj1166 >= len(yyv1166) {
-				yyv1166 = append(yyv1166, ThirdPartyResourceData{}) // var yyz1166 ThirdPartyResourceData
-				yyc1166 = true
+		for yyj1161 := 0; !r.CheckBreak(); yyj1161++ {
+			if yyj1161 >= len(yyv1161) {
+				yyv1161 = append(yyv1161, ThirdPartyResourceData{}) // var yyz1161 ThirdPartyResourceData
+				yyc1161 = true
 			}
 
-			if yyj1166 < len(yyv1166) {
+			if yyj1161 < len(yyv1161) {
 				if r.TryDecodeAsNil() {
-					yyv1166[yyj1166] = ThirdPartyResourceData{}
+					yyv1161[yyj1161] = ThirdPartyResourceData{}
 				} else {
-					yyv1169 := &yyv1166[yyj1166]
-					yyv1169.CodecDecodeSelf(d)
+					yyv1164 := &yyv1161[yyj1161]
+					yyv1164.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13305,10 +13261,10 @@ func (x codecSelfer1234) decSliceThirdPartyResourceData(v *[]ThirdPartyResourceD
 			}
 
 		}
-		yyh1166.End()
+		yyh1161.End()
 	}
-	if yyc1166 {
-		*v = yyv1166
+	if yyc1161 {
+		*v = yyv1161
 	}
 
 }
@@ -13318,9 +13274,9 @@ func (x codecSelfer1234) encSliceJob(v []Job, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1170 := range v {
-		yy1171 := &yyv1170
-		yy1171.CodecEncodeSelf(e)
+	for _, yyv1165 := range v {
+		yy1166 := &yyv1165
+		yy1166.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13330,75 +13286,75 @@ func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1172 := *v
-	yyh1172, yyl1172 := z.DecSliceHelperStart()
+	yyv1167 := *v
+	yyh1167, yyl1167 := z.DecSliceHelperStart()
 
-	var yyrr1172, yyrl1172 int
-	var yyc1172, yyrt1172 bool
-	_, _, _ = yyc1172, yyrt1172, yyrl1172
-	yyrr1172 = yyl1172
+	var yyrr1167, yyrl1167 int
+	var yyc1167, yyrt1167 bool
+	_, _, _ = yyc1167, yyrt1167, yyrl1167
+	yyrr1167 = yyl1167
 
-	if yyv1172 == nil {
-		if yyrl1172, yyrt1172 = z.DecInferLen(yyl1172, z.DecBasicHandle().MaxInitLen, 632); yyrt1172 {
-			yyrr1172 = yyrl1172
+	if yyv1167 == nil {
+		if yyrl1167, yyrt1167 = z.DecInferLen(yyl1167, z.DecBasicHandle().MaxInitLen, 632); yyrt1167 {
+			yyrr1167 = yyrl1167
 		}
-		yyv1172 = make([]Job, yyrl1172)
-		yyc1172 = true
+		yyv1167 = make([]Job, yyrl1167)
+		yyc1167 = true
 	}
 
-	if yyl1172 == 0 {
-		if len(yyv1172) != 0 {
-			yyv1172 = yyv1172[:0]
-			yyc1172 = true
+	if yyl1167 == 0 {
+		if len(yyv1167) != 0 {
+			yyv1167 = yyv1167[:0]
+			yyc1167 = true
 		}
-	} else if yyl1172 > 0 {
+	} else if yyl1167 > 0 {
 
-		if yyl1172 > cap(yyv1172) {
-			yyrl1172, yyrt1172 = z.DecInferLen(yyl1172, z.DecBasicHandle().MaxInitLen, 632)
-			yyv1172 = make([]Job, yyrl1172)
-			yyc1172 = true
+		if yyl1167 > cap(yyv1167) {
+			yyrl1167, yyrt1167 = z.DecInferLen(yyl1167, z.DecBasicHandle().MaxInitLen, 632)
+			yyv1167 = make([]Job, yyrl1167)
+			yyc1167 = true
 
-			yyrr1172 = len(yyv1172)
-		} else if yyl1172 != len(yyv1172) {
-			yyv1172 = yyv1172[:yyl1172]
-			yyc1172 = true
+			yyrr1167 = len(yyv1167)
+		} else if yyl1167 != len(yyv1167) {
+			yyv1167 = yyv1167[:yyl1167]
+			yyc1167 = true
 		}
-		yyj1172 := 0
-		for ; yyj1172 < yyrr1172; yyj1172++ {
+		yyj1167 := 0
+		for ; yyj1167 < yyrr1167; yyj1167++ {
 			if r.TryDecodeAsNil() {
-				yyv1172[yyj1172] = Job{}
+				yyv1167[yyj1167] = Job{}
 			} else {
-				yyv1173 := &yyv1172[yyj1172]
-				yyv1173.CodecDecodeSelf(d)
+				yyv1168 := &yyv1167[yyj1167]
+				yyv1168.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1172 {
-			for ; yyj1172 < yyl1172; yyj1172++ {
-				yyv1172 = append(yyv1172, Job{})
+		if yyrt1167 {
+			for ; yyj1167 < yyl1167; yyj1167++ {
+				yyv1167 = append(yyv1167, Job{})
 				if r.TryDecodeAsNil() {
-					yyv1172[yyj1172] = Job{}
+					yyv1167[yyj1167] = Job{}
 				} else {
-					yyv1174 := &yyv1172[yyj1172]
-					yyv1174.CodecDecodeSelf(d)
+					yyv1169 := &yyv1167[yyj1167]
+					yyv1169.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1172 := 0; !r.CheckBreak(); yyj1172++ {
-			if yyj1172 >= len(yyv1172) {
-				yyv1172 = append(yyv1172, Job{}) // var yyz1172 Job
-				yyc1172 = true
+		for yyj1167 := 0; !r.CheckBreak(); yyj1167++ {
+			if yyj1167 >= len(yyv1167) {
+				yyv1167 = append(yyv1167, Job{}) // var yyz1167 Job
+				yyc1167 = true
 			}
 
-			if yyj1172 < len(yyv1172) {
+			if yyj1167 < len(yyv1167) {
 				if r.TryDecodeAsNil() {
-					yyv1172[yyj1172] = Job{}
+					yyv1167[yyj1167] = Job{}
 				} else {
-					yyv1175 := &yyv1172[yyj1172]
-					yyv1175.CodecDecodeSelf(d)
+					yyv1170 := &yyv1167[yyj1167]
+					yyv1170.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13406,10 +13362,10 @@ func (x codecSelfer1234) decSliceJob(v *[]Job, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh1172.End()
+		yyh1167.End()
 	}
-	if yyc1172 {
-		*v = yyv1172
+	if yyc1167 {
+		*v = yyv1167
 	}
 
 }
@@ -13419,9 +13375,9 @@ func (x codecSelfer1234) encSliceJobCondition(v []JobCondition, e *codec1978.Enc
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1176 := range v {
-		yy1177 := &yyv1176
-		yy1177.CodecEncodeSelf(e)
+	for _, yyv1171 := range v {
+		yy1172 := &yyv1171
+		yy1172.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13431,75 +13387,75 @@ func (x codecSelfer1234) decSliceJobCondition(v *[]JobCondition, d *codec1978.De
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1178 := *v
-	yyh1178, yyl1178 := z.DecSliceHelperStart()
+	yyv1173 := *v
+	yyh1173, yyl1173 := z.DecSliceHelperStart()
 
-	var yyrr1178, yyrl1178 int
-	var yyc1178, yyrt1178 bool
-	_, _, _ = yyc1178, yyrt1178, yyrl1178
-	yyrr1178 = yyl1178
+	var yyrr1173, yyrl1173 int
+	var yyc1173, yyrt1173 bool
+	_, _, _ = yyc1173, yyrt1173, yyrl1173
+	yyrr1173 = yyl1173
 
-	if yyv1178 == nil {
-		if yyrl1178, yyrt1178 = z.DecInferLen(yyl1178, z.DecBasicHandle().MaxInitLen, 112); yyrt1178 {
-			yyrr1178 = yyrl1178
+	if yyv1173 == nil {
+		if yyrl1173, yyrt1173 = z.DecInferLen(yyl1173, z.DecBasicHandle().MaxInitLen, 112); yyrt1173 {
+			yyrr1173 = yyrl1173
 		}
-		yyv1178 = make([]JobCondition, yyrl1178)
-		yyc1178 = true
+		yyv1173 = make([]JobCondition, yyrl1173)
+		yyc1173 = true
 	}
 
-	if yyl1178 == 0 {
-		if len(yyv1178) != 0 {
-			yyv1178 = yyv1178[:0]
-			yyc1178 = true
+	if yyl1173 == 0 {
+		if len(yyv1173) != 0 {
+			yyv1173 = yyv1173[:0]
+			yyc1173 = true
 		}
-	} else if yyl1178 > 0 {
+	} else if yyl1173 > 0 {
 
-		if yyl1178 > cap(yyv1178) {
-			yyrl1178, yyrt1178 = z.DecInferLen(yyl1178, z.DecBasicHandle().MaxInitLen, 112)
-			yyv1178 = make([]JobCondition, yyrl1178)
-			yyc1178 = true
+		if yyl1173 > cap(yyv1173) {
+			yyrl1173, yyrt1173 = z.DecInferLen(yyl1173, z.DecBasicHandle().MaxInitLen, 112)
+			yyv1173 = make([]JobCondition, yyrl1173)
+			yyc1173 = true
 
-			yyrr1178 = len(yyv1178)
-		} else if yyl1178 != len(yyv1178) {
-			yyv1178 = yyv1178[:yyl1178]
-			yyc1178 = true
+			yyrr1173 = len(yyv1173)
+		} else if yyl1173 != len(yyv1173) {
+			yyv1173 = yyv1173[:yyl1173]
+			yyc1173 = true
 		}
-		yyj1178 := 0
-		for ; yyj1178 < yyrr1178; yyj1178++ {
+		yyj1173 := 0
+		for ; yyj1173 < yyrr1173; yyj1173++ {
 			if r.TryDecodeAsNil() {
-				yyv1178[yyj1178] = JobCondition{}
+				yyv1173[yyj1173] = JobCondition{}
 			} else {
-				yyv1179 := &yyv1178[yyj1178]
-				yyv1179.CodecDecodeSelf(d)
+				yyv1174 := &yyv1173[yyj1173]
+				yyv1174.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1178 {
-			for ; yyj1178 < yyl1178; yyj1178++ {
-				yyv1178 = append(yyv1178, JobCondition{})
+		if yyrt1173 {
+			for ; yyj1173 < yyl1173; yyj1173++ {
+				yyv1173 = append(yyv1173, JobCondition{})
 				if r.TryDecodeAsNil() {
-					yyv1178[yyj1178] = JobCondition{}
+					yyv1173[yyj1173] = JobCondition{}
 				} else {
-					yyv1180 := &yyv1178[yyj1178]
-					yyv1180.CodecDecodeSelf(d)
+					yyv1175 := &yyv1173[yyj1173]
+					yyv1175.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1178 := 0; !r.CheckBreak(); yyj1178++ {
-			if yyj1178 >= len(yyv1178) {
-				yyv1178 = append(yyv1178, JobCondition{}) // var yyz1178 JobCondition
-				yyc1178 = true
+		for yyj1173 := 0; !r.CheckBreak(); yyj1173++ {
+			if yyj1173 >= len(yyv1173) {
+				yyv1173 = append(yyv1173, JobCondition{}) // var yyz1173 JobCondition
+				yyc1173 = true
 			}
 
-			if yyj1178 < len(yyv1178) {
+			if yyj1173 < len(yyv1173) {
 				if r.TryDecodeAsNil() {
-					yyv1178[yyj1178] = JobCondition{}
+					yyv1173[yyj1173] = JobCondition{}
 				} else {
-					yyv1181 := &yyv1178[yyj1178]
-					yyv1181.CodecDecodeSelf(d)
+					yyv1176 := &yyv1173[yyj1173]
+					yyv1176.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13507,10 +13463,10 @@ func (x codecSelfer1234) decSliceJobCondition(v *[]JobCondition, d *codec1978.De
 			}
 
 		}
-		yyh1178.End()
+		yyh1173.End()
 	}
-	if yyc1178 {
-		*v = yyv1178
+	if yyc1173 {
+		*v = yyv1173
 	}
 
 }
@@ -13520,9 +13476,9 @@ func (x codecSelfer1234) encSliceIngress(v []Ingress, e *codec1978.Encoder) {
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1182 := range v {
-		yy1183 := &yyv1182
-		yy1183.CodecEncodeSelf(e)
+	for _, yyv1177 := range v {
+		yy1178 := &yyv1177
+		yy1178.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13532,75 +13488,75 @@ func (x codecSelfer1234) decSliceIngress(v *[]Ingress, d *codec1978.Decoder) {
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1184 := *v
-	yyh1184, yyl1184 := z.DecSliceHelperStart()
+	yyv1179 := *v
+	yyh1179, yyl1179 := z.DecSliceHelperStart()
 
-	var yyrr1184, yyrl1184 int
-	var yyc1184, yyrt1184 bool
-	_, _, _ = yyc1184, yyrt1184, yyrl1184
-	yyrr1184 = yyl1184
+	var yyrr1179, yyrl1179 int
+	var yyc1179, yyrt1179 bool
+	_, _, _ = yyc1179, yyrt1179, yyrl1179
+	yyrr1179 = yyl1179
 
-	if yyv1184 == nil {
-		if yyrl1184, yyrt1184 = z.DecInferLen(yyl1184, z.DecBasicHandle().MaxInitLen, 248); yyrt1184 {
-			yyrr1184 = yyrl1184
+	if yyv1179 == nil {
+		if yyrl1179, yyrt1179 = z.DecInferLen(yyl1179, z.DecBasicHandle().MaxInitLen, 248); yyrt1179 {
+			yyrr1179 = yyrl1179
 		}
-		yyv1184 = make([]Ingress, yyrl1184)
-		yyc1184 = true
+		yyv1179 = make([]Ingress, yyrl1179)
+		yyc1179 = true
 	}
 
-	if yyl1184 == 0 {
-		if len(yyv1184) != 0 {
-			yyv1184 = yyv1184[:0]
-			yyc1184 = true
+	if yyl1179 == 0 {
+		if len(yyv1179) != 0 {
+			yyv1179 = yyv1179[:0]
+			yyc1179 = true
 		}
-	} else if yyl1184 > 0 {
+	} else if yyl1179 > 0 {
 
-		if yyl1184 > cap(yyv1184) {
-			yyrl1184, yyrt1184 = z.DecInferLen(yyl1184, z.DecBasicHandle().MaxInitLen, 248)
-			yyv1184 = make([]Ingress, yyrl1184)
-			yyc1184 = true
+		if yyl1179 > cap(yyv1179) {
+			yyrl1179, yyrt1179 = z.DecInferLen(yyl1179, z.DecBasicHandle().MaxInitLen, 248)
+			yyv1179 = make([]Ingress, yyrl1179)
+			yyc1179 = true
 
-			yyrr1184 = len(yyv1184)
-		} else if yyl1184 != len(yyv1184) {
-			yyv1184 = yyv1184[:yyl1184]
-			yyc1184 = true
+			yyrr1179 = len(yyv1179)
+		} else if yyl1179 != len(yyv1179) {
+			yyv1179 = yyv1179[:yyl1179]
+			yyc1179 = true
 		}
-		yyj1184 := 0
-		for ; yyj1184 < yyrr1184; yyj1184++ {
+		yyj1179 := 0
+		for ; yyj1179 < yyrr1179; yyj1179++ {
 			if r.TryDecodeAsNil() {
-				yyv1184[yyj1184] = Ingress{}
+				yyv1179[yyj1179] = Ingress{}
 			} else {
-				yyv1185 := &yyv1184[yyj1184]
-				yyv1185.CodecDecodeSelf(d)
+				yyv1180 := &yyv1179[yyj1179]
+				yyv1180.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1184 {
-			for ; yyj1184 < yyl1184; yyj1184++ {
-				yyv1184 = append(yyv1184, Ingress{})
+		if yyrt1179 {
+			for ; yyj1179 < yyl1179; yyj1179++ {
+				yyv1179 = append(yyv1179, Ingress{})
 				if r.TryDecodeAsNil() {
-					yyv1184[yyj1184] = Ingress{}
+					yyv1179[yyj1179] = Ingress{}
 				} else {
-					yyv1186 := &yyv1184[yyj1184]
-					yyv1186.CodecDecodeSelf(d)
+					yyv1181 := &yyv1179[yyj1179]
+					yyv1181.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1184 := 0; !r.CheckBreak(); yyj1184++ {
-			if yyj1184 >= len(yyv1184) {
-				yyv1184 = append(yyv1184, Ingress{}) // var yyz1184 Ingress
-				yyc1184 = true
+		for yyj1179 := 0; !r.CheckBreak(); yyj1179++ {
+			if yyj1179 >= len(yyv1179) {
+				yyv1179 = append(yyv1179, Ingress{}) // var yyz1179 Ingress
+				yyc1179 = true
 			}
 
-			if yyj1184 < len(yyv1184) {
+			if yyj1179 < len(yyv1179) {
 				if r.TryDecodeAsNil() {
-					yyv1184[yyj1184] = Ingress{}
+					yyv1179[yyj1179] = Ingress{}
 				} else {
-					yyv1187 := &yyv1184[yyj1184]
-					yyv1187.CodecDecodeSelf(d)
+					yyv1182 := &yyv1179[yyj1179]
+					yyv1182.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13608,10 +13564,10 @@ func (x codecSelfer1234) decSliceIngress(v *[]Ingress, d *codec1978.Decoder) {
 			}
 
 		}
-		yyh1184.End()
+		yyh1179.End()
 	}
-	if yyc1184 {
-		*v = yyv1184
+	if yyc1179 {
+		*v = yyv1179
 	}
 
 }
@@ -13621,9 +13577,9 @@ func (x codecSelfer1234) encSliceIngressRule(v []IngressRule, e *codec1978.Encod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1188 := range v {
-		yy1189 := &yyv1188
-		yy1189.CodecEncodeSelf(e)
+	for _, yyv1183 := range v {
+		yy1184 := &yyv1183
+		yy1184.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13633,75 +13589,75 @@ func (x codecSelfer1234) decSliceIngressRule(v *[]IngressRule, d *codec1978.Deco
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1190 := *v
-	yyh1190, yyl1190 := z.DecSliceHelperStart()
+	yyv1185 := *v
+	yyh1185, yyl1185 := z.DecSliceHelperStart()
 
-	var yyrr1190, yyrl1190 int
-	var yyc1190, yyrt1190 bool
-	_, _, _ = yyc1190, yyrt1190, yyrl1190
-	yyrr1190 = yyl1190
+	var yyrr1185, yyrl1185 int
+	var yyc1185, yyrt1185 bool
+	_, _, _ = yyc1185, yyrt1185, yyrl1185
+	yyrr1185 = yyl1185
 
-	if yyv1190 == nil {
-		if yyrl1190, yyrt1190 = z.DecInferLen(yyl1190, z.DecBasicHandle().MaxInitLen, 24); yyrt1190 {
-			yyrr1190 = yyrl1190
+	if yyv1185 == nil {
+		if yyrl1185, yyrt1185 = z.DecInferLen(yyl1185, z.DecBasicHandle().MaxInitLen, 24); yyrt1185 {
+			yyrr1185 = yyrl1185
 		}
-		yyv1190 = make([]IngressRule, yyrl1190)
-		yyc1190 = true
+		yyv1185 = make([]IngressRule, yyrl1185)
+		yyc1185 = true
 	}
 
-	if yyl1190 == 0 {
-		if len(yyv1190) != 0 {
-			yyv1190 = yyv1190[:0]
-			yyc1190 = true
+	if yyl1185 == 0 {
+		if len(yyv1185) != 0 {
+			yyv1185 = yyv1185[:0]
+			yyc1185 = true
 		}
-	} else if yyl1190 > 0 {
+	} else if yyl1185 > 0 {
 
-		if yyl1190 > cap(yyv1190) {
-			yyrl1190, yyrt1190 = z.DecInferLen(yyl1190, z.DecBasicHandle().MaxInitLen, 24)
-			yyv1190 = make([]IngressRule, yyrl1190)
-			yyc1190 = true
+		if yyl1185 > cap(yyv1185) {
+			yyrl1185, yyrt1185 = z.DecInferLen(yyl1185, z.DecBasicHandle().MaxInitLen, 24)
+			yyv1185 = make([]IngressRule, yyrl1185)
+			yyc1185 = true
 
-			yyrr1190 = len(yyv1190)
-		} else if yyl1190 != len(yyv1190) {
-			yyv1190 = yyv1190[:yyl1190]
-			yyc1190 = true
+			yyrr1185 = len(yyv1185)
+		} else if yyl1185 != len(yyv1185) {
+			yyv1185 = yyv1185[:yyl1185]
+			yyc1185 = true
 		}
-		yyj1190 := 0
-		for ; yyj1190 < yyrr1190; yyj1190++ {
+		yyj1185 := 0
+		for ; yyj1185 < yyrr1185; yyj1185++ {
 			if r.TryDecodeAsNil() {
-				yyv1190[yyj1190] = IngressRule{}
+				yyv1185[yyj1185] = IngressRule{}
 			} else {
-				yyv1191 := &yyv1190[yyj1190]
-				yyv1191.CodecDecodeSelf(d)
+				yyv1186 := &yyv1185[yyj1185]
+				yyv1186.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1190 {
-			for ; yyj1190 < yyl1190; yyj1190++ {
-				yyv1190 = append(yyv1190, IngressRule{})
+		if yyrt1185 {
+			for ; yyj1185 < yyl1185; yyj1185++ {
+				yyv1185 = append(yyv1185, IngressRule{})
 				if r.TryDecodeAsNil() {
-					yyv1190[yyj1190] = IngressRule{}
+					yyv1185[yyj1185] = IngressRule{}
 				} else {
-					yyv1192 := &yyv1190[yyj1190]
-					yyv1192.CodecDecodeSelf(d)
+					yyv1187 := &yyv1185[yyj1185]
+					yyv1187.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1190 := 0; !r.CheckBreak(); yyj1190++ {
-			if yyj1190 >= len(yyv1190) {
-				yyv1190 = append(yyv1190, IngressRule{}) // var yyz1190 IngressRule
-				yyc1190 = true
+		for yyj1185 := 0; !r.CheckBreak(); yyj1185++ {
+			if yyj1185 >= len(yyv1185) {
+				yyv1185 = append(yyv1185, IngressRule{}) // var yyz1185 IngressRule
+				yyc1185 = true
 			}
 
-			if yyj1190 < len(yyv1190) {
+			if yyj1185 < len(yyv1185) {
 				if r.TryDecodeAsNil() {
-					yyv1190[yyj1190] = IngressRule{}
+					yyv1185[yyj1185] = IngressRule{}
 				} else {
-					yyv1193 := &yyv1190[yyj1190]
-					yyv1193.CodecDecodeSelf(d)
+					yyv1188 := &yyv1185[yyj1185]
+					yyv1188.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13709,10 +13665,10 @@ func (x codecSelfer1234) decSliceIngressRule(v *[]IngressRule, d *codec1978.Deco
 			}
 
 		}
-		yyh1190.End()
+		yyh1185.End()
 	}
-	if yyc1190 {
-		*v = yyv1190
+	if yyc1185 {
+		*v = yyv1185
 	}
 
 }
@@ -13722,9 +13678,9 @@ func (x codecSelfer1234) encSliceHTTPIngressPath(v []HTTPIngressPath, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1194 := range v {
-		yy1195 := &yyv1194
-		yy1195.CodecEncodeSelf(e)
+	for _, yyv1189 := range v {
+		yy1190 := &yyv1189
+		yy1190.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13734,75 +13690,75 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1196 := *v
-	yyh1196, yyl1196 := z.DecSliceHelperStart()
+	yyv1191 := *v
+	yyh1191, yyl1191 := z.DecSliceHelperStart()
 
-	var yyrr1196, yyrl1196 int
-	var yyc1196, yyrt1196 bool
-	_, _, _ = yyc1196, yyrt1196, yyrl1196
-	yyrr1196 = yyl1196
+	var yyrr1191, yyrl1191 int
+	var yyc1191, yyrt1191 bool
+	_, _, _ = yyc1191, yyrt1191, yyrl1191
+	yyrr1191 = yyl1191
 
-	if yyv1196 == nil {
-		if yyrl1196, yyrt1196 = z.DecInferLen(yyl1196, z.DecBasicHandle().MaxInitLen, 64); yyrt1196 {
-			yyrr1196 = yyrl1196
+	if yyv1191 == nil {
+		if yyrl1191, yyrt1191 = z.DecInferLen(yyl1191, z.DecBasicHandle().MaxInitLen, 64); yyrt1191 {
+			yyrr1191 = yyrl1191
 		}
-		yyv1196 = make([]HTTPIngressPath, yyrl1196)
-		yyc1196 = true
+		yyv1191 = make([]HTTPIngressPath, yyrl1191)
+		yyc1191 = true
 	}
 
-	if yyl1196 == 0 {
-		if len(yyv1196) != 0 {
-			yyv1196 = yyv1196[:0]
-			yyc1196 = true
+	if yyl1191 == 0 {
+		if len(yyv1191) != 0 {
+			yyv1191 = yyv1191[:0]
+			yyc1191 = true
 		}
-	} else if yyl1196 > 0 {
+	} else if yyl1191 > 0 {
 
-		if yyl1196 > cap(yyv1196) {
-			yyrl1196, yyrt1196 = z.DecInferLen(yyl1196, z.DecBasicHandle().MaxInitLen, 64)
-			yyv1196 = make([]HTTPIngressPath, yyrl1196)
-			yyc1196 = true
+		if yyl1191 > cap(yyv1191) {
+			yyrl1191, yyrt1191 = z.DecInferLen(yyl1191, z.DecBasicHandle().MaxInitLen, 64)
+			yyv1191 = make([]HTTPIngressPath, yyrl1191)
+			yyc1191 = true
 
-			yyrr1196 = len(yyv1196)
-		} else if yyl1196 != len(yyv1196) {
-			yyv1196 = yyv1196[:yyl1196]
-			yyc1196 = true
+			yyrr1191 = len(yyv1191)
+		} else if yyl1191 != len(yyv1191) {
+			yyv1191 = yyv1191[:yyl1191]
+			yyc1191 = true
 		}
-		yyj1196 := 0
-		for ; yyj1196 < yyrr1196; yyj1196++ {
+		yyj1191 := 0
+		for ; yyj1191 < yyrr1191; yyj1191++ {
 			if r.TryDecodeAsNil() {
-				yyv1196[yyj1196] = HTTPIngressPath{}
+				yyv1191[yyj1191] = HTTPIngressPath{}
 			} else {
-				yyv1197 := &yyv1196[yyj1196]
-				yyv1197.CodecDecodeSelf(d)
+				yyv1192 := &yyv1191[yyj1191]
+				yyv1192.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1196 {
-			for ; yyj1196 < yyl1196; yyj1196++ {
-				yyv1196 = append(yyv1196, HTTPIngressPath{})
+		if yyrt1191 {
+			for ; yyj1191 < yyl1191; yyj1191++ {
+				yyv1191 = append(yyv1191, HTTPIngressPath{})
 				if r.TryDecodeAsNil() {
-					yyv1196[yyj1196] = HTTPIngressPath{}
+					yyv1191[yyj1191] = HTTPIngressPath{}
 				} else {
-					yyv1198 := &yyv1196[yyj1196]
-					yyv1198.CodecDecodeSelf(d)
+					yyv1193 := &yyv1191[yyj1191]
+					yyv1193.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1196 := 0; !r.CheckBreak(); yyj1196++ {
-			if yyj1196 >= len(yyv1196) {
-				yyv1196 = append(yyv1196, HTTPIngressPath{}) // var yyz1196 HTTPIngressPath
-				yyc1196 = true
+		for yyj1191 := 0; !r.CheckBreak(); yyj1191++ {
+			if yyj1191 >= len(yyv1191) {
+				yyv1191 = append(yyv1191, HTTPIngressPath{}) // var yyz1191 HTTPIngressPath
+				yyc1191 = true
 			}
 
-			if yyj1196 < len(yyv1196) {
+			if yyj1191 < len(yyv1191) {
 				if r.TryDecodeAsNil() {
-					yyv1196[yyj1196] = HTTPIngressPath{}
+					yyv1191[yyj1191] = HTTPIngressPath{}
 				} else {
-					yyv1199 := &yyv1196[yyj1196]
-					yyv1199.CodecDecodeSelf(d)
+					yyv1194 := &yyv1191[yyj1191]
+					yyv1194.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13810,10 +13766,10 @@ func (x codecSelfer1234) decSliceHTTPIngressPath(v *[]HTTPIngressPath, d *codec1
 			}
 
 		}
-		yyh1196.End()
+		yyh1191.End()
 	}
-	if yyc1196 {
-		*v = yyv1196
+	if yyc1191 {
+		*v = yyv1191
 	}
 
 }
@@ -13823,9 +13779,9 @@ func (x codecSelfer1234) encSliceNodeUtilization(v []NodeUtilization, e *codec19
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1200 := range v {
-		yy1201 := &yyv1200
-		yy1201.CodecEncodeSelf(e)
+	for _, yyv1195 := range v {
+		yy1196 := &yyv1195
+		yy1196.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13835,75 +13791,75 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1202 := *v
-	yyh1202, yyl1202 := z.DecSliceHelperStart()
+	yyv1197 := *v
+	yyh1197, yyl1197 := z.DecSliceHelperStart()
 
-	var yyrr1202, yyrl1202 int
-	var yyc1202, yyrt1202 bool
-	_, _, _ = yyc1202, yyrt1202, yyrl1202
-	yyrr1202 = yyl1202
+	var yyrr1197, yyrl1197 int
+	var yyc1197, yyrt1197 bool
+	_, _, _ = yyc1197, yyrt1197, yyrl1197
+	yyrr1197 = yyl1197
 
-	if yyv1202 == nil {
-		if yyrl1202, yyrt1202 = z.DecInferLen(yyl1202, z.DecBasicHandle().MaxInitLen, 24); yyrt1202 {
-			yyrr1202 = yyrl1202
+	if yyv1197 == nil {
+		if yyrl1197, yyrt1197 = z.DecInferLen(yyl1197, z.DecBasicHandle().MaxInitLen, 24); yyrt1197 {
+			yyrr1197 = yyrl1197
 		}
-		yyv1202 = make([]NodeUtilization, yyrl1202)
-		yyc1202 = true
+		yyv1197 = make([]NodeUtilization, yyrl1197)
+		yyc1197 = true
 	}
 
-	if yyl1202 == 0 {
-		if len(yyv1202) != 0 {
-			yyv1202 = yyv1202[:0]
-			yyc1202 = true
+	if yyl1197 == 0 {
+		if len(yyv1197) != 0 {
+			yyv1197 = yyv1197[:0]
+			yyc1197 = true
 		}
-	} else if yyl1202 > 0 {
+	} else if yyl1197 > 0 {
 
-		if yyl1202 > cap(yyv1202) {
-			yyrl1202, yyrt1202 = z.DecInferLen(yyl1202, z.DecBasicHandle().MaxInitLen, 24)
-			yyv1202 = make([]NodeUtilization, yyrl1202)
-			yyc1202 = true
+		if yyl1197 > cap(yyv1197) {
+			yyrl1197, yyrt1197 = z.DecInferLen(yyl1197, z.DecBasicHandle().MaxInitLen, 24)
+			yyv1197 = make([]NodeUtilization, yyrl1197)
+			yyc1197 = true
 
-			yyrr1202 = len(yyv1202)
-		} else if yyl1202 != len(yyv1202) {
-			yyv1202 = yyv1202[:yyl1202]
-			yyc1202 = true
+			yyrr1197 = len(yyv1197)
+		} else if yyl1197 != len(yyv1197) {
+			yyv1197 = yyv1197[:yyl1197]
+			yyc1197 = true
 		}
-		yyj1202 := 0
-		for ; yyj1202 < yyrr1202; yyj1202++ {
+		yyj1197 := 0
+		for ; yyj1197 < yyrr1197; yyj1197++ {
 			if r.TryDecodeAsNil() {
-				yyv1202[yyj1202] = NodeUtilization{}
+				yyv1197[yyj1197] = NodeUtilization{}
 			} else {
-				yyv1203 := &yyv1202[yyj1202]
-				yyv1203.CodecDecodeSelf(d)
+				yyv1198 := &yyv1197[yyj1197]
+				yyv1198.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1202 {
-			for ; yyj1202 < yyl1202; yyj1202++ {
-				yyv1202 = append(yyv1202, NodeUtilization{})
+		if yyrt1197 {
+			for ; yyj1197 < yyl1197; yyj1197++ {
+				yyv1197 = append(yyv1197, NodeUtilization{})
 				if r.TryDecodeAsNil() {
-					yyv1202[yyj1202] = NodeUtilization{}
+					yyv1197[yyj1197] = NodeUtilization{}
 				} else {
-					yyv1204 := &yyv1202[yyj1202]
-					yyv1204.CodecDecodeSelf(d)
+					yyv1199 := &yyv1197[yyj1197]
+					yyv1199.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1202 := 0; !r.CheckBreak(); yyj1202++ {
-			if yyj1202 >= len(yyv1202) {
-				yyv1202 = append(yyv1202, NodeUtilization{}) // var yyz1202 NodeUtilization
-				yyc1202 = true
+		for yyj1197 := 0; !r.CheckBreak(); yyj1197++ {
+			if yyj1197 >= len(yyv1197) {
+				yyv1197 = append(yyv1197, NodeUtilization{}) // var yyz1197 NodeUtilization
+				yyc1197 = true
 			}
 
-			if yyj1202 < len(yyv1202) {
+			if yyj1197 < len(yyv1197) {
 				if r.TryDecodeAsNil() {
-					yyv1202[yyj1202] = NodeUtilization{}
+					yyv1197[yyj1197] = NodeUtilization{}
 				} else {
-					yyv1205 := &yyv1202[yyj1202]
-					yyv1205.CodecDecodeSelf(d)
+					yyv1200 := &yyv1197[yyj1197]
+					yyv1200.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -13911,10 +13867,10 @@ func (x codecSelfer1234) decSliceNodeUtilization(v *[]NodeUtilization, d *codec1
 			}
 
 		}
-		yyh1202.End()
+		yyh1197.End()
 	}
-	if yyc1202 {
-		*v = yyv1202
+	if yyc1197 {
+		*v = yyv1197
 	}
 
 }
@@ -13924,9 +13880,9 @@ func (x codecSelfer1234) encSliceClusterAutoscaler(v []ClusterAutoscaler, e *cod
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1206 := range v {
-		yy1207 := &yyv1206
-		yy1207.CodecEncodeSelf(e)
+	for _, yyv1201 := range v {
+		yy1202 := &yyv1201
+		yy1202.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -13936,75 +13892,75 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1208 := *v
-	yyh1208, yyl1208 := z.DecSliceHelperStart()
+	yyv1203 := *v
+	yyh1203, yyl1203 := z.DecSliceHelperStart()
 
-	var yyrr1208, yyrl1208 int
-	var yyc1208, yyrt1208 bool
-	_, _, _ = yyc1208, yyrt1208, yyrl1208
-	yyrr1208 = yyl1208
+	var yyrr1203, yyrl1203 int
+	var yyc1203, yyrt1203 bool
+	_, _, _ = yyc1203, yyrt1203, yyrl1203
+	yyrr1203 = yyl1203
 
-	if yyv1208 == nil {
-		if yyrl1208, yyrt1208 = z.DecInferLen(yyl1208, z.DecBasicHandle().MaxInitLen, 232); yyrt1208 {
-			yyrr1208 = yyrl1208
+	if yyv1203 == nil {
+		if yyrl1203, yyrt1203 = z.DecInferLen(yyl1203, z.DecBasicHandle().MaxInitLen, 232); yyrt1203 {
+			yyrr1203 = yyrl1203
 		}
-		yyv1208 = make([]ClusterAutoscaler, yyrl1208)
-		yyc1208 = true
+		yyv1203 = make([]ClusterAutoscaler, yyrl1203)
+		yyc1203 = true
 	}
 
-	if yyl1208 == 0 {
-		if len(yyv1208) != 0 {
-			yyv1208 = yyv1208[:0]
-			yyc1208 = true
+	if yyl1203 == 0 {
+		if len(yyv1203) != 0 {
+			yyv1203 = yyv1203[:0]
+			yyc1203 = true
 		}
-	} else if yyl1208 > 0 {
+	} else if yyl1203 > 0 {
 
-		if yyl1208 > cap(yyv1208) {
-			yyrl1208, yyrt1208 = z.DecInferLen(yyl1208, z.DecBasicHandle().MaxInitLen, 232)
-			yyv1208 = make([]ClusterAutoscaler, yyrl1208)
-			yyc1208 = true
+		if yyl1203 > cap(yyv1203) {
+			yyrl1203, yyrt1203 = z.DecInferLen(yyl1203, z.DecBasicHandle().MaxInitLen, 232)
+			yyv1203 = make([]ClusterAutoscaler, yyrl1203)
+			yyc1203 = true
 
-			yyrr1208 = len(yyv1208)
-		} else if yyl1208 != len(yyv1208) {
-			yyv1208 = yyv1208[:yyl1208]
-			yyc1208 = true
+			yyrr1203 = len(yyv1203)
+		} else if yyl1203 != len(yyv1203) {
+			yyv1203 = yyv1203[:yyl1203]
+			yyc1203 = true
 		}
-		yyj1208 := 0
-		for ; yyj1208 < yyrr1208; yyj1208++ {
+		yyj1203 := 0
+		for ; yyj1203 < yyrr1203; yyj1203++ {
 			if r.TryDecodeAsNil() {
-				yyv1208[yyj1208] = ClusterAutoscaler{}
+				yyv1203[yyj1203] = ClusterAutoscaler{}
 			} else {
-				yyv1209 := &yyv1208[yyj1208]
-				yyv1209.CodecDecodeSelf(d)
+				yyv1204 := &yyv1203[yyj1203]
+				yyv1204.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1208 {
-			for ; yyj1208 < yyl1208; yyj1208++ {
-				yyv1208 = append(yyv1208, ClusterAutoscaler{})
+		if yyrt1203 {
+			for ; yyj1203 < yyl1203; yyj1203++ {
+				yyv1203 = append(yyv1203, ClusterAutoscaler{})
 				if r.TryDecodeAsNil() {
-					yyv1208[yyj1208] = ClusterAutoscaler{}
+					yyv1203[yyj1203] = ClusterAutoscaler{}
 				} else {
-					yyv1210 := &yyv1208[yyj1208]
-					yyv1210.CodecDecodeSelf(d)
+					yyv1205 := &yyv1203[yyj1203]
+					yyv1205.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1208 := 0; !r.CheckBreak(); yyj1208++ {
-			if yyj1208 >= len(yyv1208) {
-				yyv1208 = append(yyv1208, ClusterAutoscaler{}) // var yyz1208 ClusterAutoscaler
-				yyc1208 = true
+		for yyj1203 := 0; !r.CheckBreak(); yyj1203++ {
+			if yyj1203 >= len(yyv1203) {
+				yyv1203 = append(yyv1203, ClusterAutoscaler{}) // var yyz1203 ClusterAutoscaler
+				yyc1203 = true
 			}
 
-			if yyj1208 < len(yyv1208) {
+			if yyj1203 < len(yyv1203) {
 				if r.TryDecodeAsNil() {
-					yyv1208[yyj1208] = ClusterAutoscaler{}
+					yyv1203[yyj1203] = ClusterAutoscaler{}
 				} else {
-					yyv1211 := &yyv1208[yyj1208]
-					yyv1211.CodecDecodeSelf(d)
+					yyv1206 := &yyv1203[yyj1203]
+					yyv1206.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -14012,10 +13968,10 @@ func (x codecSelfer1234) decSliceClusterAutoscaler(v *[]ClusterAutoscaler, d *co
 			}
 
 		}
-		yyh1208.End()
+		yyh1203.End()
 	}
-	if yyc1208 {
-		*v = yyv1208
+	if yyc1203 {
+		*v = yyv1203
 	}
 
 }
@@ -14025,9 +13981,9 @@ func (x codecSelfer1234) encSlicePodSelectorRequirement(v []PodSelectorRequireme
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
-	for _, yyv1212 := range v {
-		yy1213 := &yyv1212
-		yy1213.CodecEncodeSelf(e)
+	for _, yyv1207 := range v {
+		yy1208 := &yyv1207
+		yy1208.CodecEncodeSelf(e)
 	}
 	r.EncodeEnd()
 }
@@ -14037,75 +13993,75 @@ func (x codecSelfer1234) decSlicePodSelectorRequirement(v *[]PodSelectorRequirem
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
-	yyv1214 := *v
-	yyh1214, yyl1214 := z.DecSliceHelperStart()
+	yyv1209 := *v
+	yyh1209, yyl1209 := z.DecSliceHelperStart()
 
-	var yyrr1214, yyrl1214 int
-	var yyc1214, yyrt1214 bool
-	_, _, _ = yyc1214, yyrt1214, yyrl1214
-	yyrr1214 = yyl1214
+	var yyrr1209, yyrl1209 int
+	var yyc1209, yyrt1209 bool
+	_, _, _ = yyc1209, yyrt1209, yyrl1209
+	yyrr1209 = yyl1209
 
-	if yyv1214 == nil {
-		if yyrl1214, yyrt1214 = z.DecInferLen(yyl1214, z.DecBasicHandle().MaxInitLen, 56); yyrt1214 {
-			yyrr1214 = yyrl1214
+	if yyv1209 == nil {
+		if yyrl1209, yyrt1209 = z.DecInferLen(yyl1209, z.DecBasicHandle().MaxInitLen, 56); yyrt1209 {
+			yyrr1209 = yyrl1209
 		}
-		yyv1214 = make([]PodSelectorRequirement, yyrl1214)
-		yyc1214 = true
+		yyv1209 = make([]PodSelectorRequirement, yyrl1209)
+		yyc1209 = true
 	}
 
-	if yyl1214 == 0 {
-		if len(yyv1214) != 0 {
-			yyv1214 = yyv1214[:0]
-			yyc1214 = true
+	if yyl1209 == 0 {
+		if len(yyv1209) != 0 {
+			yyv1209 = yyv1209[:0]
+			yyc1209 = true
 		}
-	} else if yyl1214 > 0 {
+	} else if yyl1209 > 0 {
 
-		if yyl1214 > cap(yyv1214) {
-			yyrl1214, yyrt1214 = z.DecInferLen(yyl1214, z.DecBasicHandle().MaxInitLen, 56)
-			yyv1214 = make([]PodSelectorRequirement, yyrl1214)
-			yyc1214 = true
+		if yyl1209 > cap(yyv1209) {
+			yyrl1209, yyrt1209 = z.DecInferLen(yyl1209, z.DecBasicHandle().MaxInitLen, 56)
+			yyv1209 = make([]PodSelectorRequirement, yyrl1209)
+			yyc1209 = true
 
-			yyrr1214 = len(yyv1214)
-		} else if yyl1214 != len(yyv1214) {
-			yyv1214 = yyv1214[:yyl1214]
-			yyc1214 = true
+			yyrr1209 = len(yyv1209)
+		} else if yyl1209 != len(yyv1209) {
+			yyv1209 = yyv1209[:yyl1209]
+			yyc1209 = true
 		}
-		yyj1214 := 0
-		for ; yyj1214 < yyrr1214; yyj1214++ {
+		yyj1209 := 0
+		for ; yyj1209 < yyrr1209; yyj1209++ {
 			if r.TryDecodeAsNil() {
-				yyv1214[yyj1214] = PodSelectorRequirement{}
+				yyv1209[yyj1209] = PodSelectorRequirement{}
 			} else {
-				yyv1215 := &yyv1214[yyj1214]
-				yyv1215.CodecDecodeSelf(d)
+				yyv1210 := &yyv1209[yyj1209]
+				yyv1210.CodecDecodeSelf(d)
 			}
 
 		}
-		if yyrt1214 {
-			for ; yyj1214 < yyl1214; yyj1214++ {
-				yyv1214 = append(yyv1214, PodSelectorRequirement{})
+		if yyrt1209 {
+			for ; yyj1209 < yyl1209; yyj1209++ {
+				yyv1209 = append(yyv1209, PodSelectorRequirement{})
 				if r.TryDecodeAsNil() {
-					yyv1214[yyj1214] = PodSelectorRequirement{}
+					yyv1209[yyj1209] = PodSelectorRequirement{}
 				} else {
-					yyv1216 := &yyv1214[yyj1214]
-					yyv1216.CodecDecodeSelf(d)
+					yyv1211 := &yyv1209[yyj1209]
+					yyv1211.CodecDecodeSelf(d)
 				}
 
 			}
 		}
 
 	} else {
-		for yyj1214 := 0; !r.CheckBreak(); yyj1214++ {
-			if yyj1214 >= len(yyv1214) {
-				yyv1214 = append(yyv1214, PodSelectorRequirement{}) // var yyz1214 PodSelectorRequirement
-				yyc1214 = true
+		for yyj1209 := 0; !r.CheckBreak(); yyj1209++ {
+			if yyj1209 >= len(yyv1209) {
+				yyv1209 = append(yyv1209, PodSelectorRequirement{}) // var yyz1209 PodSelectorRequirement
+				yyc1209 = true
 			}
 
-			if yyj1214 < len(yyv1214) {
+			if yyj1209 < len(yyv1209) {
 				if r.TryDecodeAsNil() {
-					yyv1214[yyj1214] = PodSelectorRequirement{}
+					yyv1209[yyj1209] = PodSelectorRequirement{}
 				} else {
-					yyv1217 := &yyv1214[yyj1214]
-					yyv1217.CodecDecodeSelf(d)
+					yyv1212 := &yyv1209[yyj1209]
+					yyv1212.CodecDecodeSelf(d)
 				}
 
 			} else {
@@ -14113,10 +14069,10 @@ func (x codecSelfer1234) decSlicePodSelectorRequirement(v *[]PodSelectorRequirem
 			}
 
 		}
-		yyh1214.End()
+		yyh1209.End()
 	}
-	if yyc1214 {
-		*v = yyv1214
+	if yyc1209 {
+		*v = yyv1209
 	}
 
 }

--- a/pkg/apis/extensions/v1beta1/types.go
+++ b/pkg/apis/extensions/v1beta1/types.go
@@ -59,8 +59,6 @@ type ReplicationControllerDummy struct {
 type SubresourceReference struct {
 	// Kind of the referent; More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
 	Kind string `json:"kind,omitempty"`
-	// Namespace of the referent; More info: http://releases.k8s.io/HEAD/docs/user-guide/namespaces.md
-	Namespace string `json:"namespace,omitempty"`
 	// Name of the referent; More info: http://releases.k8s.io/HEAD/docs/user-guide/identifiers.md#names
 	Name string `json:"name,omitempty"`
 	// API version of the referent

--- a/pkg/apis/extensions/v1beta1/types_swagger_doc_generated.go
+++ b/pkg/apis/extensions/v1beta1/types_swagger_doc_generated.go
@@ -445,7 +445,6 @@ func (ScaleStatus) SwaggerDoc() map[string]string {
 var map_SubresourceReference = map[string]string{
 	"":            "SubresourceReference contains enough information to let you inspect or modify the referred subresource.",
 	"kind":        "Kind of the referent; More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds\"",
-	"namespace":   "Namespace of the referent; More info: http://releases.k8s.io/HEAD/docs/user-guide/namespaces.md",
 	"name":        "Name of the referent; More info: http://releases.k8s.io/HEAD/docs/user-guide/identifiers.md#names",
 	"apiVersion":  "API version of the referent",
 	"subresource": "Subresource name of the referent",

--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -68,8 +68,7 @@ func (a *HorizontalController) Run(syncPeriod time.Duration) {
 	}, syncPeriod, util.NeverStop)
 }
 
-func (a *HorizontalController) computeReplicasForCPUUtilization(hpa extensions.HorizontalPodAutoscaler,
-	scale *extensions.Scale) (int, *int, error) {
+func (a *HorizontalController) computeReplicasForCPUUtilization(hpa extensions.HorizontalPodAutoscaler, scale *extensions.Scale) (int, *int, error) {
 	if hpa.Spec.CPUUtilization == nil {
 		// If CPUTarget is not specified than we should return some default values.
 		// Since we always take maximum number of replicas from all policies it is safe
@@ -77,7 +76,7 @@ func (a *HorizontalController) computeReplicasForCPUUtilization(hpa extensions.H
 		return 0, nil, nil
 	}
 	currentReplicas := scale.Status.Replicas
-	currentUtilization, err := a.metricsClient.GetCPUUtilization(hpa.Spec.ScaleRef.Namespace, scale.Status.Selector)
+	currentUtilization, err := a.metricsClient.GetCPUUtilization(hpa.Namespace, scale.Status.Selector)
 
 	// TODO: what to do on partial errors (like metrics obtained for 75% of pods).
 	if err != nil {
@@ -94,9 +93,9 @@ func (a *HorizontalController) computeReplicasForCPUUtilization(hpa extensions.H
 }
 
 func (a *HorizontalController) reconcileAutoscaler(hpa extensions.HorizontalPodAutoscaler) error {
-	reference := fmt.Sprintf("%s/%s/%s", hpa.Spec.ScaleRef.Kind, hpa.Spec.ScaleRef.Namespace, hpa.Spec.ScaleRef.Name)
+	reference := fmt.Sprintf("%s/%s/%s", hpa.Spec.ScaleRef.Kind, hpa.Namespace, hpa.Spec.ScaleRef.Name)
 
-	scale, err := a.client.Extensions().Scales(hpa.Spec.ScaleRef.Namespace).Get(hpa.Spec.ScaleRef.Kind, hpa.Spec.ScaleRef.Name)
+	scale, err := a.client.Extensions().Scales(hpa.Namespace).Get(hpa.Spec.ScaleRef.Kind, hpa.Spec.ScaleRef.Name)
 	if err != nil {
 		a.eventRecorder.Event(&hpa, "FailedGetScale", err.Error())
 		return fmt.Errorf("failed to query scale subresource for %s: %v", reference, err)

--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -90,7 +90,6 @@ func (tc *testCase) prepareTestClient(t *testing.T) *testclient.Fake {
 						ScaleRef: extensions.SubresourceReference{
 							Kind:        "replicationController",
 							Name:        rcName,
-							Namespace:   namespace,
 							Subresource: "scale",
 						},
 						MinReplicas: &tc.minReplicas,

--- a/pkg/kubectl/autoscale.go
+++ b/pkg/kubectl/autoscale.go
@@ -36,7 +36,6 @@ func (HorizontalPodAutoscalerV1Beta1) ParamNames() []GeneratorParam {
 		{"default-name", true},
 		{"name", false},
 		{"scaleRef-kind", false},
-		{"scaleRef-namespace", false},
 		{"scaleRef-name", false},
 		{"scaleRef-apiVersion", false},
 		{"scaleRef-subresource", false},
@@ -94,7 +93,6 @@ func (HorizontalPodAutoscalerV1Beta1) Generate(genericParams map[string]interfac
 		Spec: extensions.HorizontalPodAutoscalerSpec{
 			ScaleRef: extensions.SubresourceReference{
 				Kind:        params["scaleRef-kind"],
-				Namespace:   params["scaleRef-namespace"],
 				Name:        params["scaleRef-name"],
 				APIVersion:  params["scaleRef-apiVersion"],
 				Subresource: scaleSubResource,

--- a/pkg/kubectl/cmd/autoscale.go
+++ b/pkg/kubectl/cmd/autoscale.go
@@ -111,7 +111,6 @@ func RunAutoscale(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []
 	params["default-name"] = name
 
 	params["scaleRef-kind"] = mapping.Kind
-	params["scaleRef-namespace"] = namespace
 	params["scaleRef-name"] = name
 	params["scaleRef-apiVersion"] = mapping.APIVersion
 

--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -1295,9 +1295,8 @@ func (d *HorizontalPodAutoscalerDescriber) Describe(namespace, name string) (str
 		fmt.Fprintf(out, "Namespace:\t%s\n", hpa.Namespace)
 		fmt.Fprintf(out, "Labels:\t%s\n", labels.FormatLabels(hpa.Labels))
 		fmt.Fprintf(out, "CreationTimestamp:\t%s\n", hpa.CreationTimestamp.Time.Format(time.RFC1123Z))
-		fmt.Fprintf(out, "Reference:\t%s/%s/%s/%s\n",
+		fmt.Fprintf(out, "Reference:\t%s/%s/%s\n",
 			hpa.Spec.ScaleRef.Kind,
-			hpa.Spec.ScaleRef.Namespace,
 			hpa.Spec.ScaleRef.Name,
 			hpa.Spec.ScaleRef.Subresource)
 		if hpa.Spec.CPUUtilization != nil {
@@ -1319,7 +1318,7 @@ func (d *HorizontalPodAutoscalerDescriber) Describe(namespace, name string) (str
 		// TODO: switch to scale subresource once the required code is submitted.
 		if strings.ToLower(hpa.Spec.ScaleRef.Kind) == "replicationcontroller" {
 			fmt.Fprintf(out, "ReplicationController pods:\t")
-			rc, err := d.client.ReplicationControllers(hpa.Spec.ScaleRef.Namespace).Get(hpa.Spec.ScaleRef.Name)
+			rc, err := d.client.ReplicationControllers(hpa.Namespace).Get(hpa.Spec.ScaleRef.Name)
 			if err == nil {
 				fmt.Fprintf(out, "%d current / %d desired\n", rc.Status.Replicas, rc.Spec.Replicas)
 			} else {

--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -1376,9 +1376,8 @@ func printDeploymentList(list *extensions.DeploymentList, w io.Writer, withNames
 func printHorizontalPodAutoscaler(hpa *extensions.HorizontalPodAutoscaler, w io.Writer, withNamespace bool, wide bool, showAll bool, columnLabels []string) error {
 	namespace := hpa.Namespace
 	name := hpa.Name
-	reference := fmt.Sprintf("%s/%s/%s/%s",
+	reference := fmt.Sprintf("%s/%s/%s",
 		hpa.Spec.ScaleRef.Kind,
-		hpa.Spec.ScaleRef.Namespace,
 		hpa.Spec.ScaleRef.Name,
 		hpa.Spec.ScaleRef.Subresource)
 	target := "<unset>"

--- a/test/e2e/horizontal_pod_autoscaling.go
+++ b/test/e2e/horizontal_pod_autoscaling.go
@@ -68,7 +68,6 @@ func createCPUHorizontalPodAutoscaler(rc *ResourceConsumer, cpu int) {
 			ScaleRef: extensions.SubresourceReference{
 				Kind:        kind,
 				Name:        rc.name,
-				Namespace:   rc.framework.Namespace.Name,
 				Subresource: subresource,
 			},
 			MinReplicas:    &minReplicas,


### PR DESCRIPTION
Related to https://github.com/kubernetes/kubernetes/issues/16661

This eliminates the cross namespace escalation attack, but does not fix the API types themselves.

@kubernetes/kube-api @ncdc @liggitt @smarterclayton 
