### PR TITLE
Print out URL of where to find uploaded logs and artifacts, and a few other fixes

### DIFF
--- a/hack/jenkins/upload-to-gcs.sh
+++ b/hack/jenkins/upload-to-gcs.sh
@@ -72,6 +72,8 @@ function upload_logs_to_gcs() {
       cp -a "${gcs_acl}" - "${gcs_job_path}/latest-build.txt" || continue
     break  # all uploads succeeded if we hit this point
   done
+  local -r results_url=${gcs_build_path//"gs:/"/"https://storage.cloud.google.com"}
+  echo -e "\n\n\n*** View logs and artifacts at ${results_url} ***\n\n"
 }
 
 # Automatically upload logs to GCS on exit or timeout.

--- a/hack/jenkins/upload-to-gcs.sh
+++ b/hack/jenkins/upload-to-gcs.sh
@@ -17,10 +17,13 @@
 # Source this script in the Jenkins "Execute shell" build action to have all
 # test artifacts and the console log uploaded at the end of the test run.
 
-# For example, you might use the following line as the first command:
-# mkdir -p _tmp/ && curl -fsS --retry 3 -o _tmp/upload-to-gcs.sh \
-#   "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/upload-to-gcs.sh" \
-#   && source _tmp/upload-to-gcs.sh
+# For example, you might use the following snippet as the first few lines:
+#
+# if [[ -f ./hack/jenkins/upload-to-gcs.sh ]]; then
+#   source ./hack/jenkins/upload-to-gcs.sh
+# else
+#   curl -fsS -o upload-to-gcs.sh --retry 3 "https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/jenkins/upload-to-gcs.sh" && source upload-to-gcs.sh; rm -f upload-to-gcs.sh
+# fi
 
 # Note that this script requires the Jenkins shell binary to be set to bash, not
 # the system default (which may be dash on Debian-based systems).


### PR DESCRIPTION
Now that we're not really using the Google Cloud Storage Upload Jenkins plugin, it's not as obvious where to find uploaded build logs and artifacts, so print it out obviously in the console log.

Also update the comment describing how to use the script, and don't fail if the console log can't be found.
