### PR TITLE
Fixing missing swagger spec for apis/extensions

### DIFF
--- a/api/swagger-spec/apis.json
+++ b/api/swagger-spec/apis.json
@@ -1,0 +1,28 @@
+{
+  "swaggerVersion": "1.2",
+  "apiVersion": "",
+  "basePath": "https://10.10.10.10:6443",
+  "resourcePath": "/apis",
+  "apis": [
+   {
+    "path": "/apis",
+    "description": "get available API versions",
+    "operations": [
+     {
+      "type": "void",
+      "method": "GET",
+      "summary": "get available API versions",
+      "nickname": "getAPIVersions",
+      "parameters": [],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "application/json"
+      ]
+     }
+    ]
+   }
+  ],
+  "models": {}
+ }

--- a/api/swagger-spec/extensions.json
+++ b/api/swagger-spec/extensions.json
@@ -1,0 +1,28 @@
+{
+  "swaggerVersion": "1.2",
+  "apiVersion": "",
+  "basePath": "https://10.10.10.10:6443",
+  "resourcePath": "/apis/extensions",
+  "apis": [
+   {
+    "path": "/apis/extensions",
+    "description": "get information of a group",
+    "operations": [
+     {
+      "type": "void",
+      "method": "GET",
+      "summary": "get information of a group",
+      "nickname": "getAPIGroup",
+      "parameters": [],
+      "produces": [
+       "application/json"
+      ],
+      "consumes": [
+       "application/json"
+      ]
+     }
+    ]
+   }
+  ],
+  "models": {}
+ }

--- a/api/swagger-spec/resourceListing.json
+++ b/api/swagger-spec/resourceListing.json
@@ -14,7 +14,7 @@
     "description": "API at /apis/extensions/v1beta1"
    },
    {
-    "path": "/apis/extensions/",
+    "path": "/apis/extensions",
     "description": "get information of a group"
    },
    {

--- a/hack/after-build/update-swagger-spec.sh
+++ b/hack/after-build/update-swagger-spec.sh
@@ -69,6 +69,8 @@ curl -fs ${SWAGGER_API_PATH} > ${SWAGGER_ROOT_DIR}/resourceListing.json
 curl -fs ${SWAGGER_API_PATH}version > ${SWAGGER_ROOT_DIR}/version.json
 curl -fs ${SWAGGER_API_PATH}api > ${SWAGGER_ROOT_DIR}/api.json
 curl -fs ${SWAGGER_API_PATH}api/v1 > ${SWAGGER_ROOT_DIR}/v1.json
+curl -fs ${SWAGGER_API_PATH}apis > ${SWAGGER_ROOT_DIR}/apis.json
+curl -fs ${SWAGGER_API_PATH}apis/extensions > ${SWAGGER_ROOT_DIR}/extensions.json
 curl -fs ${SWAGGER_API_PATH}apis/extensions/v1beta1 > ${SWAGGER_ROOT_DIR}/v1beta1.json
 
 kube::log::status "SUCCESS"

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -672,7 +672,7 @@ func (m *Master) init(c *Config) {
 			Versions:         expAPIVersions,
 			PreferredVersion: unversioned.GroupVersion{GroupVersion: storageVersion, Version: apiutil.GetVersion(storageVersion)},
 		}
-		apiserver.AddGroupWebService(m.handlerContainer, c.APIGroupPrefix+"/"+latest.GroupOrDie("extensions").Group+"/", group)
+		apiserver.AddGroupWebService(m.handlerContainer, c.APIGroupPrefix+"/"+latest.GroupOrDie("extensions").Group, group)
 		allGroups = append(allGroups, group)
 		apiserver.InstallServiceErrorHandler(m.handlerContainer, m.newRequestInfoResolver(), []string{expVersion.Version})
 	}


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/16687

The only difference between /apis/extensions and other paths (such as /apis) was "/" at the end. I tried removing it and that fixed the issue :)

cc @bgrant0607 @caesarxuchao @lavalamp 
