### PR TITLE
Delete all files and all hidden files  without . & .. error for PV recycler

### DIFF
--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -405,7 +405,7 @@ func NewPersistentVolumeRecyclerPodTemplate() *api.Pod {
 					Name:    "pv-recycler",
 					Image:   "gcr.io/google_containers/busybox",
 					Command: []string{"/bin/sh"},
-					Args:    []string{"-c", "test -e /scrub && echo $(date) > /scrub/trash.txt && rm -rf /scrub/* /scrub/.* && test -z \"$(ls -A /scrub)\" || exit 1"},
+					Args:    []string{"-c", "test -e /scrub && echo $(date) > /scrub/trash.txt && find /scrub -mindepth 1 -maxdepth 1 -delete && test -z \"$(ls -A /scrub)\" || exit 1"},
 					VolumeMounts: []api.VolumeMount{
 						{
 							Name:      "vol",


### PR DESCRIPTION
When PV recycling, it failed: 

```
$ kubectl get pv
NAME      LABELS       CAPACITY   ACCESSMODES   STATUS    CLAIM           REASON    AGE
pv0001    type=local   10Gi       RWO           Failed    default/test3             11m
```

The default PV recycler Pod command to delete all files and all hidden files is:

```
rm -rf /scrub/* /scrub/.*
```

this will cause error, because it try to delete . and ..

```
rm: can't remove '.' or '..'
rm: can't remove '.' or '..'
```

so replace the rm command by:

```
find /scrub -mindepth 1 -maxdepth 1 -delete
```
