### PR TITLE
enable deployments by default in test clusters

### DIFF
--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -111,7 +111,7 @@ if [[ "${ENABLE_NODE_AUTOSCALER}" == "true" ]]; then
 fi
 
 # Optional: Enable deployment experimental feature, not ready for production use.
-ENABLE_DEPLOYMENTS="${KUBE_ENABLE_DEPLOYMENTS:-false}"
+ENABLE_DEPLOYMENTS="${KUBE_ENABLE_DEPLOYMENTS:-true}"
 if [[ "${ENABLE_DEPLOYMENTS}" == "true" ]]; then
   ENABLE_EXPERIMENTAL_API=true
 fi


### PR DESCRIPTION
For convenience 
