### PR TITLE
use current-context from .kube/config when getting cluster credentials

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -179,7 +179,7 @@ function gen-kube-basicauth() {
 function get-kubeconfig-bearertoken() {
   export KUBECONFIG=${KUBECONFIG:-$DEFAULT_KUBECONFIG}
 
-  local cc="current-context"
+  local cc=$("${KUBE_ROOT}/cluster/kubectl.sh" config view -o jsonpath="{.current-context}")
   if [[ ! -z "${KUBE_CONTEXT:-}" ]]; then
     cc="${KUBE_CONTEXT}"
   fi
@@ -229,7 +229,7 @@ function load-or-gen-kube-bearertoken() {
 function detect-master-from-kubeconfig() {
   export KUBECONFIG=${KUBECONFIG:-$DEFAULT_KUBECONFIG}
 
-  local cc="current-context"
+  local cc=$("${KUBE_ROOT}/cluster/kubectl.sh" config view -o jsonpath="{.current-context}")
   if [[ ! -z "${KUBE_CONTEXT:-}" ]]; then
     cc="${KUBE_CONTEXT}"
   fi


### PR DESCRIPTION
#16345 merged on master broke kubernetes-upgrade-1.0-1.1-gce which seems wrong since kubernetes-upgrade-1.0-1.1-gce should be versioned pinned but it currently is not.

cc @ihmccreery
