### PR TITLE
Better error handling for output format when "kubectl config view"

### DIFF
--- a/pkg/util/jsonpath/parser.go
+++ b/pkg/util/jsonpath/parser.go
@@ -63,8 +63,12 @@ func NewParser(name string) *Parser {
 // parseAction parsed the expression inside delimiter
 func parseAction(name, text string) (*Parser, error) {
 	p, err := Parse(name, fmt.Sprintf("%s%s%s", leftDelim, text, rightDelim))
+	// when error happens, p will be nil, so we need to return here
+	if err != nil {
+		return p, err
+	}
 	p.Root = p.Root.Nodes[0].(*ListNode)
-	return p, err
+	return p, nil
 }
 
 func (p *Parser) Parse(text string) error {


### PR DESCRIPTION
Fixes #16684

`kubectl config view -o jsonpath=<malformed input>` or `kubectl config view -o wide` will panic. Improve error handling for both cases. 

cc @kubernetes/kubectl @kubernetes/goog-ux @mikedanese 
