### PR TITLE
Read error from failed upgrade attempts

### DIFF
--- a/pkg/client/unversioned/remotecommand/remotecommand.go
+++ b/pkg/client/unversioned/remotecommand/remotecommand.go
@@ -130,10 +130,6 @@ func (e *streamExecutor) Dial(protocols ...string) (httpstream.Connection, strin
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusSwitchingProtocols {
-		return nil, "", fmt.Errorf("unexpected response status code %d (%s)", resp.StatusCode, http.StatusText(resp.StatusCode))
-	}
-
 	conn, err := e.upgrader.NewConnection(resp)
 	if err != nil {
 		return nil, "", err

--- a/pkg/util/httpstream/spdy/roundtripper.go
+++ b/pkg/util/httpstream/spdy/roundtripper.go
@@ -205,7 +205,7 @@ func (s *SpdyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 func (s *SpdyRoundTripper) NewConnection(resp *http.Response) (httpstream.Connection, error) {
 	connectionHeader := strings.ToLower(resp.Header.Get(httpstream.HeaderConnection))
 	upgradeHeader := strings.ToLower(resp.Header.Get(httpstream.HeaderUpgrade))
-	if !strings.Contains(connectionHeader, strings.ToLower(httpstream.HeaderUpgrade)) || !strings.Contains(upgradeHeader, strings.ToLower(HeaderSpdy31)) {
+	if (resp.StatusCode != http.StatusSwitchingProtocols) || !strings.Contains(connectionHeader, strings.ToLower(httpstream.HeaderUpgrade)) || !strings.Contains(upgradeHeader, strings.ToLower(HeaderSpdy31)) {
 		defer resp.Body.Close()
 		responseError := ""
 		responseErrorBytes, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
If a non-upgrade response is received for an upgrade request, we attempt to read the response body to see if it is a server error response. However, remotecommand was short circuiting on non upgrade status codes. This restores that particular error handling behavior that existed prior to 3d1cafc2c38396f7f55e5927b694f402834cb5af and adds the response status code to the conditions the spdy roundtripper checks for
